### PR TITLE
[pom.xml] changed parent groupId

### DIFF
--- a/bundles/sirix-saxon/pom.xml
+++ b/bundles/sirix-saxon/pom.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.github.johanneslichtenberger.sirix</groupId>
+		<groupId>com.github.sirixdb.sirix</groupId>
 		<artifactId>sirix-parent</artifactId>
 		<version>0.1.3-SNAPSHOT</version>
 		<relativePath>../../pom.xml</relativePath>


### PR DESCRIPTION
changed parent groupId from
com.github.johanneslichtenberger.sirix
to
com.github.sirixdb.sirix

There are more referenes to com.github.johanneslichtenberger.sirix in other pom.xml files.
