### PR TITLE
Remove commented out method in sirix-query.

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/Main.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/Main.java
@@ -258,25 +258,6 @@ public final class Main {
     return strbuf.isEmpty() ? null : strbuf.toString();
   }
 
-  //  private static String readStringFromScannerWithEndMark() {
-  //    final Scanner scanner = new Scanner(System.in);
-  //    final StringBuilder strbuf = new StringBuilder();
-  //
-  //    for (int i = 0; scanner.hasNextLine(); i++) {
-  //      final String line = scanner.nextLine();
-  //
-  //      if (line.isEmpty())
-  //        break;
-  //
-  //      if (i != 0) {
-  //        strbuf.append(System.lineSeparator());
-  //      }
-  //      strbuf.append(line);
-  //    }
-  //
-  //    return strbuf.isEmpty() ? null : strbuf.toString();
-  //  }
-
   private static String readString() throws IOException {
     int r;
     ByteArrayOutputStream payload = new ByteArrayOutputStream();


### PR DESCRIPTION
Removed commented out, seemingly duplicate, method in sirix-query Main class. The method is implemented by injecting a LineReader as an argument. Initially, it seems that this method only supported reading from System.in. 

Should be removed as it is not serving any purpose besides cluttering the codebase.😃 