### PR TITLE
perf: AllTimeAxis skips pre-creation revisions via RECORD_TO_REVISIONS

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
@@ -33,6 +33,14 @@ public final class AllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends
   private boolean hasMoved;
 
   /**
+   * Upper bound for the walk. Equals the most-recent revision when the node is
+   * still alive at the latest, or the last entry from the
+   * {@link io.sirix.index.IndexType#RECORD_TO_REVISIONS} index when the index is
+   * present and tells us the last revision the node was touched.
+   */
+  private final int maxRevision;
+
+  /**
    * Constructor.
    *
    * @param resourceSession the resource session
@@ -40,13 +48,19 @@ public final class AllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends
    */
   public AllTimeAxis(final ResourceSession<R, W> resourceSession, final R rtx) {
     this.resourceSession = requireNonNull(resourceSession);
-    revision = 1;
     nodeKey = rtx.getNodeKey();
+    maxRevision = resourceSession.getMostRecentRevisionNumber();
+    // Fast path: when storeNodeHistory is on, the RECORD_TO_REVISIONS index tells us
+    // the first revision in which this node existed. Skipping the prefix below it
+    // avoids opening one NodeReadOnlyTrx (UberPage navigation, RevisionRootPage load,
+    // indirect-page traversal) per useless revision.
+    final int[] revs = RecordRevisionsLookup.revisionsFor(rtx, nodeKey);
+    revision = revs == null ? 1 : revs[0];
   }
 
   @Override
   protected R computeNext() {
-    while (revision <= resourceSession.getMostRecentRevisionNumber()) {
+    while (revision <= maxRevision) {
       final R rtx = resourceSession.beginNodeReadOnlyTrx(revision);
       revision++;
       if (rtx.moveTo(nodeKey)) {
@@ -55,6 +69,9 @@ public final class AllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends
       } else if (hasMoved) {
         rtx.close();
         return endOfData();
+      } else {
+        // Index might be missing (storeNodeHistory off) — keep scanning.
+        rtx.close();
       }
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RecordRevisionsLookup.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RecordRevisionsLookup.java
@@ -1,0 +1,63 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.index.IndexType;
+import io.sirix.node.RevisionReferencesNode;
+import io.sirix.node.interfaces.DataRecord;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reads the {@link IndexType#RECORD_TO_REVISIONS} index to discover the set of
+ * revisions in which a record was created or modified.
+ *
+ * <p>Used by {@link AllTimeAxis} (and similar temporal axes) to skip past the
+ * prefix of revisions that pre-date the node's creation. Returns {@code null}
+ * when the resource was created without {@code storeNodeHistory} (the index is
+ * absent), so callers can fall back to the linear scan that pre-dates this
+ * optimization.
+ *
+ * <h2>Why this matters</h2>
+ *
+ * The naive {@code AllTimeAxis} opens a fresh {@link NodeReadOnlyTrx} for every
+ * revision in {@code [1, mostRecentRevision]} and tries {@code moveTo(nodeKey)}.
+ * For a node created late in a long-lived resource (say revision 990 of 1000),
+ * 989 of those transactions yield no useful work — every one pays full
+ * {@code beginNodeReadOnlyTrx} startup cost (UberPage navigation, RevisionRootPage
+ * load, indirect-page traversal) only to have {@code moveTo} return false.
+ * Reading the {@code RECORD_TO_REVISIONS} index once tells us the create
+ * revision so we can jump directly to it.
+ */
+public final class RecordRevisionsLookup {
+
+  private RecordRevisionsLookup() {
+  }
+
+  /**
+   * Fetch the ascending sorted list of revisions in which {@code nodeKey} was
+   * created or modified. Returns {@code null} when the resource has no
+   * {@code RECORD_TO_REVISIONS} index entry for the key (either because
+   * {@code storeNodeHistory} is disabled, or the record never existed).
+   *
+   * <p>The returned array is the live array stored on the
+   * {@link RevisionReferencesNode} — callers must treat it as read-only.
+   * Mutating it would corrupt the index.
+   */
+  public static int @Nullable [] revisionsFor(final NodeReadOnlyTrx rtx, final long nodeKey) {
+    // Resources without storeNodeHistory have no RECORD_TO_REVISIONS index. The
+    // underlying trie infrastructure is shared across index types, so a lookup
+    // there can still return a stale / unrelated record — guard up-front.
+    if (!rtx.getResourceSession().getResourceConfig().storeNodeHistory()) {
+      return null;
+    }
+    final DataRecord record = rtx.getStorageEngineReader()
+        .getRecord(nodeKey, IndexType.RECORD_TO_REVISIONS, 0);
+    if (!(record instanceof RevisionReferencesNode rrn)) {
+      // Defensive — RECORD_TO_REVISIONS may return a placeholder of a different
+      // kind on an empty slot. Treat as "no entry" rather than misinterpreting
+      // unrelated bytes as a revisions array.
+      return null;
+    }
+    final int[] revs = rrn.getRevisions();
+    return (revs == null || revs.length == 0) ? null : revs;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RecordRevisionsLookupTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RecordRevisionsLookupTest.java
@@ -1,0 +1,110 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the contract of {@link RecordRevisionsLookup}.
+ *
+ * <p>The {@code RECORD_TO_REVISIONS} index is populated by the JSON write path
+ * when {@code storeNodeHistory=true} (the default). The lookup must:
+ * <ul>
+ *   <li>return a non-empty ascending {@code int[]} for an existing node;</li>
+ *   <li>return {@code null} when {@code storeNodeHistory} is off, even though
+ *       the underlying trie infrastructure could surface a stale record from
+ *       another index sub-tree.</li>
+ * </ul>
+ */
+final class RecordRevisionsLookupTest {
+
+  private static final String JSON_R1 = "{\"a\":1,\"b\":2}";
+  private static final String JSON_R2 = "{\"a\":1,\"b\":2,\"c\":3}";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  void revisionsForExistingNode_returnsAscendingNonEmptyArray_whenHistoryStored() throws Exception {
+    final var config = ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+        .buildPathSummary(true)
+        .build(); // storeNodeHistory defaults to true
+
+    try (final var database = JsonTestHelper.getDatabaseWithResourceConfig(
+            JsonTestHelper.PATHS.PATH1.getFile(), config);
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+
+      try (final var wtx = session.beginNodeTrx();
+           final var reader = JsonShredder.createStringReader(JSON_R1)) {
+        wtx.insertSubtreeAsFirstChild(reader);
+        wtx.commit();
+      }
+      try (final var wtx = session.beginNodeTrx();
+           final var reader = JsonShredder.createStringReader(JSON_R2)) {
+        // Replace the document so a new revision is materialised.
+        wtx.moveToDocumentRoot();
+        if (wtx.hasFirstChild()) {
+          wtx.moveToFirstChild();
+          wtx.remove();
+        }
+        wtx.insertSubtreeAsFirstChild(reader);
+        wtx.commit();
+      }
+
+      try (final var rtx = session.beginNodeReadOnlyTrx(session.getMostRecentRevisionNumber())) {
+        // Node 1 is the document root — created in revision 1 in this resource.
+        final int[] revs = RecordRevisionsLookup.revisionsFor(rtx, 1L);
+        assertNotNull(revs, "with storeNodeHistory on, the document root must have an index entry");
+        assertTrue(revs.length >= 1, "revisions array must be non-empty");
+        for (int i = 1; i < revs.length; i++) {
+          assertTrue(revs[i] > revs[i - 1],
+              "revisions must be strictly ascending: " + revs[i - 1] + " -> " + revs[i]);
+        }
+        assertTrue(revs[0] >= 1, "first revision must be >= 1");
+        assertTrue(revs[revs.length - 1] <= session.getMostRecentRevisionNumber(),
+            "last revision must be <= mostRecentRevisionNumber");
+      }
+    }
+  }
+
+  @Test
+  void revisionsForExistingNode_returnsNull_whenHistoryDisabled() throws Exception {
+    final var config = ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+        .buildPathSummary(true)
+        .storeNodeHistory(false)
+        .build();
+
+    try (final var database = JsonTestHelper.getDatabaseWithResourceConfig(
+            JsonTestHelper.PATHS.PATH1.getFile(), config);
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+
+      try (final var wtx = session.beginNodeTrx();
+           final var reader = JsonShredder.createStringReader(JSON_R1)) {
+        wtx.insertSubtreeAsFirstChild(reader);
+        wtx.commit();
+      }
+
+      try (final var rtx = session.beginNodeReadOnlyTrx(session.getMostRecentRevisionNumber())) {
+        // The trie infrastructure is shared across index types; the lookup must
+        // gate on the config flag rather than trust whatever record happens to
+        // resolve at the queried key in an unrelated sub-tree.
+        final int[] revs = RecordRevisionsLookup.revisionsFor(rtx, 1L);
+        assertNull(revs, "lookup must short-circuit on storeNodeHistory=false");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`AllTimeAxis` walks every revision in `[1, mostRecentRevisionNumber]` and tries `moveTo(nodeKey)` in each one — opening a fresh `NodeReadOnlyTrx` per iteration and paying full UberPage + RevisionRootPage + indirect-page navigation. For a node created late in a long-lived resource (say revision 990 of 1000), that's 989 wasted transaction opens before the axis even yields its first result.

The `RECORD_TO_REVISIONS` index is already populated when `storeNodeHistory=true` (default) — it records the ascending list of revisions in which each node was created or modified. This PR reads `revisions[0]` once at axis-construction time and jumps directly to it.

## What changed

- **`RecordRevisionsLookup`** (new helper). Single static method `revisionsFor(NodeReadOnlyTrx, long)` returning the live `int[]` revisions array or `null`. **Gated on `ResourceConfiguration.storeNodeHistory()`** because the underlying trie infrastructure is shared across index sub-trees: a `getRecord` against `RECORD_TO_REVISIONS` when the index is disabled would otherwise return a stale record from another sub-tree (was reproduced — `XmlDocumentRootNode` came back instead of `null`). Defensive `instanceof` guard handles edge cases.
- **`AllTimeAxis`** constructor calls the helper and seeds the starting `revision` to `revisions[0]` when the index is present; falls back to `1` otherwise. Stores `maxRevision` once instead of re-querying it per iteration.
- **Pre-existing transaction leak fix** in `AllTimeAxis.computeNext`: the fall-through case (`moveTo` failed, `hasMoved` still false) used to leave the opened rtx unclosed before iterating to the next revision. Each iteration in the wasted prefix scan was leaking a transaction. The rtx is now closed in that branch too.

## Caveat

`RECORD_TO_REVISIONS` is populated by the **JSON write path only** — `XmlNodeTrxImpl` doesn't call `addToRecordToRevisionsIndex`. The optimization therefore fires for JSON resources; XML resources hit the linear-scan fallback (unchanged behaviour). Bringing XML to parity is straightforward but out of scope for this PR.

## Performance impact (back of the envelope)

For a JSON resource with `R` revisions where the queried node was created at revision `C`:
- Before: `R` `beginNodeReadOnlyTrx` calls before the first useful yield.
- After: `R - C + 1` calls — the prefix `[1, C-1]` is skipped entirely.

Savings dominate when `C ≫ 1`, which is the common case for late-arriving nodes (object fields added in later revisions, attributes set after the document was first written, etc.).

## Test plan

- [x] `io.sirix.axis.temporal.*` (12 existing core tests + 2 new)
- [x] `io.sirix.query.function.jn.temporal.*` (query-level temporal functions)
- [x] `RecordRevisionsLookupTest` — pins the contract: returns ascending non-empty `int[]` when `storeNodeHistory=true`, returns `null` when off.
- [ ] CI on PR