### PR TITLE
remove hard-coded USER_HOME, use ${user.home}

### DIFF
--- a/bundles/sirix-core/src/main/resources/logback.xml
+++ b/bundles/sirix-core/src/main/resources/logback.xml
@@ -29,7 +29,6 @@
 -->
 
 <configuration>
-    <property name="USER_HOME" value="/home/johannes" />
     <timestamp key="byDay" datePattern="yyyyMMdd'T'HHmmss"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -44,7 +43,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>${USER_HOME}/sirix-${byDay}.log</file>
+        <file>${user.home}/sirix-${byDay}.log</file>
         <append>true</append>
         <encoder>
             <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>


### PR DESCRIPTION
remove hard-coded USER_HOME in logback config, use ${user.home}