### PR TITLE
Added ResourceConfiguration as parameter in NodeKind 

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.jcp.xml.dsig.internal.dom.Utils;
+
 
 import io.sirix.BinaryEncodingVersion;
 import io.sirix.access.ResourceConfiguration;


### PR DESCRIPTION
In the PageKind , Removed the PageReadOnlyTrx parameter and added a ResourceConfiguration parameter for passing the necessary data required for serialization and deserialization.

#519 