### PR TITLE
use java toolchain support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,15 +90,13 @@ subprojects {
     apply plugin: "com.diffplug.spotless"
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
         withSourcesJar()
         withJavadocJar()
-
-        if (JavaVersion.current() != targetCompatibility) {
-            throw new GradleException(JavaVersion.current().toString() + targetCompatibility.toString())
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
         }
     }
+
 
     javadoc {
         failOnError = false
@@ -204,7 +202,7 @@ subprojects {
             onlyIf { isReleaseVersion }
         }
     }
-    
+
     signing {
         //def signingKey = System.getenv("OSSRH_GPG_SECRET_KEY")
         //def signingPassword = System.getenv("OSSRH_GPG_SECRET_KEY_PASSWORD")


### PR DESCRIPTION
currently the build needs jdk 21, which is not mentioned in the readme and when a wrong jdk is detected a very cryptic error message is thrown (in my case I was running with jdk 20 and the error message was: "2021")

this pr uses the gradle java toolchain support to ensure that jdk 21 is used.

I hope the tests still work, I'm on a mac so I only tried `./gradlew build -x test` 