### PR TITLE
Make OAuth flow configurable between PASSWORD and AUTH_CODE

### DIFF
--- a/bundles/sirix-rest-api/src/main/resources/sirix-conf.json
+++ b/bundles/sirix-rest-api/src/main/resources/sirix-conf.json
@@ -1,5 +1,8 @@
 {
   "https.port": 9443,
-  "client.secret": "c8b9b4ed-67bb-47d9-bd73-a3babc470b2c",
-  "keycloak.url": "http://localhost:8080/auth/realms/master"
+  "keycloak.url": "http://localhost:8080/auth/realms/master",
+  "auth-server-url": "http://localhost:8080/auth",
+  "client.secret": "fdcdbc28-51c3-4ac2-a652-322f37ee5fed",
+  "oAuthFlowType" : "PASSWORD", //Possible values: PASSWORD, AUTH_CODE
+  "redirect_uri" : "<redirect_uri>"
 }


### PR DESCRIPTION
- Make OAuth flow configurable between PASSWORD and AUTH_CODE
- add new endpoint for getting the auth server url login page with redirect_uri set
- Change name of /login endpoint to /token 
- add relevant values in config file

I tested the auth_flow manually with my own web app. If there is a way to make an automated test based on this, let me know. I'm curious how to do that.  

Please send me your feedback on what you think