### PR TITLE
Made changes in order to check if user already exists in keycloak script

### DIFF
--- a/bundles/sirix-rest-api/src/test/resources/create-sirix-users.sh
+++ b/bundles/sirix-rest-api/src/test/resources/create-sirix-users.sh
@@ -1,1 +1,24 @@
-/opt/jboss/keycloak/bin/add-user-keycloak.sh -r sirixdb -u admin -p admin --roles create,modify,delete,view
+#!/bin/bash
+
+KEYCLOAK_HOME="/opt/jboss/keycloak"
+REALM="sirixdb"
+USERNAME="admin"
+PASSWORD="admin"
+ROLES="create,modify,delete,view"
+
+user_exists() {
+  $KEYCLOAK_HOME/bin/kcadm.sh get users -r "$REALM" -q "username=$USERNAME" --fields username | grep -q "\"username\" : \"$USERNAME\""
+}
+
+$KEYCLOAK_HOME/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user "$USERNAME" --password "$PASSWORD"
+
+if user_exists; then
+  echo "User '$USERNAME' already exists in realm '$REALM'."
+else
+  if $KEYCLOAK_HOME/bin/add-user-keycloak.sh -r "$REALM" -u "$USERNAME" -p "$PASSWORD" --roles "$ROLES"; then
+    echo "User '$USERNAME' added to realm '$REALM'."
+  else
+    echo "Failed to add user '$USERNAME' to realm '$REALM'."
+    exit 1
+  fi
+fi


### PR DESCRIPTION
Refined `add-user-keycloak.sh` script to include functionality for verifying user existence in Keycloak before proceeding with user addition. This update ensures appropriate messages are displayed based on different scenarios encountered during user checks.