### PR TITLE
Refactor to extract common logic between XML and JSON creation

### DIFF
--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/AbstractCreateHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/AbstractCreateHandler.kt
@@ -1,0 +1,133 @@
+package org.sirix.rest.crud
+
+import io.vertx.core.Context
+import io.vertx.core.Promise
+import io.vertx.core.file.impl.FileResolver
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.BodyHandler
+import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.sirix.access.DatabaseConfiguration
+import org.sirix.access.ResourceConfiguration
+import org.sirix.access.User
+import org.sirix.access.trx.node.HashType
+import org.sirix.api.Database
+import org.sirix.api.NodeCursor
+import org.sirix.api.NodeReadOnlyTrx
+import org.sirix.api.NodeTrx
+import org.sirix.api.ResourceSession
+import java.nio.file.Files
+import java.nio.file.Path
+
+abstract class AbstractCreateHandler<T: ResourceSession<*, *>>(
+        private val location: Path,
+        private val createMultipleResources: Boolean = false
+) : Handler {
+
+    override suspend fun handle(ctx: RoutingContext): Route {
+        val databaseName = ctx.pathParam("database")
+        val resource = ctx.pathParam("resource")
+
+        if(resource == null) {
+            val dbFile = location.resolve(databaseName)
+            val vertxContext = ctx.vertx().orCreateContext
+            createDatabaseIfNotExists(dbFile, vertxContext)
+            ctx.response().setStatusCode(201).end()
+            return ctx.currentRoute()
+        }
+
+        if(databaseName == null) {
+            throw IllegalArgumentException("Database name and resource data to store not given.")
+        }
+        else {
+            if(createMultipleResources) {
+                createMultipleResources(databaseName, ctx)
+                return ctx.currentRoute()
+            }
+            shredder(databaseName, resource, ctx)
+            return ctx.currentRoute()
+        }
+    }
+    suspend fun prepareDatabasePath(dbFile: Path, context: Context): DatabaseConfiguration? {
+        return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
+            val dbExists = Files.exists(dbFile)
+
+            if (!dbExists) {
+                Files.createDirectories(dbFile.parent)
+            }
+
+            val dbConfig = DatabaseConfiguration(dbFile)
+            promise.complete(dbConfig)
+        }.await()
+    }
+
+    suspend fun createOrRemoveAndCreateResource(
+            database: Database<*>,
+            resConfig: ResourceConfiguration?,
+            resPathName: String, dispatcher: CoroutineDispatcher) {
+        withContext(dispatcher) {
+            if (!database.createResource(resConfig)) {
+                database.removeResource(resPathName)
+                database.createResource(resConfig)
+            }
+        }
+    }
+
+    suspend fun shredder(
+            databaseName: String, resPathName: String = databaseName,
+            ctx: RoutingContext
+    ) {
+        val dbFile = location.resolve(databaseName)
+        val context = ctx.vertx().orCreateContext
+        ctx.request().pause()
+        createDatabaseIfNotExists(dbFile, context)
+        ctx.request().resume()
+        insertResource(dbFile, resPathName, ctx)
+    }
+
+    suspend fun createMultipleResources(databaseName: String, ctx: RoutingContext) {
+        val dbFile = location.resolve(databaseName)
+        val context = ctx.vertx().orCreateContext
+        val dispatcher = ctx.vertx().dispatcher()
+        val sirixDBUser = SirixDBUser.create(ctx)
+
+        createDatabaseIfNotExists(dbFile, context)
+
+        withContext(Dispatchers.IO) {
+            val database = openDatabase(dbFile, sirixDBUser)
+            database.use {
+                BodyHandler.create().handle(ctx)
+                val fileResolver = FileResolver()
+                val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
+                ctx.fileUploads().forEach { fileUpload ->
+                    val fileName = fileUpload.fileName()
+                    val resConfig = ResourceConfiguration.Builder(fileName).useDeweyIDs(true)
+                            .hashKind(HashType.valueOf(hashType.uppercase())).build()
+                    createOrRemoveAndCreateResource(database, resConfig, fileName, dispatcher)
+
+                    val manager = database.beginResourceSession(fileName)
+
+                    manager.use{
+                        insertResourceSubtreeAsFirstChild(
+                                manager,
+                                fileResolver.resolveFile(fileUpload.uploadedFileName()).toPath(),
+                                ctx
+                        )
+                    }
+                }
+
+            }
+            ctx.response().setStatusCode(201).end()
+        }
+    }
+    abstract suspend fun createDatabaseIfNotExists(dbFile: Path, context: Context): DatabaseConfiguration?
+    abstract suspend fun insertResource(dbFile: Path?, resPathName: String, ctx: RoutingContext)
+    abstract fun insertResourceSubtreeAsFirstChild(manager: T, filePath: Path, ctx: RoutingContext): Long
+    abstract suspend fun openDatabase(dbFile: Path, sirixDBUser: User): Database<T>
+
+    abstract fun serializeResource(manager: T, routingContext: RoutingContext): String
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/Handler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/Handler.kt
@@ -1,0 +1,8 @@
+package org.sirix.rest.crud
+
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+
+interface Handler {
+    suspend fun handle(ctx: RoutingContext): Route
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/json/JsonCreate.kt
@@ -8,16 +8,15 @@ import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.kotlin.coroutines.await
+import io.vertx.kotlin.coroutines.dispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.sirix.access.DatabaseConfiguration
-import org.sirix.access.Databases
-import org.sirix.access.DatabasesInternals
-import org.sirix.access.ResourceConfiguration
+import org.sirix.access.*
 import org.sirix.access.trx.node.HashType
 import org.sirix.api.Database
 import org.sirix.api.json.JsonResourceSession
 import org.sirix.rest.KotlinJsonStreamingShredder
+import org.sirix.rest.crud.AbstractCreateHandler
 import org.sirix.rest.crud.Revisions
 import org.sirix.rest.crud.SirixDBUser
 import org.sirix.service.json.serialize.JsonSerializer
@@ -35,91 +34,8 @@ private val logger = LogWrapper(LoggerFactory.getLogger(DatabasesInternals::clas
 class JsonCreate(
     private val location: Path,
     private val createMultipleResources: Boolean = false
-) {
-    suspend fun handle(ctx: RoutingContext): Route {
-        val databaseName = ctx.pathParam("database")
-        val resource = ctx.pathParam("resource")
-
-        if (resource == null) {
-            val dbFile = location.resolve(databaseName)
-            val vertxContext = ctx.vertx().orCreateContext
-            createDatabaseIfNotExists(dbFile, vertxContext)
-            ctx.response().setStatusCode(201).end()
-            return ctx.currentRoute()
-        }
-
-        if (databaseName == null) {
-            throw IllegalArgumentException("Database name and resource data to store not given.")
-        } else {
-            if (createMultipleResources) {
-                createMultipleResources(databaseName, ctx)
-                return ctx.currentRoute()
-            }
-
-            shredder(databaseName, resource, ctx)
-        }
-
-        return ctx.currentRoute()
-    }
-
-    private suspend fun createMultipleResources(
-        databaseName: String,
-        ctx: RoutingContext
-    ) {
-        val dbFile = location.resolve(databaseName)
-        val context = ctx.vertx().orCreateContext
-        createDatabaseIfNotExists(dbFile, context)
-
-        val sirixDBUser = SirixDBUser.create(ctx)
-
-        ctx.vertx().executeBlocking<Unit> {
-            val database = Databases.openJsonDatabase(dbFile, sirixDBUser)
-
-            database.use {
-                BodyHandler.create().handle(ctx)
-                val fileResolver = FileResolver()
-                val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
-                ctx.fileUploads().forEach { fileUpload ->
-                    val fileName = fileUpload.fileName()
-                    val resConfig = ResourceConfiguration.Builder(fileName).useDeweyIDs(true).hashKind(
-                        HashType.valueOf(hashType.uppercase())
-                    ).build()
-
-                    val resourceHasBeenCreated = createResourceIfNotExisting(
-                        database,
-                        resConfig
-                    )
-
-                    if (resourceHasBeenCreated) {
-                        val manager = database.beginResourceSession(fileName)
-
-                        manager.use {
-                            insertJsonSubtreeAsFirstChild(
-                                manager,
-                                fileResolver.resolveFile(fileUpload.uploadedFileName()).toPath()
-                            )
-                        }
-                    }
-                }
-            }
-        }.await()
-
-        ctx.response().setStatusCode(201).end()
-    }
-
-    private suspend fun shredder(
-        databaseName: String, resPathName: String = databaseName,
-        ctx: RoutingContext
-    ) {
-        val dbFile = location.resolve(databaseName)
-        val context = ctx.vertx().orCreateContext
-        ctx.request().pause()
-        createDatabaseIfNotExists(dbFile, context)
-        ctx.request().resume()
-        insertResource(dbFile, resPathName, ctx)
-    }
-
-    private suspend fun insertResource(
+): AbstractCreateHandler<JsonResourceSession>(location, createMultipleResources) {
+    override suspend fun insertResource(
         dbFile: Path?, resPathName: String,
         ctx: RoutingContext
     ) {
@@ -142,6 +58,7 @@ class JsonCreate(
             var body: String? = null
             val sirixDBUser = SirixDBUser.create(ctx)
             val database = Databases.openJsonDatabase(dbFile, sirixDBUser)
+            val dispatcher = ctx.vertx().dispatcher()
 
             database.use {
                 val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
@@ -152,27 +69,15 @@ class JsonCreate(
                         .customCommitTimestamps(commitTimestampAsString != null)
                         .build()
 
-                val resourceHasBeenCreated = createResourceIfNotExisting(
-                    database,
-                    resConfig
-                )
+                createOrRemoveAndCreateResource(database, resConfig, resPathName, dispatcher)
 
                 val manager = database.beginResourceSession(resPathName)
 
                 manager.use {
-                    val maxNodeKey = if (resourceHasBeenCreated) {
-                        insertJsonSubtreeAsFirstChild(manager, ctx)
-                    } else {
-                        val rtx = manager.beginNodeReadOnlyTrx()
-
-                        rtx.use {
-                            return@use rtx.maxNodeKey
-                        }
-                    }
-//                    ctx.vertx().fileSystem().delete(pathToFile.toAbsolutePath().toString()).await()
+                    val maxNodeKey = insertJsonSubtreeAsFirstChild(manager, ctx)
 
                     if (maxNodeKey < MAX_NODES_TO_SERIALIZE) {
-                        body = serializeJson(manager, ctx)
+                        body = serializeResource(manager, ctx)
                     } else {
                         ctx.response().setStatusCode(200)
                     }
@@ -187,7 +92,7 @@ class JsonCreate(
         }
     }
 
-    private fun serializeJson(
+    override fun serializeResource(
         manager: JsonResourceSession,
         routingCtx: RoutingContext
     ): String {
@@ -205,19 +110,12 @@ class JsonCreate(
         )
     }
 
-    private suspend fun createDatabaseIfNotExists(
+    override suspend fun createDatabaseIfNotExists(
         dbFile: Path,
         context: Context
     ): DatabaseConfiguration? {
+        val dbConfig = prepareDatabasePath(dbFile, context)
         return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
-            val dbExists = Files.exists(dbFile)
-
-            if (!dbExists) {
-                Files.createDirectories(dbFile.parent)
-            }
-
-            val dbConfig = DatabaseConfiguration(dbFile)
-
             if (!Databases.existsDatabase(dbFile)) {
                 Databases.createJsonDatabase(dbConfig)
             }
@@ -226,13 +124,6 @@ class JsonCreate(
         }.await()
     }
 
-    private fun createResourceIfNotExisting(
-        database: Database<JsonResourceSession>,
-        resConfig: ResourceConfiguration?,
-    ): Boolean {
-        logger.debug("Try to create resource: $resConfig")
-        return database.createResource(resConfig)
-    }
 
     private suspend fun insertJsonSubtreeAsFirstChild(
         manager: JsonResourceSession,
@@ -257,9 +148,10 @@ class JsonCreate(
         }
     }
 
-    private fun insertJsonSubtreeAsFirstChild(
+    override fun insertResourceSubtreeAsFirstChild(
         manager: JsonResourceSession,
-        resFileToStore: Path
+        resFileToStore: Path,
+        ctx: RoutingContext
     ): Long {
         val wtx = manager.beginNodeTrx()
         return wtx.use {
@@ -269,5 +161,9 @@ class JsonCreate(
             }
             wtx.maxNodeKey
         }
+    }
+
+    override suspend fun openDatabase(dbFile: Path, sirixDBUser: User): Database<JsonResourceSession> {
+        return Databases.openJsonDatabase(dbFile, sirixDBUser)
     }
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/xml/XmlCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/org/sirix/rest/crud/xml/XmlCreate.kt
@@ -4,9 +4,7 @@ import io.vertx.core.Context
 import io.vertx.core.Promise
 import io.vertx.core.file.OpenOptions
 import io.vertx.core.file.impl.FileResolver
-import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
-import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.kotlin.coroutines.await
 import io.vertx.kotlin.coroutines.dispatcher
 import kotlinx.coroutines.CoroutineDispatcher
@@ -15,10 +13,12 @@ import kotlinx.coroutines.withContext
 import org.sirix.access.DatabaseConfiguration
 import org.sirix.access.Databases
 import org.sirix.access.ResourceConfiguration
+import org.sirix.access.User
 import org.sirix.access.trx.node.HashType
 import org.sirix.api.Database
 import org.sirix.api.xml.XmlNodeTrx
 import org.sirix.api.xml.XmlResourceSession
+import org.sirix.rest.crud.AbstractCreateHandler
 import org.sirix.rest.crud.Revisions
 import org.sirix.rest.crud.SirixDBUser
 import org.sirix.service.xml.serialize.XmlSerializer
@@ -29,92 +29,17 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.*
 
-class XmlCreate(private val location: Path, private val createMultipleResources: Boolean = false) {
-    suspend fun handle(ctx: RoutingContext): Route {
-        val databaseName = ctx.pathParam("database")
-        val resource = ctx.pathParam("resource")
+class XmlCreate(
+        private val location: Path,
+        private val createMultipleResources: Boolean = false
+): AbstractCreateHandler<XmlResourceSession>(location, createMultipleResources) {
 
-        if (resource == null) {
-            val dbFile = location.resolve(databaseName)
-            val vertxContext = ctx.vertx().orCreateContext
-            createDatabaseIfNotExists(dbFile, vertxContext)
-            ctx.response().setStatusCode(201).end()
-            return ctx.currentRoute()
-        }
 
-        if (databaseName == null) {
-            throw IllegalArgumentException("Database name and resource data to store not given.")
-        }
-
-        if (createMultipleResources) {
-            createMultipleResources(databaseName, ctx)
-            ctx.response().setStatusCode(201).end()
-            return ctx.currentRoute()
-        }
-
-        shredder(databaseName, resource, ctx)
-
-        return ctx.currentRoute()
-    }
-
-    private suspend fun createMultipleResources(databaseName: String, ctx: RoutingContext) {
-        val dbFile = location.resolve(databaseName)
-        val context = ctx.vertx().orCreateContext
-        val dispatcher = ctx.vertx().dispatcher()
-        createDatabaseIfNotExists(dbFile, context)
-
-        val sirixDBUser = SirixDBUser.create(ctx)
-
-        withContext(Dispatchers.IO) {
-            val database = Databases.openXmlDatabase(dbFile, sirixDBUser)
-
-            database.use {
-                BodyHandler.create().handle(ctx)
-                val fileResolver = FileResolver()
-                ctx.fileUploads().forEach { fileUpload ->
-                    val fileName = fileUpload.fileName()
-                    val hashType = ctx.queryParam("hashType").getOrNull(0) ?: "NONE"
-                    val resConfig =
-                        ResourceConfiguration.Builder(fileName).useDeweyIDs(true)
-                            .hashKind(HashType.valueOf(hashType.uppercase())).build()
-
-                    createOrRemoveAndCreateResource(database, resConfig, fileName, dispatcher)
-
-                    val manager = database.beginResourceSession(fileName)
-
-                    manager.use {
-                        insertXmlSubtreeAsFirstChild(
-                            manager,
-                            fileResolver.resolveFile(fileUpload.uploadedFileName()).toPath(),
-                            ctx
-                        )
-                    }
-                }
-            }
-
-            ctx.response().setStatusCode(200).end()
-        }
-    }
-
-    private suspend fun shredder(
-        databaseName: String, resPathName: String = databaseName,
-        ctx: RoutingContext
-    ) {
-        val dbFile = location.resolve(databaseName)
-        val context = ctx.vertx().orCreateContext
-        val dispatcher = ctx.vertx().dispatcher()
-        ctx.request().pause()
-        createDatabaseIfNotExists(dbFile, context)
-        ctx.request().resume()
-
-        insertResource(dbFile, resPathName, dispatcher, ctx)
-    }
-
-    private suspend fun insertResource(
+    override suspend fun insertResource(
         dbFile: Path?, resPathName: String,
-        dispatcher: CoroutineDispatcher,
         ctx: RoutingContext
     ) {
+        val dispatcher = ctx.vertx().dispatcher()
         ctx.request().pause()
         val fileResolver = FileResolver()
 
@@ -145,12 +70,12 @@ class XmlCreate(private val location: Path, private val createMultipleResources:
 
                 manager.use {
                     val pathToFile = filePath.toPath()
-                    val maxNodeKey = insertXmlSubtreeAsFirstChild(manager, pathToFile.toAbsolutePath(), ctx)
+                    val maxNodeKey = insertResourceSubtreeAsFirstChild(manager, pathToFile.toAbsolutePath(), ctx)
 
                     ctx.vertx().fileSystem().delete(filePath.toString()).await()
 
                     if (maxNodeKey < 5000) {
-                        body = serializeXml(manager, ctx)
+                        body = serializeResource(manager, ctx)
                     } else {
                         ctx.response().setStatusCode(200)
                     }
@@ -165,7 +90,7 @@ class XmlCreate(private val location: Path, private val createMultipleResources:
         }
     }
 
-    private fun serializeXml(
+    override fun serializeResource(
         manager: XmlResourceSession,
         routingCtx: RoutingContext
     ): String {
@@ -176,41 +101,21 @@ class XmlCreate(private val location: Path, private val createMultipleResources:
         return XmlSerializeHelper().serializeXml(serializer, out, routingCtx, manager, null)
     }
 
-    private suspend fun createDatabaseIfNotExists(
+    override suspend fun createDatabaseIfNotExists(
         dbFile: Path,
         context: Context
     ): DatabaseConfiguration? {
+        val dbConfig = prepareDatabasePath(dbFile, context)
+
         return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
-            val dbExists = Files.exists(dbFile)
-
-            if (!dbExists) {
-                Files.createDirectories(dbFile.parent)
-            }
-
-            val dbConfig = DatabaseConfiguration(dbFile)
-
             if (!Databases.existsDatabase(dbFile)) {
                 Databases.createXmlDatabase(dbConfig)
             }
-
             promise.complete(dbConfig)
         }.await()
     }
-
-    private suspend fun createOrRemoveAndCreateResource(
-        database: Database<XmlResourceSession>,
-        resConfig: ResourceConfiguration?,
-        resPathName: String, dispatcher: CoroutineDispatcher
-    ) {
-        withContext(dispatcher) {
-            if (!database.createResource(resConfig)) {
-                database.removeResource(resPathName)
-                database.createResource(resConfig)
-            }
-        }
-    }
-
-    private fun insertXmlSubtreeAsFirstChild(
+    
+    override fun insertResourceSubtreeAsFirstChild(
         manager: XmlResourceSession,
         resFileToStore: Path,
         ctx: RoutingContext
@@ -234,5 +139,9 @@ class XmlCreate(private val location: Path, private val createMultipleResources:
                 wtx.maxNodeKey
             }
         }
+    }
+
+    override suspend fun openDatabase(dbFile: Path, sirixDBUser: User): Database<XmlResourceSession> {
+        return Databases.openXmlDatabase(dbFile, sirixDBUser)
     }
 }


### PR DESCRIPTION
Refactored common logics to `AbstractCreateHandler.kt`. 

Refactored following common functions to abstract class:
- `handle`
- `createOrRemoveAndCreateResource`
- `shredder`
- `createMultipleResources`

Renamed `insert[Json/Xml]SubtreeAsFirstChild` to `insertResourceSubtreeAsFirstChild` for abstracting in the common function.