### PR TITLE
Issue#523: Refactor XML and JSON handling in CRUD operations

### DIFF
--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
@@ -234,7 +234,7 @@ abstract class AbstractGetHandler<T : ResourceSession<*, *>,
         vertxContext: Context
     ): String {
         return vertxContext.executeBlocking { promise: Promise<String> ->
-            val serializedString = serializeResourceInternal(manager, revisions, nodeId, ctx)
+            val serializedString = getSerializedString(manager, revisions, nodeId, ctx)
             promise.complete(serializedString)
         }.await()
         ctx.response().setStatusCode(200)
@@ -266,7 +266,7 @@ abstract class AbstractGetHandler<T : ResourceSession<*, *>,
         endResultSeqIndex: Long?
     )
 
-    protected abstract fun serializeResourceInternal(
+    protected abstract fun getSerializedString(
         manager: T,
         revisions: IntArray,
         nodeId: Long?,

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractUpdateHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractUpdateHandler.kt
@@ -1,0 +1,78 @@
+package io.sirix.rest.crud
+
+import io.sirix.access.ResourceConfiguration
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+import java.nio.file.Path
+import java.time.Instant
+import io.sirix.access.trx.node.HashType
+import io.sirix.api.NodeTrx
+import io.vertx.core.http.HttpHeaders
+
+
+abstract class AbstractUpdateHandler(protected val location: Path) {
+    suspend fun handle(ctx: RoutingContext): Route {
+        val databaseName = ctx.pathParam("database")
+        val resource = ctx.pathParam("resource")
+        val nodeId: String? = ctx.queryParam("nodeId").getOrNull(0)
+        val insertionMode: String? = ctx.queryParam("insert").getOrNull(0)
+
+        if (databaseName == null || resource == null) {
+            throw IllegalArgumentException("Database name and resource name not given.")
+        }
+
+        val body = ctx.body().asString()
+
+        update(databaseName, resource, nodeId?.toLongOrNull(), insertionMode, body, ctx)
+
+        return ctx.currentRoute()
+    }
+    protected abstract suspend fun update(
+        databaseName: String,
+        resPathName: String,
+        nodeId: Long?,
+        insertionMode: String?,
+        resFileToStore: String,
+        ctx: RoutingContext
+    )
+    protected fun getCommitTimestamp(ctx: RoutingContext): Instant? {
+        val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
+        return if (commitTimestampAsString == null) {
+            null
+        } else {
+            Revisions.parseRevisionTimestamp(commitTimestampAsString).toInstant()
+        }
+    }
+    protected fun checkHashCode(ctx: RoutingContext, wtx: NodeTrx, resourceConfig: ResourceConfiguration) {
+        if (resourceConfig.hashType != HashType.NONE && !wtx.isDocumentRoot) {
+            val hashCode = ctx.request().getHeader(HttpHeaders.ETAG)
+                ?: throw IllegalStateException("Hash code is missing in ETag HTTP-Header.")
+
+            if (wtx.hash != hashCode.toLong()) {
+                throw IllegalArgumentException("Someone might have changed the resource in the meantime.")
+            }
+        }
+    }
+
+    protected fun handleResponse(
+        ctx: RoutingContext,
+        maxNodeKey: Long,
+        hash: Long,
+        resourceConfig: ResourceConfiguration,
+        body: String?
+    ) {
+        if (maxNodeKey > 5000) {
+            ctx.response().statusCode = 200
+
+            if (resourceConfig.hashType != HashType.NONE) {
+                ctx.response().putHeader(HttpHeaders.ETAG, hash.toString())
+            }
+
+            ctx.response().end()
+        } else if (body != null) {
+            ctx.response().end(body)
+        } else {
+            ctx.response().end()
+        }
+        }
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
@@ -1,7 +1,5 @@
 package io.sirix.rest.crud.json
 
-import io.vertx.core.Context
-import io.vertx.core.Promise
 import io.vertx.core.parsetools.JsonParser
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.coroutines.await

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
@@ -24,7 +24,6 @@ import io.sirix.service.json.shredder.JsonShredder
 import java.io.StringWriter
 import java.nio.file.Path
 
-private const val MAX_NODES_TO_SERIALIZE = 5000
 
 class JsonCreate(
     location: Path,
@@ -92,20 +91,6 @@ class JsonCreate(
         )
     }
 
-    override suspend fun createDatabaseIfNotExists(
-        dbFile: Path,
-        context: Context
-    ): DatabaseConfiguration? {
-        val dbConfig = prepareDatabasePath(dbFile, context)
-        return context.executeBlocking { promise: Promise<DatabaseConfiguration> ->
-            if (!Databases.existsDatabase(dbFile)) {
-                Databases.createJsonDatabase(dbConfig)
-            }
-
-            promise.complete(dbConfig)
-        }.await()
-    }
-
 
     private suspend fun insertJsonSubtreeAsFirstChild(
         manager: JsonResourceSession,
@@ -147,5 +132,9 @@ class JsonCreate(
 
     override suspend fun openDatabase(dbFile: Path, sirixDBUser: User): Database<JsonResourceSession> {
         return Databases.openJsonDatabase(dbFile, sirixDBUser)
+    }
+
+    override fun createDatabase(dbConfig: DatabaseConfiguration?) {
+        Databases.createJsonDatabase(dbConfig)
     }
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonDelete.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonDelete.kt
@@ -2,7 +2,6 @@ package io.sirix.rest.crud.json
 
 import io.vertx.ext.auth.User
 import io.vertx.ext.auth.authorization.AuthorizationProvider
-import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.brackit.query.jdm.StructuredItemStore
 import io.sirix.access.DatabaseType

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonDelete.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonDelete.kt
@@ -16,26 +16,13 @@ import io.sirix.query.json.BasicJsonDBStore
 import java.nio.file.Path
 
 class JsonDelete(location: Path, private val authz: AuthorizationProvider) : AbstractDeleteHandler(location) {
-    suspend fun handle(ctx: RoutingContext): Route {
-        val databaseName: String? = ctx.pathParam("database") ?: ctx.get("databaseName")
-        val resource: String? = ctx.pathParam("resource")
-        val nodeId: String? = ctx.queryParam("nodeId").getOrNull(0)
-
-        if (databaseName == null) {
-            dropDatabasesOfType(ctx, DatabaseType.JSON)
-        } else {
-            delete(databaseName, resource, nodeId?.toLongOrNull(), ctx)
-        }
-
-        return ctx.currentRoute()
-    }
 
     override fun createStore(ctx: RoutingContext): StructuredItemStore {
         return JsonSessionDBStore(ctx, BasicJsonDBStore.newBuilder().build(), ctx.get("user") as User, authz)
     }
 
     override fun database(dbFile: Path, sirixDBUser: io.sirix.access.User): Database<*> {
-        return Databases.openJsonDatabase(dbFile,  sirixDBUser)
+        return Databases.openJsonDatabase(dbFile, sirixDBUser)
     }
 
     override fun hashType(manager: ResourceSession<*, *>): HashType {
@@ -44,4 +31,6 @@ class JsonDelete(location: Path, private val authz: AuthorizationProvider) : Abs
         else
             throw IllegalArgumentException("Resource manager is not of JSON type.")
     }
+
+    override fun getDatabaseType(): DatabaseType = DatabaseType.JSON
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonGet.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonGet.kt
@@ -59,7 +59,7 @@ class JsonGet(location: Path, private val keycloak: OAuth2Auth, private val auth
         }
     }
 
-    override fun serializeResourceInternal(
+    override fun getSerializedString(
         manager: JsonResourceSession,
         revisions: IntArray,
         nodeId: Long?,

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlDelete.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlDelete.kt
@@ -2,7 +2,6 @@ package io.sirix.rest.crud.xml
 
 import io.vertx.ext.auth.User
 import io.vertx.ext.auth.authorization.AuthorizationProvider
-import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.brackit.query.jdm.StructuredItemStore
 import io.sirix.access.DatabaseType
@@ -16,26 +15,13 @@ import io.sirix.query.node.BasicXmlDBStore
 import java.nio.file.Path
 
 class XmlDelete(location: Path, private val authz: AuthorizationProvider) : AbstractDeleteHandler(location) {
-    suspend fun handle(ctx: RoutingContext): Route {
-        val databaseName: String? = ctx.pathParam("database") ?: ctx.get("databaseName")
-        val resource: String? = ctx.pathParam("resource")
-        val nodeId: String? = ctx.queryParam("nodeId").getOrNull(0)
-
-        if (databaseName == null) {
-            dropDatabasesOfType(ctx, DatabaseType.XML)
-        } else {
-            delete(databaseName, resource, nodeId?.toLongOrNull(), ctx)
-        }
-
-        return ctx.currentRoute()
-    }
 
     override fun createStore(ctx: RoutingContext): StructuredItemStore {
         return XmlSessionDBStore(ctx, BasicXmlDBStore.newBuilder().build(), ctx.get("user") as User, authz)
     }
 
     override fun database(dbFile: Path, sirixDBUser: io.sirix.access.User): Database<*> {
-        return Databases.openXmlDatabase(dbFile,  sirixDBUser)
+        return Databases.openXmlDatabase(dbFile, sirixDBUser)
     }
 
     override fun hashType(manager: ResourceSession<*, *>): HashType {
@@ -44,4 +30,6 @@ class XmlDelete(location: Path, private val authz: AuthorizationProvider) : Abst
         else
             throw IllegalArgumentException("Resource manager is not of XML type.")
     }
+
+    override fun getDatabaseType(): DatabaseType = DatabaseType.XML
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlGet.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlGet.kt
@@ -139,7 +139,7 @@ class XmlGet(private val location: Path, private val keycloak: OAuth2Auth, priva
         }
     }
 
-    override fun serializeResourceInternal(
+    override fun getSerializedString(
         manager: XmlResourceSession, revisions: IntArray, nodeId: Long?, ctx: RoutingContext
     ): String {
         val out = ByteArrayOutputStream()


### PR DESCRIPTION
# [WIP] Initial Refactoring of XML and JSON handling in CRUD operations

## Overview
This PR introduces to handle common logic for XML and JSON operations in the CRUD directory. The focus is on enhancing abstraction for create and delete operations, to reduce code duplication and improve maintainability.

## Changes
1. AbstractCreateHandler Enhancement:
   - Extended with implementing Common Method `createDatabaseIfNotExists()`
   - Refactored `XMLCreate` and `JsonCreate` to use this shared method.
 2. AbstractDeleteHandler Enhancement:
   - Extended with implementing Common Method `handle()`
   - Refactored `XMLDelete` and `JsonDelete` to use this shared method.
  
## Next Steps
- Review and refine current changes based on feedback
- Extend similar refactoring to other operations.
- Consider creating abstract base classes for classes which have almost similar methods and content.
   
## Review Request
Please focus on:
1. Effectiveness of the abstraction and adherence to "Template Method" design (Interface+Abstact+Implementations)
2. Potential issues with format-specific operations
3. Suggestions for further improvements or extensions of this refactoring approach