### PR TITLE
perf: SIMD scan for PathSummary findPathsByLocalName

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathLocalNameIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathLocalNameIndex.java
@@ -1,0 +1,192 @@
+package io.sirix.index.path.summary;
+
+import io.brackit.query.atomic.QNm;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Dense SIMD-friendly index from {@code localName} to the {@link PathNode}s whose
+ * QNm carries that local name. Built lazily from {@link PathSummaryReader#qnmMapping}
+ * on first lookup, then reused until a mutation invalidates it.
+ *
+ * <p>Hot-path query: {@link SirixVectorizedExecutor} calls
+ * {@link PathSummaryReader#findPathsByLocalName(String)} per query field; that scan
+ * used to walk the whole {@code qnmMapping} entrySet with a {@code String.equals} per
+ * entry. This index reduces it to a SIMD-int-equals over a dense {@code int[]} of
+ * pre-hashed {@code localName.hashCode()} keys, branchless on the no-match positions.
+ *
+ * <h2>HFT properties</h2>
+ * <ul>
+ *   <li>Single linear scan over a contiguous {@code int[]} — cache-friendly.</li>
+ *   <li>Vector-API path uses {@link IntVector#SPECIES_PREFERRED} (8 lanes on
+ *       AVX2 / 16 on AVX-512) with {@code compare(EQ)} → mask. Tail handled scalar.</li>
+ *   <li>Hash hits are verified via a single {@link String#equals} per matched
+ *       slot (collisions are vanishingly rare on real workloads).</li>
+ *   <li>Empty-result lookups allocate nothing — the hot {@code containsLocalName}
+ *       fast path returns a {@code boolean} without a result list.</li>
+ *   <li>Build cost is paid once and amortised across lookups; mutators on
+ *       {@code qnmMapping} call {@link #invalidate()} so the index rebuilds lazily.</li>
+ * </ul>
+ */
+final class PathLocalNameIndex {
+
+  private static final VectorSpecies<Integer> INT_SPECIES = IntVector.SPECIES_PREFERRED;
+  private static final int LANES = INT_SPECIES.length();
+
+  /**
+   * Parallel arrays — entry {@code i} pairs {@code localNameKeys[i]} (the
+   * {@code String#hashCode} of the localName) with {@code paths[i]} (the set of
+   * PathNodes whose QNm has that localName). {@code localNames[i]} is the actual
+   * localName string, retained for collision verification.
+   *
+   * <p>{@code null} signals "not yet built" — the caller must rebuild from
+   * {@code qnmMapping} before the next lookup.
+   */
+  private int @Nullable [] localNameKeys;
+  private String @Nullable [] localNames;
+  private Set<PathNode> @Nullable [] paths;
+
+  /**
+   * Build (or rebuild) the dense arrays from the supplied qnmMapping. Idempotent —
+   * subsequent calls with the same mapping reproduce the same arrays in the same
+   * order (HashMap iteration order is undefined but stable within a single instance).
+   */
+  void build(final Map<QNm, Set<PathNode>> qnmMapping) {
+    final int n = qnmMapping.size();
+    final int[] keys = new int[n];
+    final String[] names = new String[n];
+    @SuppressWarnings("unchecked")
+    final Set<PathNode>[] arr = (Set<PathNode>[]) new Set<?>[n];
+    int i = 0;
+    for (final Map.Entry<QNm, Set<PathNode>> e : qnmMapping.entrySet()) {
+      final String ln = e.getKey().getLocalName();
+      // Pre-hash with the same function used at lookup time. Empty/null collapses
+      // to 0 (String.hashCode() of "" is 0); callers guard against null lookups.
+      keys[i] = ln == null ? 0 : ln.hashCode();
+      names[i] = ln;
+      arr[i] = e.getValue();
+      i++;
+    }
+    this.localNameKeys = keys;
+    this.localNames = names;
+    this.paths = arr;
+  }
+
+  /** Drop the dense arrays — next lookup will rebuild from qnmMapping. */
+  void invalidate() {
+    this.localNameKeys = null;
+    this.localNames = null;
+    this.paths = null;
+  }
+
+  boolean isBuilt() {
+    return localNameKeys != null;
+  }
+
+  /**
+   * SIMD-scan {@link #localNameKeys} for {@code String.hashCode()} of {@code localName},
+   * union the {@code paths[i]} sets at matching positions whose stored localName equals
+   * the query (collision-safe), return the merged list. Returns {@link List#of()} (the
+   * shared empty list, no allocation) when no match is found.
+   */
+  List<PathNode> findByLocalName(final String localName) {
+    final int[] keys = localNameKeys;
+    final String[] names = localNames;
+    final Set<PathNode>[] arr = paths;
+    if (keys == null || names == null || arr == null) {
+      return List.of();
+    }
+    final int n = keys.length;
+    if (n == 0) {
+      return List.of();
+    }
+    final int target = localName.hashCode();
+    final IntVector vTarget = IntVector.broadcast(INT_SPECIES, target);
+
+    List<PathNode> result = null;
+    int i = 0;
+    final int upper = INT_SPECIES.loopBound(n);
+    for (; i < upper; i += LANES) {
+      final IntVector v = IntVector.fromArray(INT_SPECIES, keys, i);
+      final VectorMask<Integer> mask = v.compare(VectorOperators.EQ, vTarget);
+      if (!mask.anyTrue()) {
+        continue;
+      }
+      // Resolve hits in this lane block.
+      long bits = mask.toLong();
+      while (bits != 0) {
+        final int lane = Long.numberOfTrailingZeros(bits);
+        bits &= bits - 1L;
+        final int pos = i + lane;
+        if (localName.equals(names[pos])) {
+          final Set<PathNode> hit = arr[pos];
+          if (result == null) {
+            result = new ArrayList<>(hit.size());
+          }
+          result.addAll(hit);
+        }
+      }
+    }
+    // Scalar tail.
+    for (; i < n; i++) {
+      if (keys[i] == target && localName.equals(names[i])) {
+        final Set<PathNode> hit = arr[i];
+        if (result == null) {
+          result = new ArrayList<>(hit.size());
+        }
+        result.addAll(hit);
+      }
+    }
+    return result == null ? List.of() : result;
+  }
+
+  /**
+   * Existence-check fast path — same SIMD scan as {@link #findByLocalName} but
+   * stops on the first verified hit. Allocates nothing; returns boolean.
+   */
+  boolean containsLocalName(final String localName) {
+    final int[] keys = localNameKeys;
+    final String[] names = localNames;
+    if (keys == null || names == null) {
+      return false;
+    }
+    final int n = keys.length;
+    if (n == 0) {
+      return false;
+    }
+    final int target = localName.hashCode();
+    final IntVector vTarget = IntVector.broadcast(INT_SPECIES, target);
+
+    int i = 0;
+    final int upper = INT_SPECIES.loopBound(n);
+    for (; i < upper; i += LANES) {
+      final IntVector v = IntVector.fromArray(INT_SPECIES, keys, i);
+      final VectorMask<Integer> mask = v.compare(VectorOperators.EQ, vTarget);
+      if (!mask.anyTrue()) {
+        continue;
+      }
+      long bits = mask.toLong();
+      while (bits != 0) {
+        final int lane = Long.numberOfTrailingZeros(bits);
+        bits &= bits - 1L;
+        if (localName.equals(names[i + lane])) {
+          return true;
+        }
+      }
+    }
+    for (; i < n; i++) {
+      if (keys[i] == target && localName.equals(names[i])) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryReader.java
@@ -108,6 +108,15 @@ public final class PathSummaryReader implements NodeReadOnlyTrx, NodeCursor {
   private final Map<QNm, Set<PathNode>> qnmMapping;
 
   /**
+   * Lazy SIMD-friendly localName → PathNodes index. Built on first call to
+   * {@link #findPathsByLocalName(String)} (or {@link #containsLocalName(String)})
+   * from {@link #qnmMapping}; invalidated by {@link #putQNameMapping} /
+   * {@link #removeQNameMapping}. PathSummary mutations are rare relative to
+   * lookups so the rebuild cost amortises trivially.
+   */
+  private final PathLocalNameIndex localNameIndex = new PathLocalNameIndex();
+
+  /**
    * The path cache.
    */
   private final Map<Path<QNm>, LongSet> pathCache;
@@ -308,6 +317,7 @@ public final class PathSummaryReader implements NodeReadOnlyTrx, NodeCursor {
     final Set<PathNode> pathNodes = qnmMapping.computeIfAbsent(this.getName(), (unused) -> new HashSet<>());
     pathNodes.add(node);
     qnmMapping.put(name, pathNodes);
+    localNameIndex.invalidate();
   }
 
   // package private, only used in writer to keep the mapping always up-to-date
@@ -318,6 +328,7 @@ public final class PathSummaryReader implements NodeReadOnlyTrx, NodeCursor {
     } else {
       pathNodes.remove(node);
     }
+    localNameIndex.invalidate();
   }
 
   /**
@@ -425,16 +436,27 @@ public final class PathSummaryReader implements NodeReadOnlyTrx, NodeCursor {
     if (localName == null) {
       return List.of();
     }
-    List<PathNode> result = null;
-    for (final Map.Entry<QNm, Set<PathNode>> entry : qnmMapping.entrySet()) {
-      if (localName.equals(entry.getKey().getLocalName())) {
-        if (result == null) {
-          result = new ArrayList<>(entry.getValue().size());
-        }
-        result.addAll(entry.getValue());
-      }
+    if (!localNameIndex.isBuilt()) {
+      localNameIndex.build(qnmMapping);
     }
-    return result == null ? List.of() : result;
+    return localNameIndex.findByLocalName(localName);
+  }
+
+  /**
+   * Existence-only variant of {@link #findPathsByLocalName(String)} — returns
+   * {@code true} when at least one path's QNm has the given localName.
+   * Allocates nothing on the hot path; SIMD-scans {@link #qnmMapping}'s dense
+   * localName-key array and stops on the first verified hit.
+   */
+  public boolean containsLocalName(final String localName) {
+    assertNotClosed();
+    if (localName == null) {
+      return false;
+    }
+    if (!localNameIndex.isBuilt()) {
+      localNameIndex.build(qnmMapping);
+    }
+    return localNameIndex.containsLocalName(localName);
   }
 
   /**

--- a/bundles/sirix-core/src/test/java/io/sirix/index/path/summary/PathLocalNameIndexTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/path/summary/PathLocalNameIndexTest.java
@@ -1,0 +1,117 @@
+package io.sirix.index.path.summary;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.node.NodeKind;
+import io.sirix.node.SirixDeweyID;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the SIMD scan returns identical results to the previous linear-walk
+ * fallback, including hash-collision and namespace-difference cases.
+ */
+final class PathLocalNameIndexTest {
+
+  private static PathNode pathNode(final String localName) {
+    return new PathNode(new QNm(localName), NodeKind.OBJECT_NAMED_OBJECT, 1, 1,
+        1L, -1L, -1, 0, (SirixDeweyID) null,
+        -1L, -1L, -1L, -1L, 0L, 0L,
+        -1, -1, localName.hashCode(), 0L);
+  }
+
+  private static Map<QNm, Set<PathNode>> mapping(final String... localNames) {
+    final Map<QNm, Set<PathNode>> m = new LinkedHashMap<>();
+    for (final String n : localNames) {
+      final QNm qn = new QNm(n);
+      final PathNode pn = pathNode(n);
+      m.computeIfAbsent(qn, k -> new HashSet<>()).add(pn);
+    }
+    return m;
+  }
+
+  @Test
+  void emptyIndex_returnsEmptyAndAllocatesNothing() {
+    final PathLocalNameIndex idx = new PathLocalNameIndex();
+    idx.build(new HashMap<>());
+    assertSame(List.of(), idx.findByLocalName("anything"),
+        "empty mapping must return the shared empty list — no allocation");
+    assertFalse(idx.containsLocalName("anything"));
+  }
+
+  @Test
+  void singleEntry_findsHit() {
+    final PathLocalNameIndex idx = new PathLocalNameIndex();
+    idx.build(mapping("age"));
+    final List<PathNode> hits = idx.findByLocalName("age");
+    assertEquals(1, hits.size());
+    assertEquals("age", hits.getFirst().getName().getLocalName());
+    assertTrue(idx.containsLocalName("age"));
+    assertFalse(idx.containsLocalName("missing"));
+  }
+
+  @Test
+  void manyEntries_simdScanCorrectAcrossLaneBoundary() {
+    // Picked so we cross at least one IntVector lane boundary on common species
+    // (8 ints @ 256-bit, 16 @ 512-bit). 33 entries forces tail handling too.
+    final String[] names = new String[33];
+    for (int i = 0; i < 33; i++) {
+      names[i] = "field" + i;
+    }
+    final PathLocalNameIndex idx = new PathLocalNameIndex();
+    idx.build(mapping(names));
+    for (final String n : names) {
+      assertTrue(idx.containsLocalName(n), "missing " + n);
+      final List<PathNode> hits = idx.findByLocalName(n);
+      assertEquals(1, hits.size());
+      assertEquals(n, hits.getFirst().getName().getLocalName());
+    }
+    assertFalse(idx.containsLocalName("not-present"));
+  }
+
+  @Test
+  void hashCollision_isResolvedByEqualsCheck() {
+    // "Aa" and "BB" have identical String#hashCode(). Both must be findable
+    // and neither must spuriously match the other on a SIMD hash hit.
+    assertEquals("Aa".hashCode(), "BB".hashCode(),
+        "test premise: 'Aa' and 'BB' must collide on hashCode");
+
+    final PathLocalNameIndex idx = new PathLocalNameIndex();
+    idx.build(mapping("Aa", "BB"));
+
+    final List<PathNode> aHits = idx.findByLocalName("Aa");
+    assertEquals(1, aHits.size());
+    assertEquals("Aa", aHits.getFirst().getName().getLocalName());
+
+    final List<PathNode> bHits = idx.findByLocalName("BB");
+    assertEquals(1, bHits.size());
+    assertEquals("BB", bHits.getFirst().getName().getLocalName());
+
+    assertTrue(idx.containsLocalName("Aa"));
+    assertTrue(idx.containsLocalName("BB"));
+    assertFalse(idx.containsLocalName("Cc"));
+  }
+
+  @Test
+  void invalidate_dropsArraysAndForcesRebuild() {
+    final PathLocalNameIndex idx = new PathLocalNameIndex();
+    idx.build(mapping("age", "city"));
+    assertTrue(idx.isBuilt());
+    idx.invalidate();
+    assertFalse(idx.isBuilt());
+    // After invalidation queries return empty until rebuilt — caller is
+    // responsible for rebuild on the lookup path.
+    assertSame(List.of(), idx.findByLocalName("age"));
+    assertFalse(idx.containsLocalName("age"));
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -3612,7 +3612,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     if (session.getResourceConfig().withPathSummary) {
       try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision);
            var summary = rtx.getResourceSession().openPathSummary(revision)) {
-        if (summary != null && !summary.findPathsByLocalName(field).isEmpty()) {
+        if (summary != null && summary.containsLocalName(field)) {
           return rtx.keyForName(field);
         }
       } catch (final Exception ignored) {


### PR DESCRIPTION
## Summary

`PathSummaryReader.findPathsByLocalName(String)` previously walked the entire `qnmMapping` entrySet and called `String.equals` on every key — O(N_distinct_paths) work per query field, hit twice from `SirixVectorizedExecutor`'s hot path (lines 993 & 3615). Replace with a SIMD scan over a dense `int[]` of pre-hashed `localName.hashCode()` values.

## What changed

- New `PathLocalNameIndex` class — lazy dense parallel arrays `(localNameKeys: int[], localNames: String[], paths: Set<PathNode>[])`, scanned with `IntVector.SPECIES_PREFERRED.compare(EQ)`. Hash hits are verified via a single `String.equals` per matched lane (collision-safe).
- `PathSummaryReader` builds the index on first lookup, invalidates it inside `putQNameMapping` / `removeQNameMapping` (rare), and rebuilds on the next lookup.
- New `containsLocalName(String)` existence-check fast path — same SIMD scan but stops at first verified hit and **allocates nothing**. The `SirixVectorizedExecutor:3615` call site that previously allocated a `List` just to check `isEmpty()` is rerouted to it.
- Empty-result lookups return the shared `List.of()` — also zero allocation.

## HFT properties

- Single linear scan over a contiguous `int[]` — cache-friendly, branchless on the no-match positions.
- `IntVector.SPECIES_PREFERRED` (8 ints @ AVX2 / 16 @ AVX-512) with `compare(EQ)` → mask. Tail handled scalar.
- Per-lookup hashing happens once outside the loop (`localName.hashCode()`); the inner loop is pure int compare.
- The mutators on `qnmMapping` only invalidate (no double-bookkeeping).

## Test plan

- [x] `PathLocalNameIndexTest` — empty mapping, single hit, lane-boundary scans (33 entries to cross both 8-lane and 16-lane species), hash-collision pair `"Aa"` / `"BB"`, invalidate/rebuild semantics.
- [x] `io.sirix.index.path.summary.*`
- [x] `io.sirix.access.node.json.PathSummaryTest`, `io.sirix.access.node.xml.PathSummaryTest`
- [x] `io.sirix.diff.algorithm.JsonFMSEPathSummaryTest`
- [ ] CI on PR