### PR TITLE
Introduce Dagger as DI framework for the project

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -14,11 +14,14 @@ dependencies {
     api implLibraries.jsr305
     api implLibraries.caffeine
     api implLibraries.tink
+    api implLibraries.dagger
 
     implementation implLibraries.snappyJava
     implementation implLibraries.browniesCollections
     implementation implLibraries.chronicleMap
     implementation implLibraries.integercompression
+
+    annotationProcessor implLibraries.daggerCompiler
 
     testImplementation testLibraries.junitJupiterApi
     testImplementation testLibraries.junitJupiterEngine

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
@@ -1,0 +1,22 @@
+package org.sirix.access;
+
+import dagger.Component;
+import org.sirix.api.json.JsonResourceManager;
+import org.sirix.api.xml.XmlResourceManager;
+
+import javax.inject.Singleton;
+
+/**
+ * The Dagger component that manages database dependencies. This class is internal and managed by {@link Databases}.
+ *
+ * @author Joao Sousa
+ */
+@Component(modules = DatabaseModule.class)
+@Singleton
+public interface DatabaseManager {
+
+    LocalDatabaseFactory<JsonResourceManager> jsonDatabaseFactory();
+
+    LocalDatabaseFactory<XmlResourceManager> xmlDatabaseFactory();
+
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
@@ -1,0 +1,21 @@
+package org.sirix.access;
+
+import dagger.Binds;
+import dagger.Module;
+import org.sirix.api.json.JsonResourceManager;
+import org.sirix.api.xml.XmlResourceManager;
+
+/**
+ * The DI module that bridges interfaces to implementations.
+ *
+ * @author Joao Sousa
+ */
+@Module
+public interface DatabaseModule {
+
+    @Binds
+    LocalDatabaseFactory<JsonResourceManager> bindJsonDatabaseFactory(LocalJsonDatabaseFactory jsonFactory);
+
+    @Binds
+    LocalDatabaseFactory<XmlResourceManager> bindXmlDatabaseFactory(LocalXmlDatabaseFactory xmlFactory);
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
@@ -1,10 +1,6 @@
 package org.sirix.access;
 
-import org.sirix.access.json.JsonResourceStore;
-import org.sirix.access.xml.XmlResourceStore;
 import org.sirix.api.Database;
-import org.sirix.api.NodeReadOnlyTrx;
-import org.sirix.api.NodeTrx;
 import org.sirix.api.ResourceManager;
 import org.sirix.node.SirixDeweyID;
 import org.sirix.node.delegates.NodeDelegate;
@@ -23,9 +19,9 @@ public enum DatabaseType {
   XML("xml") {
     @SuppressWarnings("unchecked")
     @Override
-    public <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>, S extends ResourceStore<R>> Database<R> createDatabase(
-        DatabaseConfiguration dbConfig, S store) {
-      return (Database<R>) new LocalXmlDatabase(dbConfig, (XmlResourceStore) store);
+    public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+            final DatabaseManager manager, DatabaseConfiguration dbConfig, User user) {
+      return (Database<R>) manager.xmlDatabaseFactory().createDatabase(dbConfig, user);
     }
 
     @Override
@@ -42,9 +38,9 @@ public enum DatabaseType {
   JSON("json") {
     @SuppressWarnings("unchecked")
     @Override
-    public <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>, S extends ResourceStore<R>> Database<R> createDatabase(
-        DatabaseConfiguration dbConfig, S store) {
-      return (Database<R>) new LocalJsonDatabase(dbConfig, (JsonResourceStore) store);
+    public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+            final DatabaseManager manager, DatabaseConfiguration dbConfig, User user) {
+      return (Database<R>) manager.jsonDatabaseFactory().createDatabase(dbConfig, user);
     }
 
     @Override
@@ -75,8 +71,8 @@ public enum DatabaseType {
     return Optional.ofNullable(stringToEnum.get(symbol));
   }
 
-  public abstract <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>, S extends ResourceStore<R>> Database<R> createDatabase(
-      DatabaseConfiguration dbConfig, S store);
+  public abstract <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+          final DatabaseManager manager, DatabaseConfiguration dbConfig, User user);
 
   public abstract Node getDocumentNode(SirixDeweyID id);
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
@@ -20,8 +20,8 @@ public enum DatabaseType {
     @SuppressWarnings("unchecked")
     @Override
     public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
-            final DatabaseManager manager, DatabaseConfiguration dbConfig, User user) {
-      return (Database<R>) manager.xmlDatabaseFactory().createDatabase(dbConfig, user);
+            DatabaseConfiguration dbConfig, User user) {
+      return (Database<R>) Databases.MANAGER.xmlDatabaseFactory().createDatabase(dbConfig, user);
     }
 
     @Override
@@ -39,8 +39,8 @@ public enum DatabaseType {
     @SuppressWarnings("unchecked")
     @Override
     public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
-            final DatabaseManager manager, DatabaseConfiguration dbConfig, User user) {
-      return (Database<R>) manager.jsonDatabaseFactory().createDatabase(dbConfig, user);
+            DatabaseConfiguration dbConfig, User user) {
+      return (Database<R>) Databases.MANAGER.jsonDatabaseFactory().createDatabase(dbConfig, user);
     }
 
     @Override
@@ -72,7 +72,7 @@ public enum DatabaseType {
   }
 
   public abstract <R extends ResourceManager<?, ?>> Database<R> createDatabase(
-          final DatabaseManager manager, DatabaseConfiguration dbConfig, User user);
+          DatabaseConfiguration dbConfig, User user);
 
   public abstract Node getDocumentNode(SirixDeweyID id);
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseType.java
@@ -1,6 +1,8 @@
 package org.sirix.access;
 
 import org.sirix.api.Database;
+import org.sirix.api.NodeReadOnlyTrx;
+import org.sirix.api.NodeTrx;
 import org.sirix.api.ResourceManager;
 import org.sirix.node.SirixDeweyID;
 import org.sirix.node.delegates.NodeDelegate;
@@ -19,7 +21,7 @@ public enum DatabaseType {
   XML("xml") {
     @SuppressWarnings("unchecked")
     @Override
-    public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+    public <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>> Database<R> createDatabase(
             DatabaseConfiguration dbConfig, User user) {
       return (Database<R>) Databases.MANAGER.xmlDatabaseFactory().createDatabase(dbConfig, user);
     }
@@ -38,7 +40,7 @@ public enum DatabaseType {
   JSON("json") {
     @SuppressWarnings("unchecked")
     @Override
-    public <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+    public <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>> Database<R> createDatabase(
             DatabaseConfiguration dbConfig, User user) {
       return (Database<R>) Databases.MANAGER.jsonDatabaseFactory().createDatabase(dbConfig, user);
     }
@@ -71,7 +73,7 @@ public enum DatabaseType {
     return Optional.ofNullable(stringToEnum.get(symbol));
   }
 
-  public abstract <R extends ResourceManager<?, ?>> Database<R> createDatabase(
+  public abstract <R extends ResourceManager<? extends NodeReadOnlyTrx, ? extends NodeTrx>> Database<R> createDatabase(
           DatabaseConfiguration dbConfig, User user);
 
   public abstract Node getDocumentNode(SirixDeweyID id);

--- a/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
@@ -162,7 +162,6 @@ public final class Databases {
    * @throws SirixUsageException if Sirix is not used properly
    * @throws NullPointerException if {@code file} is {@code null}
    */
-  @SuppressWarnings("unchecked")
   public static synchronized Database<XmlResourceManager> openXmlDatabase(final Path file, final User user) {
     return openDatabase(file, user, DatabaseType.XML);
   }
@@ -216,7 +215,6 @@ public final class Databases {
    * @throws SirixUsageException if Sirix is not used properly
    * @throws NullPointerException if {@code file} is {@code null}
    */
-  @SuppressWarnings("unchecked")
   public static synchronized Database<XmlResourceManager> openXmlDatabase(final Path file) {
     return openDatabase(file, createAdminUser(), DatabaseType.XML);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
@@ -1,8 +1,5 @@
 package org.sirix.access;
 
-import org.jetbrains.annotations.NotNull;
-import org.sirix.access.json.JsonResourceStore;
-import org.sirix.access.xml.XmlResourceStore;
 import org.sirix.api.Database;
 import org.sirix.api.NodeCursor;
 import org.sirix.api.NodeReadOnlyTrx;
@@ -41,6 +38,11 @@ public final class Databases {
 
   /** Central repository of all running resource managers. */
   static final ConcurrentMap<Path, Set<ResourceManager<?, ?>>> RESOURCE_MANAGERS = new ConcurrentHashMap<>();
+
+  /**
+   * DI component that manages the database.
+   */
+  static final DatabaseManager MANAGER = DaggerDatabaseManager.create();
 
   /** Central repository of all resource {@code <=>} write locks mappings. */
   static final ConcurrentMap<Path, Lock> RESOURCE_WRITE_LOCKS = new ConcurrentHashMap<>();
@@ -233,8 +235,7 @@ public final class Databases {
     if (dbConfig == null) {
       throw new IllegalStateException("Configuration may not be null!");
     }
-    final DatabaseManager databaseManager = DaggerDatabaseManager.create();
-    final Database<M> database = databaseType.createDatabase(databaseManager, dbConfig, user);
+    final Database<M> database = databaseType.createDatabase(dbConfig, user);
     putDatabase(file.toAbsolutePath(), database);
     return database;
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseFactory.java
@@ -1,0 +1,15 @@
+package org.sirix.access;
+
+import org.sirix.api.Database;
+import org.sirix.api.ResourceManager;
+
+/**
+ * A factory that creates {@link Database database sessions}.
+ *
+ * @author Joao Sousa
+ */
+public interface LocalDatabaseFactory<M extends ResourceManager<?, ?>> {
+
+    Database<M> createDatabase(DatabaseConfiguration configuration, final User user);
+
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
@@ -1,0 +1,27 @@
+package org.sirix.access;
+
+import org.sirix.access.json.JsonResourceStore;
+import org.sirix.api.Database;
+import org.sirix.api.json.JsonResourceManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * A database session factory for Json databases.
+ *
+ * @author Joao Sousa
+ */
+@Singleton
+public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResourceManager> {
+
+    @Inject
+    LocalJsonDatabaseFactory() {}
+
+    @Override
+    public Database<JsonResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
+
+        return new LocalJsonDatabase(configuration, new JsonResourceStore(user));
+    }
+
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
@@ -3,6 +3,8 @@ package org.sirix.access;
 import org.sirix.access.json.JsonResourceStore;
 import org.sirix.api.Database;
 import org.sirix.api.json.JsonResourceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -15,12 +17,18 @@ import javax.inject.Singleton;
 @Singleton
 public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResourceManager> {
 
+    /**
+     * Logger for {@link LocalJsonDatabaseFactory}.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(LocalJsonDatabaseFactory.class);
+
     @Inject
     LocalJsonDatabaseFactory() {}
 
     @Override
     public Database<JsonResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
 
+        logger.trace("Creating new local json database");
         return new LocalJsonDatabase(configuration, new JsonResourceStore(user));
     }
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
@@ -1,0 +1,26 @@
+package org.sirix.access;
+
+import org.sirix.access.xml.XmlResourceStore;
+import org.sirix.api.Database;
+import org.sirix.api.xml.XmlResourceManager;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * A database session factory for Json databases.
+ *
+ * @author Joao Sousa
+ */
+@Singleton
+public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResourceManager> {
+
+    @Inject
+    LocalXmlDatabaseFactory() {}
+
+    @Override
+    public Database<XmlResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
+
+        return new LocalXmlDatabase(configuration, new XmlResourceStore(user));
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
@@ -3,6 +3,8 @@ package org.sirix.access;
 import org.sirix.access.xml.XmlResourceStore;
 import org.sirix.api.Database;
 import org.sirix.api.xml.XmlResourceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -15,12 +17,18 @@ import javax.inject.Singleton;
 @Singleton
 public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResourceManager> {
 
+    /**
+     * Logger for {@link LocalXmlDatabaseFactory}.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(LocalXmlDatabaseFactory.class);
+
     @Inject
     LocalXmlDatabaseFactory() {}
 
     @Override
     public Database<XmlResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
 
+        logger.trace("Creating new local xml database");
         return new LocalXmlDatabase(configuration, new XmlResourceStore(user));
     }
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
@@ -35,13 +35,6 @@ public final class JsonResourceStore extends AbstractResourceStore<JsonResourceM
   private static final LogWrapper LOGGER = new LogWrapper(LoggerFactory.getLogger(JsonResourceStore.class));
 
   /**
-   * Default constructor.
-   */
-  public JsonResourceStore() {
-    super(new ConcurrentHashMap<>(), new User("admin", UUID.randomUUID()));
-  }
-
-  /**
    * Constructor.
    */
   public JsonResourceStore(final User user) {

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
@@ -26,13 +26,6 @@ import org.sirix.page.UberPage;
 public final class XmlResourceStore extends AbstractResourceStore<XmlResourceManager> {
 
   /**
-   * Default constructor.
-   */
-  public XmlResourceStore() {
-    super(new ConcurrentHashMap<>(), new User("admin", UUID.randomUUID()));
-  }
-
-  /**
    * Constructor.
    */
   public XmlResourceStore(final User user) {

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -35,7 +35,9 @@ implLibraries = [
         kotlinStdlibJdk8         : 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61',
         jsoup                    : 'org.jsoup:jsoup:1.11.3',
         kotlinxCli               : 'org.jetbrains.kotlinx:kotlinx-cli:0.2.1',
-        integercompression       : 'me.lemire.integercompression:JavaFastPFOR:0.1.12'
+        integercompression       : 'me.lemire.integercompression:JavaFastPFOR:0.1.12',
+        dagger                   : 'com.google.dagger:dagger:2.32',
+        daggerCompiler           : 'com.google.dagger:dagger-compiler:2.32'
 ]
 
 testLibraries = [


### PR DESCRIPTION
Adds Dagger as a dependency to the project. Dagger is used in sirix-core, to create a `DatabaseManager` component.  This component, in this initial stage will simple register dependencies to create `Database` instances. In order to achieve this, a new `LocalDatabaseFactory` concept was introduced, with implementations for Json and XML.

At this point, the component is hidden behind `Databases`, in order to avoid breaking the entrypoint.

The next stages in this track is to extract most of the `Databases` business logic (e.g., sessions map) into separate classes, in order to increase maintainability and testing.

Closes #343 