### PR TITLE
Upgrade to Gradle 6.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Stage-1
 # Build jar
 
-FROM gradle:6.3.0-jdk14 as builder
+FROM gradle:6.5.1-jdk14 as builder
 LABEL maintainer="Johannes Lichtenberger <johannes.lichtenberger@sirix.io>"
 WORKDIR /usr/app/
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 apply from: "${rootDir}/libraries.gradle"
 
+if (JavaVersion.current() != JavaVersion.VERSION_14){
+    throw new GradleException("This build must be run with Java 14")
+}
+
 buildscript {
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,5 @@
 apply from: "${rootDir}/libraries.gradle"
 
-if (JavaVersion.current() != JavaVersion.VERSION_14){
-    throw new GradleException("This build must be run with Java 14")
-}
-
 buildscript {
     repositories {
         maven {
@@ -79,6 +75,10 @@ subprojects {
         targetCompatibility = JavaVersion.VERSION_14
         withSourcesJar()
         withJavadocJar()
+
+        if (JavaVersion.current() != targetCompatibility){
+            throw new GradleException("This build must be run with Java " + targetCompatibility.toString())
+        }
     }
 
     javadoc {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Wed Apr 15 16:46:22 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Ran ./gradlew wrapper --gradle-version 6.5.1 to upgrade the
reference to gradle. Upgraded the Dockerfile to use the correct
version of the Gradle as well.  I was able to build the jar
locally as well as a new Docker image without any issues.

In addition I added a check to verify that you running with the
proper version of Java. When I was first trying to get things
to compile gradle would fail with a cryptic message about plugins
because I was using a earlier version of Java. Hopefully this
will prevent that from happening in the future.