### PR TITLE
fix docker-compose to write data to a named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "9443:9443"
     restart: always
     volumes:
-      - /opt/sirix
+      - /opt/sirix/sirix-data:/opt/sirix/sirix-data
       - ./bundles/sirix-rest-api/src/main/resources/cert.pem:/opt/sirix/sirix-data/cert.pem
       - ./bundles/sirix-rest-api/src/main/resources/key.pem:/opt/sirix/sirix-data/key.pem
       - ./bundles/sirix-rest-api/src/main/resources/sirix-conf.json:/opt/sirix/sirix-conf.json


### PR DESCRIPTION
I also removed the anonymous volume `/opt/sirix`, as I don't see the purpose in mounting the entire sirix directory in a volume (and in an anonymous volume in particular).