### PR TITLE
Fix XMLInputFactory vulnerability

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/service/xml/shredder/WikipediaImport.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/service/xml/shredder/WikipediaImport.java
@@ -131,6 +131,8 @@ public final class WikipediaImport implements Import<StartElement> {
   public WikipediaImport(final Path xmlFile, final Path sirixDatabase) throws SirixException {
     mPageEvents = new ArrayDeque<>();
     final XMLInputFactory xmlif = XMLInputFactory.newInstance();
+    xmlif.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+
     try {
       mReader = xmlif.createXMLEventReader(new FileInputStream(checkNotNull(xmlFile.toFile())));
     } catch (XMLStreamException | FileNotFoundException e) {


### PR DESCRIPTION
This commit fixes a potential vulnerability detected by SonarCloud. SonarCloud recommends disabling DOCTYPE declerations when constructing the XMLInputFactory to resolve the problem