### PR TITLE
Removes redudant revision field in UberPage

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/api/ResourceManager.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/api/ResourceManager.java
@@ -101,7 +101,9 @@ public interface ResourceManager<R extends NodeReadOnlyTrx & NodeCursor, W exten
    *
    * @return new {@link PageReadOnlyTrx} instance
    */
-  PageReadOnlyTrx beginPageReadOnlyTrx();
+  default PageReadOnlyTrx beginPageReadOnlyTrx() {
+    return beginPageReadOnlyTrx(getMostRecentRevisionNumber());
+  }
 
   /**
    * Begin a new {@link PageReadOnlyTrx}.
@@ -118,7 +120,9 @@ public interface ResourceManager<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * @return new {@link PageTrx} instance
    * @throws SirixException if Sirix fails to create a new instance
    */
-  PageTrx beginPageTrx();
+  default PageTrx beginPageTrx() {
+    return beginPageTrx(getMostRecentRevisionNumber());
+  }
 
   /**
    * Begin a new {@link PageTrx}.
@@ -136,7 +140,9 @@ public interface ResourceManager<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * @return instance of a class, which implements the {@link XmlNodeReadOnlyTrx} interface
    * @throws SirixException if can't begin Read Transaction
    */
-  R beginNodeReadOnlyTrx();
+  default R beginNodeReadOnlyTrx() {
+    return beginNodeReadOnlyTrx(getMostRecentRevisionNumber());
+  }
 
   /**
    * Begin a read-only transaction on the given revision number.
@@ -273,7 +279,9 @@ public interface ResourceManager<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * @return {@link PathSummaryReader} instance
    * @throws SirixException if can't open path summary
    */
-  PathSummaryReader openPathSummary();
+  default PathSummaryReader openPathSummary() {
+    return openPathSummary(getMostRecentRevisionNumber());
+  }
 
   /**
    * Get the revision number, which was committed at the closest time to the given point in time.

--- a/bundles/sirix-core/src/main/java/org/sirix/page/RevisionRootPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/RevisionRootPage.java
@@ -376,7 +376,7 @@ public final class RevisionRootPage extends AbstractForwardingPage {
    */
   @Override
   public void commit(@Nonnull final PageTrx pageWriteTrx) {
-    if (revision == pageWriteTrx.getUberPage().getRevision()) {
+    if (revision == pageWriteTrx.getUberPage().getRevisionNumber()) {
       super.commit(pageWriteTrx);
     }
   }

--- a/bundles/sirix-core/src/main/java/org/sirix/page/UberPage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/page/UberPage.java
@@ -68,11 +68,6 @@ public final class UberPage extends AbstractForwardingPage {
   private RevisionRootPage rootPage;
 
   /**
-   * The current most recent revision
-   */
-  private final int revision;
-
-  /**
    * Key to previous uberpage in persistent storage.
    */
   private long previousUberPageKey;
@@ -87,7 +82,6 @@ public final class UberPage extends AbstractForwardingPage {
    */
   public UberPage() {
     delegate = new ReferencesPage4();
-    revision = Constants.UBP_ROOT_REVISION_NUMBER;
     revisionCount = Constants.UBP_ROOT_REVISION_COUNT;
     isBootstrap = true;
     previousUberPageKey = -1;
@@ -106,7 +100,6 @@ public final class UberPage extends AbstractForwardingPage {
     revisionCount = in.readInt();
     if (in.readBoolean())
       previousUberPageKey = in.readLong();
-    revision = revisionCount == 0 ? 0 : revisionCount - 1;
     isBootstrap = false;
     rootPage = null;
     currentMaxLevelOfIndirectPages = in.readByte() & 0xFF;
@@ -128,12 +121,10 @@ public final class UberPage extends AbstractForwardingPage {
     }
     this.previousUberPageKey = previousUberPageKey;
     if (committedUberPage.isBootstrap()) {
-      revision = committedUberPage.revision;
       revisionCount = committedUberPage.revisionCount;
       isBootstrap = committedUberPage.isBootstrap;
       rootPage = committedUberPage.rootPage;
     } else {
-      revision = committedUberPage.revision + 1;
       revisionCount = committedUberPage.revisionCount + 1;
       isBootstrap = false;
       rootPage = null;
@@ -283,15 +274,6 @@ public final class UberPage extends AbstractForwardingPage {
         throw new IllegalStateException("page kind not known!");
     }
     return inpLevelPageCountExp;
-  }
-
-  /**
-   * Get the revision number.
-   *
-   * @return revision number
-   */
-  public int getRevision() {
-    return revision;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/org/sirix/settings/VersioningType.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/settings/VersioningType.java
@@ -135,7 +135,7 @@ public enum VersioningType {
       assert pages.size() <= 2;
       final T firstPage = pages.get(0);
       final long recordPageKey = firstPage.getPageKey();
-      final int revision = pageReadTrx.getUberPage().getRevision();
+      final int revision = pageReadTrx.getUberPage().getRevisionNumber();
       final List<T> returnVal = new ArrayList<>(2);
 
       reference.setPageFragments(List.of(new PageFragmentKeyImpl(pageReadTrx.getRevisionNumber(), reference.getKey())));


### PR DESCRIPTION
Removes the redundant `org.sirix.page.UberPage#getRevision` and correspondent field. Also, pull some of the methods related to last committed revision up to the interface, as their default implementation is straightforward enough to live there.