### PR TITLE
[WIP] Docker and docker-compose issues

### DIFF
--- a/bundles/sirix-rest-api/docker-compose.yml
+++ b/bundles/sirix-rest-api/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   web:
     build: .
+    image: sirixdb/sirix
     ports:
       - "9443:9443"
     volumes:
@@ -12,18 +13,7 @@ services:
     image: jboss/keycloak
     ports:
       - 8080:8080
-    KEYCLOAK_URL=http://localhost:8080/auth
-    KEYCLOAK_USER: admin
-    KEYCLOAK_PASSWORD: admin
-    KEYCLOAK_IMPORT:
-    volumes:
-      - C:\logs\keycloak:/usr/app/logs
-      - C:\settings:/etc/settings
-  networks:
-    keycloak:
-      driver: bridge
-      ipam:
-        driver: default
-        config:
-          - subnet: 172.0.0.0/16
-
+    environment:
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=admin
+      - KEYCLOAK_LOGLEVEL=DEBUG

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd bundles/sirix-rest-api
 mvn clean package -DskipTests
-docker build -t sirixdb/sirix .
+docker-compose build
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push sirixdb/sirix
+docker-compose push


### PR DESCRIPTION
Working on 
#50 Docker setup / Fix README
#51  Docker compose
#100 Starting a rest-api service that fails to connect to keycloak exits with status code 0

Some initial feedback would be great before proceeding further, as I have limited knowledge about the project.

1. Planning to add multi stage docker build, so that we can avoid doing mvn build before running docker
2. Added image name to the docker compose file itself, Avoid running docker commands directly.
3. Network configuration is unnecessary with docker compose. Containers are reachable to each other with the service name as hostname. Initially we could provide in the readme to change the hostname in sirix-conf.json file as:
```"keycloak.url": "http://keycloak:8080/auth/realms/master"```
Eventually I would suggest using environment variables and .env file instead of conf file itself.

The volume mount seems to be a bit confusing. (Sorry again for the lack of in depth knowledge about the project). Please review and suggest if any changes are required in volume mounts I have changed. Absolute paths in host system is not recommended as it won't be platform specific.
