### PR TITLE
Fix typo in javadoc

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/api/NodeWriteTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/api/NodeWriteTrx.java
@@ -213,7 +213,7 @@ public interface NodeWriteTrx extends NodeReadTrx {
 	NodeWriteTrx replaceNode(NodeReadTrx rtx) throws SirixException;
 
 	/**
-	 * Move a subtree rooted at {@code pToKey} to the first child of the current
+	 * Move a subtree rooted at {@code fromKey} to the first child of the current
 	 * node.
 	 * 
 	 * @param fromKey


### PR DESCRIPTION
The javadoc was referencing `pToKey` when it should refer to `fromKey` instead
