### PR TITLE
Extract resource write lock management to its own class

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/Databases.java
@@ -15,12 +15,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.Lock;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -37,9 +35,6 @@ public final class Databases {
    * DI component that manages the database.
    */
   static final DatabaseManager MANAGER = DaggerDatabaseManager.create();
-
-  /** Central repository of all resource {@code <=>} write locks mappings. */
-  static final ConcurrentMap<Path, Lock> RESOURCE_WRITE_LOCKS = new ConcurrentHashMap<>();
 
   /**
    * Get the database type

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabasesInternals.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabasesInternals.java
@@ -5,22 +5,11 @@ import org.sirix.api.Database;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 public final class DatabasesInternals {
 
   private DatabasesInternals() {
     throw new AssertionError();
-  }
-
-  public static Lock computeWriteLockIfAbsent(Path resourcePath) {
-    return Databases.RESOURCE_WRITE_LOCKS.computeIfAbsent(resourcePath, res -> new ReentrantLock());
-  }
-
-  public static void removeWriteLock(Path resourcePath) {
-    Databases.RESOURCE_WRITE_LOCKS.remove(resourcePath);
   }
 
   public static Map<Path, Set<Database<?>>> getOpenDatabases() {

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabase.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabase.java
@@ -96,22 +96,26 @@ public class LocalDatabase<T extends ResourceManager<? extends NodeReadOnlyTrx, 
 
   private final PathBasedPool<ResourceManager<?, ?>> resourceManagers;
 
+  /**
+   * This field should be use to fetch the locks for resource managers.
+   */
   private final WriteLocksRegistry writeLocks;
 
   /**
    * Constructor.
    *
-   * @param dbConfig      {@link ResourceConfiguration} reference to configure the {@link Database}
-   * @param sessions      The database sessions management instance.
-   * @param resourceStore The resource store used by this database.
+   * @param dbConfig         {@link ResourceConfiguration} reference to configure the {@link Database}
+   * @param sessions         The database sessions management instance.
+   * @param resourceStore    The resource store used by this database.
+   * @param writeLocks       Manages the locks for resource managers.
    * @param resourceManagers The pool for resource managers.
-   * @param writeLocks
    */
   LocalDatabase(final DatabaseConfiguration dbConfig,
                 final PathBasedPool<Database<?>> sessions,
                 final ResourceStore<T> resourceStore,
                 final WriteLocksRegistry writeLocks,
                 final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+
     this.dbConfig = checkNotNull(dbConfig);
     this.sessions = sessions;
     this.resourceStore = resourceStore;

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalJsonDatabaseFactory.java
@@ -28,10 +28,14 @@ public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResour
     private final PathBasedPool<Database<?>> sessions;
     private final PathBasedPool<ResourceManager<?, ?>> resourceManagers;
 
+    private final WriteLocksRegistry writeLocks;
+
     @Inject
     LocalJsonDatabaseFactory(final PathBasedPool<Database<?>> sessions,
-                             final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+                             final PathBasedPool<ResourceManager<?, ?>> resourceManagers,
+                             final WriteLocksRegistry writeLocks) {
         this.sessions = sessions;
+        this.writeLocks = writeLocks;
         this.resourceManagers = resourceManagers;
     }
 
@@ -45,7 +49,8 @@ public class LocalJsonDatabaseFactory implements LocalDatabaseFactory<JsonResour
         return new LocalDatabase<>(
                 configuration,
                 sessions,
-                new JsonResourceStore(user, resourceManagers),
+                new JsonResourceStore(user, writeLocks, resourceManagers),
+                writeLocks,
                 resourceManagers);
     }
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalXmlDatabaseFactory.java
@@ -25,12 +25,15 @@ public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResource
 
     private final PathBasedPool<Database<?>> sessions;
     private final PathBasedPool<ResourceManager<?, ?>> resourceManagers;
+    private final WriteLocksRegistry writeLocks;
 
     @Inject
     LocalXmlDatabaseFactory(final PathBasedPool<Database<?>> sessions,
-                            final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+                            final PathBasedPool<ResourceManager<?, ?>> resourceManagers,
+                            final WriteLocksRegistry writeLocks) {
         this.sessions = sessions;
         this.resourceManagers = resourceManagers;
+        this.writeLocks = writeLocks;
     }
 
     @Override
@@ -40,7 +43,8 @@ public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResource
         return new LocalDatabase<>(
                 configuration,
                 this.sessions,
-                new XmlResourceStore(user, resourceManagers),
+                new XmlResourceStore(user, writeLocks, resourceManagers),
+                writeLocks,
                 resourceManagers
         );
     }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/WriteLocksRegistry.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/WriteLocksRegistry.java
@@ -1,0 +1,65 @@
+package org.sirix.access;
+
+import org.sirix.api.ResourceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A registry for write locks used for {@link ResourceManager resource managers}.
+ *
+ * <p>Each {@link ResourceManager}, identified by its {@link Path resource path}, will be
+ * assigned a unique write lock.
+ *
+ * @author Joao Sousa
+ */
+@Singleton
+@ThreadSafe
+public class WriteLocksRegistry {
+
+    /**
+     * Logger for {@link WriteLocksRegistry}.
+     */
+    private static final Logger logger = LoggerFactory.getLogger(WriteLocksRegistry.class);
+
+    /** Central repository of all resource {@code <=>} write locks mappings. */
+    private final Map<Path, Lock> locks;
+
+    @Inject
+    WriteLocksRegistry() {
+        locks = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Fetches the write lock for the provider resource, identified by its {@code resourcePath}.
+     *
+     * <p>This method will create a new write lock if no lock exists for the provided resource.
+     *
+     * @param resourcePath The path that identifies the resource.
+     * @return The lock to be used to perform write operations to the given resource.
+     */
+    public Lock getWriteLock(final Path resourcePath) {
+        logger.trace("Fetching log for resource with path {}", resourcePath);
+
+        return this.locks.computeIfAbsent(resourcePath, res -> new ReentrantLock());
+    }
+
+    /**
+     * De-registers the lock for the provided resource, identified by its {@code resourcePath}.
+     *
+     * <p><b>Note</b> that this method does not prevent the de-registered lock from still being used.
+     *
+     * @param resourcePath The path that identifies the resource.
+     */
+    public void removeWriteLock(final Path resourcePath) {
+        this.locks.remove(resourcePath);
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
@@ -5,6 +5,7 @@ import org.sirix.access.DatabasesInternals;
 import org.sirix.access.PathBasedPool;
 import org.sirix.access.ResourceConfiguration;
 import org.sirix.access.User;
+import org.sirix.access.WriteLocksRegistry;
 import org.sirix.access.trx.node.json.JsonResourceManagerImpl;
 import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
@@ -13,8 +14,6 @@ import org.sirix.cache.BufferManager;
 import org.sirix.io.IOStorage;
 import org.sirix.io.StorageType;
 import org.sirix.page.UberPage;
-import org.sirix.utils.LogWrapper;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.nio.file.Path;
@@ -30,17 +29,17 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class JsonResourceStore extends AbstractResourceStore<JsonResourceManager> {
 
-  /**
-   * {@link LogWrapper} reference.
-   */
-  private static final LogWrapper LOGGER = new LogWrapper(LoggerFactory.getLogger(JsonResourceStore.class));
+  private final WriteLocksRegistry writeLocksRegistry;
 
   /**
    * Constructor.
    */
   public JsonResourceStore(final User user,
+                           final WriteLocksRegistry writeLocksRegistry,
                            final PathBasedPool<ResourceManager<?, ?>> allResourceManagers) {
     super(new ConcurrentHashMap<>(), allResourceManagers, user);
+
+    this.writeLocksRegistry = writeLocksRegistry;
   }
 
   @Override
@@ -56,7 +55,7 @@ public final class JsonResourceStore extends AbstractResourceStore<JsonResourceM
       final IOStorage storage = StorageType.getStorage(resourceConfig);
       final UberPage uberPage = getUberPage(storage);
 
-      final Lock writeLock = DatabasesInternals.computeWriteLockIfAbsent(resourceConfig.getResource());
+      final Lock writeLock = this.writeLocksRegistry.getWriteLock(resourceConfig.getResource());
 
       // Create the resource manager instance.
       final JsonResourceManager resourceManager = new JsonResourceManagerImpl(database, this, resourceConfig,

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
@@ -29,6 +29,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class JsonResourceStore extends AbstractResourceStore<JsonResourceManager> {
 
+  /**
+   * This field should be use to fetch the locks for resource managers.
+   */
   private final WriteLocksRegistry writeLocksRegistry;
 
   /**

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
@@ -29,6 +29,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class XmlResourceStore extends AbstractResourceStore<XmlResourceManager> {
 
+  /**
+   * This field should be use to fetch the locks for resource managers.
+   */
   private final WriteLocksRegistry writeLocksRegistry;
 
   /**

--- a/bundles/sirix-core/src/test/java/org/sirix/access/WriteLocksRegistryTest.java
+++ b/bundles/sirix-core/src/test/java/org/sirix/access/WriteLocksRegistryTest.java
@@ -1,0 +1,88 @@
+package org.sirix.access;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Tests the behavior of {@link WriteLocksRegistry}.
+ *
+ * @author Joao Sousa
+ */
+class WriteLocksRegistryTest {
+
+    private WriteLocksRegistry registry;
+
+    @TempDir
+    private Path resourcePath;
+
+    @TempDir
+    private Path altResourcePath;
+
+    @BeforeEach
+    public void setup() {
+        this.registry = new WriteLocksRegistry();
+    }
+
+    /**
+     * Tests that calling {@link WriteLocksRegistry#getWriteLock(Path)} on
+     * an empty {@link WriteLocksRegistry} will still return a valid lock.
+     */
+    @Test
+    public final void getOnEmptyRegistryReturnsLock() {
+        assertNotNull(this.registry.getWriteLock(this.resourcePath));
+    }
+
+    /**
+     * Tests that calling {@link WriteLocksRegistry#getWriteLock(Path)} multiple
+     * times for the same resource path outputs the same object.
+     */
+    @Test
+    public final void multipleGetsOnSamePathReturnSameLock() {
+        final var lock = this.registry.getWriteLock(this.resourcePath);
+        final var sameLock = this.registry.getWriteLock(this.resourcePath);
+
+        assertSame(lock, sameLock);
+    }
+
+    /**
+     * Tests that calling {@link WriteLocksRegistry#getWriteLock(Path)} with different
+     * resource paths will lead to different locks.
+     */
+    @Test
+    public final void differentPathsCreateDifferentLocks() {
+        final var oneLock = this.registry.getWriteLock(this.resourcePath);
+        final var anotherLock = this.registry.getWriteLock(this.altResourcePath);
+
+        assertNotSame(oneLock, anotherLock);
+    }
+
+    /**
+     * Tests that calling {@link WriteLocksRegistry#getWriteLock(Path)} after
+     * {@link WriteLocksRegistry#removeWriteLock(Path)} returns a different lock that the initial one.
+     */
+    @Test
+    public final void getAfterRemoveResetsLock() {
+        final var initialLock = this.registry.getWriteLock(this.resourcePath);
+        this.registry.removeWriteLock(this.resourcePath);
+        final var anotherLock = this.registry.getWriteLock(this.resourcePath);
+
+        assertNotSame(initialLock, anotherLock);
+    }
+
+    /**
+     * Tests that calling {@link WriteLocksRegistry#removeWriteLock(Path)} on an empty
+     * {@link WriteLocksRegistry} does not throw an exception.
+     */
+    @Test
+    public final void removeOnEmptyRegistryDoesNotThrowException() {
+        this.registry.removeWriteLock(this.resourcePath);
+    }
+
+}


### PR DESCRIPTION
This patch extracts write lock management on `ResourceManager` to its own class. This class is now being registered in the central `DatabaseManager` component.