### PR TITLE
Add healthcheck to verify if keycloak is up before running server.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - "-bmanagement 0.0.0.0"
     networks:
       - auth-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
   server:
     build: .
     image: sirixdb/sirix
@@ -32,7 +37,8 @@ services:
       - ./bundles/sirix-rest-api/src/main/resources/sirix-conf.json:/opt/sirix/sirix-conf.json
       - ./bundles/sirix-rest-api/src/test/resources/logback-test.xml:/opt/sirix/logback-test.xml
     depends_on:
-      - keycloak
+      keycloak:
+        condition: service_healthy
     networks:
       - auth-network
     links:


### PR DESCRIPTION
Added healthcheck to make sirix server wait until keycloak is completely up and running. Fixes sirixdb/sirix#549