### PR TITLE
fix object serialization bug

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
@@ -138,6 +138,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
           if (!rtx.hasFirstChild() || (mVisitor != null && currentLevel() + 1 >= maxLevel())) {
             appendObjectEnd(rtx.hasChildren());
+            appendArrayEnd(rtx.hasChildren());
 
             if (mWithMetaData) {
               appendObjectEnd(rtx.hasChildren());

--- a/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/json/serialize/JsonSerializer.java
@@ -138,7 +138,9 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
           if (!rtx.hasFirstChild() || (mVisitor != null && currentLevel() + 1 >= maxLevel())) {
             appendObjectEnd(rtx.hasChildren());
-            appendArrayEnd(rtx.hasChildren());
+            if (mWithMetaData && rtx.hasFirstChild()) {
+              appendArrayEnd(rtx.hasChildren());
+            }
 
             if (mWithMetaData) {
               appendObjectEnd(rtx.hasChildren());


### PR DESCRIPTION
when at last level of JSON metadata serialization, and the value field of of object is an array, the array was not closed, resulting in malformed JSON. I have implemented proper closing of the array.

Sorry, I haven't written tests for this, I don't normally work with Java.