### PR TITLE
Docker compose updates with create-keycloak startup script

### DIFF
--- a/bundles/sirix-rest-api/src/main/resources/sirix-conf.json
+++ b/bundles/sirix-rest-api/src/main/resources/sirix-conf.json
@@ -1,9 +1,9 @@
 {
   "https.port": 9443,
-  "keycloak.url": "http://localhost:8080/auth/realms/sirixdb",
-  "client.secret": "9b101ec5-b26a-4135-a60a-9da85ceae2d7",
+  "keycloak.url": "http://keycloak:8080/auth/realms/sirixdb",
+  "client.secret": "78a294c4-0492-4e44-a35f-7eb9cab0d831",
   "oAuthFlowType": "AUTH_CODE",
-  "redirect.uri": "http://localhost:3005/callback",
-  "cors.allowedOriginPattern": "http://localhost:3005",
+  "redirect.uri": "http://keycloak:3005/callback",
+  "cors.allowedOriginPattern": "http://keycloak:3005",
   "cors.allowCredentials": true
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,5 @@
 version: '3'
 services:
-  waitforkeycloak:
-    image: dadarek/wait-for-dependencies
-    depends_on:
-      - keycloak
-    command: keycloak:8080
-    networks:
-      - auth-network
   keycloak:
     image: jboss/keycloak
     ports:
@@ -20,7 +13,7 @@ services:
     restart: always
     volumes:
       - ./bundles/sirix-rest-api/src/test/resources/realm-export.json:/opt/keycloak/realm-export.json
-      - ./bundles/sirix-rest-api/src/test/resources/create-keycloak-user.sh:/opt/keycloak/create-keycloak-user.sh
+      - ./bundles/sirix-rest-api/src/test/resources/create-sirix-users.sh:/opt/jboss/startup-scripts/create-sirix-users.sh
     command:
       - "-b 0.0.0.0"
       - "-bmanagement 0.0.0.0"


### PR DESCRIPTION
I have updated the docker-compose to use keycloak startup-scripts. This way we can create any type of user with any type of user before start-up of keycloak server.

**Problems**
1. Docker compose V3 doesn't support depends_on condition. So sirix_server will fail until the keycloak is up and running.
**Soultion** 
Since `restart: always` is set, sirix_server will restart always until keycloak is up
2. sirix-config.json contains keycloak URL as localhost:8080 / localhost:3005. Keycloak ports is not bound to sirix container thus 8080 and 3005 will not be accessible. 
**Soultion**
Modified localhost to keycloak (service name). Such that keycload will be resolved to keycloak server IP.