### PR TITLE
Issue #537 (alternative kafka approach)

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation implLibraries.chronicleBytes
     implementation implLibraries.fastObjectPool
     implementation implLibraries.zeroAllocationHashing
-
+    implementation 'org.apache.kafka:kafka-clients:3.7.0'
     annotationProcessor implLibraries.daggerCompiler
 
     testImplementation testLibraries.junitJupiterApi

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonResourceSessionImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonResourceSessionImpl.java
@@ -119,6 +119,8 @@ public final class JsonResourceSessionImpl extends AbstractResourceSession<JsonN
     } else {
       pathSummaryWriter = null;
     }
+    String bootstrapServers = "localhost:9092"; // Example Kafka broker address
+    String topic = databaseName;
 
     // Synchronize commit and other public methods if needed.
     final var isAutoCommitting = maxNodeCount > 0 || !autoCommitDelay.isZero();
@@ -135,7 +137,7 @@ public final class JsonResourceSessionImpl extends AbstractResourceSession<JsonN
                                nodeFactory,
                                afterCommitState,
                                new RecordToRevisionsIndex(pageTrx),
-                               isAutoCommitting);
+                               isAutoCommitting,new KafkaChangeProducer(bootstrapServers, topic));
   }
 
   @SuppressWarnings("unchecked")

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/KafkaChangeProducer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/KafkaChangeProducer.java
@@ -1,0 +1,47 @@
+package io.sirix.access.trx.node.json;
+
+
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import java.util.Properties;
+
+public class KafkaChangeProducer {
+    private final KafkaProducer<String, String> producer;
+    final String topic;
+
+    public KafkaChangeProducer(String bootstrapServers, String topic) {
+        
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+
+        // Create Kafka producer
+        this.producer = new KafkaProducer<>(props);
+        this.topic = topic;
+    }
+
+    public void sendChange(String key, String value) {
+        
+        if (producer != null) {
+           
+            ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, value);
+
+            // Send the record to the Kafka topic
+            producer.send(record);
+        } else {
+            throw new IllegalStateException("Kafka producer is not initialized.");
+        }
+    }
+
+    public void close() {
+        // Close the Kafka producer
+        if (producer != null) {
+            producer.close();
+        }
+    }
+}


### PR DESCRIPTION
As discussed under the issue https://github.com/sirixdb/sirix/issues/537 me and @ElenaSkep would like to propose an enhancement and use apache kafka as an alternative for backend storage.

What it does: Kafka listens to the changes made in a db/resource and stores them in a topic which takes the name of the db.Doing that you can see from the topic of your db the history of all the changes.

Prerequisite:Please download the zip file of apache kafka and run it in the bash with these 2 commands $ bin/zookeeper-server-start.sh config/zookeeper.properties and this $ bin/kafka-server-start.sh config/server.properties.

After that whenever you change something in your db you can see the changes by doing this $ bin/kafka-console-consumer.sh --topic your-db-name --from-beginning --bootstrap-server localhost:9092