### PR TITLE
Remove cyclic dependency between Database and ResourceStore

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/AbstractResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/AbstractResourceStore.java
@@ -1,5 +1,6 @@
 package org.sirix.access;
 
+import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.NodeReadOnlyTrx;
 import org.sirix.api.NodeTrx;
 import org.sirix.api.ResourceManager;
@@ -27,13 +28,19 @@ public abstract class AbstractResourceStore<R extends ResourceManager<? extends 
    * The user, which interacts with SirixDB.
    */
   protected final User user;
+  protected final String databaseName;
+  protected final PageTrxFactory pageTrxFactory;
 
   public AbstractResourceStore(final ConcurrentMap<Path, R> resourceManagers,
-                               final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
-                               final User user) {
+                              final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
+                               final User user,
+                               final String databaseName,
+                               final PageTrxFactory pageTrxFactory) {
     this.resourceManagers = resourceManagers;
     this.allResourceManagers = allResourceManagers;
     this.user = user;
+    this.databaseName = databaseName;
+    this.pageTrxFactory = pageTrxFactory;
   }
 
   protected UberPage getUberPage(final IOStorage storage) {

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
@@ -3,6 +3,8 @@ package org.sirix.access;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
+import org.sirix.access.json.LocalJsonDatabaseFactory;
+import org.sirix.access.xml.LocalXmlDatabaseFactory;
 import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
 import org.sirix.api.json.JsonResourceManager;

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabase.java
@@ -110,11 +110,11 @@ public class LocalDatabase<T extends ResourceManager<? extends NodeReadOnlyTrx, 
    * @param writeLocks       Manages the locks for resource managers.
    * @param resourceManagers The pool for resource managers.
    */
-  LocalDatabase(final DatabaseConfiguration dbConfig,
-                final PathBasedPool<Database<?>> sessions,
-                final ResourceStore<T> resourceStore,
-                final WriteLocksRegistry writeLocks,
-                final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+  public LocalDatabase(final DatabaseConfiguration dbConfig,
+                       final PathBasedPool<Database<?>> sessions,
+                       final ResourceStore<T> resourceStore,
+                       final WriteLocksRegistry writeLocks,
+                       final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
 
     this.dbConfig = checkNotNull(dbConfig);
     this.sessions = sessions;
@@ -165,7 +165,7 @@ public class LocalDatabase<T extends ResourceManager<? extends NodeReadOnlyTrx, 
       addResourceToBufferManagerMapping(resourceFile, resourceConfig);
     }
 
-    return resourceStore.openResource(this, resourceConfig, bufferManagers.get(resourceFile), resourceFile);
+    return resourceStore.openResource(resourceConfig, bufferManagers.get(resourceFile), resourceFile);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/ResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/ResourceStore.java
@@ -1,6 +1,5 @@
 package org.sirix.access;
 
-import org.sirix.api.Database;
 import org.sirix.api.NodeReadOnlyTrx;
 import org.sirix.api.NodeTrx;
 import org.sirix.api.ResourceManager;
@@ -17,21 +16,18 @@ public interface ResourceStore<R extends ResourceManager<? extends NodeReadOnlyT
    * Open a resource, that is get an instance of a {@link ResourceManager} in order to read/write from
    * the resource.
    *
-   * @param database The database.
    * @param resourceConfig The resource configuration.
    * @param bufferManager The buffer manager.
    * @param resourceFile The resource to open.
    * @return A resource manager.
    * @throws NullPointerException if one if the arguments is {@code null}
    */
-  public R openResource(@Nonnull Database<R> database, @Nonnull ResourceConfiguration resourceConfig,
-      @Nonnull BufferManager bufferManager, @Nonnull Path resourceFile);
+  R openResource(@Nonnull ResourceConfiguration resourceConfig,
+                 @Nonnull BufferManager bufferManager, @Nonnull Path resourceFile);
 
   boolean hasOpenResourceManager(Path resourceFile);
 
   R getOpenResourceManager(Path resourceFile);
-
-
 
   @Override
   void close();

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/LocalJsonDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/LocalJsonDatabaseFactory.java
@@ -1,6 +1,12 @@
-package org.sirix.access;
+package org.sirix.access.json;
 
-import org.sirix.access.json.JsonResourceStore;
+import org.sirix.access.DatabaseConfiguration;
+import org.sirix.access.LocalDatabase;
+import org.sirix.access.LocalDatabaseFactory;
+import org.sirix.access.PathBasedPool;
+import org.sirix.access.User;
+import org.sirix.access.WriteLocksRegistry;
+import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
 import org.sirix.api.json.JsonResourceManager;
@@ -46,10 +52,13 @@ public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResour
 
         logger.trace("Creating new local json database");
 
+        final String databaseName = configuration.getDatabaseName();
+        final PageTrxFactory pageTrxFactory = new PageTrxFactory(configuration.getDatabaseType());
+
         return new LocalDatabase<>(
                 configuration,
                 sessions,
-                new JsonResourceStore(user, writeLocks, resourceManagers),
+                new JsonResourceStore(user, writeLocks, resourceManagers, databaseName, pageTrxFactory),
                 writeLocks,
                 resourceManagers);
     }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlResourceManagerImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlResourceManagerImpl.java
@@ -27,8 +27,8 @@ import org.sirix.access.User;
 import org.sirix.access.trx.node.AbstractResourceManager;
 import org.sirix.access.trx.node.AfterCommitState;
 import org.sirix.access.trx.node.InternalResourceManager;
+import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.access.xml.XmlResourceStore;
-import org.sirix.api.Database;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.api.PageTrx;
 import org.sirix.api.xml.XmlNodeReadOnlyTrx;
@@ -67,21 +67,22 @@ public final class XmlResourceManagerImpl extends AbstractResourceManager<XmlNod
   /**
    * Package private constructor.
    *
-   * @param database      {@link Database} for centralized operations on related sessions
-   * @param resourceStore the resource store with which this manager has been created
-   * @param resourceConf  {@link DatabaseConfiguration} for general setting about the storage
-   * @param bufferManager the cache of in-memory pages shared amongst all node transactions
-   * @param storage       the storage itself, used for I/O
-   * @param uberPage      the UberPage, which is the main entry point into a resource
-   * @param writeLock     the write lock, which ensures, that only a single read-write transaction is
-   *                      opened on a resource
-   * @param user          a user, which interacts with SirixDB, might be {@code null}
+   * @param resourceStore  the resource store with which this manager has been created
+   * @param resourceConf   {@link DatabaseConfiguration} for general setting about the storage
+   * @param bufferManager  the cache of in-memory pages shared amongst all node transactions
+   * @param storage        the storage itself, used for I/O
+   * @param uberPage       the UberPage, which is the main entry point into a resource
+   * @param writeLock      the write lock, which ensures, that only a single read-write transaction is
+   *                       opened on a resource
+   * @param user           a user, which interacts with SirixDB, might be {@code null}
+   * @param pageTrxFactory A factory that creates new {@link PageTrx} instances.
    */
-  public XmlResourceManagerImpl(final Database<XmlResourceManager> database,
-      final @Nonnull XmlResourceStore resourceStore, final @Nonnull ResourceConfiguration resourceConf,
-      final @Nonnull BufferManager bufferManager, final @Nonnull IOStorage storage, final @Nonnull UberPage uberPage,
-      final @Nonnull Lock writeLock, final @Nullable User user) {
-    super(database, resourceStore, resourceConf, bufferManager, storage, uberPage, writeLock, user);
+  public XmlResourceManagerImpl(final String databaseName, final @Nonnull XmlResourceStore resourceStore,
+                                final @Nonnull ResourceConfiguration resourceConf,
+                                final @Nonnull BufferManager bufferManager, final @Nonnull IOStorage storage, final @Nonnull UberPage uberPage,
+                                final @Nonnull Lock writeLock, final @Nullable User user, final PageTrxFactory pageTrxFactory) {
+
+    super(resourceStore, resourceConf, bufferManager, storage, uberPage, writeLock, databaseName, user, pageTrxFactory);
 
     rtxIndexControllers = new ConcurrentHashMap<>();
     wtxIndexControllers = new ConcurrentHashMap<>();

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/PageTrxFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/PageTrxFactory.java
@@ -28,6 +28,7 @@
 package org.sirix.access.trx.page;
 
 import org.brackit.xquery.xdm.DocumentException;
+import org.sirix.access.DatabaseType;
 import org.sirix.access.ResourceConfiguration;
 import org.sirix.access.trx.node.IndexController;
 import org.sirix.access.trx.node.InternalResourceManager;
@@ -59,6 +60,12 @@ import java.nio.file.Path;
  * @author Johannes Lichtenberger <a href="mailto:lichtenberger.johannes@gmail.com">mail</a>
  */
 public final class PageTrxFactory {
+
+  private final DatabaseType databaseType;
+
+  public PageTrxFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
 
   /**
    * Create a page write trx.
@@ -120,15 +127,15 @@ public final class PageTrxFactory {
     newRevisionRootPage.setMaxNodeKeyInRecordToRevisionsIndex(lastCommitedRoot.getMaxNodeKeyInRecordToRevisionsIndex());
 
     // First create revision tree if needed.
-    newRevisionRootPage.createDocumentIndexTree(pageRtx, log);
-    newRevisionRootPage.createChangedNodesIndexTree(pageRtx, log);
-    newRevisionRootPage.createRecordToRevisionsIndexTree(pageRtx, log);
+    newRevisionRootPage.createDocumentIndexTree(this.databaseType, pageRtx, log);
+    newRevisionRootPage.createChangedNodesIndexTree(this.databaseType, pageRtx, log);
+    newRevisionRootPage.createRecordToRevisionsIndexTree(this.databaseType, pageRtx, log);
 
     if (usePathSummary) {
       // Create path summary tree if needed.
       final PathSummaryPage page = pageRtx.getPathSummaryPage(newRevisionRootPage);
 
-      page.createPathSummaryTree(pageRtx, 0, log);
+      page.createPathSummaryTree(this.databaseType, pageRtx, 0, log);
 
       if (PageContainer.emptyInstance().equals(log.get(newRevisionRootPage.getPathSummaryPageReference(), pageRtx))) {
         log.put(newRevisionRootPage.getPathSummaryPageReference(), PageContainer.getInstance(page, page));
@@ -140,14 +147,14 @@ public final class PageTrxFactory {
       final DeweyIDPage deweyIDPage = pageRtx.getDeweyIDPage(newRevisionRootPage);
 
       if (resourceManager instanceof JsonResourceManager) {
-        namePage.createNameIndexTree(pageRtx, NamePage.JSON_OBJECT_KEY_REFERENCE_OFFSET, log);
-        deweyIDPage.createIndexTree(pageRtx, log);
+        namePage.createNameIndexTree(this.databaseType, pageRtx, NamePage.JSON_OBJECT_KEY_REFERENCE_OFFSET, log);
+        deweyIDPage.createIndexTree(this.databaseType, pageRtx, log);
       } else if (resourceManager instanceof XmlResourceManager) {
-        namePage.createNameIndexTree(pageRtx, NamePage.ATTRIBUTES_REFERENCE_OFFSET, log);
-        namePage.createNameIndexTree(pageRtx, NamePage.ELEMENTS_REFERENCE_OFFSET, log);
-        namePage.createNameIndexTree(pageRtx, NamePage.NAMESPACE_REFERENCE_OFFSET, log);
-        namePage.createNameIndexTree(pageRtx, NamePage.PROCESSING_INSTRUCTION_REFERENCE_OFFSET, log);
-        deweyIDPage.createIndexTree(pageRtx, log);
+        namePage.createNameIndexTree(this.databaseType, pageRtx, NamePage.ATTRIBUTES_REFERENCE_OFFSET, log);
+        namePage.createNameIndexTree(this.databaseType, pageRtx, NamePage.ELEMENTS_REFERENCE_OFFSET, log);
+        namePage.createNameIndexTree(this.databaseType, pageRtx, NamePage.NAMESPACE_REFERENCE_OFFSET, log);
+        namePage.createNameIndexTree(this.databaseType, pageRtx, NamePage.PROCESSING_INSTRUCTION_REFERENCE_OFFSET, log);
+        deweyIDPage.createIndexTree(this.databaseType, pageRtx, log);
       } else {
         throw new IllegalStateException("Resource manager type not known.");
       }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/LocalXmlDatabaseFactory.java
@@ -1,14 +1,20 @@
-package org.sirix.access;
+package org.sirix.access.xml;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-
-import org.sirix.access.xml.XmlResourceStore;
+import org.sirix.access.DatabaseConfiguration;
+import org.sirix.access.LocalDatabase;
+import org.sirix.access.LocalDatabaseFactory;
+import org.sirix.access.PathBasedPool;
+import org.sirix.access.User;
+import org.sirix.access.WriteLocksRegistry;
+import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * A database session factory for Json databases.
@@ -40,10 +46,12 @@ public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResource
     public Database<XmlResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
         logger.trace("Creating new local xml database");
 
+        final String databaseName = configuration.getDatabaseName();
+        final PageTrxFactory pageTrxFactory = new PageTrxFactory( configuration.getDatabaseType());
         return new LocalDatabase<>(
                 configuration,
                 this.sessions,
-                new XmlResourceStore(user, writeLocks, resourceManagers),
+                new XmlResourceStore(user, writeLocks, resourceManagers, databaseName, pageTrxFactory),
                 writeLocks,
                 resourceManagers
         );

--- a/bundles/sirix-core/src/main/java/org/sirix/api/ResourceManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/api/ResourceManager.java
@@ -59,13 +59,6 @@ public interface ResourceManager<R extends NodeReadOnlyTrx & NodeCursor, W exten
     extends AutoCloseable {
 
   /**
-   * Get the {@link Database} this session is bound to.
-   *
-   * @return {@link Database} this session is bound to
-   */
-  Database<?> getDatabase();
-
-  /**
    * Get the resource path.
    *
    * @return the resource path

--- a/bundles/sirix-core/src/main/java/org/sirix/diff/JsonDiffSerializer.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/diff/JsonDiffSerializer.java
@@ -14,13 +14,19 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 
 public final class JsonDiffSerializer {
+
+  private final String databaseName;
   private final JsonResourceManager resourceManager;
   private final int oldRevisionNumber;
   private final int newRevisionNumber;
   private final Collection<DiffTuple> diffs;
 
-  public JsonDiffSerializer(JsonResourceManager resourceManager, int oldRevisionNumber, int newRevisionNumber,
-      Collection<DiffTuple> diffs) {
+  public JsonDiffSerializer(final String databaseName,
+                            JsonResourceManager resourceManager,
+                            int oldRevisionNumber,
+                            int newRevisionNumber,
+                            Collection<DiffTuple> diffs) {
+    this.databaseName = databaseName;
     this.resourceManager = resourceManager;
     this.oldRevisionNumber = oldRevisionNumber;
     this.newRevisionNumber = newRevisionNumber;
@@ -28,7 +34,6 @@ public final class JsonDiffSerializer {
   }
 
   public String serialize(boolean emitFromDiffAlgorithm) {
-    final var databaseName = resourceManager.getDatabase().getName();
     final var resourceName = resourceManager.getResourceConfig().getName();
 
     final var json = createMetaInfo(databaseName, resourceName, oldRevisionNumber, newRevisionNumber);

--- a/bundles/sirix-core/src/main/java/org/sirix/index/cas/CASIndexBuilderFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/cas/CASIndexBuilderFactory.java
@@ -1,19 +1,27 @@
 package org.sirix.index.cas;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
+import org.sirix.index.path.summary.PathSummaryReader;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.CASValue;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
-import org.sirix.index.path.summary.PathSummaryReader;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class CASIndexBuilderFactory {
+
+  private final DatabaseType databaseType;
+
+  public CASIndexBuilderFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
 
   public CASIndexBuilder create(final PageTrx pageTrx,
       final PathSummaryReader pathSummaryReader, final IndexDef indexDef) {
     final var avlTreeWriter =
-        RBTreeWriter.<CASValue, NodeReferences>getInstance(pageTrx, indexDef.getType(), indexDef.getID());
+        RBTreeWriter.<CASValue, NodeReferences>getInstance(this.databaseType, pageTrx, indexDef.getType(), indexDef.getID());
     final var pathSummary = checkNotNull(pathSummaryReader);
     final var paths = checkNotNull(indexDef.getPaths());
     final var type = checkNotNull(indexDef.getContentType());

--- a/bundles/sirix-core/src/main/java/org/sirix/index/cas/CASIndexListenerFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/cas/CASIndexListenerFactory.java
@@ -1,20 +1,33 @@
 package org.sirix.index.cas;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
+import org.sirix.index.path.summary.PathSummaryReader;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.CASValue;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
-import org.sirix.index.path.summary.PathSummaryReader;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class CASIndexListenerFactory {
+
+  private final DatabaseType databaseType;
+
+  public CASIndexListenerFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
 
   public CASIndexListener create(final PageTrx pageTrx,
       final PathSummaryReader pathSummaryReader, final IndexDef indexDef) {
     final var pathSummary = checkNotNull(pathSummaryReader);
     final var avlTreeWriter =
-        RBTreeWriter.<CASValue, NodeReferences>getInstance(pageTrx, indexDef.getType(), indexDef.getID());
+        RBTreeWriter.<CASValue, NodeReferences>getInstance(
+                this.databaseType,
+                pageTrx,
+                indexDef.getType(),
+                indexDef.getID()
+        );
     final var type = checkNotNull(indexDef.getContentType());
     final var paths = checkNotNull(indexDef.getPaths());
 

--- a/bundles/sirix-core/src/main/java/org/sirix/index/cas/json/JsonCASIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/cas/json/JsonCASIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.cas.json;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.api.json.JsonNodeReadOnlyTrx;
 import org.sirix.index.IndexDef;
@@ -14,8 +15,8 @@ public final class JsonCASIndexImpl implements JsonCASIndex {
   private final CASIndexListenerFactory casIndexListenerFactory;
 
   public JsonCASIndexImpl() {
-    casIndexBuilderFactory = new CASIndexBuilderFactory();
-    casIndexListenerFactory = new CASIndexListenerFactory();
+    casIndexBuilderFactory = new CASIndexBuilderFactory(DatabaseType.JSON);
+    casIndexListenerFactory = new CASIndexListenerFactory(DatabaseType.JSON);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/cas/xml/XmlCASIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/cas/xml/XmlCASIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.cas.xml;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.api.xml.XmlNodeReadOnlyTrx;
 import org.sirix.index.IndexDef;
@@ -14,8 +15,8 @@ public final class XmlCASIndexImpl implements XmlCASIndex {
   private final CASIndexListenerFactory casIndexListenerFactory;
 
   public XmlCASIndexImpl() {
-    casIndexBuilderFactory = new CASIndexBuilderFactory();
-    casIndexListenerFactory = new CASIndexListenerFactory();
+    casIndexBuilderFactory = new CASIndexBuilderFactory(DatabaseType.XML);
+    casIndexListenerFactory = new CASIndexListenerFactory(DatabaseType.XML);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/name/NameIndexBuilderFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/name/NameIndexBuilderFactory.java
@@ -1,22 +1,34 @@
 package org.sirix.index.name;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import org.brackit.xquery.atomic.QNm;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.IndexType;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public final class NameIndexBuilderFactory {
 
-  public NameIndexBuilder create(final PageTrx pageTrx,
-      final IndexDef indexDefinition) {
+  private final DatabaseType databaseType;
+
+  public NameIndexBuilderFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
+
+  public NameIndexBuilder create(final PageTrx pageTrx, final IndexDef indexDefinition) {
+
     final var includes = checkNotNull(indexDefinition.getIncluded());
     final var excludes = checkNotNull(indexDefinition.getExcluded());
     assert indexDefinition.getType() == IndexType.NAME;
-    final var avlTreeWriter = RBTreeWriter.<QNm, NodeReferences>getInstance(pageTrx, indexDefinition.getType(),
-                                                                            indexDefinition.getID());
+    final var avlTreeWriter = RBTreeWriter.<QNm, NodeReferences>getInstance(
+            this.databaseType,
+            pageTrx,
+            indexDefinition.getType(),
+            indexDefinition.getID()
+    );
 
     return new NameIndexBuilder(includes, excludes, avlTreeWriter);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/index/name/NameIndexListenerFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/name/NameIndexListenerFactory.java
@@ -1,22 +1,34 @@
 package org.sirix.index.name;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import org.brackit.xquery.atomic.QNm;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.IndexType;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public final class NameIndexListenerFactory {
+
+  private final DatabaseType databaseType;
+
+  public NameIndexListenerFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
 
   public NameIndexListener create(final PageTrx pageWriteTrx,
       final IndexDef indexDefinition) {
     final var includes = checkNotNull(indexDefinition.getIncluded());
     final var excludes = checkNotNull(indexDefinition.getExcluded());
     assert indexDefinition.getType() == IndexType.NAME;
-    final var avlTreeWriter = RBTreeWriter.<QNm, NodeReferences>getInstance(pageWriteTrx, indexDefinition.getType(),
-                                                                            indexDefinition.getID());
+    final var avlTreeWriter = RBTreeWriter.<QNm, NodeReferences>getInstance(
+            this.databaseType,
+            pageWriteTrx,
+            indexDefinition.getType(),
+            indexDefinition.getID()
+    );
 
     return new NameIndexListener(includes, excludes, avlTreeWriter);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/index/name/json/JsonNameIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/name/json/JsonNameIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.name.json;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.name.NameIndexBuilderFactory;
@@ -12,8 +13,8 @@ public final class JsonNameIndexImpl implements JsonNameIndex {
   private final NameIndexListenerFactory nameIndexListenerFactory;
 
   public JsonNameIndexImpl() {
-    nameIndexBuilderFactory = new NameIndexBuilderFactory();
-    nameIndexListenerFactory = new NameIndexListenerFactory();
+    nameIndexBuilderFactory = new NameIndexBuilderFactory(DatabaseType.JSON);
+    nameIndexListenerFactory = new NameIndexListenerFactory(DatabaseType.JSON);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/name/xml/XmlNameIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/name/xml/XmlNameIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.name.xml;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.name.NameIndexBuilderFactory;
@@ -12,8 +13,8 @@ public final class XmlNameIndexImpl implements XmlNameIndex {
   private final NameIndexListenerFactory nameIndexListenerFactory;
 
   public XmlNameIndexImpl() {
-    nameIndexBuilderFactory = new NameIndexBuilderFactory();
-    nameIndexListenerFactory = new NameIndexListenerFactory();
+    nameIndexBuilderFactory = new NameIndexBuilderFactory(DatabaseType.XML);
+    nameIndexListenerFactory = new NameIndexListenerFactory(DatabaseType.XML);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/path/PathIndexBuilderFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/path/PathIndexBuilderFactory.java
@@ -1,22 +1,30 @@
 package org.sirix.index.path;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.IndexType;
+import org.sirix.index.path.summary.PathSummaryReader;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
-import org.sirix.index.path.summary.PathSummaryReader;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class PathIndexBuilderFactory {
+
+  private final DatabaseType databaseType;
+
+  public PathIndexBuilderFactory(final DatabaseType databaseType) {
+    this.databaseType = databaseType;
+  }
 
   public PathIndexBuilder create(final PageTrx pageTrx,
       final PathSummaryReader pathSummaryReader, final IndexDef indexDef) {
     final var pathSummary = checkNotNull(pathSummaryReader);
     final var paths = checkNotNull(indexDef.getPaths());
     assert indexDef.getType() == IndexType.PATH;
-    final var avlTreeWriter =
-        RBTreeWriter.<Long, NodeReferences>getInstance(pageTrx, indexDef.getType(), indexDef.getID());
+    final var avlTreeWriter = RBTreeWriter.<Long, NodeReferences>getInstance(
+            this.databaseType, pageTrx, indexDef.getType(), indexDef.getID());
 
     return new PathIndexBuilder(avlTreeWriter, pathSummary, paths);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/index/path/PathIndexListenerFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/path/PathIndexListenerFactory.java
@@ -1,19 +1,33 @@
 package org.sirix.index.path;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
+import org.sirix.index.path.summary.PathSummaryReader;
 import org.sirix.index.redblacktree.RBTreeWriter;
 import org.sirix.index.redblacktree.keyvalue.NodeReferences;
-import org.sirix.index.path.summary.PathSummaryReader;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class PathIndexListenerFactory {
+
+  private final DatabaseType databaseType;
+
+  public PathIndexListenerFactory(final DatabaseType databaseType) {
+
+    this.databaseType = databaseType;
+  }
+
   public PathIndexListener create(final PageTrx pageTrx,
       final PathSummaryReader pathSummaryReader, final IndexDef indexDef) {
     final var pathSummary = checkNotNull(pathSummaryReader);
     final var paths = checkNotNull(indexDef.getPaths());
-    final var avlTreeWriter =
-        RBTreeWriter.<Long, NodeReferences>getInstance(pageTrx, indexDef.getType(), indexDef.getID());
+    final var avlTreeWriter = RBTreeWriter.<Long, NodeReferences>getInstance(
+            this.databaseType,
+            pageTrx,
+            indexDef.getType(),
+            indexDef.getID()
+    );
 
     return new PathIndexListener(paths, pathSummary, avlTreeWriter);
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/index/path/json/JsonPathIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/path/json/JsonPathIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.path.json;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.path.PathIndexBuilderFactory;
@@ -13,8 +14,8 @@ public final class JsonPathIndexImpl implements JsonPathIndex {
   private final PathIndexListenerFactory pathIndexListenerFactory;
 
   public JsonPathIndexImpl() {
-    pathIndexBuilderFactory = new PathIndexBuilderFactory();
-    pathIndexListenerFactory = new PathIndexListenerFactory();
+    pathIndexBuilderFactory = new PathIndexBuilderFactory(DatabaseType.JSON);
+    pathIndexListenerFactory = new PathIndexListenerFactory(DatabaseType.JSON);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/path/xml/XmlPathIndexImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/path/xml/XmlPathIndexImpl.java
@@ -1,5 +1,6 @@
 package org.sirix.index.path.xml;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageTrx;
 import org.sirix.index.IndexDef;
 import org.sirix.index.path.PathIndexBuilderFactory;
@@ -13,8 +14,8 @@ public final class XmlPathIndexImpl implements XmlPathIndex {
   private final PathIndexListenerFactory pathIndexListenerFactory;
 
   public XmlPathIndexImpl() {
-    pathIndexBuilderFactory = new PathIndexBuilderFactory();
-    pathIndexListenerFactory = new PathIndexListenerFactory();
+    pathIndexBuilderFactory = new PathIndexBuilderFactory(DatabaseType.XML);
+    pathIndexListenerFactory = new PathIndexListenerFactory(DatabaseType.XML);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/index/redblacktree/RBTreeWriter.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/index/redblacktree/RBTreeWriter.java
@@ -1,5 +1,6 @@
 package org.sirix.index.redblacktree;
 
+import org.sirix.access.DatabaseType;
 import org.sirix.access.trx.node.AbstractForwardingNodeCursor;
 import org.sirix.api.NodeCursor;
 import org.sirix.api.PageTrx;
@@ -50,10 +51,14 @@ public final class RBTreeWriter<K extends Comparable<? super K>, V extends Refer
   /**
    * Private constructor.
    *
-   * @param pageTrx {@link PageTrx} for persistent storage
-   * @param type    type of index
+   * @param databaseType The type of database.
+   * @param pageTrx      {@link PageTrx} for persistent storage
+   * @param type         type of index
    */
-  private RBTreeWriter(final PageTrx pageTrx, final IndexType type, final @Nonnegative int index) {
+  private RBTreeWriter(final DatabaseType databaseType,
+                       final PageTrx pageTrx,
+                       final IndexType type,
+                       final @Nonnegative int index) {
     try {
       final RevisionRootPage revisionRootPage = pageTrx.getActualRevisionRootPage();
       final PageReference reference;
@@ -63,21 +68,21 @@ public final class RBTreeWriter<K extends Comparable<? super K>, V extends Refer
           final PathPage pathPage = pageTrx.getPathPage(revisionRootPage);
           reference = revisionRootPage.getPathPageReference();
           pageTrx.appendLogRecord(reference, PageContainer.getInstance(pathPage, pathPage));
-          pathPage.createPathIndexTree(pageTrx, index, pageTrx.getLog());
+          pathPage.createPathIndexTree(databaseType, pageTrx, index, pageTrx.getLog());
           break;
         case CAS:
           // Create CAS index tree if needed.
           final CASPage casPage = pageTrx.getCASPage(revisionRootPage);
           reference = revisionRootPage.getCASPageReference();
           pageTrx.appendLogRecord(reference, PageContainer.getInstance(casPage, casPage));
-          casPage.createCASIndexTree(pageTrx, index, pageTrx.getLog());
+          casPage.createCASIndexTree(databaseType, pageTrx, index, pageTrx.getLog());
           break;
         case NAME:
           // Create name index tree if needed.
           final NamePage namePage = pageTrx.getNamePage(revisionRootPage);
           reference = revisionRootPage.getNamePageReference();
           pageTrx.appendLogRecord(reference, PageContainer.getInstance(namePage, namePage));
-          namePage.createNameIndexTree(pageTrx, index, pageTrx.getLog());
+          namePage.createNameIndexTree(databaseType, pageTrx, index, pageTrx.getLog());
           break;
         default:
           // Must not happen.
@@ -92,14 +97,17 @@ public final class RBTreeWriter<K extends Comparable<? super K>, V extends Refer
   /**
    * Get a new instance.
    *
+   * @param databaseType The type of database.
    * @param pageWriteTrx {@link PageTrx} for persistent storage
    * @param type         type of index
    * @param index        the index number
+   *
    * @return new tree instance
    */
   public static <K extends Comparable<? super K>, V extends References> RBTreeWriter<K, V> getInstance(
-      final PageTrx pageWriteTrx, final IndexType type, final int index) {
-    return new RBTreeWriter<>(pageWriteTrx, type, index);
+          final DatabaseType databaseType, final PageTrx pageWriteTrx, final IndexType type, final int index) {
+
+    return new RBTreeWriter<>(databaseType, pageWriteTrx, type, index);
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/org/sirix/page/CASPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/CASPage.java
@@ -1,6 +1,7 @@
 package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.cache.TransactionIntentLog;
 import org.sirix.index.IndexType;
@@ -94,8 +95,10 @@ public final class CASPage extends AbstractForwardingPage {
    * @param index the index number
    * @param log the transaction intent log
    */
-  public void createCASIndexTree(final PageReadOnlyTrx pageReadTrx, final int index,
-      final TransactionIntentLog log) {
+  public void createCASIndexTree(final DatabaseType databaseType,
+                                 final PageReadOnlyTrx pageReadTrx,
+                                 final int index,
+                                 final TransactionIntentLog log) {
     PageReference reference = getOrCreateReference(index);
     if (reference == null) {
       delegate = new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT, (ReferencesPage4) delegate());
@@ -104,7 +107,7 @@ public final class CASPage extends AbstractForwardingPage {
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
         && reference.getLogKey() == Constants.NULL_ID_INT
         && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.CAS, pageReadTrx, log);
+      PageUtils.createTree(databaseType, reference, IndexType.CAS, pageReadTrx, log);
       if (maxNodeKeys.get(index) == null) {
         maxNodeKeys.put(index, 0L);
       } else {

--- a/bundles/sirix-core/src/main/java/org/sirix/page/DeweyIDPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/DeweyIDPage.java
@@ -23,6 +23,7 @@ package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
 import net.openhft.chronicle.map.ChronicleMap;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.api.PageTrx;
 import org.sirix.cache.TransactionIntentLog;
@@ -119,12 +120,14 @@ public final class DeweyIDPage extends AbstractForwardingPage {
    * @param pageReadTrx {@link PageReadOnlyTrx} instance
    * @param log         the transaction intent log
    */
-  public void createIndexTree(final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
+  public void createIndexTree(final DatabaseType databaseType,
+                              final PageReadOnlyTrx pageReadTrx,
+                              final TransactionIntentLog log) {
     PageReference reference = getIndirectPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
         && reference.getLogKey() == Constants.NULL_ID_INT
         && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.DEWEYID_TO_RECORDID, pageReadTrx, log);
+      PageUtils.createTree(databaseType, reference, IndexType.DEWEYID_TO_RECORDID, pageReadTrx, log);
       incrementAndGetMaxNodeKey();
     }
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/page/NamePage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/NamePage.java
@@ -22,13 +22,13 @@
 package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.api.PageTrx;
 import org.sirix.cache.TransactionIntentLog;
 import org.sirix.index.IndexType;
 import org.sirix.index.name.Names;
 import org.sirix.node.NodeKind;
-import org.sirix.node.interfaces.DataRecord;
 import org.sirix.page.delegates.BitmapReferencesPage;
 import org.sirix.page.delegates.ReferencesPage4;
 import org.sirix.page.interfaces.Page;
@@ -432,20 +432,24 @@ public final class NamePage extends AbstractForwardingPage {
   /**
    * Initialize name index tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param index the index number
-   * @param log the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param index        the index number
+   * @param log          the transaction intent log
    */
-  public void createNameIndexTree(final PageReadOnlyTrx pageReadTrx, final int index, final TransactionIntentLog log) {
+  public void createNameIndexTree(final DatabaseType databaseType,
+                                  final PageReadOnlyTrx pageReadTrx,
+                                  final int index,
+                                  final TransactionIntentLog log) {
     PageReference reference = getOrCreateReference(index);
     if (reference == null) {
       delegate = new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT, (ReferencesPage4) delegate());
       reference = delegate.getOrCreateReference(index);
     }
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.NAME, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.NAME, pageReadTrx, log);
       if (maxNodeKeys.get(index) == null) {
         maxNodeKeys.put(index, 0L);
       } else {

--- a/bundles/sirix-core/src/main/java/org/sirix/page/PageUtils.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/PageUtils.java
@@ -66,28 +66,27 @@ public final class PageUtils {
   /**
    * Create the initial tree structure.
    *
-   * @param reference reference from revision root
-   * @param indexType  the index type
+   * @param databaseType The type of database.
+   * @param reference    reference from revision root
+   * @param indexType    the index type
    */
-  public static void createTree(@Nonnull PageReference reference, final IndexType indexType,
-      final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
+  public static void createTree(final DatabaseType databaseType,
+                                @Nonnull PageReference reference, final IndexType indexType,
+                                final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
     final Page page = new IndirectPage();
     log.put(reference, PageContainer.getInstance(page, page));
     reference = page.getOrCreateReference(0);
 
     // Create new record page.
     final UnorderedKeyValuePage recordPage =
-        new UnorderedKeyValuePage(Fixed.ROOT_PAGE_KEY.getStandardProperty(), indexType, pageReadTrx);
+            new UnorderedKeyValuePage(Fixed.ROOT_PAGE_KEY.getStandardProperty(), indexType, pageReadTrx);
 
     final ResourceConfiguration resourceConfiguration = pageReadTrx.getResourceManager().getResourceConfig();
 
     // Create a {@link DocumentRootNode}.
     final SirixDeweyID id = resourceConfiguration.areDeweyIDsStored ? SirixDeweyID.newRootID() : null;
 
-    // TODO: Should be passed from the method... chaining up.
-    final DatabaseType dbType = pageReadTrx.getResourceManager().getDatabase().getDatabaseConfig().getDatabaseType();
-
-    recordPage.setRecord(0L, dbType.getDocumentNode(id));
+    recordPage.setRecord(0L, databaseType.getDocumentNode(id));
 
     log.put(reference, PageContainer.getInstance(recordPage, recordPage));
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/page/PathPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/PathPage.java
@@ -1,6 +1,7 @@
 package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.cache.TransactionIntentLog;
 import org.sirix.index.IndexType;
@@ -84,21 +85,24 @@ public final class PathPage extends AbstractForwardingPage {
   /**
    * Initialize path index tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param index the index number
-   * @param log the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param index        the index number
+   * @param log          the transaction intent log
    */
-  public void createPathIndexTree(final PageReadOnlyTrx pageReadTrx, final int index,
-      final TransactionIntentLog log) {
+  public void createPathIndexTree(final DatabaseType databaseType,
+                                  final PageReadOnlyTrx pageReadTrx,
+                                  final int index,
+                                  final TransactionIntentLog log) {
     PageReference reference = getOrCreateReference(index);
     if (reference == null) {
       delegate = new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT, (ReferencesPage4) delegate());
       reference = delegate.getOrCreateReference(index);
     }
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.PATH, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.PATH, pageReadTrx, log);
       if (maxNodeKeys.get(index) == null) {
         maxNodeKeys.put(index, 0L);
       } else {

--- a/bundles/sirix-core/src/main/java/org/sirix/page/PathSummaryPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/PathSummaryPage.java
@@ -1,6 +1,7 @@
 package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
+import org.sirix.access.DatabaseType;
 import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.cache.TransactionIntentLog;
 import org.sirix.index.IndexType;
@@ -83,21 +84,24 @@ public final class PathSummaryPage extends AbstractForwardingPage {
   /**
    * Initialize path summary tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param index the index number
-   * @param log the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param index        the index number
+   * @param log          the transaction intent log
    */
-  public void createPathSummaryTree(final PageReadOnlyTrx pageReadTrx, final int index,
-      final TransactionIntentLog log) {
+  public void createPathSummaryTree(final DatabaseType databaseType,
+                                    final PageReadOnlyTrx pageReadTrx,
+                                    final int index,
+                                    final TransactionIntentLog log) {
     PageReference reference = getOrCreateReference(index);
     if (reference == null) {
       delegate = new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT, (ReferencesPage4) delegate());
       reference = delegate.getOrCreateReference(index);
     }
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.PATH_SUMMARY, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.PATH_SUMMARY, pageReadTrx, log);
       if (maxNodeKeys.get(index) == null) {
         maxNodeKeys.put(index, 0L);
       } else {

--- a/bundles/sirix-core/src/main/java/org/sirix/page/RevisionRootPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/RevisionRootPage.java
@@ -22,6 +22,7 @@
 package org.sirix.page;
 
 import com.google.common.base.MoreObjects;
+import org.sirix.access.DatabaseType;
 import org.sirix.access.User;
 import org.sirix.access.trx.node.CommitCredentials;
 import org.sirix.api.PageReadOnlyTrx;
@@ -454,15 +455,18 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   /**
    * Initialize document index tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param log         the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param log          the transaction intent log
    */
-  public void createDocumentIndexTree(final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
+  public void createDocumentIndexTree(final DatabaseType databaseType,
+                                      final PageReadOnlyTrx pageReadTrx,
+                                      final TransactionIntentLog log) {
     PageReference reference = getIndirectDocumentIndexPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.DOCUMENT, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.DOCUMENT, pageReadTrx, log);
       incrementAndGetMaxNodeKeyInDocumentIndex();
     }
   }
@@ -470,15 +474,18 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   /**
    * Initialize record to revisions index tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param log         the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param log          the transaction intent log
    */
-  public void createChangedNodesIndexTree(final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
+  public void createChangedNodesIndexTree(final DatabaseType databaseType,
+                                          final PageReadOnlyTrx pageReadTrx,
+                                          final TransactionIntentLog log) {
     PageReference reference = getIndirectChangedNodesIndexPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.CHANGED_NODES, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.CHANGED_NODES, pageReadTrx, log);
       incrementAndGetMaxNodeKeyInChangedNodesIndex();
     }
   }
@@ -486,15 +493,18 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   /**
    * Initialize changed records index tree.
    *
-   * @param pageReadTrx {@link PageReadOnlyTrx} instance
-   * @param log         the transaction intent log
+   * @param databaseType The type of database.
+   * @param pageReadTrx  {@link PageReadOnlyTrx} instance
+   * @param log          the transaction intent log
    */
-  public void createRecordToRevisionsIndexTree(final PageReadOnlyTrx pageReadTrx, final TransactionIntentLog log) {
+  public void createRecordToRevisionsIndexTree(final DatabaseType databaseType,
+                                               final PageReadOnlyTrx pageReadTrx,
+                                               final TransactionIntentLog log) {
     PageReference reference = getIndirectRecordToRevisionsIndexPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
-        && reference.getLogKey() == Constants.NULL_ID_INT
-        && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
-      PageUtils.createTree(reference, IndexType.RECORD_TO_REVISIONS, pageReadTrx, log);
+            && reference.getLogKey() == Constants.NULL_ID_INT
+            && reference.getPersistentLogKey() == Constants.NULL_ID_LONG) {
+      PageUtils.createTree(databaseType, reference, IndexType.RECORD_TO_REVISIONS, pageReadTrx, log);
       incrementAndGetMaxNodeKeyInRecordToRevisionsIndex();
     }
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/service/json/BasicJsonDiff.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/json/BasicJsonDiff.java
@@ -18,11 +18,15 @@ import java.util.List;
 public final class BasicJsonDiff implements DiffObserver, JsonDiff {
 
   private final List<DiffTuple> diffs;
+  private final String databaseName;
 
   /**
    * Constructor.
+   *
+   * @param databaseName The database name.
    */
-  public BasicJsonDiff() {
+  public BasicJsonDiff(final String databaseName) {
+    this.databaseName = databaseName;
     this.diffs = new ArrayList<>();
   }
 
@@ -62,7 +66,7 @@ public final class BasicJsonDiff implements DiffObserver, JsonDiff {
                                                                       .oldStartKey(startNodeKey)
                                                                       .oldMaxDepth(maxDepth));
 
-    return new JsonDiffSerializer(resourceManager, oldRevisionNumber, newRevisionNumber, diffs).serialize(true);
+    return new JsonDiffSerializer(this.databaseName, resourceManager, oldRevisionNumber, newRevisionNumber, diffs).serialize(true);
   }
 
   @Override

--- a/bundles/sirix-core/src/test/java/org/sirix/service/json/BasicJsonDiffTest.java
+++ b/bundles/sirix-core/src/test/java/org/sirix/service/json/BasicJsonDiffTest.java
@@ -33,6 +33,7 @@ public final class BasicJsonDiffTest {
 
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.moveTo(15);
@@ -42,10 +43,10 @@ public final class BasicJsonDiffTest {
       wtx.insertObjectRecordAsRightSibling("111hereIAm", new StringValue("111yeah"));
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 1, 2);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 2);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("diffRev1Rev2.json")), diffRev1Rev2);
 
-      final String diffRev1Rev3 = new BasicJsonDiff().generateDiff(manager, 1, 3);
+      final String diffRev1Rev3 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 3);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("diffRev1Rev3.json")), diffRev1Rev3);
     }
   }
@@ -56,6 +57,7 @@ public final class BasicJsonDiffTest {
 
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.moveTo(4);
@@ -65,7 +67,7 @@ public final class BasicJsonDiffTest {
       wtx.moveTo(4);
       wtx.insertSubtreeAsRightSibling(JsonShredder.createStringReader("{\"new\":\"stuff\"}"));
 
-      final String diffRev1Rev4 = new BasicJsonDiff().generateDiff(manager, 1, 4);
+      final String diffRev1Rev4 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 4);
       System.out.println(diffRev1Rev4);
     }
   }
@@ -74,6 +76,7 @@ public final class BasicJsonDiffTest {
   public void test_whenMultipleRevisionsExist_thenDiff3() throws IOException {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.insertArrayAsFirstChild();
@@ -81,7 +84,7 @@ public final class BasicJsonDiffTest {
       wtx.insertObjectAsFirstChild();
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 1, 2);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 2);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("emptyObjectDiffRev1Rev2.json")),
                    diffRev1Rev2);
     }
@@ -91,6 +94,7 @@ public final class BasicJsonDiffTest {
   public void test_whenMultipleRevisionsExist_thenDiff4() throws IOException {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[\"test\", \"test\"]"));
@@ -100,7 +104,7 @@ public final class BasicJsonDiffTest {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[]"));
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 1, 2);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 2);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("replace.json")), diffRev1Rev2);
     }
   }
@@ -109,6 +113,7 @@ public final class BasicJsonDiffTest {
   public void test_whenMultipleRevisionsExist_thenDiff5() throws IOException {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"baz\":\"hello\"}"));
@@ -116,7 +121,7 @@ public final class BasicJsonDiffTest {
       wtx.replaceObjectRecordValue(new StringValue("test"));
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 1, 2);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 1, 2);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("replace1.json")), diffRev1Rev2);
     }
   }
@@ -125,6 +130,7 @@ public final class BasicJsonDiffTest {
   public void test_whenMultipleRevisionsExist_thenDiff6() throws IOException {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[]"));
@@ -144,7 +150,7 @@ public final class BasicJsonDiffTest {
       wtx.remove();
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 2, 5);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 2, 5);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("deletion-at-eof.json")), diffRev1Rev2);
     }
   }
@@ -153,6 +159,7 @@ public final class BasicJsonDiffTest {
   public void test_whenMultipleRevisionsExist_thenDiff7() throws IOException {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     assert database != null;
+    final var databaseName = database.getName();
     try (final var manager = database.openResourceManager(JsonTestHelper.RESOURCE);
          final var wtx = manager.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[]"));
@@ -168,7 +175,7 @@ public final class BasicJsonDiffTest {
       wtx.remove();
       wtx.commit();
 
-      final String diffRev1Rev2 = new BasicJsonDiff().generateDiff(manager, 2, 4);
+      final String diffRev1Rev2 = new BasicJsonDiff(databaseName).generateDiff(manager, 2, 4);
       assertEquals(Files.readString(JSON.resolve("basicJsonDiffTest").resolve("replace2.json")), diffRev1Rev2);
     }
   }

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/DiffHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/DiffHandler.kt
@@ -2,7 +2,6 @@ package org.sirix.rest.crud
 
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
-import io.vertx.core.Promise
 import io.vertx.core.http.HttpHeaders
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
@@ -86,7 +85,7 @@ class DiffHandler(private val location: Path) {
                                 }
                             }
                         } else {
-                            diffString = BasicJsonDiff().generateDiff(
+                            diffString = BasicJsonDiff(databaseName).generateDiff(
                                 resourceManager,
                                 firstRevision.toInt(),
                                 secondRevision.toInt(),

--- a/bundles/sirix-xquery/src/main/java/org/sirix/xquery/function/jn/diff/Diff.java
+++ b/bundles/sirix-xquery/src/main/java/org/sirix/xquery/function/jn/diff/Diff.java
@@ -40,7 +40,6 @@ import org.brackit.xquery.xdm.Signature;
 import org.sirix.service.json.BasicJsonDiff;
 import org.sirix.api.JsonDiff;
 import org.sirix.xquery.function.FunUtil;
-import org.sirix.xquery.function.jn.JNFun;
 import org.sirix.xquery.json.JsonDBCollection;
 
 /**
@@ -93,7 +92,7 @@ public final class Diff extends AbstractFunction {
     final var maxLevel = FunUtil.getInt(args, 5, "maxLevel", 0, null, false);
     final var doc = col.getDocument(expResName);
 
-    final JsonDiff jsonDiff = new BasicJsonDiff();
+    final JsonDiff jsonDiff = new BasicJsonDiff(col.getDatabase().getName());
 
     return new Str(jsonDiff.generateDiff(doc.getResourceManager(), oldRevision, newRevision, startNodeKey, maxLevel));
   }


### PR DESCRIPTION
This commit removes the cyclic dependency between `Database` and `ResourceStore´.