### PR TITLE
Docker multistage build

### DIFF
--- a/bundles/sirix-rest-api/Dockerfile
+++ b/bundles/sirix-rest-api/Dockerfile
@@ -34,4 +34,5 @@ VOLUME $VERTICLE_HOME
 EXPOSE 9443
 
 # Launch the verticle
-CMD ["java -jar -Duser.home=$VERTICLE_HOME $VERTICLE_FILE -conf sirix-conf.json -cp $VERTICLE_HOME/*"]
+ENTRYPOINT ["sh", "-c"]
+CMD ["exec java -jar -Duser.home=$VERTICLE_HOME $VERTICLE_FILE -conf sirix-conf.json -cp $VERTICLE_HOME/*"]

--- a/bundles/sirix-rest-api/Dockerfile
+++ b/bundles/sirix-rest-api/Dockerfile
@@ -1,30 +1,37 @@
-###
-# Sirix Vert.x based HTTP(S)-server backend packaged as a fatjar.
-# To build (current dir is the sirix-rest-api module root):
-#  docker build -t sirixdb/sirix .
-# To run:
-#  docker run -t -i -p 9443:9443 sirixdb/sirix
-###
+# Stage-1
+# Build jar
 
-FROM openjdk:11.0.1-jre
-MAINTAINER Johannes Lichtenberger <johannes.lichtenberger@sirix.io>
+FROM maven:3-jdk-11 as builder
+LABEL maintainer="Johannes Lichtenberger <johannes.lichtenberger@sirix.io>"
+WORKDIR /usr/app
 
+# Resolve dependencies
+COPY pom.xml .
+RUN ["/usr/local/bin/mvn-entrypoint.sh", "mvn", "verify", "clean", "--fail-never"]
+
+# Package jar
+COPY . .
+RUN mvn package -DskipTests
+
+# Stage-2
+# Copy jar and run the server 
+
+FROM openjdk:14-alpine as server
 ENV VERTICLE_FILE sirix-rest-api-*-SNAPSHOT-fat.jar
-
 # Set the location of the verticles
 ENV VERTICLE_HOME /opt/sirix
+WORKDIR /opt/sirix
+
+# Copy fat jar to the container
+COPY --from=builder /usr/app/target/$VERTICLE_FILE ./
+COPY src/main/resources/cert.pem ./sirix-data/
+COPY src/main/resources/key.pem ./sirix-data/
+COPY src/main/resources/sirix-conf.json ./
+# Replace localhost url with keyclock url in docker compose file
+RUN sed -i 's/localhost/keyclock/g' sirix-conf.json
 
 VOLUME $VERTICLE_HOME
-
 EXPOSE 9443
 
-# Copy your fat jar to the container
-COPY target/$VERTICLE_FILE $VERTICLE_HOME/
-COPY src/main/resources/cert.pem $VERTICLE_HOME/sirix-data/
-COPY src/main/resources/key.pem $VERTICLE_HOME/sirix-data/
-COPY src/main/resources/sirix-conf.json $VERTICLE_HOME/
-
 # Launch the verticle
-WORKDIR $VERTICLE_HOME
-ENTRYPOINT ["sh", "-c"]
-CMD ["exec java -jar -Duser.home=$VERTICLE_HOME $VERTICLE_FILE -conf sirix-conf.json -cp $VERTICLE_HOME/*"]
+CMD ["java -jar -Duser.home=$VERTICLE_HOME $VERTICLE_FILE -conf sirix-conf.json -cp $VERTICLE_HOME/*"]

--- a/bundles/sirix-rest-api/Dockerfile
+++ b/bundles/sirix-rest-api/Dockerfile
@@ -27,8 +27,8 @@ COPY --from=builder /usr/app/target/$VERTICLE_FILE ./
 COPY src/main/resources/cert.pem ./sirix-data/
 COPY src/main/resources/key.pem ./sirix-data/
 COPY src/main/resources/sirix-conf.json ./
-# Replace localhost url with keyclock url in docker compose file
-RUN sed -i 's/localhost/keyclock/g' sirix-conf.json
+# Replace localhost url with keycloack url in docker compose file
+RUN sed -i 's/localhost/keycloack/g' sirix-conf.json
 
 VOLUME $VERTICLE_HOME
 EXPOSE 9443

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 cd bundles/sirix-rest-api
-mvn clean package -DskipTests
 docker-compose build
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 docker-compose push


### PR DESCRIPTION
Closes #51 
Closes #100 

- Added docker multi stage build. No need to run ```mvn package``` command outside the container anymore.
- Updated the base images to use smaller disk size. Now the final build is around 370 MB
- Updated deprecated commands from Dockerfile
- The localhost url in conf file is automatically updated with the keycloack url upon building the container.

We Need to test the container thoroughly once and make sure it is working exactly as outside the container