### PR TITLE
tests: extend StorageTest and fix bug in RAMStorage.truncate

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/io/ram/RAMStorage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/ram/RAMStorage.java
@@ -111,6 +111,7 @@ public final class RAMStorage implements Storage {
     public Writer truncate() {
       mUberPageKey.clear();
       mResourceFileStorage.clear();
+      mExists = false;
       return this;
     }
 
@@ -133,6 +134,7 @@ public final class RAMStorage implements Storage {
       final Page page = pageReference.getPage();
       pageReference.setKey(mPageKey);
       mResourceFileStorage.put(mPageKey++, page);
+      mExists = true;
       return this;
     }
 
@@ -142,6 +144,7 @@ public final class RAMStorage implements Storage {
       pageReference.setKey(mPageKey);
       mResourceFileStorage.put(mPageKey, page);
       mUberPageKey.put(-1, mPageKey++);
+      mExists = true;
       return this;
     }
 


### PR DESCRIPTION
The underlying bool in `RAMStorage.exists()` is only set on construction, and not properly set to false when `.truncate()` is called. This patch sets the bool to false in `truncate` and then sets it to true whenever `write` and `writeUberPageReference` succeeds. The patch also adds tests for the bug.

The whitespace noise comes from `RAMStorage.java` having Windows CRLF line endings. I took the liberty to change this to Unix line endings to match the rest of the source tree.