### PR TITLE
Extract database session management to a separate class

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/AbstractLocalDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/AbstractLocalDatabase.java
@@ -8,15 +8,18 @@ import com.google.crypto.tink.JsonKeysetWriter;
 import com.google.crypto.tink.KeysetHandle;
 import com.google.crypto.tink.streamingaead.StreamingAeadKeyTemplates;
 import org.sirix.access.trx.TransactionManagerImpl;
-import org.sirix.api.*;
+import org.sirix.api.Database;
+import org.sirix.api.NodeReadOnlyTrx;
+import org.sirix.api.NodeTrx;
+import org.sirix.api.ResourceManager;
+import org.sirix.api.Transaction;
+import org.sirix.api.TransactionManager;
 import org.sirix.cache.BufferManager;
 import org.sirix.cache.BufferManagerImpl;
 import org.sirix.exception.SirixIOException;
 import org.sirix.io.StorageType;
 import org.sirix.io.bytepipe.Encryptor;
 import org.sirix.utils.SirixFiles;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnegative;
 import java.io.IOException;
@@ -67,6 +70,13 @@ public abstract class AbstractLocalDatabase<T extends ResourceManager<? extends 
    */
   protected final DatabaseConfiguration dbConfig;
 
+  /**
+   * The session management instance.
+   *
+   * <p>Instances of this class are responsible for registering themselves in the pool (in
+   * {@link #AbstractLocalDatabase(DatabaseConfiguration, DatabaseSessionPool, ResourceStore)}), as well as
+   * de-registering themselves (in {@link #close()}).
+   */
   private final DatabaseSessionPool sessions;
 
   /**
@@ -76,9 +86,10 @@ public abstract class AbstractLocalDatabase<T extends ResourceManager<? extends 
 
   /**
    * Constructor.
-   *  @param dbConfig {@link ResourceConfiguration} reference to configure the {@link Database}
-   * @param sessions
-   * @param resourceStore
+   *
+   * @param dbConfig      {@link ResourceConfiguration} reference to configure the {@link Database}
+   * @param sessions      The database sessions management instance.
+   * @param resourceStore The resource store used by this database.
    */
   public AbstractLocalDatabase(final DatabaseConfiguration dbConfig, final DatabaseSessionPool sessions, final ResourceStore<T> resourceStore) {
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/AbstractLocalDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/AbstractLocalDatabase.java
@@ -92,7 +92,6 @@ public abstract class AbstractLocalDatabase<T extends ResourceManager<? extends 
    * @param resourceStore The resource store used by this database.
    */
   public AbstractLocalDatabase(final DatabaseConfiguration dbConfig, final DatabaseSessionPool sessions, final ResourceStore<T> resourceStore) {
-
     this.dbConfig = checkNotNull(dbConfig);
     this.sessions = sessions;
     this.resourceStore = resourceStore;

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
@@ -1,6 +1,7 @@
 package org.sirix.access;
 
 import dagger.Component;
+import org.sirix.api.Database;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 
@@ -18,5 +19,7 @@ public interface DatabaseManager {
     LocalDatabaseFactory<JsonResourceManager> jsonDatabaseFactory();
 
     LocalDatabaseFactory<XmlResourceManager> xmlDatabaseFactory();
+
+    DatabaseSessionPool sessions();
 
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
@@ -2,6 +2,7 @@ package org.sirix.access;
 
 import dagger.Binds;
 import dagger.Module;
+import dagger.Provides;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 
@@ -18,4 +19,5 @@ public interface DatabaseModule {
 
     @Binds
     LocalDatabaseFactory<XmlResourceManager> bindXmlDatabaseFactory(LocalXmlDatabaseFactory xmlFactory);
+
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseSessionPool.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseSessionPool.java
@@ -1,0 +1,107 @@
+package org.sirix.access;
+
+import org.sirix.api.Database;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages all active database sessions in the current component.
+ *
+ * @author Joao Sousa
+ */
+@ThreadSafe
+@Singleton
+class DatabaseSessionPool {
+
+    /**
+     * Logger for {@link DatabaseSessionPool}.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(DatabaseSessionPool.class);
+
+    /**
+     * The thread safe map of active sessions.
+     */
+    private final Map<Path, Set<Database<?>>> sessions;
+
+    /**
+     * Default Constructor
+     */
+    @Inject
+    DatabaseSessionPool() {
+
+        this.sessions = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Package private method to put a file/database into the internal map.
+     *
+     * @param file database file to put into the map
+     * @param database database handle to put into the map
+     */
+    void putDatabase(final Path file, final Database<?> database) {
+
+        this.sessions.compute(file, (key, value) -> append(key, value, database));
+    }
+
+    /**
+     * Checks if the provided {@code file} has any active session.
+     *
+     * @param file The file which might have registered sessions.
+     * @return {@code true} if the provided {@code file} has 1 or more active sessions associated.
+     */
+    boolean containsSessions(final Path file) {
+
+        return this.sessions.containsKey(file);
+    }
+
+    /**
+     * Package private method to remove a database.
+     *
+     * @param file database file to remove
+     */
+    void removeDatabase(final Path file, final Database<?> database) {
+        this.sessions.compute(file, (key, value) -> remove(key, value, database));
+    }
+
+    @Nullable
+    private Set<Database<?>> remove(final Path path, @Nullable final Set<Database<?>> sessions,
+                                    final Database<?> database) {
+
+        if (sessions == null) {
+            logger.debug("No sessions registered for path {}", path);
+            return null;
+        }
+
+        logger.trace("Removing session in path {}", path);
+        sessions.remove(database);
+
+        // coalesce to null if empty
+        return sessions.isEmpty() ? null : sessions;
+    }
+
+    private Set<Database<?>> append(final Path path, @Nullable final Set<Database<?>> sessions,
+                                    final Database<?> database) {
+
+        final Set<Database<?>> coalescedSessions = sessions == null ? new HashSet<>() : sessions;
+
+        logger.trace("Registering new session in path {}", path);
+        coalescedSessions.add(database);
+        return coalescedSessions;
+    }
+
+    public Map<Path, Set<Database<?>>> asMap() {
+
+        return Collections.unmodifiableMap(this.sessions);
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseSessionPool.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseSessionPool.java
@@ -9,11 +9,12 @@ import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.unmodifiableMap;
 
 /**
  * Manages all active database sessions in the current component.
@@ -39,7 +40,6 @@ class DatabaseSessionPool {
      */
     @Inject
     DatabaseSessionPool() {
-
         this.sessions = new ConcurrentHashMap<>();
     }
 
@@ -50,7 +50,6 @@ class DatabaseSessionPool {
      * @param database database handle to put into the map
      */
     void putDatabase(final Path file, final Database<?> database) {
-
         this.sessions.compute(file, (key, value) -> append(key, value, database));
     }
 
@@ -61,7 +60,6 @@ class DatabaseSessionPool {
      * @return {@code true} if the provided {@code file} has 1 or more active sessions associated.
      */
     boolean containsSessions(final Path file) {
-
         return this.sessions.containsKey(file);
     }
 
@@ -77,7 +75,6 @@ class DatabaseSessionPool {
     @Nullable
     private Set<Database<?>> remove(final Path path, @Nullable final Set<Database<?>> sessions,
                                     final Database<?> database) {
-
         if (sessions == null) {
             logger.debug("No sessions registered for path {}", path);
             return null;
@@ -92,7 +89,6 @@ class DatabaseSessionPool {
 
     private Set<Database<?>> append(final Path path, @Nullable final Set<Database<?>> sessions,
                                     final Database<?> database) {
-
         final Set<Database<?>> coalescedSessions = sessions == null ? new HashSet<>() : sessions;
 
         logger.trace("Registering new session in path {}", path);
@@ -101,7 +97,6 @@ class DatabaseSessionPool {
     }
 
     public Map<Path, Set<Database<?>>> asMap() {
-
-        return Collections.unmodifiableMap(this.sessions);
+        return unmodifiableMap(this.sessions);
     }
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabasesInternals.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabasesInternals.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
@@ -31,8 +32,8 @@ public final class DatabasesInternals {
     Databases.RESOURCE_WRITE_LOCKS.remove(resourcePath);
   }
 
-  public static ConcurrentMap<Path, Set<Database<?>>> getOpenDatabases() {
-    return Databases.DATABASE_SESSIONS;
+  public static Map<Path, Set<Database<?>>> getOpenDatabases() {
+    return Databases.MANAGER.sessions().asMap();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabase.java
@@ -55,7 +55,8 @@ public final class LocalJsonDatabase extends AbstractLocalDatabase<JsonResourceM
    * Package private constructor.
    *
    * @param dbConfig {@link ResourceConfiguration} reference to configure the {@link Database}
-   * @param sessions
+   * @param sessions The database sessions management instance.
+   *
    * @throws SirixException if something weird happens
    */
   LocalJsonDatabase(final DatabaseConfiguration dbConfig,

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabase.java
@@ -31,7 +31,6 @@ import org.sirix.api.json.JsonResourceManager;
 import org.sirix.exception.SirixException;
 import org.sirix.exception.SirixUsageException;
 import org.sirix.utils.LogWrapper;
-import org.sirix.utils.SirixFiles;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
@@ -53,36 +52,17 @@ public final class LocalJsonDatabase extends AbstractLocalDatabase<JsonResourceM
   private static final LogWrapper LOGWRAPPER = new LogWrapper(LoggerFactory.getLogger(LocalJsonDatabase.class));
 
   /**
-   * The resource store to open/close resource-managers.
-   */
-  private final JsonResourceStore resourceStore;
-
-  /**
    * Package private constructor.
    *
    * @param dbConfig {@link ResourceConfiguration} reference to configure the {@link Database}
+   * @param sessions
    * @throws SirixException if something weird happens
    */
-  LocalJsonDatabase(final DatabaseConfiguration dbConfig, final JsonResourceStore store) {
-    super(dbConfig);
-    resourceStore = store;
-  }
+  LocalJsonDatabase(final DatabaseConfiguration dbConfig,
+                    final JsonResourceStore store,
+                    final DatabaseSessionPool sessions) {
 
-  @Override
-  public synchronized void close() {
-    if (isClosed) {
-      return;
-    }
-
-    isClosed = true;
-    resourceStore.close();
-    transactionManager.close();
-
-    // Remove from database mapping.
-    Databases.removeDatabase(dbConfig.getDatabaseFile(), this);
-
-    // Remove lock file.
-    SirixFiles.recursiveRemove(dbConfig.getDatabaseFile().resolve(DatabaseConfiguration.DatabasePaths.LOCK.getFile()));
+    super(dbConfig, sessions, store);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
@@ -22,14 +22,18 @@ public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResour
      */
     private static final Logger logger = LoggerFactory.getLogger(LocalJsonDatabaseFactory.class);
 
+    private final DatabaseSessionPool sessions;
+
     @Inject
-    LocalJsonDatabaseFactory() {}
+    LocalJsonDatabaseFactory(final DatabaseSessionPool sessions) {
+        this.sessions = sessions;
+    }
 
     @Override
     public Database<JsonResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
 
         logger.trace("Creating new local json database");
-        return new LocalJsonDatabase(configuration, new JsonResourceStore(user));
+        return new LocalJsonDatabase(configuration, new JsonResourceStore(user), this.sessions);
     }
 
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabase.java
@@ -48,14 +48,12 @@ public final class LocalXmlDatabase extends AbstractLocalDatabase<XmlResourceMan
   /** {@link LogWrapper} reference. */
   private static final LogWrapper LOGWRAPPER = new LogWrapper(LoggerFactory.getLogger(LocalXmlDatabase.class));
 
-  /** The resource store to open/close resource-managers. */
-  private final XmlResourceStore resourceStore;
-
   /**
    * Package private constructor.
    *
    * @param dbConfig {@link ResourceConfiguration} reference to configure the {@link Database}
-   * @param sessions
+   * @param sessions The database sessions management instance.
+   *
    * @throws SirixException if something weird happens
    */
   LocalXmlDatabase(final DatabaseConfiguration dbConfig,
@@ -63,7 +61,6 @@ public final class LocalXmlDatabase extends AbstractLocalDatabase<XmlResourceMan
                    final DatabaseSessionPool sessions) {
 
     super(dbConfig, sessions, store);
-    resourceStore = store;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabase.java
@@ -30,7 +30,6 @@ import org.sirix.api.xml.XmlResourceManager;
 import org.sirix.exception.SirixException;
 import org.sirix.exception.SirixUsageException;
 import org.sirix.utils.LogWrapper;
-import org.sirix.utils.SirixFiles;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
@@ -56,28 +55,15 @@ public final class LocalXmlDatabase extends AbstractLocalDatabase<XmlResourceMan
    * Package private constructor.
    *
    * @param dbConfig {@link ResourceConfiguration} reference to configure the {@link Database}
+   * @param sessions
    * @throws SirixException if something weird happens
    */
-  LocalXmlDatabase(final DatabaseConfiguration dbConfig, final XmlResourceStore store) {
-    super(dbConfig);
+  LocalXmlDatabase(final DatabaseConfiguration dbConfig,
+                   final XmlResourceStore store,
+                   final DatabaseSessionPool sessions) {
+
+    super(dbConfig, sessions, store);
     resourceStore = store;
-  }
-
-  @Override
-  public synchronized void close() throws SirixException {
-    if (isClosed) {
-      return;
-    }
-
-    isClosed = true;
-    resourceStore.close();
-    transactionManager.close();
-
-    // Remove from database mapping.
-    Databases.removeDatabase(dbConfig.getDatabaseFile(), this);
-
-    // Remove lock file.
-    SirixFiles.recursiveRemove(dbConfig.getDatabaseFile().resolve(DatabaseConfiguration.DatabasePaths.LOCK.getFile()));
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
@@ -22,13 +22,17 @@ public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResource
      */
     private static final Logger logger = LoggerFactory.getLogger(LocalXmlDatabaseFactory.class);
 
+    private final DatabaseSessionPool sessions;
+
     @Inject
-    LocalXmlDatabaseFactory() {}
+    LocalXmlDatabaseFactory(final DatabaseSessionPool sessions) {
+        this.sessions = sessions;
+    }
 
     @Override
     public Database<XmlResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
 
         logger.trace("Creating new local xml database");
-        return new LocalXmlDatabase(configuration, new XmlResourceStore(user));
+        return new LocalXmlDatabase(configuration, new XmlResourceStore(user), this.sessions);
     }
 }

--- a/bundles/sirix-core/src/test/java/org/sirix/access/DatabaseSessionPoolTest.java
+++ b/bundles/sirix-core/src/test/java/org/sirix/access/DatabaseSessionPoolTest.java
@@ -1,0 +1,98 @@
+package org.sirix.access;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sirix.api.Database;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class DatabaseSessionPoolTest {
+
+    private DatabaseSessionPool sessions;
+
+    @BeforeEach
+    public void setup() {
+
+        this.sessions = new DatabaseSessionPool();
+    }
+
+    /**
+     * Tests that {@link DatabaseSessionPool#putDatabase(Path, Database)} matches the following requirements:
+     * <ul>
+     *     <li>Entries are persisted</li>
+     *     <li>Entries from different keys are independent</li>
+     *     <li>Entries from the same key are grouped in the same {@link Set}</li>
+     * </ul>
+     */
+    @Test
+    public final void putWillPersistTheDatabaseInMap() {
+
+        final Path key1 = mock(Path.class);
+        final Database<?> db1 = mock(Database.class);
+        final Database<?> db2 = mock(Database.class);
+
+        final Path key2 = mock(Path.class);
+        final Database<?> db3 = mock(Database.class);
+
+        this.sessions.putDatabase(key1, db1);
+        this.sessions.putDatabase(key1, db2);
+        this.sessions.putDatabase(key2, db3);
+
+        final Map<Path, Set<Database<?>>> expected = ImmutableMap.of(
+                key1, ImmutableSet.of(db1, db2),
+                key2, ImmutableSet.of(db3)
+        );
+
+        assertEquals(expected, this.sessions.asMap());
+    }
+
+    /**
+     * Tests that {@link DatabaseSessionPool#containsSessions(Path)} reports {@code true} for at least one
+     * session, and {@code false} for no sessions.
+     */
+    @Test
+    public final void containsShouldReportExistingKeys() {
+
+        final Path keySingle = mock(Path.class);
+        final Path keyMulti = mock(Path.class);
+        final Path keyNone = mock(Path.class);
+
+        final Database<?> db1 = mock(Database.class);
+        final Database<?> db2 = mock(Database.class);
+        final Database<?> db3 = mock(Database.class);
+
+        this.sessions.putDatabase(keySingle, db1);
+        this.sessions.putDatabase(keyMulti, db2);
+        this.sessions.putDatabase(keyMulti, db3);
+
+        assertTrue(this.sessions.containsSessions(keySingle));
+        assertTrue(this.sessions.containsSessions(keyMulti));
+        assertFalse(this.sessions.containsSessions(keyNone));
+    }
+
+    /**
+     * Tests that {@link DatabaseSessionPool#removeDatabase(Path, Database)} will eliminate the
+     * entry from the pool.
+     */
+    @Test
+    public final void removeShouldEliminateEntries() {
+
+        final Path key = mock(Path.class);
+        final Database<?> db1 = mock(Database.class);
+
+        this.sessions.putDatabase(key, db1);
+        this.sessions.removeDatabase(key, db1);
+
+        assertFalse(this.sessions.containsSessions(key));
+    }
+
+}

--- a/bundles/sirix-core/src/test/java/org/sirix/access/DatabaseSessionPoolTest.java
+++ b/bundles/sirix-core/src/test/java/org/sirix/access/DatabaseSessionPoolTest.java
@@ -15,13 +15,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+/**
+ * Tests the behavior of {@link DatabaseSessionPool}.
+ *
+ * @author João Sousa
+ */
 class DatabaseSessionPoolTest {
 
     private DatabaseSessionPool sessions;
 
     @BeforeEach
     public void setup() {
-
         this.sessions = new DatabaseSessionPool();
     }
 
@@ -35,7 +39,6 @@ class DatabaseSessionPoolTest {
      */
     @Test
     public final void putWillPersistTheDatabaseInMap() {
-
         final Path key1 = mock(Path.class);
         final Database<?> db1 = mock(Database.class);
         final Database<?> db2 = mock(Database.class);
@@ -61,7 +64,6 @@ class DatabaseSessionPoolTest {
      */
     @Test
     public final void containsShouldReportExistingKeys() {
-
         final Path keySingle = mock(Path.class);
         final Path keyMulti = mock(Path.class);
         final Path keyNone = mock(Path.class);
@@ -85,7 +87,6 @@ class DatabaseSessionPoolTest {
      */
     @Test
     public final void removeShouldEliminateEntries() {
-
         final Path key = mock(Path.class);
         final Database<?> db1 = mock(Database.class);
 


### PR DESCRIPTION
This patch extracts the database session management into its own class. Also, it adds tests to the session management logic. This new class is maintained by Dagger.

Closes #382