### PR TITLE
Reduce cyclomatic complexity in service.json.serialize.StringValue.escape

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/StringValue.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/StringValue.java
@@ -1,53 +1,44 @@
 package org.sirix.service.json.serialize;
 
+import java.util.HashMap;
+
 public final class StringValue {
   public static String escape(final String value) {
+
+    var asciiCharacters = new HashMap<Character, String>() {
+      {
+        put('"', "\\\"");
+        put('\\', "\\\\");
+        put('\b', "\\b");
+        put('\f', "\\f");
+        put('\n', "\\n");
+        put('\r', "\\r");
+        put('\t', "\\t");
+        put('/', "\\/");
+      }
+    };
+
     final StringBuilder sb = new StringBuilder();
     final int len = value.length();
 
     for (int i = 0; i < len; i++) {
       char ch = value.charAt(i);
-      switch (ch) {
-        case '"':
-          sb.append("\\\"");
-          break;
-        case '\\':
-          sb.append("\\\\");
-          break;
-        case '\b':
-          sb.append("\\b");
-          break;
-        case '\f':
-          sb.append("\\f");
-          break;
-        case '\n':
-          sb.append("\\n");
-          break;
-        case '\r':
-          sb.append("\\r");
-          break;
-        case '\t':
-          sb.append("\\t");
-          break;
-        case '/':
-          sb.append("\\/");
-          break;
-        default:
-          //Reference: http://www.unicode.org/versions/Unicode5.1.0/
-          if ((ch >= '\u0000' && ch <= '\u001F') || (ch >= '\u007F' && ch <= '\u009F') || (ch >= '\u2000'
-              && ch <= '\u20FF')) {
-            String ss = Integer.toHexString(ch);
-            sb.append("\\u");
-            for (int k = 0; k < 4 - ss.length(); k++) {
-              sb.append('0');
-            }
-            sb.append(ss.toUpperCase());
-          } else {
-            sb.append(ch);
-          }
-      }
+      sb.append(asciiCharacters.computeIfAbsent(ch, StringValue::escapeUnicode));
     }
+    return sb.toString();
+  }
 
+  private static String escapeUnicode(char ch) {
+    StringBuilder sb = new StringBuilder();
+    //Reference: http://www.unicode.org/versions/Unicode5.1.0/
+    if ((ch >= '\u0000' && ch <= '\u001F') || (ch >= '\u007F' && ch <= '\u009F') || (ch >= '\u2000' && ch <= '\u20FF')) {
+      String ss = Integer.toHexString(ch);
+      sb.append("\\u");
+      sb.append("0".repeat(4 - ss.length()));
+      sb.append(ss.toUpperCase());
+    } else {
+      sb.append(ch);
+    }
     return sb.toString();
   }
 }


### PR DESCRIPTION
Replace a switch with a HashMap and break out the specific unicode
escaping to a separate function. Fixes #16