### PR TITLE
Gradle Support - Maven central publish support with signing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
     apply plugin: 'com.github.ben-manes.versions'
     apply plugin: "com.github.johnrengelman.shadow"
     apply plugin: "com.diffplug.gradle.spotless"
@@ -88,7 +89,34 @@ subprojects {
     publishing {
         publications {
             maven(MavenPublication) {
-                from(components.java)
+                afterEvaluate {
+                    pom {
+                        name = "${project.name}"
+                        description = "${project.description}"
+                        url = "https://sirix.io"
+                        licenses {
+                            license {
+                                name = "New BSD"
+                                url = "http://www.opensource.org/licenses/bsd-license.php"
+                                comments = "3-clause BSD License"
+                            }
+                        }
+                        scm {
+                            connection = "scm:git:git@github.com:sirixdb/sirix.git"
+                            developerConnection = "scm:git:git@github.com:sirixdb/sirix.git"
+                            url = "https://github.com/sirixdb/sirix"
+                        }
+                        issueManagement {
+                            url = "https://github.com/sirixdb/sirix/issues"
+                            system = "GitHub Issues"
+                        }
+                        ciManagement {
+                            system = "Travis CI"
+                            url = "http://travis-ci.org/#!/sirixdb/sirix"
+                        }
+                    }
+                    from components.java
+                }
             }
         }
         repositories {
@@ -102,6 +130,10 @@ subprojects {
                 url = rootProject.getProperties().version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             }
         }
+    }
+
+    signing {
+        sign publishing.publications.maven
     }
 
     configurations.all {


### PR DESCRIPTION
This PR is to provide support for maven central publication and maven artifact signing.

The generated jar will contain the required tags by maven central like **description, url, license etc. in the pom.xml**
Also during maven publication, the published jar will be signed, to give signing properties, the below properties can be added to a gradle.properties file under USER_HOME (create a new file if not present)

**gradle.properties**
signing.keyId=24875D73
signing.password=secret
signing.secretKeyRingFile=/Users/me/.gnupg/secring.gpg

**Note**
Either `gradlew release` (or) the following command can also be used to just publish jars to maven central 
`gradlew publishAllPublicationsToMavenRepository`