### PR TITLE
ci: Cache gradle dependencies

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,10 +25,20 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '19'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew clean build --info --stacktrace --refresh-dependencies
+      - name: Stop gradle daemon
+        run: gradlew --stop
       - name: run python client tests
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew clean build --info --stacktrace --refresh-dependencies
       - name: Stop gradle daemon
-        run: gradlew --stop
+        run: ./gradlew --stop
       - name: run python client tests
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Uses actions/cache to cache Gradle dependencies to speed up CI runs. Also stops the Gradle daemon at the end of the job so the cache can be built in the post-workflow steps.

See https://github.com/actions/cache/blob/main/examples.md#java---gradle