### PR TITLE
perf: prefetch-pipelined temporal axes (AllTime / Past / Future)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -861,6 +861,14 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   /**
+   * Number of currently-open read-only or read-write node transactions on this session.
+   * Useful for diagnostics and for asserting the absence of resource leaks in tests.
+   */
+  public int activeTrxCount() {
+    return nodeTrxMap.size();
+  }
+
+  /**
    * Begin a read-only transaction at the revision that was valid at the given point in time.
    * 
    * <p>

--- a/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
@@ -95,6 +95,14 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   Optional<W> getNodeTrx();
 
   /**
+   * Number of currently-open read-only or read-write node transactions on this session.
+   * Useful for diagnostics and for asserting the absence of resource leaks in tests.
+   *
+   * @return the number of open node transactions, including the single writer if any
+   */
+  int activeTrxCount();
+
+  /**
    * Begin a new {@link StorageEngineReader}.
    *
    * @return new {@link StorageEngineReader} instance

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/AbstractTemporalAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/AbstractTemporalAxis.java
@@ -9,11 +9,24 @@ import io.sirix.utils.AbstractComputingIterator;
 /**
  * TemporalAxis abstract class.
  *
- * @author Johannes Lichtenberger
+ * <p>Implements {@link AutoCloseable} so consumers (typically a wrapping
+ * {@code TemporalSirix*Stream}) can release any resources the axis holds — most
+ * importantly, prefetched read-only transactions held by look-ahead variants. The
+ * default {@link #close()} is a no-op for axes that hold no per-iteration resources.
  *
+ * @author Johannes Lichtenberger
  */
 public abstract class AbstractTemporalAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends NodeTrx & NodeCursor>
-    extends AbstractComputingIterator<R> {
+    extends AbstractComputingIterator<R> implements AutoCloseable {
 
   public abstract ResourceSession<R, W> getResourceSession();
+
+  /**
+   * Release any resources this axis holds. Safe to call multiple times. The default
+   * implementation does nothing; look-ahead axes override to cancel pending prefetches.
+   */
+  @Override
+  public void close() {
+    // no-op default
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
@@ -52,8 +52,13 @@ public final class AllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends
       if (rtx.moveTo(nodeKey)) {
         hasMoved = true;
         return rtx;
-      } else if (hasMoved) {
-        rtx.close();
+      }
+      // moveTo failed: either we're still in the prefix before the node was created, or
+      // the node was deleted after a prior yield. Either way, this rtx is ours alone —
+      // close it so it does not leak. (Past/FutureAxis already do this; AllTimeAxis used
+      // to leak the prefix rtxs.)
+      rtx.close();
+      if (hasMoved) {
         return endOfData();
       }
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedAllTimeAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedAllTimeAxis.java
@@ -58,6 +58,7 @@ public final class PrefetchedAllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor,
       final RtxResult<R> result = prefetcher.poll();
       if (result == null) {
         drained = true;
+        prefetcher.close();
         return endOfData();
       }
       if (result.nodeFound) {
@@ -78,5 +79,11 @@ public final class PrefetchedAllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor,
   @Override
   public ResourceSession<R, W> getResourceSession() {
     return resourceSession;
+  }
+
+  @Override
+  public void close() {
+    drained = true;
+    prefetcher.close();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedAllTimeAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedAllTimeAxis.java
@@ -1,0 +1,82 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.api.NodeCursor;
+import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.api.NodeTrx;
+import io.sirix.api.ResourceSession;
+import io.sirix.axis.AbstractTemporalAxis;
+import io.sirix.axis.temporal.RevisionPrefetcher.RtxResult;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Look-ahead-prefetch variant of {@link AllTimeAxis}. Yields the same sequence of
+ * read-only transactions but overlaps the per-revision
+ * {@link ResourceSession#beginNodeReadOnlyTrx} cost with consumer-side work via a
+ * fixed-depth virtual-thread pipeline. See {@link RevisionPrefetcher}.
+ *
+ * <p>Iteration semantics match {@link AllTimeAxis} byte-for-byte:
+ * <ul>
+ *   <li>Walks revisions 1 through the most-recent revision in ascending order.</li>
+ *   <li>Yields the rtx for each revision in which {@code moveTo(nodeKey)} succeeds.</li>
+ *   <li>Terminates once a {@code moveTo} fails after at least one prior success
+ *       (the node was deleted) — the consumer keeps the previously-yielded rtxs.</li>
+ *   <li>Closes any rtx it opened that is not yielded to the consumer (no leak).</li>
+ * </ul>
+ *
+ * <p>This class additionally avoids a pre-existing leak in the original
+ * {@link AllTimeAxis}: the prefix of revisions before the node is created used to
+ * leak the opened-but-not-yielded rtx — here, every rtx whose {@code moveTo} fails
+ * is closed.
+ */
+public final class PrefetchedAllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor,
+    W extends NodeTrx & NodeCursor> extends AbstractTemporalAxis<R, W> {
+
+  private final ResourceSession<R, W> resourceSession;
+  private final RevisionPrefetcher<R, W> prefetcher;
+  private boolean hasMoved;
+  private boolean drained;
+
+  public PrefetchedAllTimeAxis(final ResourceSession<R, W> resourceSession, final R rtx) {
+    this.resourceSession = requireNonNull(resourceSession);
+    final long nodeKey = rtx.getNodeKey();
+    final int maxRevision = resourceSession.getMostRecentRevisionNumber();
+    final int[] cursor = new int[] {1};
+    this.prefetcher = new RevisionPrefetcher<>(resourceSession, nodeKey, () -> {
+      final int next = cursor[0];
+      if (next > maxRevision) {
+        return -1;
+      }
+      cursor[0] = next + 1;
+      return next;
+    }, RevisionPrefetcher.DEFAULT_DEPTH);
+  }
+
+  @Override
+  protected R computeNext() {
+    while (!drained) {
+      final RtxResult<R> result = prefetcher.poll();
+      if (result == null) {
+        drained = true;
+        return endOfData();
+      }
+      if (result.nodeFound) {
+        hasMoved = true;
+        return result.rtx;
+      }
+      result.rtx.close();
+      if (hasMoved) {
+        // Node existed and is now gone — terminate, releasing any further prefetched rtx.
+        prefetcher.close();
+        drained = true;
+        return endOfData();
+      }
+    }
+    return endOfData();
+  }
+
+  @Override
+  public ResourceSession<R, W> getResourceSession() {
+    return resourceSession;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedFutureAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedFutureAxis.java
@@ -1,0 +1,75 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.api.NodeCursor;
+import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.api.NodeTrx;
+import io.sirix.api.ResourceSession;
+import io.sirix.axis.AbstractTemporalAxis;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.axis.temporal.RevisionPrefetcher.RtxResult;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Look-ahead-prefetch variant of {@link FutureAxis}. Walks revisions ascending from
+ * (currentRevision + 1) (or currentRevision when {@code includeSelf == YES}) up to
+ * the most-recent revision, yielding the rtx in each revision in which
+ * {@code moveTo(nodeKey)} succeeds. Terminates on the first failure (deletion).
+ *
+ * <p>The look-ahead overlaps the per-revision trx-open cost with consumer-side work
+ * via {@link RevisionPrefetcher}.
+ */
+public final class PrefetchedFutureAxis<R extends NodeReadOnlyTrx & NodeCursor,
+    W extends NodeTrx & NodeCursor> extends AbstractTemporalAxis<R, W> {
+
+  private final ResourceSession<R, W> resourceSession;
+  private final RevisionPrefetcher<R, W> prefetcher;
+  private boolean drained;
+
+  public PrefetchedFutureAxis(final ResourceSession<R, W> resourceSession, final R rtx) {
+    this(resourceSession, rtx, IncludeSelf.NO);
+  }
+
+  public PrefetchedFutureAxis(final ResourceSession<R, W> resourceSession, final R rtx,
+      final IncludeSelf includeSelf) {
+    this.resourceSession = requireNonNull(resourceSession);
+    final long nodeKey = rtx.getNodeKey();
+    final int startRevision = requireNonNull(includeSelf) == IncludeSelf.YES
+        ? rtx.getRevisionNumber()
+        : rtx.getRevisionNumber() + 1;
+    final int maxRevision = resourceSession.getMostRecentRevisionNumber();
+    final int[] cursor = new int[] {startRevision};
+    this.prefetcher = new RevisionPrefetcher<>(resourceSession, nodeKey, () -> {
+      final int next = cursor[0];
+      if (next > maxRevision) {
+        return -1;
+      }
+      cursor[0] = next + 1;
+      return next;
+    }, RevisionPrefetcher.DEFAULT_DEPTH);
+  }
+
+  @Override
+  protected R computeNext() {
+    if (drained) {
+      return endOfData();
+    }
+    final RtxResult<R> result = prefetcher.poll();
+    if (result == null) {
+      drained = true;
+      return endOfData();
+    }
+    if (result.nodeFound) {
+      return result.rtx;
+    }
+    result.rtx.close();
+    prefetcher.close();
+    drained = true;
+    return endOfData();
+  }
+
+  @Override
+  public ResourceSession<R, W> getResourceSession() {
+    return resourceSession;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedFutureAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedFutureAxis.java
@@ -57,6 +57,7 @@ public final class PrefetchedFutureAxis<R extends NodeReadOnlyTrx & NodeCursor,
     final RtxResult<R> result = prefetcher.poll();
     if (result == null) {
       drained = true;
+      prefetcher.close();
       return endOfData();
     }
     if (result.nodeFound) {
@@ -71,5 +72,11 @@ public final class PrefetchedFutureAxis<R extends NodeReadOnlyTrx & NodeCursor,
   @Override
   public ResourceSession<R, W> getResourceSession() {
     return resourceSession;
+  }
+
+  @Override
+  public void close() {
+    drained = true;
+    prefetcher.close();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedPastAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedPastAxis.java
@@ -1,0 +1,75 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.api.NodeCursor;
+import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.api.NodeTrx;
+import io.sirix.api.ResourceSession;
+import io.sirix.axis.AbstractTemporalAxis;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.axis.temporal.RevisionPrefetcher.RtxResult;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Look-ahead-prefetch variant of {@link PastAxis}. Walks revisions descending from
+ * (currentRevision − 1) (or currentRevision when {@code includeSelf == YES}) down
+ * to revision 1, yielding the rtx in each revision in which {@code moveTo(nodeKey)}
+ * succeeds. Terminates on the first failure.
+ *
+ * <p>The look-ahead overlaps the per-revision trx-open cost with consumer-side work
+ * via {@link RevisionPrefetcher}.
+ */
+public final class PrefetchedPastAxis<R extends NodeReadOnlyTrx & NodeCursor,
+    W extends NodeTrx & NodeCursor> extends AbstractTemporalAxis<R, W> {
+
+  private final ResourceSession<R, W> resourceSession;
+  private final RevisionPrefetcher<R, W> prefetcher;
+  private boolean drained;
+
+  public PrefetchedPastAxis(final ResourceSession<R, W> resourceSession, final R rtx) {
+    this(resourceSession, rtx, IncludeSelf.NO);
+  }
+
+  public PrefetchedPastAxis(final ResourceSession<R, W> resourceSession, final R rtx,
+      final IncludeSelf includeSelf) {
+    this.resourceSession = requireNonNull(resourceSession);
+    final long nodeKey = rtx.getNodeKey();
+    final int startRevision = requireNonNull(includeSelf) == IncludeSelf.YES
+        ? rtx.getRevisionNumber()
+        : rtx.getRevisionNumber() - 1;
+    final int[] cursor = new int[] {startRevision};
+    this.prefetcher = new RevisionPrefetcher<>(resourceSession, nodeKey, () -> {
+      final int next = cursor[0];
+      if (next < 1) {
+        return -1;
+      }
+      cursor[0] = next - 1;
+      return next;
+    }, RevisionPrefetcher.DEFAULT_DEPTH);
+  }
+
+  @Override
+  protected R computeNext() {
+    if (drained) {
+      return endOfData();
+    }
+    final RtxResult<R> result = prefetcher.poll();
+    if (result == null) {
+      drained = true;
+      return endOfData();
+    }
+    if (result.nodeFound) {
+      return result.rtx;
+    }
+    result.rtx.close();
+    // First failure terminates a temporal-direction axis — release the rest.
+    prefetcher.close();
+    drained = true;
+    return endOfData();
+  }
+
+  @Override
+  public ResourceSession<R, W> getResourceSession() {
+    return resourceSession;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedPastAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/PrefetchedPastAxis.java
@@ -56,6 +56,7 @@ public final class PrefetchedPastAxis<R extends NodeReadOnlyTrx & NodeCursor,
     final RtxResult<R> result = prefetcher.poll();
     if (result == null) {
       drained = true;
+      prefetcher.close();
       return endOfData();
     }
     if (result.nodeFound) {
@@ -71,5 +72,11 @@ public final class PrefetchedPastAxis<R extends NodeReadOnlyTrx & NodeCursor,
   @Override
   public ResourceSession<R, W> getResourceSession() {
     return resourceSession;
+  }
+
+  @Override
+  public void close() {
+    drained = true;
+    prefetcher.close();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
@@ -6,38 +6,58 @@ import io.sirix.api.NodeTrx;
 import io.sirix.api.ResourceSession;
 
 import java.util.ArrayDeque;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
 import java.util.function.IntSupplier;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Look-ahead prefetcher for the multi-revision temporal axes
  * ({@link PrefetchedAllTimeAxis}, {@link PrefetchedPastAxis}, {@link PrefetchedFutureAxis}).
  *
- * <p>The naive temporal axes pay one full {@link ResourceSession#beginNodeReadOnlyTrx(int)}
- * per yielded revision — UberPage navigation, RevisionRootPage load, indirect-page
- * traversal — sequentially. While the consumer processes the rtx for revision N, the
- * cores spent on opening N+1 are otherwise idle. The prefetcher overlaps those opens
- * with consumer work using a fixed-depth queue of {@link CompletableFuture}s, each
- * spawning a {@link Thread#startVirtualThread virtual thread} to do its trx open.
+ * <p>Each yielded revision costs a {@link ResourceSession#beginNodeReadOnlyTrx(int)} plus
+ * a {@link io.sirix.api.NodeCursor#moveTo(long)}. The prefetcher overlaps those steps
+ * with consumer-side work using a fixed-depth queue of {@link CompletableFuture}s, each
+ * spawning a {@link Thread#startVirtualThread virtual thread} that opens the trx and
+ * walks to the target node.
  *
- * <h2>HFT properties</h2>
+ * <h2>What runs in parallel — and what doesn't</h2>
  * <ul>
- *   <li>Bounded memory: at most {@code depth} rtx in flight + the one being yielded.</li>
- *   <li>No long-lived executor — each task starts a virtual thread directly. No
- *       per-axis pool, no shutdown coordination.</li>
- *   <li>Backpressure-free reads: poll() blocks on the head future via {@code .join()};
- *       the consumer's processing time gates the prefetch rate naturally.</li>
- *   <li>Leak-free shutdown: pending futures attach a {@code thenAccept} that closes
- *       their rtx as soon as the open completes, even after the axis is abandoned.</li>
+ *   <li>{@code beginNodeReadOnlyTrx} is {@code synchronized} on the resource session, so
+ *       its body (RevisionRoot load, document-node fetch, trx-map registration) executes
+ *       one task at a time. After a warm cache this is a small fraction of the per-yield
+ *       cost.</li>
+ *   <li>The subsequent {@code rtx.moveTo(nodeKey)} runs on per-trx state with the shared
+ *       page cache and traverses the indirect-page index for the target node. Multiple
+ *       in-flight tasks walk different revisions of that index in parallel — that is
+ *       where the depth-{@code N} pipeline pays off, especially for deep histories.</li>
  * </ul>
  *
- * <p>Not thread-safe: an axis is single-consumer by contract.
+ * <h2>Lifecycle</h2>
+ * <ul>
+ *   <li>Lazy: the constructor submits nothing. The first call to {@link #poll()} fills
+ *       the pipeline up to {@code depth}. A consumer that constructs the axis but never
+ *       iterates pays no I/O cost.</li>
+ *   <li>Bounded: at most {@code depth} rtx in flight + the one being yielded.</li>
+ *   <li>{@link #close()} flips a flag observed by every supplier; pending tasks
+ *       short-circuit before opening a trx, in-flight tasks close their rtx inline once
+ *       the open returns, and futures already completed have their rtx closed via a
+ *       {@code whenComplete} callback. Idempotent.</li>
+ * </ul>
+ *
+ * <p>Single-consumer by contract: {@link #poll()} and {@link #close()} must be called by
+ * the same thread (typically the axis's iterator thread). The supplier bodies run on
+ * their own virtual threads and read the {@link #closed} flag through a {@code volatile}
+ * publish.
  */
 final class RevisionPrefetcher<R extends NodeReadOnlyTrx & NodeCursor,
     W extends NodeTrx & NodeCursor> implements AutoCloseable {
 
-  /** Default look-ahead depth — overlaps roughly four trx opens behind the consumer. */
+  /** Default look-ahead depth. */
   static final int DEFAULT_DEPTH = 4;
 
   /** Carry the rtx and the moveTo result so the consumer can branch without reopening. */
@@ -53,44 +73,82 @@ final class RevisionPrefetcher<R extends NodeReadOnlyTrx & NodeCursor,
 
   private static final Executor VIRTUAL_THREAD_EXECUTOR = Thread::startVirtualThread;
 
+  /**
+   * Hoisted, capture-free close-on-complete callback. Used by {@link #close()} for every
+   * pending future so that an rtx already opened by a finished supplier is still
+   * released even though the consumer abandoned the axis. Static + capture-free →
+   * single instance for the JVM lifetime → zero allocation per close().
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static final BiConsumer<RtxResult, Throwable> CLOSE_RESULT_RTX = (result, ex) -> {
+    if (result != null && result.rtx != null) {
+      result.rtx.close();
+    }
+  };
+
   private final ResourceSession<R, W> resourceSession;
   private final long nodeKey;
   private final IntSupplier nextRevision;
   private final int depth;
   private final ArrayDeque<CompletableFuture<RtxResult<R>>> queue;
 
+  /** Set by {@link #close()}; suppliers observe this and abort or close-inline. */
+  private volatile boolean closed;
+
   /**
    * @param resourceSession the session each prefetch task opens an rtx on
    * @param nodeKey         the record to {@code moveTo} after each open
-   * @param nextRevision    yields the next revision number to fetch, or {@code -1}
+   * @param nextRevision    yields the next revision number to fetch, or a negative value
    *                        once the iteration is exhausted
-   * @param depth           look-ahead window — bounded number of in-flight opens
+   * @param depth           look-ahead window, must be {@code > 0}
    */
   RevisionPrefetcher(final ResourceSession<R, W> resourceSession, final long nodeKey,
       final IntSupplier nextRevision, final int depth) {
-    this.resourceSession = resourceSession;
+    this.resourceSession = requireNonNull(resourceSession, "resourceSession");
+    this.nextRevision = requireNonNull(nextRevision, "nextRevision");
+    if (depth <= 0) {
+      throw new IllegalArgumentException("depth must be > 0, got " + depth);
+    }
     this.nodeKey = nodeKey;
-    this.nextRevision = nextRevision;
     this.depth = depth;
     this.queue = new ArrayDeque<>(depth);
-    for (int i = 0; i < depth; i++) {
-      if (!submitNext()) {
-        break;
-      }
-    }
   }
 
   /**
-   * Submit one more open task to the back of the queue, drawn from {@link #nextRevision}.
-   * Returns {@code false} when the iterator is exhausted (no more revisions to fetch).
+   * Top up the in-flight queue to {@link #depth}. No-op once {@link #closed} is set or
+   * the revision iterator is exhausted.
    */
+  private void fillToDepth() {
+    if (closed) {
+      return;
+    }
+    while (queue.size() < depth && submitNext()) {
+      // keep filling
+    }
+  }
+
+  /** Submit one more open task. Returns {@code false} if the iterator is exhausted. */
   private boolean submitNext() {
     final int rev = nextRevision.getAsInt();
     if (rev < 0) {
       return false;
     }
     queue.offer(CompletableFuture.supplyAsync(() -> {
+      // Cooperative cancellation point #1: skip the trx-open entirely if close() has
+      // already been called. No rtx allocated → nothing to leak.
+      // (CompletableFuture.cancel(true) does NOT interrupt this body — Java contract
+      //  explicitly. So we don't bother reading the thread interrupt flag.)
+      if (closed) {
+        return null;
+      }
       final R rtx = resourceSession.beginNodeReadOnlyTrx(rev);
+      // Cooperative cancellation point #2: close() ran while we held the session monitor
+      // or did the trx-open. The rtx is solely ours — close it inline rather than handing
+      // a phantom to a consumer that has already abandoned the axis.
+      if (closed) {
+        rtx.close();
+        return null;
+      }
       final boolean ok = rtx.moveTo(nodeKey);
       return new RtxResult<>(rtx, ok);
     }, VIRTUAL_THREAD_EXECUTOR));
@@ -98,33 +156,51 @@ final class RevisionPrefetcher<R extends NodeReadOnlyTrx & NodeCursor,
   }
 
   /**
-   * Block on the head future, return its result, then top up the pipeline so the
-   * window stays full. Returns {@code null} when no more results will be produced.
+   * Block on the head future and return its result; returns {@code null} when no more
+   * results will be produced (iterator exhausted or {@link #close()} called).
    */
   RtxResult<R> poll() {
+    if (closed) {
+      return null;
+    }
+    fillToDepth();
     final CompletableFuture<RtxResult<R>> head = queue.poll();
     if (head == null) {
       return null;
     }
-    final RtxResult<R> result = head.join();
-    submitNext();
+    final RtxResult<R> result;
+    try {
+      result = head.join();
+    } catch (final CancellationException | CompletionException ex) {
+      // Either close() raced us (cancelled) or the supplier threw — the supplier's own
+      // close-inline path released any rtx it managed to open.
+      return null;
+    }
+    fillToDepth();
     return result;
   }
 
   /**
-   * Releases all in-flight prefetched rtx — those completed get closed inline; those
-   * still in flight have a continuation attached that closes them on completion. Safe
-   * to call multiple times.
+   * Cancels every pending task, closes any rtx that already completed but was not
+   * yielded, and prevents future {@link #poll()} calls from producing results. Tasks
+   * that finish after this returns observe the {@link #closed} flag and close their own
+   * rtx. Idempotent.
    */
+  @SuppressWarnings({"rawtypes", "unchecked"})
   @Override
   public void close() {
+    if (closed) {
+      return;
+    }
+    closed = true;
     while (!queue.isEmpty()) {
       final CompletableFuture<RtxResult<R>> f = queue.poll();
-      f.thenAccept(result -> {
-        if (result != null && result.rtx != null) {
-          result.rtx.close();
-        }
-      }).exceptionally(ex -> null);
+      // cancel(true) on a CompletableFuture only flips its state — it does NOT interrupt
+      // the supplyAsync body. The body cooperates by reading `closed` and self-closing
+      // any rtx it opened. whenComplete catches the case where the future already
+      // completed normally before we got here, so its rtx still gets released.
+      f.cancel(true);
+      f.whenComplete((BiConsumer) CLOSE_RESULT_RTX);
     }
   }
 
@@ -136,5 +212,10 @@ final class RevisionPrefetcher<R extends NodeReadOnlyTrx & NodeCursor,
   /** Diagnostic accessor — configured look-ahead depth. */
   int depth() {
     return depth;
+  }
+
+  /** Diagnostic accessor — whether {@link #close()} has been called. */
+  boolean isClosed() {
+    return closed;
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
@@ -1,0 +1,140 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.api.NodeCursor;
+import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.api.NodeTrx;
+import io.sirix.api.ResourceSession;
+
+import java.util.ArrayDeque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.IntSupplier;
+
+/**
+ * Look-ahead prefetcher for the multi-revision temporal axes
+ * ({@link PrefetchedAllTimeAxis}, {@link PrefetchedPastAxis}, {@link PrefetchedFutureAxis}).
+ *
+ * <p>The naive temporal axes pay one full {@link ResourceSession#beginNodeReadOnlyTrx(int)}
+ * per yielded revision — UberPage navigation, RevisionRootPage load, indirect-page
+ * traversal — sequentially. While the consumer processes the rtx for revision N, the
+ * cores spent on opening N+1 are otherwise idle. The prefetcher overlaps those opens
+ * with consumer work using a fixed-depth queue of {@link CompletableFuture}s, each
+ * spawning a {@link Thread#startVirtualThread virtual thread} to do its trx open.
+ *
+ * <h2>HFT properties</h2>
+ * <ul>
+ *   <li>Bounded memory: at most {@code depth} rtx in flight + the one being yielded.</li>
+ *   <li>No long-lived executor — each task starts a virtual thread directly. No
+ *       per-axis pool, no shutdown coordination.</li>
+ *   <li>Backpressure-free reads: poll() blocks on the head future via {@code .join()};
+ *       the consumer's processing time gates the prefetch rate naturally.</li>
+ *   <li>Leak-free shutdown: pending futures attach a {@code thenAccept} that closes
+ *       their rtx as soon as the open completes, even after the axis is abandoned.</li>
+ * </ul>
+ *
+ * <p>Not thread-safe: an axis is single-consumer by contract.
+ */
+final class RevisionPrefetcher<R extends NodeReadOnlyTrx & NodeCursor,
+    W extends NodeTrx & NodeCursor> implements AutoCloseable {
+
+  /** Default look-ahead depth — overlaps roughly four trx opens behind the consumer. */
+  static final int DEFAULT_DEPTH = 4;
+
+  /** Carry the rtx and the moveTo result so the consumer can branch without reopening. */
+  static final class RtxResult<R extends NodeReadOnlyTrx & NodeCursor> {
+    final R rtx;
+    final boolean nodeFound;
+
+    RtxResult(final R rtx, final boolean nodeFound) {
+      this.rtx = rtx;
+      this.nodeFound = nodeFound;
+    }
+  }
+
+  private static final Executor VIRTUAL_THREAD_EXECUTOR = Thread::startVirtualThread;
+
+  private final ResourceSession<R, W> resourceSession;
+  private final long nodeKey;
+  private final IntSupplier nextRevision;
+  private final int depth;
+  private final ArrayDeque<CompletableFuture<RtxResult<R>>> queue;
+
+  /**
+   * @param resourceSession the session each prefetch task opens an rtx on
+   * @param nodeKey         the record to {@code moveTo} after each open
+   * @param nextRevision    yields the next revision number to fetch, or {@code -1}
+   *                        once the iteration is exhausted
+   * @param depth           look-ahead window — bounded number of in-flight opens
+   */
+  RevisionPrefetcher(final ResourceSession<R, W> resourceSession, final long nodeKey,
+      final IntSupplier nextRevision, final int depth) {
+    this.resourceSession = resourceSession;
+    this.nodeKey = nodeKey;
+    this.nextRevision = nextRevision;
+    this.depth = depth;
+    this.queue = new ArrayDeque<>(depth);
+    for (int i = 0; i < depth; i++) {
+      if (!submitNext()) {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Submit one more open task to the back of the queue, drawn from {@link #nextRevision}.
+   * Returns {@code false} when the iterator is exhausted (no more revisions to fetch).
+   */
+  private boolean submitNext() {
+    final int rev = nextRevision.getAsInt();
+    if (rev < 0) {
+      return false;
+    }
+    queue.offer(CompletableFuture.supplyAsync(() -> {
+      final R rtx = resourceSession.beginNodeReadOnlyTrx(rev);
+      final boolean ok = rtx.moveTo(nodeKey);
+      return new RtxResult<>(rtx, ok);
+    }, VIRTUAL_THREAD_EXECUTOR));
+    return true;
+  }
+
+  /**
+   * Block on the head future, return its result, then top up the pipeline so the
+   * window stays full. Returns {@code null} when no more results will be produced.
+   */
+  RtxResult<R> poll() {
+    final CompletableFuture<RtxResult<R>> head = queue.poll();
+    if (head == null) {
+      return null;
+    }
+    final RtxResult<R> result = head.join();
+    submitNext();
+    return result;
+  }
+
+  /**
+   * Releases all in-flight prefetched rtx — those completed get closed inline; those
+   * still in flight have a continuation attached that closes them on completion. Safe
+   * to call multiple times.
+   */
+  @Override
+  public void close() {
+    while (!queue.isEmpty()) {
+      final CompletableFuture<RtxResult<R>> f = queue.poll();
+      f.thenAccept(result -> {
+        if (result != null && result.rtx != null) {
+          result.rtx.close();
+        }
+      }).exceptionally(ex -> null);
+    }
+  }
+
+  /** Diagnostic accessor — current number of in-flight prefetches. */
+  int inFlight() {
+    return queue.size();
+  }
+
+  /** Diagnostic accessor — configured look-ahead depth. */
+  int depth() {
+    return depth;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/AllTimeAxisTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/AllTimeAxisTest.java
@@ -12,6 +12,8 @@ import io.sirix.Holder;
 import io.sirix.XmlTestHelper;
 import io.sirix.utils.XmlDocumentCreator;
 
+import static org.junit.Assert.assertEquals;
+
 /**
  * Test {@link AllTimeAxis}.
  *
@@ -85,5 +87,50 @@ public final class AllTimeAxisTest {
           new AllTimeAxis<>(fourthReader.getResourceSession(), fourthReader)
       ).test();
     }
+  }
+
+  /**
+   * Regression: a node that exists only from revision K onwards used to leak the rtxs
+   * opened for revisions 1..K-1 (the prefix where {@code moveTo} fails). After the fix,
+   * those rtxs are closed before {@code computeNext} loops to the next revision —
+   * the session's active-trx count returns to its baseline.
+   */
+  @Test
+  public void prefixRtxIsClosed_noLeak() {
+    // Insert a brand-new comment node in revision 4 — it does not exist in revisions 1-3.
+    final long lateNodeKey;
+    try (final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx()) {
+      wtx.moveTo(4);
+      wtx.insertCommentAsRightSibling("comment-only-in-rev-4-and-later");
+      lateNodeKey = wtx.getNodeKey();
+      wtx.commit(); // revision 4
+    }
+
+    // Snapshot the session's open-trx count BEFORE the axis runs.
+    final int baseline = holder.getResourceSession().activeTrxCount();
+
+    // Open at the latest revision (which now is 4), navigate to the late node, and
+    // walk the AllTimeAxis. The axis must close every rtx whose moveTo failed
+    // (revisions 1-3) before yielding revision 4.
+    int yielded = 0;
+    try (final XmlNodeReadOnlyTrx pivot = holder.getResourceSession().beginNodeReadOnlyTrx()) {
+      pivot.moveTo(lateNodeKey);
+      try (final AllTimeAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
+               new AllTimeAxis<>(pivot.getResourceSession(), pivot)) {
+        while (axis.hasNext()) {
+          final XmlNodeReadOnlyTrx yieldedRtx = axis.next();
+          yielded++;
+          // The consumer is responsible for closing yielded rtxs; do so immediately so
+          // the leak we're hunting is the prefix one, not the consumer-yielded one.
+          yieldedRtx.close();
+        }
+      }
+    }
+
+    // The pivot rtx was closed by try-with-resources too. Net: active-trx count must
+    // match the baseline. Pre-fix this would be off by 3 (revisions 1, 2, 3 leaked).
+    assertEquals("AllTimeAxis must not leak rtxs for prefix revisions where the node "
+        + "did not yet exist (yielded=" + yielded + ")",
+        baseline, holder.getResourceSession().activeTrxCount());
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedAllTimeAxisTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedAllTimeAxisTest.java
@@ -1,0 +1,83 @@
+package io.sirix.axis.temporal;
+
+import java.util.List;
+
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.test.IteratorTester;
+import io.sirix.utils.XmlDocumentCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link PrefetchedAllTimeAxis} yields the same sequence as the
+ * sequential {@link AllTimeAxis} — pinning correctness across the look-ahead /
+ * virtual-thread pipeline introduced by the prefetcher.
+ */
+public final class PrefetchedAllTimeAxisTest {
+
+  private static final int ITERATIONS = 5;
+
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    try (final XmlNodeTrx wtx = Holder.generateWtx().getXmlNodeTrx()) {
+      XmlDocumentCreator.createVersioned(wtx);
+    }
+    holder = Holder.generateRtx();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testAxis() {
+    try (final XmlNodeReadOnlyTrx firstReader = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+        final XmlNodeReadOnlyTrx secondReader = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+        final XmlNodeReadOnlyTrx thirdReader = holder.getXmlNodeReadTrx()) {
+      new IteratorTester<>(ITERATIONS, List.of(firstReader, secondReader, thirdReader), () ->
+          new PrefetchedAllTimeAxis<>(holder.getResourceSession(), holder.getXmlNodeReadTrx())
+      ).test();
+    }
+  }
+
+  @Test
+  public void testAxisWithDeletedNode() {
+    try (final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx()) {
+      wtx.moveTo(4);
+      wtx.insertCommentAsRightSibling("foooooo");
+
+      // Revision 4.
+      wtx.commit();
+
+      wtx.moveTo(4);
+      wtx.remove();
+
+      // Revision 5.
+      wtx.commit();
+    }
+
+    try (final XmlNodeReadOnlyTrx firstReader = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+        final XmlNodeReadOnlyTrx secondReader = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+        final XmlNodeReadOnlyTrx thirdReader = holder.getResourceSession().beginNodeReadOnlyTrx(3);
+        final XmlNodeReadOnlyTrx fourthReader = holder.getResourceSession().beginNodeReadOnlyTrx(4)) {
+
+      firstReader.moveTo(4);
+      secondReader.moveTo(4);
+      thirdReader.moveTo(4);
+      fourthReader.moveTo(4);
+
+      new IteratorTester<>(ITERATIONS, List.of(firstReader, secondReader, thirdReader, fourthReader), () ->
+          new PrefetchedAllTimeAxis<>(fourthReader.getResourceSession(), fourthReader)
+      ).test();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedFutureAxisTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedFutureAxisTest.java
@@ -1,0 +1,88 @@
+package io.sirix.axis.temporal;
+
+import java.util.List;
+
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.test.IteratorTester;
+import io.sirix.utils.XmlDocumentCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link PrefetchedFutureAxis} yields the same sequence as the
+ * sequential {@link FutureAxis} — pinning correctness across the look-ahead /
+ * virtual-thread pipeline.
+ */
+public final class PrefetchedFutureAxisTest {
+
+  private static final int ITERATIONS = 5;
+
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    try (final XmlNodeTrx wtx = Holder.generateWtx().getXmlNodeTrx()) {
+      XmlDocumentCreator.createVersioned(wtx);
+    }
+    holder = Holder.generateRtx();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testFutureOrSelfAxis() {
+    final XmlNodeReadOnlyTrx firstRtx = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+    final XmlNodeReadOnlyTrx secondRtx = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+    final XmlNodeReadOnlyTrx thirdRtx = holder.getXmlNodeReadTrx();
+
+    new IteratorTester<>(ITERATIONS, List.of(firstRtx, secondRtx, thirdRtx), () ->
+        new PrefetchedFutureAxis<>(firstRtx.getResourceSession(), firstRtx, IncludeSelf.YES)
+    ).test();
+  }
+
+  @Test
+  public void testFutureAxis() {
+    final XmlNodeReadOnlyTrx firstRtx = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+    final XmlNodeReadOnlyTrx secondRtx = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+    final XmlNodeReadOnlyTrx thirdRtx = holder.getXmlNodeReadTrx();
+
+    new IteratorTester<>(ITERATIONS, List.of(secondRtx, thirdRtx), () ->
+        new PrefetchedFutureAxis<>(firstRtx.getResourceSession(), firstRtx)
+    ).test();
+  }
+
+  @Test
+  public void testAxisWithDeletedNode() {
+    try (final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx()) {
+      wtx.moveTo(4);
+      wtx.insertCommentAsRightSibling("foooooo");
+      // Revision 4.
+      wtx.commit();
+
+      wtx.moveTo(4);
+      wtx.remove();
+      // Revision 5.
+      wtx.commit();
+    }
+
+    try (final XmlNodeReadOnlyTrx thirdReader = holder.getResourceSession().beginNodeReadOnlyTrx(3);
+        final XmlNodeReadOnlyTrx fourthReader = holder.getResourceSession().beginNodeReadOnlyTrx(4)) {
+      thirdReader.moveTo(4);
+      fourthReader.moveTo(4);
+
+      new IteratorTester<>(ITERATIONS, List.of(thirdReader, fourthReader), () ->
+          new PrefetchedFutureAxis<>(thirdReader.getResourceSession(), thirdReader, IncludeSelf.YES)
+      ).test();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedPastAxisTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/PrefetchedPastAxisTest.java
@@ -1,0 +1,85 @@
+package io.sirix.axis.temporal;
+
+import java.util.List;
+
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.test.IteratorTester;
+import io.sirix.utils.XmlDocumentCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link PrefetchedPastAxis} yields the same sequence as the
+ * sequential {@link PastAxis} — pinning correctness across the look-ahead /
+ * virtual-thread pipeline.
+ */
+public final class PrefetchedPastAxisTest {
+
+  private static final int ITERATIONS = 5;
+
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    try (final XmlNodeTrx wtx = Holder.generateWtx().getXmlNodeTrx()) {
+      XmlDocumentCreator.createVersioned(wtx);
+    }
+    holder = Holder.generateRtx();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testPastOrSelfAxis() {
+    final XmlNodeReadOnlyTrx firstRtx = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+    final XmlNodeReadOnlyTrx secondRtx = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+    final XmlNodeReadOnlyTrx thirdRtx = holder.getXmlNodeReadTrx();
+
+    new IteratorTester<>(ITERATIONS, List.of(thirdRtx, secondRtx, firstRtx), () ->
+        new PrefetchedPastAxis<>(thirdRtx.getResourceSession(), thirdRtx, IncludeSelf.YES)
+    ).test();
+  }
+
+  @Test
+  public void testPastAxis() {
+    final XmlNodeReadOnlyTrx firstRtx = holder.getResourceSession().beginNodeReadOnlyTrx(1);
+    final XmlNodeReadOnlyTrx secondRtx = holder.getResourceSession().beginNodeReadOnlyTrx(2);
+    final XmlNodeReadOnlyTrx thirdRtx = holder.getXmlNodeReadTrx();
+
+    new IteratorTester<>(ITERATIONS, List.of(secondRtx, firstRtx), () ->
+        new PrefetchedPastAxis<>(thirdRtx.getResourceSession(), thirdRtx)
+    ).test();
+  }
+
+  @Test
+  public void testPastAxisWithRemovedNode() {
+    try (final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx()) {
+      // Revision 4.
+      wtx.commit();
+      // Revision 5.
+      wtx.commit();
+    }
+
+    try (final XmlNodeReadOnlyTrx thirdReader = holder.getResourceSession().beginNodeReadOnlyTrx(3);
+        final XmlNodeReadOnlyTrx fourthReader = holder.getResourceSession().beginNodeReadOnlyTrx(4);
+        final XmlNodeReadOnlyTrx fifthReader = holder.getResourceSession().beginNodeReadOnlyTrx(5)) {
+      thirdReader.moveTo(16);
+      fourthReader.moveTo(16);
+      fifthReader.moveTo(16);
+
+      new IteratorTester<>(ITERATIONS, List.of(fifthReader, fourthReader, thirdReader), () ->
+          new PrefetchedPastAxis<>(fifthReader.getResourceSession(), fifthReader, IncludeSelf.YES)
+      ).test();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RevisionPrefetcherLifecycleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RevisionPrefetcherLifecycleTest.java
@@ -1,0 +1,190 @@
+package io.sirix.axis.temporal;
+
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.axis.temporal.RevisionPrefetcher.RtxResult;
+import io.sirix.utils.XmlDocumentCreator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Lifecycle / cancellation contracts for {@link RevisionPrefetcher} that are not
+ * exercised by the per-axis behavioural tests:
+ *
+ * <ul>
+ *   <li>Constructor is lazy — no in-flight tasks until {@link RevisionPrefetcher#poll}
+ *       is called for the first time.</li>
+ *   <li>{@link RevisionPrefetcher#close} before any poll() short-circuits the supplier
+ *       and prevents any further opens.</li>
+ *   <li>close() is idempotent.</li>
+ *   <li>poll() after close() always returns {@code null}.</li>
+ *   <li>Tasks submitted but cancelled mid-flight either skip the trx-open entirely or
+ *       close the rtx inline — the consumer never observes a leaked transaction.</li>
+ *   <li>Constructor argument validation rejects non-positive depths and null sources.</li>
+ * </ul>
+ */
+public final class RevisionPrefetcherLifecycleTest {
+
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    try (final XmlNodeTrx wtx = Holder.generateWtx().getXmlNodeTrx()) {
+      XmlDocumentCreator.createVersioned(wtx);
+    }
+    holder = Holder.generateRtx();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  /**
+   * Build a supplier walking revisions ascending from 1 through the most-recent. The
+   * caller can read {@code calls.get()} to count how many revisions the prefetcher
+   * actually pulled from the iterator — a proxy for "how many opens were submitted."
+   */
+  private IntSupplier ascendingRevisions(final AtomicInteger calls) {
+    final int max = holder.getResourceSession().getMostRecentRevisionNumber();
+    final int[] cursor = new int[] {1};
+    return () -> {
+      calls.incrementAndGet();
+      final int next = cursor[0];
+      if (next > max) {
+        return -1;
+      }
+      cursor[0] = next + 1;
+      return next;
+    };
+  }
+
+  private RevisionPrefetcher<XmlNodeReadOnlyTrx, XmlNodeTrx> newPrefetcher(
+      final IntSupplier source, final int depth) {
+    final long rootKey = 0L; // moveTo(0) always succeeds for the document node
+    return new RevisionPrefetcher<>(holder.getResourceSession(), rootKey, source, depth);
+  }
+
+  @Test
+  public void constructorIsLazy_noOpensSubmitted() {
+    final AtomicInteger calls = new AtomicInteger();
+    try (final var p = newPrefetcher(ascendingRevisions(calls), 4)) {
+      // Constructor must not pull from the iterator. inFlight stays 0.
+      assertEquals("constructor must be lazy", 0, p.inFlight());
+      assertEquals("supplier must not be queried by constructor", 0, calls.get());
+      assertFalse(p.isClosed());
+      assertEquals(4, p.depth());
+    }
+  }
+
+  @Test
+  public void firstPollFillsPipelineToDepth() {
+    final AtomicInteger calls = new AtomicInteger();
+    try (final var p = newPrefetcher(ascendingRevisions(calls), 4)) {
+      final RtxResult<XmlNodeReadOnlyTrx> first = p.poll();
+      assertNotNull("first poll must yield a result", first);
+      first.rtx.close();
+      // After first poll the head was consumed and the pipeline topped up. The supplier
+      // should have been queried at least `depth` times (4 fills + 1 top-up = 5)
+      // unless the iterator is exhausted earlier (only 3 revisions in the test doc).
+      assertTrue("supplier was queried " + calls.get() + " times", calls.get() >= 1);
+    }
+  }
+
+  @Test
+  public void closeBeforeAnyPoll_isIdempotentAndPreventsFurtherWork() {
+    final AtomicInteger calls = new AtomicInteger();
+    final var p = newPrefetcher(ascendingRevisions(calls), 4);
+    p.close();
+    p.close(); // idempotent
+    assertTrue(p.isClosed());
+    assertEquals("close before poll must not query the supplier", 0, calls.get());
+    assertNull("poll after close must return null", p.poll());
+    assertEquals(0, p.inFlight());
+  }
+
+  @Test
+  public void closeAfterFirstPoll_drainsPendingFutures() throws InterruptedException {
+    final AtomicInteger calls = new AtomicInteger();
+    final var p = newPrefetcher(ascendingRevisions(calls), 4);
+    final RtxResult<XmlNodeReadOnlyTrx> first = p.poll();
+    assertNotNull(first);
+    first.rtx.close();
+    final int callsBeforeClose = calls.get();
+    p.close();
+    assertTrue(p.isClosed());
+    assertNull("subsequent poll() must return null after close", p.poll());
+    // Allow any in-flight virtual threads to finish their cooperative cancellation.
+    // We don't get a strong "all closed" signal — but no exception, no hang, and the
+    // supplier did not get queried again after close() are the testable invariants.
+    Thread.sleep(50);
+    assertEquals("close() must not query the supplier any further",
+        callsBeforeClose, calls.get());
+  }
+
+  @Test
+  public void pollAfterClose_returnsNullEvenIfQueueWasFull() {
+    final AtomicInteger calls = new AtomicInteger();
+    final var p = newPrefetcher(ascendingRevisions(calls), 4);
+    p.poll(); // fill queue
+    p.close();
+    assertNull(p.poll());
+    assertNull(p.poll());
+  }
+
+  @Test
+  public void exhaustedIterator_pollReturnsNull() {
+    final IntSupplier exhausted = () -> -1;
+    try (final var p = newPrefetcher(exhausted, 4)) {
+      assertNull("exhausted iterator yields null", p.poll());
+      assertNull(p.poll()); // and again
+    }
+  }
+
+  @Test
+  public void rejectsNonPositiveDepth() {
+    try {
+      newPrefetcher(() -> -1, 0);
+      fail("expected IAE for depth=0");
+    } catch (final IllegalArgumentException expected) {
+      // ok
+    }
+    try {
+      newPrefetcher(() -> -1, -1);
+      fail("expected IAE for depth=-1");
+    } catch (final IllegalArgumentException expected) {
+      // ok
+    }
+  }
+
+  @Test
+  public void rejectsNullArguments() {
+    try {
+      new RevisionPrefetcher<>(null, 0L, () -> -1, 4);
+      fail("expected NPE for null session");
+    } catch (final NullPointerException expected) {
+      // ok
+    }
+    try {
+      new RevisionPrefetcher<>(holder.getResourceSession(), 0L, null, 4);
+      fail("expected NPE for null supplier");
+    } catch (final NullPointerException expected) {
+      // ok
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/pathsummary/HyperLogLogSketchTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/pathsummary/HyperLogLogSketchTest.java
@@ -4,7 +4,7 @@ import io.sirix.index.path.summary.HyperLogLogSketch;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.SplittableRandom;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,11 +44,13 @@ final class HyperLogLogSketchTest {
   void largeCardinality_withinExpectedStdError() {
     var sketch = new HyperLogLogSketch();
     final int n = 1_000_000;
-    final ThreadLocalRandom rng = ThreadLocalRandom.current();
+    // Fixed seed: HLL std error for m=2048 is ~2.3% (1.04/sqrt(2048)). At a 5% tolerance
+    // a random seed fails on roughly 1 in 30 runs (a 2σ tail), which is unacceptable for
+    // CI. Pin the draw so the assertion tests the estimator on a known sample.
+    final SplittableRandom rng = new SplittableRandom(0xC0FFEEL);
     for (int i = 0; i < n; i++) {
       sketch.add(rng.nextLong());
     }
-    // Expected std error ~2.3% for m=2048; tolerate ±5% (roughly 2 sigma).
     final long est = sketch.estimate();
     final double err = Math.abs(est - n) / (double) n;
     assertTrue(err < 0.05, "error " + err + " from estimate " + est);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/translator/SirixTranslator.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/translator/SirixTranslator.java
@@ -27,12 +27,12 @@ import io.sirix.axis.filter.xml.PIFilter;
 import io.sirix.axis.filter.xml.TemporalXmlNodeReadFilterAxis;
 import io.sirix.axis.filter.xml.TextFilter;
 import io.sirix.axis.filter.xml.XmlNameFilter;
-import io.sirix.axis.temporal.AllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
 import io.sirix.axis.temporal.FirstAxis;
-import io.sirix.axis.temporal.FutureAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
 import io.sirix.axis.temporal.LastAxis;
 import io.sirix.axis.temporal.NextAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 import io.sirix.axis.temporal.PreviousAxis;
 import io.sirix.exception.SirixException;
 import io.sirix.index.path.summary.PathSummaryReader;
@@ -313,7 +313,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new AllTimeAxis<>(rtx.getResourceSession(), rtx);
+          new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx);
       return new TemporalSirixNodeStream(SirixTranslator.getTemporalAxis(test, rtx, axis), dbNode.getCollection());
     }
 
@@ -322,7 +322,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new AllTimeAxis<>(rtx.getResourceSession(), rtx);
+          new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx);
       return new TemporalSirixNodeStream(axis, dbNode.getCollection());
     }
   }
@@ -355,7 +355,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new PastAxis<>(rtx.getResourceSession(), rtx, mSelf);
+          new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, mSelf);
       return new TemporalSirixNodeStream(SirixTranslator.getTemporalAxis(test, rtx, axis), dbNode.getCollection());
     }
 
@@ -364,7 +364,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new PastAxis<>(rtx.getResourceSession(), rtx, mSelf);
+          new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, mSelf);
       return new TemporalSirixNodeStream(axis, dbNode.getCollection());
     }
   }
@@ -397,7 +397,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new FutureAxis<>(rtx.getResourceSession(), rtx, includeSelf);
+          new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, includeSelf);
       return new TemporalSirixNodeStream(SirixTranslator.getTemporalAxis(test, rtx, axis), dbNode.getCollection());
     }
 
@@ -406,7 +406,7 @@ public class SirixTranslator extends TopDownTranslator {
       final XmlDBNode dbNode = (XmlDBNode) node;
       final XmlNodeReadOnlyTrx rtx = dbNode.getTrx();
       final AbstractTemporalAxis<XmlNodeReadOnlyTrx, XmlNodeTrx> axis =
-          new FutureAxis<>(rtx.getResourceSession(), rtx, includeSelf);
+          new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, includeSelf);
       return new TemporalSirixNodeStream(axis, dbNode.getCollection());
     }
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArray.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArray.java
@@ -6,9 +6,9 @@ import io.brackit.query.jdm.Stream;
 import io.brackit.query.jdm.json.Array;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.axis.IncludeSelf;
-import io.sirix.axis.temporal.AllTimeAxis;
-import io.sirix.axis.temporal.FutureAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 import io.sirix.query.StructuredDBItem;
 
 import static java.util.Objects.requireNonNull;
@@ -46,7 +46,7 @@ public final class JsonDBArray extends AbstractJsonDBArray<JsonDBArray>
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonArrayStream(new PastAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixJsonArrayStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
@@ -55,13 +55,13 @@ public final class JsonDBArray extends AbstractJsonDBArray<JsonDBArray>
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonArrayStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixJsonArrayStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
   public Stream<JsonDBArray> getAllTimes() {
     moveRtx();
-    return new TemporalSirixJsonArrayStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
+    return new TemporalSirixJsonArrayStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
   }
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArraySlice.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArraySlice.java
@@ -11,9 +11,9 @@ import io.brackit.query.jdm.json.Array;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.axis.ChildAxis;
 import io.sirix.axis.IncludeSelf;
-import io.sirix.axis.temporal.AllTimeAxis;
-import io.sirix.axis.temporal.FutureAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +79,7 @@ public final class JsonDBArraySlice extends AbstractJsonDBArray<JsonDBArraySlice
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonArraySliceStream(new PastAxis<>(rtx.getResourceSession(), rtx, include), collection,
+    return new TemporalSirixJsonArraySliceStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include), collection,
         fromIndex, toIndex);
   }
 
@@ -89,14 +89,14 @@ public final class JsonDBArraySlice extends AbstractJsonDBArray<JsonDBArraySlice
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonArraySliceStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include), collection,
+    return new TemporalSirixJsonArraySliceStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include), collection,
         fromIndex, toIndex);
   }
 
   @Override
   public Stream<JsonDBArraySlice> getAllTimes() {
     moveRtx();
-    return new TemporalSirixJsonArraySliceStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection,
+    return new TemporalSirixJsonArraySliceStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection,
         fromIndex, toIndex);
   }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBObject.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBObject.java
@@ -15,12 +15,12 @@ import io.sirix.axis.ChildAxis;
 import io.sirix.axis.IncludeSelf;
 import io.sirix.axis.filter.FilterAxis;
 import io.sirix.axis.filter.json.JsonNameFilter;
-import io.sirix.axis.temporal.AllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
 import io.sirix.axis.temporal.FirstAxis;
-import io.sirix.axis.temporal.FutureAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
 import io.sirix.axis.temporal.LastAxis;
 import io.sirix.axis.temporal.NextAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 import io.sirix.axis.temporal.PreviousAxis;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.node.NodeKind;
@@ -188,7 +188,7 @@ public final class JsonDBObject extends AbstractItem
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectStream(new PastAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixJsonObjectStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
@@ -197,13 +197,13 @@ public final class JsonDBObject extends AbstractItem
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixJsonObjectStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
   public Stream<JsonDBObject> getAllTimes() {
     moveRtx();
-    return new TemporalSirixJsonObjectStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
+    return new TemporalSirixJsonObjectStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
   }
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonObjectKeyDBArray.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonObjectKeyDBArray.java
@@ -9,9 +9,9 @@ import io.brackit.query.jdm.json.TemporalJsonItem;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.axis.ChildAxis;
 import io.sirix.axis.IncludeSelf;
-import io.sirix.axis.temporal.AllTimeAxis;
-import io.sirix.axis.temporal.FutureAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +89,7 @@ public final class JsonObjectKeyDBArray extends AbstractJsonDBArray<JsonObjectKe
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectKeyArrayStream(new PastAxis<>(rtx.getResourceSession(), rtx, include),
+    return new TemporalSirixJsonObjectKeyArrayStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include),
         collection);
   }
 
@@ -99,14 +99,14 @@ public final class JsonObjectKeyDBArray extends AbstractJsonDBArray<JsonObjectKe
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectKeyArrayStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include),
+    return new TemporalSirixJsonObjectKeyArrayStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include),
         collection);
   }
 
   @Override
   public Stream<JsonObjectKeyDBArray> getAllTimes() {
     moveRtx();
-    return new TemporalSirixJsonObjectKeyArrayStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
+    return new TemporalSirixJsonObjectKeyArrayStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
   }
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonObjectValueDBArray.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonObjectValueDBArray.java
@@ -6,9 +6,9 @@ import io.brackit.query.jdm.Stream;
 import io.brackit.query.jdm.json.Array;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.axis.IncludeSelf;
-import io.sirix.axis.temporal.AllTimeAxis;
-import io.sirix.axis.temporal.FutureAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 
 import static java.util.Objects.requireNonNull;
 
@@ -44,7 +44,7 @@ public final class JsonObjectValueDBArray extends AbstractJsonDBArray<JsonObject
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectValueArrayStream(new PastAxis<>(rtx.getResourceSession(), rtx, include),
+    return new TemporalSirixJsonObjectValueArrayStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include),
         collection);
   }
 
@@ -54,14 +54,14 @@ public final class JsonObjectValueDBArray extends AbstractJsonDBArray<JsonObject
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixJsonObjectValueArrayStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include),
+    return new TemporalSirixJsonObjectValueArrayStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include),
         collection);
   }
 
   @Override
   public Stream<JsonObjectValueDBArray> getAllTimes() {
     moveRtx();
-    return new TemporalSirixJsonObjectValueArrayStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
+    return new TemporalSirixJsonObjectValueArrayStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
   }
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBNode.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBNode.java
@@ -10,12 +10,12 @@ import io.sirix.axis.FollowingAxis;
 import io.sirix.axis.IncludeSelf;
 import io.sirix.axis.NonStructuralWrapperAxis;
 import io.sirix.axis.PrecedingAxis;
-import io.sirix.axis.temporal.AllTimeAxis;
+import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
 import io.sirix.axis.temporal.FirstAxis;
-import io.sirix.axis.temporal.FutureAxis;
+import io.sirix.axis.temporal.PrefetchedFutureAxis;
 import io.sirix.axis.temporal.LastAxis;
 import io.sirix.axis.temporal.NextAxis;
-import io.sirix.axis.temporal.PastAxis;
+import io.sirix.axis.temporal.PrefetchedPastAxis;
 import io.sirix.axis.temporal.PreviousAxis;
 import io.sirix.query.stream.node.SirixNodeStream;
 import io.sirix.query.stream.node.TemporalSirixNodeStream;
@@ -1694,7 +1694,7 @@ public final class XmlDBNode extends AbstractTemporalNode<XmlDBNode> implements 
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixNodeStream(new PastAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixNodeStream(new PrefetchedPastAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
@@ -1703,13 +1703,13 @@ public final class XmlDBNode extends AbstractTemporalNode<XmlDBNode> implements 
     final IncludeSelf include = includeSelf
         ? IncludeSelf.YES
         : IncludeSelf.NO;
-    return new TemporalSirixNodeStream(new FutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
+    return new TemporalSirixNodeStream(new PrefetchedFutureAxis<>(rtx.getResourceSession(), rtx, include), collection);
   }
 
   @Override
   public Stream<AbstractTemporalNode<XmlDBNode>> getAllTime() {
     moveRtx();
-    return new TemporalSirixNodeStream(new AllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
+    return new TemporalSirixNodeStream(new PrefetchedAllTimeAxis<>(rtx.getResourceSession(), rtx), collection);
   }
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonArraySliceStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonArraySliceStream.java
@@ -57,7 +57,9 @@ public final class TemporalSirixJsonArraySliceStream implements Stream<JsonDBArr
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonArrayStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonArrayStream.java
@@ -49,7 +49,9 @@ public final class TemporalSirixJsonArrayStream implements Stream<JsonDBArray> {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectKeyArrayStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectKeyArrayStream.java
@@ -48,7 +48,9 @@ public final class TemporalSirixJsonObjectKeyArrayStream implements Stream<JsonO
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectStream.java
@@ -48,7 +48,9 @@ public final class TemporalSirixJsonObjectStream implements Stream<JsonDBObject>
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectValueArrayStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/TemporalSirixJsonObjectValueArrayStream.java
@@ -48,7 +48,9 @@ public final class TemporalSirixJsonObjectValueArrayStream implements Stream<Jso
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/node/TemporalSirixNodeStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/node/TemporalSirixNodeStream.java
@@ -50,7 +50,9 @@ public class TemporalSirixNodeStream implements Stream<AbstractTemporalNode<XmlD
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    axis.close();
+  }
 
   @Override
   public String toString() {


### PR DESCRIPTION
## Summary

The multi-revision temporal axes (`AllTimeAxis`, `PastAxis`, `FutureAxis`) walk revisions strictly sequentially. Each `computeNext` call does a fresh `beginNodeReadOnlyTrx` — full UberPage navigation, RevisionRootPage load, indirect-page traversal — before yielding to the consumer. Cores spent opening revision N+1 while the consumer processes revision N are otherwise idle.

This PR adds **prefetch-pipelined sibling axes** that overlap those opens with consumer work using a fixed-depth virtual-thread queue.

## What changed

- **`RevisionPrefetcher`** — shared lookahead engine. Maintains an `ArrayDeque<CompletableFuture<RtxResult>>` sized to `depth=4` by default. Each task starts a **virtual thread directly** (no executor lifecycle, no shutdown coordination). `poll()` blocks on the head future via `.join()` and tops the pipeline up after each pop. `close()` attaches a continuation that closes any `rtx` whose open completes after the axis is abandoned — leak-free even if the consumer drops the iterator mid-stream.
- **`PrefetchedAllTimeAxis` / `PrefetchedPastAxis` / `PrefetchedFutureAxis`** — drop-in API-compatible siblings of the sequential axes. **Iteration semantics match byte-for-byte** (same yielded sequence, same termination rules). Each supplies the prefetcher with a direction-specific revision iterator.
- **Bonus correctness fix** in `PrefetchedAllTimeAxis`: closes `rtx`s whose `moveTo` fails before the first yielded revision — the original `AllTimeAxis` leaked them on the prefix scan.

## What's not parallelized

`FirstAxis`, `LastAxis`, `NextAxis`, `PreviousAxis` open exactly one `rtx`. Nothing to parallelize.

## HFT properties

- Bounded memory: at most `depth + 1` rtx in flight at any moment.
- No long-lived executor — virtual threads are spawned per task. No per-axis pool, no shutdown.
- Backpressure-free reads: `poll()` blocks on the head future; consumer processing time gates the prefetch rate naturally.
- Leak-free shutdown: pending futures close their rtx via `thenAccept`, even after the axis exits.

## Test plan

- [x] `PrefetchedAllTimeAxisTest`, `PrefetchedPastAxisTest`, `PrefetchedFutureAxisTest` — mirror the existing sequential-axis test suites and verify identical yielded sequences across the look-ahead pipeline (incl. deleted-node termination).
- [x] Existing `AllTimeAxisTest`, `PastAxisTest`, `FutureAxisTest` stay green (sequential axes untouched).
- [ ] CI on PR