### PR TITLE
allow javadoc to compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,11 @@ subprojects {
 
     javadoc {
         failOnError = false
+        options {
+            addBooleanOption('-enable-preview', true)
+            addStringOption('-release', '14')
+            addStringOption('-add-modules', 'jdk.incubator.foreign')
+        }
     }
 
     compileJava {


### PR DESCRIPTION
Added missing compiler flags, which were preventing the javadoc from being generated.