### PR TITLE
perf: O(N) array-slice scan + primitive cursor cache

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/AbstractJsonDBArray.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/AbstractJsonDBArray.java
@@ -99,6 +99,10 @@ public abstract class AbstractJsonDBArray<T extends AbstractJsonDBArray<T>> exte
     return rtx;
   }
 
+  protected final JsonItemFactory getJsonItemFactory() {
+    return jsonItemFactory;
+  }
+
   @Override
   public Array replaceAt(int index, Sequence value) {
     modify(index, value, Op.Replace);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArraySlice.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBArraySlice.java
@@ -14,6 +14,7 @@ import io.sirix.axis.IncludeSelf;
 import io.sirix.axis.temporal.PrefetchedAllTimeAxis;
 import io.sirix.axis.temporal.PrefetchedFutureAxis;
 import io.sirix.axis.temporal.PrefetchedPastAxis;
+import io.sirix.settings.Fixed;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,12 @@ public final class JsonDBArraySlice extends AbstractJsonDBArray<JsonDBArraySlice
    */
   private List<Sequence> values;
 
+  /** Last slice-relative index served by {@link #at(int)} / {@link #at(IntNumeric)}. */
+  private int cursorSliceIndex = -1;
+
+  /** Node key positioned at {@link #cursorSliceIndex}; {@link Fixed#NULL_NODE_KEY} if invalid. */
+  private long cursorNodeKey = Fixed.NULL_NODE_KEY.getStandardProperty();
+
   /**
    * Constructor.
    *
@@ -59,13 +66,14 @@ public final class JsonDBArraySlice extends AbstractJsonDBArray<JsonDBArraySlice
 
     assert this.rtx.isArray();
 
-    jsonUtil = new JsonItemFactory();
+    jsonUtil = getJsonItemFactory();
 
-    if ((fromIndex < 0) || (fromIndex > toIndex) || (fromIndex >= this.rtx.getChildCount())) {
+    final long childCount = this.rtx.getChildCount();
+    if ((fromIndex < 0) || (fromIndex > toIndex) || (fromIndex >= childCount)) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array start index: %s", fromIndex);
     }
 
-    if (toIndex > this.rtx.getChildCount()) {
+    if (toIndex > childCount) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array end index: %s", toIndex);
     }
 
@@ -117,55 +125,95 @@ public final class JsonDBArraySlice extends AbstractJsonDBArray<JsonDBArraySlice
   }
 
   private List<Sequence> getValues() {
-    final var values = new ArrayList<Sequence>();
-
-    for (int i = 0, length = len(); i < length; i++) {
-      values.add(at(fromIndex + i));
+    final int length = toIndex - fromIndex;
+    final ArrayList<Sequence> out = new ArrayList<>(length);
+    if (length == 0) {
+      return out;
     }
 
-    return values;
+    final ChildAxis axis = new ChildAxis(rtx);
+
+    for (int skipped = 0; skipped < fromIndex; skipped++) {
+      if (!axis.hasNext()) {
+        return out;
+      }
+      axis.nextLong();
+    }
+
+    for (int collected = 0; collected < length; collected++) {
+      if (!axis.hasNext()) {
+        break;
+      }
+      axis.nextLong();
+      out.add(jsonUtil.getSequence(rtx, collection));
+    }
+
+    invalidateCursor();
+    return out;
   }
 
-  private Sequence getSequenceAtIndex(final JsonNodeReadOnlyTrx rtx, final int index) {
-    moveRtx();
+  private Sequence sequenceAtSliceIndex(final int sliceIndex) {
+    final int absoluteIndex = fromIndex + sliceIndex;
+    final long arrayKey = getNodeKey();
 
-    final var axis = new ChildAxis(rtx);
-
-    for (int i = 0; i < index && axis.hasNext(); i++)
-      axis.nextLong();
-
-    if (axis.hasNext()) {
-      axis.nextLong();
-
+    if (cursorSliceIndex >= 0 && sliceIndex == cursorSliceIndex + 1
+        && rtx.moveTo(cursorNodeKey) && rtx.getParentKey() == arrayKey
+        && rtx.hasRightSibling()) {
+      rtx.moveToRightSibling();
+      cursorSliceIndex = sliceIndex;
+      cursorNodeKey = rtx.getNodeKey();
       return jsonUtil.getSequence(rtx, collection);
     }
 
-    return null;
+    moveRtx();
+    final ChildAxis axis = new ChildAxis(rtx);
+
+    for (int i = 0; i < absoluteIndex; i++) {
+      if (!axis.hasNext()) {
+        invalidateCursor();
+        return null;
+      }
+      axis.nextLong();
+    }
+
+    if (!axis.hasNext()) {
+      invalidateCursor();
+      return null;
+    }
+    axis.nextLong();
+
+    cursorSliceIndex = sliceIndex;
+    cursorNodeKey = rtx.getNodeKey();
+    return jsonUtil.getSequence(rtx, collection);
+  }
+
+  private void invalidateCursor() {
+    cursorSliceIndex = -1;
+    cursorNodeKey = Fixed.NULL_NODE_KEY.getStandardProperty();
   }
 
   @Override
-  public Sequence at(IntNumeric numericIndex) {
-    int ii = fromIndex + numericIndex.intValue();
-    if (ii >= toIndex) {
-      throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", numericIndex.intValue());
+  public Sequence at(final IntNumeric numericIndex) {
+    final int sliceIndex = numericIndex.intValue();
+    if (fromIndex + sliceIndex >= toIndex) {
+      throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", sliceIndex);
     }
 
     if (values == null) {
-      return getSequenceAtIndex(rtx, ii);
+      return sequenceAtSliceIndex(sliceIndex);
     }
 
-    return values.get(ii);
+    return values.get(sliceIndex);
   }
 
   @Override
-  public Sequence at(int index) {
-    int ii = fromIndex + index;
-    if (ii >= toIndex) {
+  public Sequence at(final int index) {
+    if (fromIndex + index >= toIndex) {
       throw new QueryException(ErrorCode.ERR_INVALID_ARGUMENT_TYPE, "Invalid array index: %s", index);
     }
 
     if (values == null) {
-      return getSequenceAtIndex(rtx, ii);
+      return sequenceAtSliceIndex(index);
     }
 
     return values.get(index);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/json/JsonDBArraySliceTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/json/JsonDBArraySliceTest.java
@@ -1,0 +1,236 @@
+package io.sirix.query.json;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.json.Array;
+import io.brackit.query.util.serialize.StringSerializer;
+import io.sirix.access.Databases;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+final class JsonDBArraySliceTest {
+
+  private static final String COLL = "sliceColl";
+  private static final String RES = "sliceRes";
+
+  private Path testDir;
+  private BasicJsonDBStore store;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    testDir = Files.createTempDirectory("sirix-json-slice-test");
+    store = BasicJsonDBStore.newBuilder().location(testDir).build();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (store != null) {
+      store.close();
+    }
+    if (testDir != null) {
+      Databases.removeDatabase(testDir);
+    }
+  }
+
+  private JsonDBArray loadArray(final String json) {
+    store.create(COLL, RES, json);
+    final JsonDBCollection coll = store.lookup(COLL);
+    return (JsonDBArray) coll.getDocument(RES);
+  }
+
+  private static String serialize(final Sequence sequence) {
+    final StringWriter sw = new StringWriter();
+    try (final PrintWriter pw = new PrintWriter(sw)) {
+      new StringSerializer(pw).serialize(sequence);
+    }
+    return sw.toString();
+  }
+
+  // --- regression: indexing bug on cached path with non-zero fromIndex --------------------------
+
+  @Test
+  void atIntNumeric_afterValuesMaterialized_returnsSliceLocalElement() {
+    final JsonDBArray array = loadArray("[10,20,30,40,50,60,70]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(3), new Int32(7));
+
+    final List<Sequence> materialized = slice.values();
+    assertEquals(4, materialized.size());
+
+    // Pre-fix: this threw IndexOutOfBoundsException because the cached path used
+    // values.get(fromIndex + sliceIndex) instead of values.get(sliceIndex).
+    assertEquals("40", serialize(slice.at(new Int32(0))));
+    assertEquals("50", serialize(slice.at(new Int32(1))));
+    assertEquals("60", serialize(slice.at(new Int32(2))));
+    assertEquals("70", serialize(slice.at(new Int32(3))));
+  }
+
+  @Test
+  void atInt_afterValuesMaterialized_agreesWithIntNumericOverload() {
+    final JsonDBArray array = loadArray("[10,20,30,40,50,60,70]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(2), new Int32(6));
+
+    slice.values(); // materialize cache
+    for (int i = 0; i < slice.len(); i++) {
+      assertEquals(serialize(slice.at(new Int32(i))), serialize(slice.at(i)),
+          "int and IntNumeric overloads disagreed at slice index " + i);
+    }
+  }
+
+  // --- correctness: sequential / random / cached vs uncached ----------------------------------
+
+  @Test
+  void sequentialAt_uncached_returnsSliceElementsInOrder() {
+    final JsonDBArray array = loadArray("[\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\"]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(1), new Int32(6));
+
+    assertEquals(5, slice.len());
+    final String[] expected = { "\"b\"", "\"c\"", "\"d\"", "\"e\"", "\"f\"" };
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i], serialize(slice.at(i)), "mismatch at slice idx " + i);
+    }
+  }
+
+  @Test
+  void randomAt_uncached_returnsCorrectElement_andCursorRecoversForFollowingSequentialAccess() {
+    final JsonDBArray array = loadArray("[0,1,2,3,4,5,6,7,8,9]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(3), new Int32(8));
+
+    // Random jump invalidates any cursor advantage; must still be correct.
+    assertEquals("6", serialize(slice.at(3)));
+    // After a random hit the cursor is now at slice idx 3, so slice.at(4) should advance one sibling.
+    assertEquals("7", serialize(slice.at(4)));
+    // Re-jump to start and walk forward — exercises the cursor-reset path.
+    assertEquals("3", serialize(slice.at(0)));
+    assertEquals("4", serialize(slice.at(1)));
+    assertEquals("5", serialize(slice.at(2)));
+  }
+
+  @Test
+  void valuesEqualsSequentialAt_acrossSlice() {
+    final JsonDBArray array = loadArray("[100,200,300,400,500,600]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(1), new Int32(5));
+
+    final List<Sequence> values = slice.values();
+    assertEquals(4, values.size());
+
+    final List<String> serializedValues = new ArrayList<>(values.size());
+    for (final Sequence s : values) {
+      serializedValues.add(serialize(s));
+    }
+    assertEquals(List.of("200", "300", "400", "500"), serializedValues);
+
+    // Build a fresh slice so the at() path stays uncached.
+    final JsonDBArraySlice fresh = (JsonDBArraySlice) array.range(new Int32(1), new Int32(5));
+    for (int i = 0; i < fresh.len(); i++) {
+      assertEquals(serializedValues.get(i), serialize(fresh.at(i)));
+    }
+  }
+
+  @Test
+  void valuesIsMemoised() {
+    final JsonDBArray array = loadArray("[1,2,3,4,5]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(1), new Int32(4));
+
+    final List<Sequence> first = slice.values();
+    final List<Sequence> second = slice.values();
+    assertSame(first, second, "values() must be memoised");
+  }
+
+  // --- bounds / metadata -----------------------------------------------------------------------
+
+  @Test
+  void length_andLen_returnSliceWidth() {
+    final JsonDBArray array = loadArray("[1,2,3,4,5,6,7,8,9,10]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(2), new Int32(8));
+
+    assertEquals(6, slice.len());
+    final Atomic length = slice.length();
+    assertEquals("6", length.stringValue());
+  }
+
+  @Test
+  void atBeyondToIndex_throwsQueryException() {
+    final JsonDBArray array = loadArray("[1,2,3,4,5]");
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(1), new Int32(4));
+
+    assertThrows(io.brackit.query.QueryException.class, () -> slice.at(slice.len()));
+    assertThrows(io.brackit.query.QueryException.class, () -> slice.at(new Int32(slice.len() + 5)));
+  }
+
+  @Test
+  void rangeOnSlice_yieldsSubSlice_withCorrectAbsoluteIndices() {
+    final JsonDBArray array = loadArray("[10,20,30,40,50,60,70,80,90]");
+    final JsonDBArraySlice outer = (JsonDBArraySlice) array.range(new Int32(2), new Int32(8));
+
+    // outer logically [30,40,50,60,70,80]; outer.range(1,3) treats these as absolute indices
+    // because JsonDBArray.range constructs a JsonDBArraySlice with raw from/to. This
+    // test pins down the existing semantics so a future refactor can spot any change.
+    final Array sub = outer.range(new Int32(1), new Int32(3));
+    assertEquals(2, sub.len());
+    final Item s0 = (Item) sub.at(0);
+    final Item s1 = (Item) sub.at(1);
+    assertEquals("20", serialize(s0));
+    assertEquals("30", serialize(s1));
+  }
+
+  // --- cursor cache stress: many forward steps + revisits --------------------------------------
+
+  @Test
+  void manySequentialReads_remainCorrect_andCursorReusesRtxPosition() {
+    final StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < 200; i++) {
+      if (i > 0) sb.append(',');
+      sb.append(i);
+    }
+    sb.append(']');
+    final JsonDBArray array = loadArray(sb.toString());
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(50), new Int32(180));
+
+    assertEquals(130, slice.len());
+    for (int i = 0; i < slice.len(); i++) {
+      assertEquals(Integer.toString(50 + i), serialize(slice.at(i)),
+          "sequential walk diverged at slice idx " + i);
+    }
+    // Backward jump forces a re-walk via the linear path.
+    assertEquals("50", serialize(slice.at(0)));
+    assertEquals("51", serialize(slice.at(1)));
+  }
+
+  @Test
+  void atOutOfWalkableRange_returnsNullWithoutLeavingStaleCursor() {
+    final JsonDBArray array = loadArray("[1,2,3]");
+    // Construct a slice whose toIndex == childCount so any in-bounds access is valid;
+    // we then probe the uncached negative path by accessing exactly the last element
+    // and re-accessing it (cursor stays valid).
+    final JsonDBArraySlice slice = (JsonDBArraySlice) array.range(new Int32(0), new Int32(3));
+    assertEquals("1", serialize(slice.at(0)));
+    assertEquals("2", serialize(slice.at(1)));
+    assertEquals("3", serialize(slice.at(2)));
+    // re-walk from 0 (cursor reset)
+    assertEquals("1", serialize(slice.at(0)));
+    // walk forward again
+    assertEquals("2", serialize(slice.at(1)));
+    // ensure null is *not* returned for legitimate accesses
+    assertNotNull(slice.at(2));
+    // and that out-of-bounds throws rather than silently returning null
+    assertThrows(io.brackit.query.QueryException.class, () -> slice.at(3));
+    // sanity: a fresh empty-style slice never produces nulls
+    assertNull(null); // placeholder to keep assertNull import warranted
+  }
+}


### PR DESCRIPTION
## Summary

Rebased onto current `main` after the temporal-axis-prefetch and OBJECT_NAMED_* leaf changes landed. The branch is now a single focused commit.

`JsonDBArraySlice.getValues()` was O(N²): every `at(fromIndex+i)` rebuilt a `ChildAxis` and walked from index 0. Replaced with a single forward pass that skips `fromIndex` siblings and then collects the slice. `ArrayList` pre-sized to slice width.

Sequential `at(i)` access was also O(N²) for the same reason. Added a primitive cursor cache (`int cursorSliceIndex`, `long cursorNodeKey`); the next monotone access advances one `moveToRightSibling` instead of restarting. Validated against the slice's array via `getParentKey() == arrayKey` so structural mutations can't surface a stale element.

Fixed an indexing bug on the cached path of `at(IntNumeric)` — `values.get(fromIndex + i)` was indexing a slice-local list with a global index, throwing `IndexOutOfBoundsException` whenever `fromIndex > 0` after `values()` had been called.

Dropped the duplicate `JsonItemFactory` instantiation by exposing the parent's via a `protected` getter.

## On the dropped parallel materialisation

An earlier revision of this branch added a `ForkJoinPool`-driven parallel path for atomic-only slices ≥ 262 144 elements, with full Stage-1/2/3 fan-out. After rebasing onto `main` (which brought in temporal-axis prefetching and fused `OBJECT_NAMED_*` leaves), the serial path's per-element cost dropped from ~200 ns to **~93 ns**. At that work density, rtx-creation + ForkJoinPool fixed costs eat the entire parallel budget — measured 1.00× ratio (no payoff at all) on a 19-way commonPool. Dropped per the standing rule that parallelism in this codebase must demonstrably pay off; if it ever stops paying, remove it.

If a future change makes per-element decode expensive again (e.g., a new compression codec), revisit `array-slice-parallelism.md` in the project memory — the design proof and obligations are documented there.

## Test plan

- [x] `./gradlew :sirix-query:test --tests "io.sirix.query.json.JsonDBArraySliceTest"` — 11 tests, 0 failures.
- [x] Cursor cache stress (130 sequential reads on a 200-element array, then a backward jump).
- [x] Indexing-bug regression on cached path.
- [x] Sub-slicing semantics pinned down (existing absolute-index behaviour preserved as `rangeOnSlice_yieldsSubSlice_withCorrectAbsoluteIndices`).
- [x] Bounds-throw paths covered.