### PR TITLE
Fix unnecessary allocation of CompletableFuture

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/NodePageReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/access/trx/page/NodePageReadOnlyTrx.java
@@ -544,11 +544,9 @@ public final class NodePageReadOnlyTrx implements PageReadOnlyTrx {
   private <V, T extends KeyValuePage<? extends V>> List<T> getPreviousPageFragments(
       final Collection<PageFragmentKey> pageFragments) {
     final var pages = pageFragments.stream()
-                                   .map(CompletableFuture::completedFuture)
-                                   .map(future -> future.thenApplyAsync(pageFragmentKey -> (T) readPage(pageFragmentKey),
-                                                                        pool))
-                                   .collect(Collectors.toList());
-
+                                                          .map((pageFragmentKey) -> CompletableFuture.supplyAsync(() ->
+                                                                  (T) readPage(pageFragmentKey), pool))
+                                                          .collect(Collectors.toList());
     return sequence(pages).join()
                           .stream()
                           .sorted(Comparator.<T, Integer>comparing(KeyValuePage::getRevision).reversed())


### PR DESCRIPTION
Hello!

I spotted unnecessary CompletableFuture allocation in the `getPreviousPageFragments` method. I think it is safe to get rid of it.