### PR TITLE
Add .gitattributes to enforce LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# .gitattributes - Configuration file for managing Git attributes
+# This file is included to specify how Git should handle various file types
+# and line endings during commit, checkout, and merge operations.
+
+# Declare .sh files that will always have LF line endings on checkout.
+# This ensures consistent behavior across different platforms.
+*.sh text eol=lf
+
+# Ensure LF line endings for Docker files and Docker Compose files
+# *.Dockerfile text eol=lf
+# docker-compose*.yml text eol=lf


### PR DESCRIPTION
## Summary
This pull request adds a `.gitattributes` file to ensure all `.sh` files maintain LF line endings, preventing Git from converting them to CRLF specifically on Windows systems. This helps ensure consistent execution of shell scripts across different environments.
Especially while running dockers

## Changes
- Added `.gitattributes` with the rule `*.sh text eol=lf`.
- Applies to all `.sh` files to enforce LF line endings and avoid CRLF conversions.

## Reason for Change
Shell scripts require LF line endings for proper execution in Unix-based environments. By enforcing LF, this change helps prevent issues related to improper line endings when collaborating on the project across different operating systems.

## Impact
- Affects only `.sh` files. No other files or default Git settings are modified.
- Ensures consistency and prevents errors related to line endings in shell scripts.

