### PR TITLE
Remove duplicate code between Json and Xml read only transaction

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeHashing.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeHashing.java
@@ -9,12 +9,11 @@ import org.sirix.node.interfaces.Node;
 import org.sirix.node.interfaces.StructNode;
 import org.sirix.node.interfaces.immutable.ImmutableNode;
 import org.sirix.node.xml.ElementNode;
-import org.sirix.page.PageKind;
 
 import javax.annotation.Nonnegative;
 import java.math.BigInteger;
 
-public abstract class AbstractNodeHashing {
+public abstract class AbstractNodeHashing<N extends ImmutableNode> {
 
   /**
    * Prime for computing the hash.
@@ -56,12 +55,12 @@ public abstract class AbstractNodeHashing {
     this.pageTrx = pageTrx;
   }
 
-  public AbstractNodeHashing setBulkInsert(boolean value) {
+  public AbstractNodeHashing<N> setBulkInsert(final boolean value) {
     this.bulkInsert = value;
     return this;
   }
 
-  public AbstractNodeHashing setAutoCommit(boolean value) {
+  public AbstractNodeHashing<N> setAutoCommit(final boolean value) {
     this.autoCommit = value;
     return this;
   }
@@ -144,7 +143,7 @@ public abstract class AbstractNodeHashing {
    */
   private void postorderAdd() {
     // start with hash to add
-    final ImmutableNode startNode = getCurrentNode();
+    final N startNode = getCurrentNode();
     // long for adapting the hash of the parent
     BigInteger hashCodeForParent = BigInteger.ZERO;
     // adapting the parent if the current node is no structural one.
@@ -193,9 +192,9 @@ public abstract class AbstractNodeHashing {
 
   protected abstract StructNode getStructuralNode();
 
-  protected abstract ImmutableNode getCurrentNode();
+  protected abstract N getCurrentNode();
 
-  protected abstract void setCurrentNode(ImmutableNode node);
+  protected abstract void setCurrentNode(N node);
 
   /**
    * Adapting the structure with a rolling hash for all ancestors only with update.
@@ -204,7 +203,7 @@ public abstract class AbstractNodeHashing {
    * @throws SirixIOException if anything weird happened
    */
   private void rollingUpdate(final BigInteger oldHash) {
-    final ImmutableNode newNode = getCurrentNode();
+    final var newNode = getCurrentNode();
     final BigInteger hash = newNode.computeHash();
     BigInteger resultNew;
 
@@ -228,7 +227,7 @@ public abstract class AbstractNodeHashing {
    * Adapting the structure with a rolling hash for all ancestors only with remove.
    */
   private void rollingRemove() {
-    final ImmutableNode startNode = getCurrentNode();
+    final N startNode = getCurrentNode();
     BigInteger hashToRemove = startNode.getHash();
     BigInteger hashToAdd = BigInteger.ZERO;
     BigInteger newHash;
@@ -277,7 +276,7 @@ public abstract class AbstractNodeHashing {
    */
   private void rollingAdd() {
     // start with hash to add
-    final ImmutableNode startNode = getCurrentNode();
+    final var startNode = getCurrentNode();
     final long oldDescendantCount = getStructuralNode().getDescendantCount();
     final long descendantCount = oldDescendantCount == 0 ? 1 : oldDescendantCount + 1;
     BigInteger hashToAdd = startNode.getHash() == null || BigInteger.ZERO.equals(startNode.getHash())
@@ -349,7 +348,7 @@ public abstract class AbstractNodeHashing {
     switch (hashType) {
       case ROLLING:
         // Setup.
-        final ImmutableNode startNode = getCurrentNode();
+        final var startNode = getCurrentNode();
         final long oldDescendantCount = getStructuralNode().getDescendantCount();
         final long descendantCount = oldDescendantCount == 0 ? 1 : oldDescendantCount + 1;
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeHashing.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeHashing.java
@@ -143,7 +143,7 @@ public abstract class AbstractNodeHashing<N extends ImmutableNode> {
    */
   private void postorderAdd() {
     // start with hash to add
-    final N startNode = getCurrentNode();
+    final var startNode = getCurrentNode();
     // long for adapting the hash of the parent
     BigInteger hashCodeForParent = BigInteger.ZERO;
     // adapting the parent if the current node is no structural one.
@@ -227,7 +227,7 @@ public abstract class AbstractNodeHashing<N extends ImmutableNode> {
    * Adapting the structure with a rolling hash for all ancestors only with remove.
    */
   private void rollingRemove() {
-    final N startNode = getCurrentNode();
+    final var startNode = getCurrentNode();
     BigInteger hashToRemove = startNode.getHash();
     BigInteger hashToAdd = BigInteger.ZERO;
     BigInteger newHash;

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -333,7 +333,7 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
    * @return structural node instance of current node
    */
   public final StructNode getStructuralNode() {
-    final N node = getCurrentNode();
+    final var node = getCurrentNode();
     if (node instanceof StructNode) {
       return (StructNode) node;
     } else {
@@ -565,7 +565,8 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     }
 
     final AbstractNodeReadOnlyTrx<?, ?, ?> that = (AbstractNodeReadOnlyTrx<?, ?, ?>) o;
-    return pageReadOnlyTrx.equals(that.pageReadOnlyTrx) && currentNode.equals(that.currentNode);
+    return currentNode.getNodeKey() == that.currentNode.getNodeKey()
+            && pageReadOnlyTrx.getRevisionNumber() == that.pageReadOnlyTrx.getRevisionNumber();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/InternalNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/InternalNodeReadOnlyTrx.java
@@ -4,10 +4,10 @@ import org.sirix.api.PageReadOnlyTrx;
 import org.sirix.node.interfaces.StructNode;
 import org.sirix.node.interfaces.immutable.ImmutableNode;
 
-public interface InternalNodeReadOnlyTrx {
-  ImmutableNode getCurrentNode();
+public interface InternalNodeReadOnlyTrx<N extends ImmutableNode> {
+  N getCurrentNode();
 
-  void setCurrentNode(ImmutableNode node);
+  void setCurrentNode(N node);
 
   StructNode getStructuralNode();
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/InternalNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/InternalNodeReadOnlyTrx.java
@@ -1,11 +1,10 @@
 package org.sirix.access.trx.node;
 
 import org.sirix.api.PageReadOnlyTrx;
-import org.sirix.api.json.JsonNodeReadOnlyTrx;
 import org.sirix.node.interfaces.StructNode;
 import org.sirix.node.interfaces.immutable.ImmutableNode;
 
-public interface InternalNodeReadOnlyTrx extends JsonNodeReadOnlyTrx {
+public interface InternalNodeReadOnlyTrx {
   ImmutableNode getCurrentNode();
 
   void setCurrentNode(ImmutableNode node);

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeReadOnlyTrx.java
@@ -2,7 +2,8 @@ package org.sirix.access.trx.node.json;
 
 import org.sirix.access.trx.node.InternalNodeReadOnlyTrx;
 import org.sirix.api.json.JsonNodeReadOnlyTrx;
+import org.sirix.node.interfaces.immutable.ImmutableNode;
 
-public interface InternalJsonNodeReadOnlyTrx extends InternalNodeReadOnlyTrx, JsonNodeReadOnlyTrx {
+public interface InternalJsonNodeReadOnlyTrx extends InternalNodeReadOnlyTrx<ImmutableNode>, JsonNodeReadOnlyTrx {
 
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeReadOnlyTrx.java
@@ -1,18 +1,8 @@
 package org.sirix.access.trx.node.json;
 
 import org.sirix.access.trx.node.InternalNodeReadOnlyTrx;
-import org.sirix.api.PageReadOnlyTrx;
-import org.sirix.node.interfaces.StructNode;
-import org.sirix.node.interfaces.immutable.ImmutableNode;
+import org.sirix.api.json.JsonNodeReadOnlyTrx;
 
-public interface InternalJsonNodeReadOnlyTrx extends InternalNodeReadOnlyTrx {
-  ImmutableNode getCurrentNode();
+public interface InternalJsonNodeReadOnlyTrx extends InternalNodeReadOnlyTrx, JsonNodeReadOnlyTrx {
 
-  void setCurrentNode(ImmutableNode node);
-
-  StructNode getStructuralNode();
-
-  void assertNotClosed();
-
-  void setPageReadTransaction(PageReadOnlyTrx trx);
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/InternalJsonNodeTrx.java
@@ -7,5 +7,4 @@ public interface InternalJsonNodeTrx extends JsonNodeTrx {
 
   void adaptHashesInPostorderTraversal();
 
-  JsonNodeTrx doCommit(String commitMessage);
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonNodeHashing.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonNodeHashing.java
@@ -3,12 +3,10 @@ package org.sirix.access.trx.node.json;
 import org.sirix.access.trx.node.AbstractNodeHashing;
 import org.sirix.access.trx.node.HashType;
 import org.sirix.api.PageTrx;
-import org.sirix.node.interfaces.DataRecord;
 import org.sirix.node.interfaces.StructNode;
 import org.sirix.node.interfaces.immutable.ImmutableNode;
-import org.sirix.page.UnorderedKeyValuePage;
 
-final class JsonNodeHashing extends AbstractNodeHashing {
+final class JsonNodeHashing extends AbstractNodeHashing<ImmutableNode> {
 
   private final InternalJsonNodeReadOnlyTrx nodeReadOnlyTrx;
 
@@ -36,7 +34,7 @@ final class JsonNodeHashing extends AbstractNodeHashing {
   }
 
   @Override
-  protected void setCurrentNode(ImmutableNode node) {
+  protected void setCurrentNode(final ImmutableNode node) {
     nodeReadOnlyTrx.setCurrentNode(node);
   }
 

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonNodeReadOnlyTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonNodeReadOnlyTrxImpl.java
@@ -63,8 +63,8 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonNodeReadOnlyTrx, JsonNodeTrx>
-    implements InternalJsonNodeReadOnlyTrx {
+public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonNodeReadOnlyTrx, JsonNodeTrx,
+        ImmutableNode> implements InternalJsonNodeReadOnlyTrx {
 
   /**
    * Constructor.
@@ -221,6 +221,8 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   @Override
   public String getValue() {
     assertNotClosed();
+
+    final var currentNode = getCurrentNode();
     // $CASES-OMITTED$
     return switch (currentNode.getKind()) {
       case OBJECT_STRING_VALUE, STRING_VALUE -> new String(((ValueNode) currentNode).getRawValue(),
@@ -242,6 +244,8 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   @Override
   public boolean getBooleanValue() {
     assertNotClosed();
+
+    final var currentNode = getCurrentNode();
     if (currentNode.getKind() == NodeKind.BOOLEAN_VALUE)
       return ((BooleanNode) currentNode).getValue();
     else if (currentNode.getKind() == NodeKind.OBJECT_BOOLEAN_VALUE)
@@ -252,6 +256,7 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   @Override
   public Number getNumberValue() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     if (currentNode.getKind() == NodeKind.NUMBER_VALUE)
       return ((NumberNode) currentNode).getValue();
     else if (currentNode.getKind() == NodeKind.OBJECT_NUMBER_VALUE)
@@ -269,6 +274,7 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   public ImmutableNode getNode() {
     assertNotClosed();
 
+    final var currentNode = getCurrentNode();
     // $CASES-OMITTED$
     return switch (currentNode.getKind()) {
       case OBJECT -> ImmutableObjectNode.of((ObjectNode) currentNode);
@@ -290,42 +296,46 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   @Override
   public boolean isArray() {
     assertNotClosed();
-    return currentNode.getKind() == NodeKind.ARRAY;
+    return getCurrentNode().getKind() == NodeKind.ARRAY;
   }
 
   @Override
   public boolean isObject() {
     assertNotClosed();
-    return currentNode.getKind() == NodeKind.OBJECT;
+    return getCurrentNode().getKind() == NodeKind.OBJECT;
   }
 
   @Override
   public boolean isObjectKey() {
     assertNotClosed();
-    return currentNode.getKind() == NodeKind.OBJECT_KEY;
+    return getCurrentNode().getKind() == NodeKind.OBJECT_KEY;
   }
 
   @Override
   public boolean isNumberValue() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     return currentNode.getKind() == NodeKind.NUMBER_VALUE || currentNode.getKind() == NodeKind.OBJECT_NUMBER_VALUE;
   }
 
   @Override
   public boolean isNullValue() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     return currentNode.getKind() == NodeKind.NULL_VALUE || currentNode.getKind() == NodeKind.OBJECT_NULL_VALUE;
   }
 
   @Override
   public boolean isStringValue() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     return currentNode.getKind() == NodeKind.STRING_VALUE || currentNode.getKind() == NodeKind.OBJECT_STRING_VALUE;
   }
 
   @Override
   public boolean isBooleanValue() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     return currentNode.getKind() == NodeKind.BOOLEAN_VALUE || currentNode.getKind() == NodeKind.OBJECT_BOOLEAN_VALUE;
   }
 
@@ -337,6 +347,7 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   @Override
   public boolean isDocumentRoot() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     return currentNode.getKind() == NodeKind.JSON_DOCUMENT;
   }
 
@@ -344,6 +355,7 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   public QNm getName() {
     assertNotClosed();
 
+    final var currentNode = getCurrentNode();
     if (currentNode.getKind() == NodeKind.OBJECT_KEY) {
       final int nameKey = ((ObjectKeyNode) currentNode).getNameKey();
       final String localName = nameKey == -1 ? "" : pageReadOnlyTrx.getName(nameKey, currentNode.getKind());
@@ -354,14 +366,15 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
   }
 
   @Override
-  public VisitResult acceptVisitor(JsonNodeVisitor visitor) {
+  public VisitResult acceptVisitor(final JsonNodeVisitor visitor) {
     assertNotClosed();
-    return ((ImmutableJsonNode) currentNode).acceptVisitor(visitor);
+    return ((ImmutableJsonNode) getCurrentNode()).acceptVisitor(visitor);
   }
 
   @Override
   public int getNameKey() {
     assertNotClosed();
+    final var currentNode = getCurrentNode();
     if (currentNode.getKind() == NodeKind.OBJECT_KEY) {
       return ((ObjectKeyNode) currentNode).getNameKey();
     }
@@ -373,6 +386,7 @@ public final class JsonNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<JsonN
     final MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this);
     helper.add("Revision number", getRevisionNumber());
 
+    final var currentNode = getCurrentNode();
     if (currentNode.getKind() == NodeKind.OBJECT_KEY) {
       helper.add("Name of Node", getName().toString());
     }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonResourceManagerImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/json/JsonResourceManagerImpl.java
@@ -102,7 +102,9 @@ public final class JsonResourceManagerImpl extends AbstractResourceManager<JsonN
   }
 
   @Override
-  public JsonNodeReadOnlyTrx createNodeReadOnlyTrx(long nodeTrxId, PageReadOnlyTrx pageReadTrx, Node documentNode) {
+  public InternalJsonNodeReadOnlyTrx createNodeReadOnlyTrx(long nodeTrxId,
+                                                           PageReadOnlyTrx pageReadTrx,
+                                                           Node documentNode) {
     return new JsonNodeReadOnlyTrxImpl(this, nodeTrxId, pageReadTrx, (ImmutableJsonNode) documentNode);
   }
 
@@ -110,8 +112,7 @@ public final class JsonResourceManagerImpl extends AbstractResourceManager<JsonN
   public JsonNodeTrx createNodeReadWriteTrx(long nodeTrxId, PageTrx pageTrx, int maxNodeCount, TimeUnit timeUnit,
       int maxTime, Node documentNode, AfterCommitState afterCommitState) {
     // The node read-only transaction.
-    final InternalJsonNodeReadOnlyTrx nodeReadOnlyTrx =
-        new JsonNodeReadOnlyTrxImpl(this, nodeTrxId, pageTrx, (ImmutableJsonNode) documentNode);
+    final InternalJsonNodeReadOnlyTrx nodeReadOnlyTrx = createNodeReadOnlyTrx(nodeTrxId, pageTrx, documentNode);
 
     // Node factory.
     final JsonNodeFactory nodeFactory = new JsonNodeFactoryImpl(getResourceConfig().nodeHashFunction, pageTrx);

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
@@ -1,18 +1,8 @@
 package org.sirix.access.trx.node.xml;
 
-import org.sirix.api.PageReadOnlyTrx;
+import org.sirix.access.trx.node.InternalNodeReadOnlyTrx;
 import org.sirix.api.xml.XmlNodeReadOnlyTrx;
-import org.sirix.node.interfaces.StructNode;
-import org.sirix.node.interfaces.immutable.ImmutableXmlNode;
 
-public interface InternalXmlNodeReadOnlyTrx extends XmlNodeReadOnlyTrx {
-  ImmutableXmlNode getCurrentNode();
+public interface InternalXmlNodeReadOnlyTrx extends InternalNodeReadOnlyTrx, XmlNodeReadOnlyTrx {
 
-  void setCurrentNode(ImmutableXmlNode node);
-
-  StructNode getStructuralNode();
-
-  void assertNotClosed();
-
-  void setPageReadTransaction(PageReadOnlyTrx trx);
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
@@ -2,7 +2,10 @@ package org.sirix.access.trx.node.xml;
 
 import org.sirix.access.trx.node.InternalNodeReadOnlyTrx;
 import org.sirix.api.xml.XmlNodeReadOnlyTrx;
+import org.sirix.node.interfaces.immutable.ImmutableXmlNode;
 
 public interface InternalXmlNodeReadOnlyTrx extends InternalNodeReadOnlyTrx, XmlNodeReadOnlyTrx {
 
+    @Override
+    ImmutableXmlNode getCurrentNode();
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/InternalXmlNodeReadOnlyTrx.java
@@ -4,8 +4,6 @@ import org.sirix.access.trx.node.InternalNodeReadOnlyTrx;
 import org.sirix.api.xml.XmlNodeReadOnlyTrx;
 import org.sirix.node.interfaces.immutable.ImmutableXmlNode;
 
-public interface InternalXmlNodeReadOnlyTrx extends InternalNodeReadOnlyTrx, XmlNodeReadOnlyTrx {
+public interface InternalXmlNodeReadOnlyTrx extends InternalNodeReadOnlyTrx<ImmutableXmlNode>, XmlNodeReadOnlyTrx {
 
-    @Override
-    ImmutableXmlNode getCurrentNode();
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeHashing.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeHashing.java
@@ -3,13 +3,10 @@ package org.sirix.access.trx.node.xml;
 import org.sirix.access.trx.node.AbstractNodeHashing;
 import org.sirix.access.trx.node.HashType;
 import org.sirix.api.PageTrx;
-import org.sirix.node.interfaces.DataRecord;
 import org.sirix.node.interfaces.StructNode;
-import org.sirix.node.interfaces.immutable.ImmutableNode;
 import org.sirix.node.interfaces.immutable.ImmutableXmlNode;
-import org.sirix.page.UnorderedKeyValuePage;
 
-final class XmlNodeHashing extends AbstractNodeHashing {
+final class XmlNodeHashing extends AbstractNodeHashing<ImmutableXmlNode> {
 
   private final InternalXmlNodeReadOnlyTrx nodeReadOnlyTrx;
 
@@ -32,13 +29,13 @@ final class XmlNodeHashing extends AbstractNodeHashing {
   }
 
   @Override
-  protected ImmutableNode getCurrentNode() {
+  protected ImmutableXmlNode getCurrentNode() {
     return nodeReadOnlyTrx.getCurrentNode();
   }
 
   @Override
-  protected void setCurrentNode(ImmutableNode node) {
-    nodeReadOnlyTrx.setCurrentNode((ImmutableXmlNode) node);
+  protected void setCurrentNode(final ImmutableXmlNode node) {
+    nodeReadOnlyTrx.setCurrentNode(node);
   }
 
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
@@ -67,12 +67,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Node reading transaction with single-threaded cursor semantics. Each reader is bound to a given
  * revision.
  */
 public final class XmlNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<XmlNodeReadOnlyTrx, XmlNodeTrx>
     implements InternalXmlNodeReadOnlyTrx {
+
+  /**
+   * Current node as an xml node.
+   */
+  private final ImmutableXmlNode currentNode;
 
   /**
    * Constructor.
@@ -83,9 +90,12 @@ public final class XmlNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<XmlNod
    * @param documentNode the document node
    */
   XmlNodeReadOnlyTrxImpl(final InternalResourceManager<XmlNodeReadOnlyTrx, XmlNodeTrx> resourceManager,
-      final @Nonnegative long trxId, final PageReadOnlyTrx pageReadTransaction, final ImmutableXmlNode documentNode) {
+                         final @Nonnegative long trxId,
+                         final PageReadOnlyTrx pageReadTransaction,
+                         final ImmutableXmlNode documentNode) {
     super(trxId, pageReadTransaction, documentNode, resourceManager, new ItemListImpl());
 
+    this.currentNode = checkNotNull(documentNode);
   }
 
   @Override
@@ -516,4 +526,8 @@ public final class XmlNodeReadOnlyTrxImpl extends AbstractNodeReadOnlyTrx<XmlNod
     return (XmlResourceManager) resourceManager;
   }
 
+  @Override
+  public ImmutableXmlNode getCurrentNode() {
+    return this.currentNode;
+  }
 }

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
@@ -367,7 +367,7 @@ final class XmlNodeTrxImpl extends AbstractForwardingXmlNodeReadOnlyTrx implemen
    * @return {@link Node} implementation
    */
   private ImmutableXmlNode getCurrentNode() {
-    return (ImmutableXmlNode) nodeReadOnlyTrx.getCurrentNode();
+    return nodeReadOnlyTrx.getCurrentNode();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
@@ -367,7 +367,7 @@ final class XmlNodeTrxImpl extends AbstractForwardingXmlNodeReadOnlyTrx implemen
    * @return {@link Node} implementation
    */
   private ImmutableXmlNode getCurrentNode() {
-    return nodeReadOnlyTrx.getCurrentNode();
+    return (ImmutableXmlNode) nodeReadOnlyTrx.getCurrentNode();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/org/sirix/api/NodeTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/api/NodeTrx.java
@@ -5,10 +5,9 @@ import org.sirix.api.xml.XmlNodeReadOnlyTrx;
 import org.sirix.exception.SirixException;
 import org.sirix.exception.SirixIOException;
 import org.sirix.index.path.summary.PathSummaryReader;
-import org.sirix.node.interfaces.DataRecord;
-import org.sirix.page.UnorderedKeyValuePage;
 
 import javax.annotation.Nonnegative;
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 public interface NodeTrx extends NodeReadOnlyTrx, AutoCloseable {
@@ -30,7 +29,7 @@ public interface NodeTrx extends NodeReadOnlyTrx, AutoCloseable {
    * @return NodeTrx return current instance
    * @throws SirixException if this revision couldn't be committed
    */
-  NodeTrx commit(String commitMessage);
+  NodeTrx commit(@Nullable String commitMessage);
 
   /**
    * Rollback all modifications of the exclusive write transaction.

--- a/bundles/sirix-core/src/main/java/org/sirix/api/PageTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/api/PageTrx.java
@@ -8,12 +8,12 @@ import org.sirix.exception.SirixIOException;
 import org.sirix.index.IndexType;
 import org.sirix.node.NodeKind;
 import org.sirix.node.interfaces.DataRecord;
-import org.sirix.page.PageKind;
 import org.sirix.page.PageReference;
 import org.sirix.page.UberPage;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Interface for writing pages to disk and to create in-memory records.
@@ -108,7 +108,7 @@ public interface PageTrx extends PageReadOnlyTrx {
    * @return UberPage the revision after commit
    * @throws SirixException if Sirix fails to commit
    */
-  UberPage commit(String commitMessage);
+  UberPage commit(@Nullable String commitMessage);
 
   /**
    * Committing a {@link PageTrx}. This method is recursively invoked by all {@link PageReference}s.


### PR DESCRIPTION
Summary:
This commit pushes all the encoding agnonstic logic of read-only transactions to
AbstractNodeReadOnlyTrx.