### PR TITLE
Introduce database-level subcomponent

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/AbstractResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/AbstractResourceStore.java
@@ -4,8 +4,8 @@ import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.NodeReadOnlyTrx;
 import org.sirix.api.NodeTrx;
 import org.sirix.api.ResourceManager;
-import org.sirix.io.Reader;
 import org.sirix.io.IOStorage;
+import org.sirix.io.Reader;
 import org.sirix.page.PageReference;
 import org.sirix.page.UberPage;
 
@@ -31,11 +31,11 @@ public abstract class AbstractResourceStore<R extends ResourceManager<? extends 
   protected final String databaseName;
   protected final PageTrxFactory pageTrxFactory;
 
-  public AbstractResourceStore(final ConcurrentMap<Path, R> resourceManagers,
-                              final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
-                               final User user,
-                               final String databaseName,
-                               final PageTrxFactory pageTrxFactory) {
+  protected AbstractResourceStore(final ConcurrentMap<Path, R> resourceManagers,
+                                  final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
+                                  final User user,
+                                  final String databaseName,
+                                  final PageTrxFactory pageTrxFactory) {
     this.resourceManagers = resourceManagers;
     this.allResourceManagers = allResourceManagers;
     this.user = user;
@@ -76,6 +76,7 @@ public abstract class AbstractResourceStore<R extends ResourceManager<? extends 
   @Override
   public void close() {
     resourceManagers.forEach((resourceName, resourceMgr) -> resourceMgr.close());
+    resourceManagers.clear();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
@@ -1,6 +1,8 @@
 package org.sirix.access;
 
 import dagger.Component;
+import org.sirix.access.json.JsonLocalDatabaseComponent;
+import org.sirix.access.xml.XmlLocalDatabaseComponent;
 import org.sirix.api.Database;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
@@ -15,6 +17,10 @@ import javax.inject.Singleton;
 @Component(modules = DatabaseModule.class)
 @Singleton
 public interface DatabaseManager {
+
+    JsonLocalDatabaseComponent.Builder jsonDatabaseBuilder();
+
+    XmlLocalDatabaseComponent.Builder xmlDatabaseBuilder();
 
     LocalDatabaseFactory<JsonResourceManager> jsonDatabaseFactory();
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseManager.java
@@ -18,8 +18,28 @@ import javax.inject.Singleton;
 @Singleton
 public interface DatabaseManager {
 
+    /**
+     * Creates a new Json database subcomponent.
+     *
+     * <p>This method is declare here in order to create a link between this component and
+     * {@link JsonLocalDatabaseComponent}, as parent component and sub-component, respectively.
+     * Hence, it should not be called. Use {@link #jsonDatabaseFactory()} instead.
+     *
+     * @return A builder, used to create a new json database subcomponent.
+     */
+    @SuppressWarnings("unused")
     JsonLocalDatabaseComponent.Builder jsonDatabaseBuilder();
 
+    /**
+     * Creates a new Json database subcomponent.
+     *
+     * <p>This method is declare here in order to create a link between this component and
+     * {@link XmlLocalDatabaseComponent}, as parent component and sub-component, respectively.
+     * Hence, it should not be called. Use {@link #xmlDatabaseFactory()} instead.
+     *
+     * @return A builder, used to create a new json database subcomponent.
+     */
+    @SuppressWarnings("unused")
     XmlLocalDatabaseComponent.Builder xmlDatabaseBuilder();
 
     LocalDatabaseFactory<JsonResourceManager> jsonDatabaseFactory();

--- a/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/DatabaseModule.java
@@ -3,10 +3,12 @@ package org.sirix.access;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
+import org.sirix.access.json.JsonLocalDatabaseComponent;
 import org.sirix.access.json.LocalJsonDatabaseFactory;
 import org.sirix.access.xml.LocalXmlDatabaseFactory;
 import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
+import org.sirix.access.xml.XmlLocalDatabaseComponent;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 
@@ -17,7 +19,7 @@ import javax.inject.Singleton;
  *
  * @author Joao Sousa
  */
-@Module
+@Module(subcomponents = { JsonLocalDatabaseComponent.class, XmlLocalDatabaseComponent.class})
 public interface DatabaseModule {
 
     @Binds

--- a/bundles/sirix-core/src/main/java/org/sirix/access/GenericLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/GenericLocalDatabaseComponent.java
@@ -5,7 +5,7 @@ import org.sirix.api.Database;
 import org.sirix.api.ResourceManager;
 
 /**
- * TODO: Class LocalDatabaseComponent's description.
+ * An interface that aggregates all the common logic between {@link Database} subcomponents.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/GenericLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/GenericLocalDatabaseComponent.java
@@ -1,0 +1,26 @@
+package org.sirix.access;
+
+import dagger.BindsInstance;
+import org.sirix.api.Database;
+import org.sirix.api.ResourceManager;
+
+/**
+ * TODO: Class LocalDatabaseComponent's description.
+ *
+ * @author Joao Sousa
+ */
+public interface GenericLocalDatabaseComponent<R extends ResourceManager<?, ?>> {
+
+    Database<R> database();
+
+    interface Builder<B extends Builder<B>> {
+
+        @BindsInstance
+        B databaseConfiguration(DatabaseConfiguration configuration);
+
+        @BindsInstance
+        B user(User user);
+
+        GenericLocalDatabaseComponent build();
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseModule.java
@@ -4,12 +4,13 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import org.sirix.access.trx.TransactionManagerImpl;
+import org.sirix.api.Database;
 import org.sirix.api.TransactionManager;
 import org.sirix.dagger.DatabaseName;
 import org.sirix.dagger.DatabaseScope;
 
 /**
- * TODO: Class LocalDatabaseModule's description.
+ * A module with common dependencies to all {@link Database} subcomponents.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/LocalDatabaseModule.java
@@ -1,0 +1,37 @@
+package org.sirix.access;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import org.sirix.access.trx.TransactionManagerImpl;
+import org.sirix.api.TransactionManager;
+import org.sirix.dagger.DatabaseName;
+import org.sirix.dagger.DatabaseScope;
+
+/**
+ * TODO: Class LocalDatabaseModule's description.
+ *
+ * @author Joao Sousa
+ */
+@Module
+public interface LocalDatabaseModule {
+
+    @Provides
+    @DatabaseScope
+    @DatabaseName
+    static String databaseName(final DatabaseConfiguration configuration) {
+        return configuration.getDatabaseName();
+    }
+
+    @Provides
+    @DatabaseScope
+    static DatabaseType databaseType(final DatabaseConfiguration configuration) {
+
+        return configuration.getDatabaseType();
+    }
+
+    @Binds
+    @DatabaseScope
+    TransactionManager transactionManager(TransactionManagerImpl transactionManager);
+
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseComponent.java
@@ -1,0 +1,23 @@
+package org.sirix.access.json;
+
+import dagger.Subcomponent;
+import org.sirix.access.GenericLocalDatabaseComponent;
+import org.sirix.api.json.JsonResourceManager;
+import org.sirix.dagger.DatabaseScope;
+
+/**
+ * TODO: Class JsonLocalDatabaseComponent's description.
+ *
+ * @author Joao Sousa
+ */
+@DatabaseScope
+@Subcomponent(modules = JsonLocalDatabaseModule.class)
+public interface JsonLocalDatabaseComponent extends GenericLocalDatabaseComponent<JsonResourceManager> {
+
+    @Subcomponent.Builder
+    interface Builder extends GenericLocalDatabaseComponent.Builder<Builder> {
+
+        @Override
+        JsonLocalDatabaseComponent build();
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseComponent.java
@@ -2,11 +2,12 @@ package org.sirix.access.json;
 
 import dagger.Subcomponent;
 import org.sirix.access.GenericLocalDatabaseComponent;
+import org.sirix.api.Database;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.dagger.DatabaseScope;
 
 /**
- * TODO: Class JsonLocalDatabaseComponent's description.
+ * A Dagger subcomponent that manages {@link Database json database sessions}.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseModule.java
@@ -17,7 +17,7 @@ import dagger.Module;
 import dagger.Provides;
 
 /**
- * TODO: Class JsonLocalDatabaseModule's description.
+ * The module for {@link JsonLocalDatabaseComponent}.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonLocalDatabaseModule.java
@@ -1,0 +1,49 @@
+package org.sirix.access.json;
+
+import org.sirix.access.DatabaseConfiguration;
+import org.sirix.access.LocalDatabase;
+import org.sirix.access.LocalDatabaseModule;
+import org.sirix.access.PathBasedPool;
+import org.sirix.access.ResourceStore;
+import org.sirix.access.WriteLocksRegistry;
+import org.sirix.api.Database;
+import org.sirix.api.ResourceManager;
+import org.sirix.api.TransactionManager;
+import org.sirix.api.json.JsonResourceManager;
+import org.sirix.dagger.DatabaseScope;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+
+/**
+ * TODO: Class JsonLocalDatabaseModule's description.
+ *
+ * @author Joao Sousa
+ */
+@Module(includes = LocalDatabaseModule.class)
+public interface JsonLocalDatabaseModule {
+
+    @DatabaseScope
+    @Binds
+    ResourceStore<JsonResourceManager> jsonResourceManager(JsonResourceStore jsonResourceStore);
+
+    @DatabaseScope
+    @Provides
+    static Database<JsonResourceManager> jsonDatabase(final TransactionManager transactionManager,
+                                                      final DatabaseConfiguration dbConfig,
+                                                      final PathBasedPool<Database<?>> sessions,
+                                                      final ResourceStore<JsonResourceManager> resourceStore,
+                                                      final WriteLocksRegistry writeLocks,
+                                                      final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+
+        return new LocalDatabase<>(
+                transactionManager,
+                dbConfig,
+                sessions,
+                resourceStore,
+                writeLocks,
+                resourceManagers
+        );
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/json/JsonResourceStore.java
@@ -1,7 +1,6 @@
 package org.sirix.access.json;
 
 import org.sirix.access.AbstractResourceStore;
-import org.sirix.access.DatabasesInternals;
 import org.sirix.access.PathBasedPool;
 import org.sirix.access.ResourceConfiguration;
 import org.sirix.access.User;
@@ -11,11 +10,14 @@ import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.ResourceManager;
 import org.sirix.api.json.JsonResourceManager;
 import org.sirix.cache.BufferManager;
+import org.sirix.dagger.DatabaseName;
+import org.sirix.dagger.DatabaseScope;
 import org.sirix.io.IOStorage;
 import org.sirix.io.StorageType;
 import org.sirix.page.UberPage;
 
 import javax.annotation.Nonnull;
+import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -27,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Johannes Lichtenberger
  */
+@DatabaseScope
 public final class JsonResourceStore extends AbstractResourceStore<JsonResourceManager> {
 
   /**
@@ -37,11 +40,12 @@ public final class JsonResourceStore extends AbstractResourceStore<JsonResourceM
   /**
    * Constructor.
    */
-  public JsonResourceStore(final User user,
-                           final WriteLocksRegistry writeLocksRegistry,
-                           final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
-                           final String databaseName,
-                           final PageTrxFactory pageTrxFactory) {
+  @Inject
+  JsonResourceStore(final User user,
+                    final WriteLocksRegistry writeLocksRegistry,
+                    final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
+                    @DatabaseName final String databaseName,
+                    final PageTrxFactory pageTrxFactory) {
     super(new ConcurrentHashMap<>(), allResourceManagers, user, databaseName, pageTrxFactory);
 
     this.writeLocksRegistry = writeLocksRegistry;

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/TransactionManagerImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/TransactionManagerImpl.java
@@ -3,6 +3,7 @@ package org.sirix.access.trx;
 import org.sirix.api.Transaction;
 import org.sirix.api.TransactionManager;
 
+import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -12,6 +13,7 @@ public final class TransactionManagerImpl implements TransactionManager {
 
   private final Set<Transaction> transactions;
 
+  @Inject
   public TransactionManagerImpl() {
     transactions = new HashSet<>();
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/PageTrxFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/PageTrxFactory.java
@@ -48,6 +48,7 @@ import org.sirix.page.*;
 import org.sirix.page.interfaces.Page;
 
 import javax.annotation.Nonnegative;
+import javax.inject.Inject;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,6 +64,7 @@ public final class PageTrxFactory {
 
   private final DatabaseType databaseType;
 
+  @Inject
   public PageTrxFactory(final DatabaseType databaseType) {
     this.databaseType = databaseType;
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/LocalXmlDatabaseFactory.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/LocalXmlDatabaseFactory.java
@@ -1,19 +1,15 @@
 package org.sirix.access.xml;
 
 import org.sirix.access.DatabaseConfiguration;
-import org.sirix.access.LocalDatabase;
 import org.sirix.access.LocalDatabaseFactory;
-import org.sirix.access.PathBasedPool;
 import org.sirix.access.User;
-import org.sirix.access.WriteLocksRegistry;
-import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.Database;
-import org.sirix.api.ResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 /**
@@ -29,31 +25,22 @@ public class LocalXmlDatabaseFactory implements LocalDatabaseFactory<XmlResource
      */
     private static final Logger logger = LoggerFactory.getLogger(LocalXmlDatabaseFactory.class);
 
-    private final PathBasedPool<Database<?>> sessions;
-    private final PathBasedPool<ResourceManager<?, ?>> resourceManagers;
-    private final WriteLocksRegistry writeLocks;
+    private final Provider<XmlLocalDatabaseComponent.Builder> subcomponentBuilder;
 
     @Inject
-    LocalXmlDatabaseFactory(final PathBasedPool<Database<?>> sessions,
-                            final PathBasedPool<ResourceManager<?, ?>> resourceManagers,
-                            final WriteLocksRegistry writeLocks) {
-        this.sessions = sessions;
-        this.resourceManagers = resourceManagers;
-        this.writeLocks = writeLocks;
+    LocalXmlDatabaseFactory(final Provider<XmlLocalDatabaseComponent.Builder> subcomponentBuilder) {
+
+        this.subcomponentBuilder = subcomponentBuilder;
     }
 
     @Override
     public Database<XmlResourceManager> createDatabase(final DatabaseConfiguration configuration, final User user) {
         logger.trace("Creating new local xml database");
 
-        final String databaseName = configuration.getDatabaseName();
-        final PageTrxFactory pageTrxFactory = new PageTrxFactory( configuration.getDatabaseType());
-        return new LocalDatabase<>(
-                configuration,
-                this.sessions,
-                new XmlResourceStore(user, writeLocks, resourceManagers, databaseName, pageTrxFactory),
-                writeLocks,
-                resourceManagers
-        );
+        return this.subcomponentBuilder.get()
+                .databaseConfiguration(configuration)
+                .user(user)
+                .build()
+                .database();
     }
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseComponent.java
@@ -2,11 +2,12 @@ package org.sirix.access.xml;
 
 import dagger.Subcomponent;
 import org.sirix.access.GenericLocalDatabaseComponent;
+import org.sirix.api.Database;
 import org.sirix.api.xml.XmlResourceManager;
 import org.sirix.dagger.DatabaseScope;
 
 /**
- * TODO: Class XmlLocalDatabaseComponent's description.
+ * A Dagger subcomponent that manages {@link Database xml database sessions}.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseComponent.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseComponent.java
@@ -1,0 +1,23 @@
+package org.sirix.access.xml;
+
+import dagger.Subcomponent;
+import org.sirix.access.GenericLocalDatabaseComponent;
+import org.sirix.api.xml.XmlResourceManager;
+import org.sirix.dagger.DatabaseScope;
+
+/**
+ * TODO: Class XmlLocalDatabaseComponent's description.
+ *
+ * @author Joao Sousa
+ */
+@DatabaseScope
+@Subcomponent(modules = {XmlLocalDatabaseModule.class})
+public interface XmlLocalDatabaseComponent extends GenericLocalDatabaseComponent<XmlResourceManager> {
+
+    @Subcomponent.Builder
+    interface Builder extends GenericLocalDatabaseComponent.Builder<Builder> {
+
+        @Override
+        XmlLocalDatabaseComponent build();
+    }
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseModule.java
@@ -1,0 +1,48 @@
+package org.sirix.access.xml;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import org.sirix.access.DatabaseConfiguration;
+import org.sirix.access.LocalDatabase;
+import org.sirix.access.LocalDatabaseModule;
+import org.sirix.access.PathBasedPool;
+import org.sirix.access.ResourceStore;
+import org.sirix.access.WriteLocksRegistry;
+import org.sirix.api.Database;
+import org.sirix.api.ResourceManager;
+import org.sirix.api.TransactionManager;
+import org.sirix.api.xml.XmlResourceManager;
+import org.sirix.dagger.DatabaseScope;
+
+/**
+ * TODO: Class XmlLocalDatabaseModule's description.
+ *
+ * @author Joao Sousa
+ */
+@Module(includes = LocalDatabaseModule.class)
+public interface XmlLocalDatabaseModule {
+
+    @DatabaseScope
+    @Provides
+    static Database<XmlResourceManager> xmlDatabase(final TransactionManager transactionManager,
+                                                    final DatabaseConfiguration dbConfig,
+                                                    final PathBasedPool<Database<?>> sessions,
+                                                    final ResourceStore<XmlResourceManager> resourceStore,
+                                                    final WriteLocksRegistry writeLocks,
+                                                    final PathBasedPool<ResourceManager<?, ?>> resourceManagers) {
+
+        return new LocalDatabase<>(
+                transactionManager,
+                dbConfig,
+                sessions,
+                resourceStore,
+                writeLocks,
+                resourceManagers
+        );
+    }
+
+    @DatabaseScope
+    @Binds
+    ResourceStore<XmlResourceManager> xmlResourceManager(XmlResourceStore xmlResourceStore);
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseModule.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlLocalDatabaseModule.java
@@ -16,7 +16,7 @@ import org.sirix.api.xml.XmlResourceManager;
 import org.sirix.dagger.DatabaseScope;
 
 /**
- * TODO: Class XmlLocalDatabaseModule's description.
+ * The module for {@link XmlLocalDatabaseComponent}.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/xml/XmlResourceStore.java
@@ -1,7 +1,6 @@
 package org.sirix.access.xml;
 
 import org.sirix.access.AbstractResourceStore;
-import org.sirix.access.DatabasesInternals;
 import org.sirix.access.PathBasedPool;
 import org.sirix.access.ResourceConfiguration;
 import org.sirix.access.User;
@@ -11,11 +10,14 @@ import org.sirix.access.trx.page.PageTrxFactory;
 import org.sirix.api.ResourceManager;
 import org.sirix.api.xml.XmlResourceManager;
 import org.sirix.cache.BufferManager;
+import org.sirix.dagger.DatabaseName;
+import org.sirix.dagger.DatabaseScope;
 import org.sirix.io.IOStorage;
 import org.sirix.io.StorageType;
 import org.sirix.page.UberPage;
 
 import javax.annotation.Nonnull;
+import javax.inject.Inject;
 import java.nio.file.Path;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -27,6 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * @author Johannes Lichtenberger
  */
+@DatabaseScope
 public final class XmlResourceStore extends AbstractResourceStore<XmlResourceManager> {
 
   /**
@@ -37,11 +40,12 @@ public final class XmlResourceStore extends AbstractResourceStore<XmlResourceMan
   /**
    * Constructor.
    */
-  public XmlResourceStore(final User user,
-                          final WriteLocksRegistry writeLocksRegistry,
-                          final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
-                          final String databaseName,
-                          final PageTrxFactory pageTrxFactory) {
+  @Inject
+  XmlResourceStore(final User user,
+                   final WriteLocksRegistry writeLocksRegistry,
+                   final PathBasedPool<ResourceManager<?, ?>> allResourceManagers,
+                   @DatabaseName final String databaseName,
+                   final PageTrxFactory pageTrxFactory) {
     super(new ConcurrentHashMap<>(), allResourceManagers, user, databaseName, pageTrxFactory);
 
     this.writeLocksRegistry = writeLocksRegistry;

--- a/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseName.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseName.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * TODO: Class DatabaseName's description.
+ * A Qualifier for the database name.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseName.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseName.java
@@ -1,0 +1,18 @@
+package org.sirix.dagger;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * TODO: Class DatabaseName's description.
+ *
+ * @author Joao Sousa
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+public @interface DatabaseName {
+}

--- a/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseScope.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseScope.java
@@ -7,7 +7,8 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * TODO: Class DatabaseScope's description.
+ * The dagger scope declaration for all the instances that should be exist only once in the context of a database
+ * session.
  *
  * @author Joao Sousa
  */

--- a/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseScope.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/dagger/DatabaseScope.java
@@ -1,0 +1,18 @@
+package org.sirix.dagger;
+
+import javax.inject.Scope;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * TODO: Class DatabaseScope's description.
+ *
+ * @author Joao Sousa
+ */
+@Scope
+@Documented
+@Retention(RUNTIME)
+public @interface DatabaseScope {
+}


### PR DESCRIPTION
This patch declares a database lifecycle as a [Dagger sub-component](https://dagger.dev/dev-guide/subcomponents.html).

At this point, the system's main component, `DatabaseManager` provides a set of methods, `DatabaseManager#jsonDatabaseBuilder` and `DatabaseManager#xmlDatabaseBuilder`, which are responsible for creating a new sub-component (per call) that not only inherits all the instances from the parent component, but also manages a new container of instances that represent a `Database` instance.

These two new subcomponents `JsonLocalDatabaseComponent` and `XmlLocalDatabaseComponent` will each be responsible for managing a Json and Xml database session, respectfully. Having one subcomponent type per database type prevents Xml instances from being instantiated on a Json database, and vice versa.