### PR TITLE
Actually copy `cert.pem` and `key.pem` to `/opt/sirix/sirix-data` in …

### DIFF
--- a/bundles/sirix-rest-api/Dockerfile
+++ b/bundles/sirix-rest-api/Dockerfile
@@ -20,8 +20,8 @@ EXPOSE 9443
 
 # Copy your fat jar to the container
 COPY target/$VERTICLE_FILE $VERTICLE_HOME/
-COPY src/main/resources/cert.pem $VERTICLE_HOME/sirix-data
-COPY src/main/resources/key.pem $VERTICLE_HOME/sirix-data
+COPY src/main/resources/cert.pem $VERTICLE_HOME/sirix-data/
+COPY src/main/resources/key.pem $VERTICLE_HOME/sirix-data/
 COPY src/main/resources/sirix-conf.json $VERTICLE_HOME/
 
 # Launch the verticle


### PR DESCRIPTION
…Dockerfile

Apparently Docker needs the trailing slash to know that it needs to create the directory.

Before this commit `sirix-data` was just a file with the contents of `key.pem`