### PR TITLE
Change io_uring configuration

### DIFF
--- a/bundles/sirix-core/src/main/java/org/sirix/io/iouring/IOUringStorage.java
+++ b/bundles/sirix-core/src/main/java/org/sirix/io/iouring/IOUringStorage.java
@@ -48,7 +48,9 @@ public final class IOUringStorage implements IOStorage {
   private final AsyncCache<Integer, RevisionFileData> cache;
 
   private static final EventExecutor eventExecutor =
-      EventExecutor.builder().entries(1024).ioRingSetupSqPoll(1_000).build();
+      EventExecutor.builder()
+              .entries(1024)
+              .build();
 
   private AsyncFile dataFile;
 

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -41,7 +41,7 @@ implLibraries = [
         chronicleBytes              : 'net.openhft:chronicle-bytes:2.22.24',
         fastUtil                    : 'it.unimi.dsi:fastutil:8.5.8',
         amazonCorettoCryptoProvider : 'software.amazon.cryptools:AmazonCorrettoCryptoProvider:1.6.1:linux-x86_64',
-        iouring                     : 'one.jasyncfio:jasyncfio:0.0.6:linux-amd64'
+        iouring                     : 'one.jasyncfio:jasyncfio:0.0.7:linux-amd64'
 ]
 
 testLibraries = [


### PR DESCRIPTION
I suggest using this jasyncfio configuration for now.

In this configuration, using io_uring the testChicago on my machine is consistently slightly (about 20 sec) faster than the other I/O backend.

To further optimize, I would go in the direction of reducing allocation per operation, namely to implement reading via io_uring ring buffer feature.

Also, updated jasyncfio to the latest version.