### PR TITLE
JSON Serializer support for pretty printing #192

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
@@ -248,7 +248,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
       if (rtx.getKind() == NodeKind.OBJECT || rtx.getKind() == NodeKind.ARRAY) {
         appendObjectSeparator()
-                .appendObjectKeyValue(quote("descendantCount"), quote(String.valueOf(rtx.getDescendantCount())))
+                .appendObjectKeyValue(quote("descendantCount"), String.valueOf(rtx.getDescendantCount()))
                 .appendObjectSeparator()
                 .appendObjectKeyValue(quote("childCount"), String.valueOf(rtx.getChildCount()));
       }


### PR DESCRIPTION
Provided support for pretty printing of JSONSerializer. 
The following builder methods can be used to construct the JSON which will handle pretty printing in a common location (If required)

- appendObjectStart()
- appendObjectEnd()
- appendArrayStart()
- appendArrayEnd()
- appendObjectKey()
- appendObjectValue() 
- appendObjectKeyValue()
- appendObjectSeparator()
- quote()
