### PR TITLE
Make working with ByteBuffer more safe

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/filechannel/FileChannelReader.java
@@ -128,8 +128,7 @@ public final class FileChannelReader implements Reader {
           // Must not happen.
             throw new IllegalStateException();
       }
-
-      buffer.position(0);
+      buffer.flip();
       final int dataLength = buffer.getInt();
 
       //      reference.setLength(dataLength + FileChannelReader.OTHER_BEACON);
@@ -138,7 +137,7 @@ public final class FileChannelReader implements Reader {
       buffer = ByteBuffer.allocate(dataLength).order(ByteOrder.nativeOrder());
 
       dataFileChannel.read(buffer, position + 4);
-      buffer.position(0);
+      buffer.flip();
       buffer.get(page);
 
       // Perform byte operations.
@@ -165,13 +164,13 @@ public final class FileChannelReader implements Reader {
 
       ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
       dataFileChannel.read(buffer, dataFileOffset);
-      buffer.position(0);
+      buffer.flip();
       final int dataLength = buffer.getInt();
       final byte[] page = new byte[dataLength];
 
       buffer = ByteBuffer.allocate(dataLength).order(ByteOrder.nativeOrder());
       dataFileChannel.read(buffer, dataFileOffset + 4);
-      buffer.position(0);
+      buffer.flip();
       buffer.get(page);
 
       // Perform byte operations.


### PR DESCRIPTION
I noticed that it is possible to make working with ByteBuffer safer.

Imagine a situation where you read fewer bytes than expected, then simply calling `position(0)` and trying to retrieve the read data will probably result in getting incorrect data because that buffer's **limit** will still be the buffer **size.**

However, if you use `flip()`, the buffer **limit** is set to its current **position** (equal to the number of bytes read) and **position** to 0. So, an exception will occur if you try to get more bytes from the buffer than were read.