### PR TITLE
Gradle support - Travis changes

### DIFF
--- a/.travis.deploy.artifacts.sh
+++ b/.travis.deploy.artifacts.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-PROJECT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -B | grep -v '\[')
-if [[ "$PROJECT_VERSION" =~ .*SNAPSHOT ]] && [[ "${TRAVIS_BRANCH}" =~ ^master$|^[0-9]+\.[0-9]+$ ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]];
-then
-  mvn clean install deploy -s .travis.maven.settings.xml -DskipTests -B;
-fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,32 +6,32 @@ jdk:
 branches:
   only:
     - master
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - "$HOME/apache-maven-3.6.2"
-install:
-  - export M2_HOME=$HOME/apache-maven-3.6.2
-  - if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz | tar zxf - -C $HOME; fi
-  - export PATH=$M2_HOME/bin:$PATH
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 jobs:
   include:
     - stage: test
-      name: "OpenJDK 13"
+      name: "Source Build"
       jdk: openjdk13
-      script: mvn -q clean verify -B -U
+      install: skip
+      script: ./gradlew clean build --info
+      after_success:
+        - ./gradlew jacocoRootReport coveralls
     - stage: deploy
       name: "Deploy to Sonatype's snapshots repository"
       if: type != pull_request AND env(SONATYPE_NEXUS_USERNAME) IS present
-      script: bash .travis.deploy.artifacts.sh
+      script: ./gradlew travisReleaseSnapshot --info
+    - stage: deploy
+      name: "Deploy to DockerHub"
+      install: skip
+      script: bash docker_push.sh
 notifications:
   email:
     on_failure: always
     recipients:
       - lichtenberger.johannes@gmail.com
-after-success:
-  mvn jacoco:report coveralls:jacoco
-deploy:
-  provider: script
-  script: bash docker_push.sh
-  on:
-    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
 # Stage-1
 # Build jar
 
-FROM maven:3-jdk-13 as builder
+FROM gradle:6.0.1-jdk13 as builder
 LABEL maintainer="Johannes Lichtenberger <johannes.lichtenberger@sirix.io>"
 WORKDIR /usr/app/
 
-# Resolve dependencies
-COPY pom.xml .
-COPY bundles/sirix-rest-api/pom.xml .
-RUN ["/usr/local/bin/mvn-entrypoint.sh", "mvn", "verify", "clean", "--fail-never", "-X"]
-
 # Package jar
 COPY . .
-RUN mvn package -DskipTests
+RUN gradle build -x test
 
 # Stage-2
 # Copy jar and run the server 
@@ -25,7 +20,7 @@ ENV VERTICLE_HOME /opt/sirix
 WORKDIR /opt/sirix
 
 # Copy fat jar to the container
-COPY --from=builder /usr/app/bundles/sirix-rest-api/target/$VERTICLE_FILE ./
+COPY --from=builder /usr/app/bundles/sirix-rest-api/build/libs/$VERTICLE_FILE ./
 
 # Copy additional configuration files
 COPY bundles/sirix-rest-api/src/main/resources/cert.pem ./sirix-data/

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,14 @@ task uploadPublications {
     }
 }
 
+task travisReleaseSnapshot {
+    if ("${version}".endsWith('SNAPSHOT') &&
+            System.getenv("TRAVIS_PULL_REQUEST") == "false" &&
+            System.getenv("TRAVIS_BRANCH") == "master") {
+        dependsOn uploadPublications
+    }
+}
+
 afterReleaseBuild.dependsOn(uploadPublications)
 
 allprojects {


### PR DESCRIPTION
The following changes are done,

- Travis updates to support gradle
- DockerFile updates to support gradle

**Travis updates**
In travis, we now have 3 stages,

- 1 Test
- 2 Deploy (Sonatype and Docker)