### PR TITLE
Issue #537 (apache kafka approach)

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation implLibraries.chronicleBytes
     implementation implLibraries.fastObjectPool
     implementation implLibraries.zeroAllocationHashing
-
+    implementation 'org.apache.kafka:kafka-clients:3.7.0'
     annotationProcessor implLibraries.daggerCompiler
 
     testImplementation testLibraries.junitJupiterApi

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonResourceSessionImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonResourceSessionImpl.java
@@ -119,6 +119,8 @@ public final class JsonResourceSessionImpl extends AbstractResourceSession<JsonN
     } else {
       pathSummaryWriter = null;
     }
+    String bootstrapServers = "localhost:9092"; // Example Kafka broker address
+    String topic = databaseName;
 
     // Synchronize commit and other public methods if needed.
     final var isAutoCommitting = maxNodeCount > 0 || !autoCommitDelay.isZero();
@@ -135,7 +137,7 @@ public final class JsonResourceSessionImpl extends AbstractResourceSession<JsonN
                                nodeFactory,
                                afterCommitState,
                                new RecordToRevisionsIndex(pageTrx),
-                               isAutoCommitting);
+                               isAutoCommitting,new KafkaChangeProducer(bootstrapServers, topic));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
As discussed under the issue #537 me and @ElenaSkep would like to propose an enhancement and use apache kafka  as an alternative for backend storage.

What it does: Kafka listens to the changes made in a db/resource and stores them in a topic which takes the name of the db.Doing that you can see from the topic of your db the history of all the changes.

Prerequisite:Please download the zip file of apache kafka and run it in the bash with these 2 commands $ bin/zookeeper-server-start.sh config/zookeeper.properties and this $ bin/kafka-server-start.sh config/server.properties.

After that whenever you change something in your db you can see the changes by doing this $ bin/kafka-topics.sh --describe --topic your-db-name  --bootstrap-server localhost:9092
