### PR TITLE
Refactoring of JSONCreate and XMLCreate to extract common logic

### DIFF
--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/SirixVerticle.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/SirixVerticle.kt
@@ -213,17 +213,17 @@ class SirixVerticle : CoroutineVerticle() {
             GetHandler(location, keycloak, authz).handle(it)
         }
 
-        put("/:database").consumes("application/xml").coroutineHandler {
+        put("/:database").coroutineHandler {
             Auth(keycloak, authz, AuthRole.CREATE).handle(it)
             it.next()
         }.handler(BodyHandler.create()).coroutineHandler {
-            XmlCreate(location, false).handle(it)
+            CreateHandler(location, false).handle(it)
         }
-        put("/:database").consumes("application/json").coroutineHandler {
+        put("/:database").coroutineHandler {
             Auth(keycloak, authz, AuthRole.CREATE).handle(it)
             it.next()
         }.coroutineHandler {
-            JsonCreate(location, true).handle(it)
+            CreateHandler(location, true).handle(it)
         }
 
         delete("/:database").coroutineHandler {

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/CreateHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/CreateHandler.kt
@@ -1,0 +1,115 @@
+package org.sirix.rest.crud
+
+import io.vertx.core.Context
+import io.vertx.core.Promise
+import io.vertx.core.http.HttpHeaders
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.sirix.access.DatabaseConfiguration
+import org.sirix.access.DatabaseType
+import org.sirix.access.Databases
+import org.sirix.access.ResourceConfiguration
+import org.sirix.access.trx.node.HashType
+import org.sirix.index.IndexDef.DbType
+import org.sirix.rest.crud.json.JsonCreate2
+import org.sirix.rest.crud.xml.XmlCreate2
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CreateHandler(
+        private val location: Path,
+        private val createMultipleResources: Boolean = false
+) {
+
+    suspend fun handle(ctx: RoutingContext): Route? {
+        val databaseName = ctx.pathParam("database")
+        val resource = ctx.pathParam("resource")
+
+        val contentType = ctx.request().getHeader(HttpHeaders.CONTENT_TYPE)
+
+        val dbFile = location.resolve(databaseName)
+        val vertxContext = ctx.vertx().orCreateContext
+        createDatabaseIfNotExists(dbFile, vertxContext, contentType)
+
+        if (resource == null) {
+            ctx.response().setStatusCode(201).end()
+            return ctx.currentRoute()
+        }
+
+        if (databaseName == null) {
+            throw IllegalArgumentException("Database name and resource data to store not given.")
+        }
+        if (createMultipleResources) {
+            createMultipleResources(databaseName, ctx)
+            ctx.response().setStatusCode(201).end()
+            return ctx.currentRoute()
+        }
+        shredder(databaseName, resource, ctx)
+
+        return ctx.currentRoute()
+    }
+
+    private suspend fun shredder(
+            databaseName: String, resPathName:String = databaseName,
+            ctx: RoutingContext
+    ) {
+        val dbFile = location.resolve(databaseName)
+        val contentType = ctx.request().getHeader(HttpHeaders.CONTENT_TYPE)
+        val dispatcher = ctx.vertx().dispatcher()
+        if(contentType.equals("application/json")) {
+            JsonCreate2().insertResource(dbFile, resPathName, ctx)
+        }
+        else if(contentType.equals("application/xml")) {
+            XmlCreate2().insertResource(dbFile, resPathName, dispatcher, ctx)
+        }
+        else if(contentType.equals("multipart/form-data")) {
+            //TODO
+        }
+
+    }
+    private suspend fun createDatabaseIfNotExists(
+            dbFile: Path,
+            context: Context,
+            dbType: String
+    ):DatabaseConfiguration?{
+        return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
+            val dbExists = Files.exists(dbFile)
+            if(!dbExists) {
+                Files.createDirectories(dbFile.parent)
+            }
+
+            val dbConfig = DatabaseConfiguration(dbFile)
+
+            if(!Databases.existsDatabase(dbFile)) {
+                if(dbType == "application/json") {
+                    Databases.createJsonDatabase(dbConfig)
+                }
+                else if(dbType == "application/xml") {
+                    Databases.createXmlDatabase(dbConfig)
+                }
+            }
+            promise.complete(dbConfig)
+        }.await()
+    }
+
+    private suspend fun createMultipleResources(
+            databaseName: String,
+            ctx: RoutingContext
+    ) {
+        val contentType = ctx.request().getHeader(HttpHeaders.CONTENT_TYPE)
+
+        if(contentType.equals("application/json")) {
+            JsonCreate2().createMultipleResources(location, databaseName, ctx)
+        }
+        else if(contentType.equals("application/xml")) {
+            XmlCreate2().createMultipleResources(location, databaseName, ctx)
+        }
+        else if(contentType.equals("multipart/form-data")) {
+            // TODO
+        }
+    }
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/json/JsonCreate2.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/json/JsonCreate2.kt
@@ -1,0 +1,207 @@
+package org.sirix.rest.crud.json
+
+import io.vertx.core.file.OpenOptions
+import io.vertx.core.file.impl.FileResolver
+import io.vertx.core.parsetools.JsonParser
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.BodyHandler
+import io.vertx.kotlin.coroutines.await
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.sirix.access.Databases
+import org.sirix.access.DatabasesInternals
+import org.sirix.access.ResourceConfiguration
+import org.sirix.access.trx.node.HashType
+import org.sirix.api.Database
+import org.sirix.api.json.JsonResourceSession
+import org.sirix.rest.KotlinJsonStreamingShredder
+import org.sirix.rest.crud.Revisions
+import org.sirix.rest.crud.SirixDBUser
+import org.sirix.service.json.serialize.JsonSerializer
+import org.sirix.service.json.shredder.JsonShredder
+import org.sirix.utils.LogWrapper
+import org.slf4j.LoggerFactory
+import java.io.StringWriter
+import java.nio.file.Path
+
+
+private const val MAX_NODES_TO_SERIALIZE = 5000
+
+private val logger = LogWrapper(LoggerFactory.getLogger(DatabasesInternals::class.java))
+
+
+class JsonCreate2 {
+    suspend fun createMultipleResources(location:Path, databaseName:String, ctx: RoutingContext) {
+        val dbFile = location.resolve(databaseName)
+        val context = ctx.vertx().orCreateContext
+
+        val sirixDBUser = SirixDBUser.create(ctx)
+
+        ctx.vertx().executeBlocking<Unit> {
+            val database = Databases.openJsonDatabase(dbFile, sirixDBUser)
+
+            database.use {
+                BodyHandler.create().handle(ctx)
+                val fileResolver = FileResolver()
+                val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
+                ctx.fileUploads().forEach { fileUpload ->
+                    val fileName = fileUpload.fileName()
+                    val resConfig = ResourceConfiguration.Builder(fileName).useDeweyIDs(true).hashKind(
+                            HashType.valueOf(hashType.uppercase())
+                    ).build()
+
+                    val resourceHasBeenCreated = createResourceIfNotExisting(
+                            database,
+                            resConfig
+                    )
+
+                    if (resourceHasBeenCreated) {
+                        val manager = database.beginResourceSession(fileName)
+
+                        manager.use {
+                            insertJsonSubtreeAsFirstChild(
+                                    manager,
+                                    fileResolver.resolveFile(fileUpload.uploadedFileName()).toPath()
+                            )
+                        }
+                    }
+                }
+            }
+        }.await()
+
+        ctx.response().setStatusCode(201).end()
+    }
+    private fun createResourceIfNotExisting(
+            database: Database<JsonResourceSession>,
+            resConfig: ResourceConfiguration?,
+    ): Boolean {
+        logger.debug("Try to create resource: $resConfig")
+        return database.createResource(resConfig)
+    }
+
+
+    public suspend fun insertResource(
+            dbFile: Path?, resPathName: String,
+            ctx: RoutingContext
+    ) {
+        ctx.request().pause()
+//        val fileResolver = FileResolver()
+//
+//        val filePath = withContext(Dispatchers.IO) {
+//            fileResolver.resolveFile(Files.createTempFile(UUID.randomUUID().toString(), null).toString())
+//        }
+//
+//        val file = ctx.vertx().fileSystem().open(
+//            filePath.toString(),
+//            OpenOptions()
+//        ).await()
+//
+//        ctx.request().resume()
+//        ctx.request().pipeTo(file).await()
+
+        withContext(Dispatchers.IO) {
+            var body: String? = null
+            val sirixDBUser = SirixDBUser.create(ctx)
+            val database = Databases.openJsonDatabase(dbFile, sirixDBUser)
+
+            database.use {
+                val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
+                val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
+                val resConfig =
+                        ResourceConfiguration.Builder(resPathName).useDeweyIDs(true)
+                                .hashKind(HashType.valueOf(hashType.uppercase()))
+                                .customCommitTimestamps(commitTimestampAsString != null)
+                                .build()
+
+                val resourceHasBeenCreated = createResourceIfNotExisting(
+                        database,
+                        resConfig
+                )
+
+                val manager = database.beginResourceSession(resPathName)
+
+                manager.use {
+                    val maxNodeKey = if (resourceHasBeenCreated) {
+                        insertJsonSubtreeAsFirstChild(manager, ctx)
+                    } else {
+                        val rtx = manager.beginNodeReadOnlyTrx()
+
+                        rtx.use {
+                            return@use rtx.maxNodeKey
+                        }
+                    }
+//                    ctx.vertx().fileSystem().delete(pathToFile.toAbsolutePath().toString()).await()
+
+                    if (maxNodeKey < MAX_NODES_TO_SERIALIZE) {
+                        body = serializeJson(manager, ctx)
+                    } else {
+                        ctx.response().setStatusCode(200)
+                    }
+                }
+            }
+
+            if (body != null) {
+                ctx.response().end(body)
+            } else {
+                ctx.response().end()
+            }
+        }
+    }
+
+    private suspend fun insertJsonSubtreeAsFirstChild(
+            manager: JsonResourceSession,
+            ctx: RoutingContext
+    ): Long {
+        val commitMessage = ctx.queryParam("commitMessage").getOrNull(0)
+        val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
+        val commitTimestamp = if (commitTimestampAsString == null) {
+            null
+        } else {
+            Revisions.parseRevisionTimestamp(commitTimestampAsString).toInstant()
+        }
+
+        val wtx = manager.beginNodeTrx()
+        return wtx.use {
+            val jsonParser = JsonParser.newParser(ctx.request())
+            val future = KotlinJsonStreamingShredder(wtx, jsonParser).call()
+            ctx.request().resume()
+            future.await()
+            wtx.commit(commitMessage, commitTimestamp)
+            return@use wtx.maxNodeKey
+        }
+    }
+
+    private fun insertJsonSubtreeAsFirstChild(
+            manager: JsonResourceSession,
+            resFileToStore: Path
+    ): Long {
+        val wtx = manager.beginNodeTrx()
+        return wtx.use {
+            val eventReader = JsonShredder.createFileReader(resFileToStore)
+            eventReader.use {
+                wtx.insertSubtreeAsFirstChild(eventReader)
+            }
+            wtx.maxNodeKey
+        }
+    }
+
+    private fun serializeJson(
+            manager: JsonResourceSession,
+            routingCtx: RoutingContext
+    ): String {
+        val out = StringWriter()
+        val serializerBuilder = JsonSerializer.newBuilder(manager, out)
+        val serializer = serializerBuilder.build()
+
+        return JsonSerializeHelper().serialize(
+                serializer,
+                out,
+                routingCtx,
+                manager,
+                intArrayOf(1),
+                null
+        )
+    }
+
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/xml/XmlCreate2.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/xml/XmlCreate2.kt
@@ -1,0 +1,195 @@
+package org.sirix.rest.crud.xml
+
+import io.vertx.core.Context
+import io.vertx.core.Promise
+import io.vertx.core.file.OpenOptions
+import io.vertx.core.file.impl.FileResolver
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.BodyHandler
+import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.sirix.access.DatabaseConfiguration
+import org.sirix.access.Databases
+import org.sirix.access.ResourceConfiguration
+import org.sirix.access.trx.node.HashType
+import org.sirix.api.Database
+import org.sirix.api.xml.XmlNodeTrx
+import org.sirix.api.xml.XmlResourceSession
+import org.sirix.rest.crud.Revisions
+import org.sirix.rest.crud.SirixDBUser
+import org.sirix.service.xml.serialize.XmlSerializer
+import org.sirix.service.xml.shredder.XmlShredder
+import java.io.ByteArrayOutputStream
+import java.io.FileInputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.*
+import kotlinx.coroutines.withContext
+
+class XmlCreate2 {
+    suspend fun createMultipleResources(location: Path, databaseName: String, ctx: RoutingContext) {
+        val dbFile = location.resolve(databaseName)
+        val dispatcher = ctx.vertx().dispatcher()
+
+        val sirixDBUser = SirixDBUser.create(ctx)
+
+        withContext(Dispatchers.IO) {
+            val database = Databases.openXmlDatabase(dbFile, sirixDBUser)
+
+            database.use {
+                BodyHandler.create().handle(ctx)
+                val fileResolver = FileResolver()
+                ctx.fileUploads().forEach { fileUpload ->
+                    val fileName = fileUpload.fileName()
+                    val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
+                    val resConfig =
+                            ResourceConfiguration.Builder(fileName).useDeweyIDs(true)
+                                    .hashKind(HashType.valueOf(hashType.uppercase())).build()
+
+                    createOrRemoveAndCreateResource(database, resConfig, fileName, dispatcher)
+
+                    val manager = database.beginResourceSession(fileName)
+
+                    manager.use {
+                        insertXmlSubtreeAsFirstChild(
+                                manager,
+                                fileResolver.resolveFile(fileUpload.uploadedFileName()).toPath(),
+                                ctx
+                        )
+                    }
+                }
+            }
+
+            ctx.response().setStatusCode(200).end()
+        }
+    }
+
+    suspend fun insertResource(
+                dbFile: Path?, resPathName: String,
+                dispatcher: CoroutineDispatcher,
+                ctx: RoutingContext
+        ) {
+            ctx.request().pause()
+            val fileResolver = FileResolver()
+
+            val filePath = withContext(Dispatchers.IO) {
+                fileResolver.resolveFile(Files.createTempFile(UUID.randomUUID().toString(), null).toString())
+            }
+
+            val file = ctx.vertx().fileSystem().open(
+                    filePath.toString(),
+                    OpenOptions()
+            ).await()
+            ctx.request().resume()
+            ctx.request().pipeTo(file).await()
+
+            withContext(Dispatchers.IO) {
+                var body: String? = null
+                val sirixDBUser = SirixDBUser.create(ctx)
+                val database = Databases.openXmlDatabase(dbFile, sirixDBUser)
+
+                database.use {
+                    val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
+                    val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
+                    val resConfig =
+                            ResourceConfiguration.Builder(resPathName).hashKind(HashType.valueOf(hashType.uppercase()))
+                                    .customCommitTimestamps(commitTimestampAsString != null).build()
+                    createOrRemoveAndCreateResource(database, resConfig, resPathName, dispatcher)
+                    val manager = database.beginResourceSession(resPathName)
+
+                    manager.use {
+                        val pathToFile = filePath.toPath()
+                        val maxNodeKey = insertXmlSubtreeAsFirstChild(manager, pathToFile.toAbsolutePath(), ctx)
+
+                        ctx.vertx().fileSystem().delete(filePath.toString()).await()
+
+                        if (maxNodeKey < 5000) {
+                            body = serializeXml(manager, ctx)
+                        } else {
+                            ctx.response().setStatusCode(200)
+                        }
+                    }
+                }
+
+                if (body != null) {
+                    ctx.response().end(body)
+                } else {
+                    ctx.response().end()
+                }
+            }
+        }
+    private fun serializeXml(
+            manager: XmlResourceSession,
+            routingCtx: RoutingContext
+    ): String {
+        val out = ByteArrayOutputStream()
+        val serializerBuilder = XmlSerializer.XmlSerializerBuilder(manager, out)
+        val serializer = serializerBuilder.emitIDs().emitRESTful().emitRESTSequence().prettyPrint().build()
+
+        return XmlSerializeHelper().serializeXml(serializer, out, routingCtx, manager, null)
+    }
+
+    private suspend fun createDatabaseIfNotExists(
+            dbFile: Path,
+            context: Context
+    ): DatabaseConfiguration? {
+        return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
+            val dbExists = Files.exists(dbFile)
+
+            if (!dbExists) {
+                Files.createDirectories(dbFile.parent)
+            }
+
+            val dbConfig = DatabaseConfiguration(dbFile)
+
+            if (!Databases.existsDatabase(dbFile)) {
+                Databases.createXmlDatabase(dbConfig)
+            }
+
+            promise.complete(dbConfig)
+        }.await()
+    }
+
+    private suspend fun createOrRemoveAndCreateResource(
+            database: Database<XmlResourceSession>,
+            resConfig: ResourceConfiguration?,
+            resPathName: String, dispatcher: CoroutineDispatcher
+    ) {
+        withContext(dispatcher) {
+            if (!database.createResource(resConfig)) {
+                database.removeResource(resPathName)
+                database.createResource(resConfig)
+            }
+        }
+    }
+
+    private fun insertXmlSubtreeAsFirstChild(
+            manager: XmlResourceSession,
+            resFileToStore: Path,
+            ctx: RoutingContext
+    ): Long {
+        val commitMessage = ctx.queryParam("commitMessage").getOrNull(0)
+        val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
+        val commitTimestamp = if (commitTimestampAsString == null) {
+            null
+        } else {
+            Revisions.parseRevisionTimestamp(commitTimestampAsString).toInstant()
+        }
+
+        val wtx = manager.beginNodeTrx()
+        return wtx.use {
+            val inputStream = FileInputStream(resFileToStore.toFile())
+            return@use inputStream.use {
+                val eventStream = XmlShredder.createFileReader(inputStream)
+                wtx.insertSubtreeAsFirstChild(eventStream, XmlNodeTrx.Commit.No)
+                eventStream.close()
+                wtx.commit(commitMessage, commitTimestamp)
+                wtx.maxNodeKey
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
For #523 
Key changes:
     - Created `CreateHandler.kt` which extracts common logic between `XMLCreate()` and `JSONCreate()`
     - Currently common logic handled: Check if database already exists and if not then create it
     - Updated `SirixVerticle.kt` to use `CreateHandler` instead of `XMLCreate` and `JSONCreate`
     - Created `XMLCreate2.kt` `JSONCreate2.kt` that has mostly code from `XMLCreate.kt` and `JSONCreate.kt` so that it is usable from `CreateHandler.kt`
      
TODO:
     - Extract more common logic between `XMLCreate2` and `JSONCreate2`
     - Handle `multipart/form-data` with `XMLCreate2` and `JSONCreate2`
     - Handle and test resource creation using `CreateHandler`
     - Eventually remove `XMLCreate` and `JSONCreate`