### PR TITLE
ci: drop redundant docker login from docker_push.sh

### DIFF
--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+set -euo pipefail
+# Authentication is handled by the docker/login-action step in the workflow;
+# this script only builds and pushes the server image.
 docker compose build --no-cache server
 docker compose push server


### PR DESCRIPTION
## Summary

`Deploy to OSSRH and Docker Hub` job has been failing on every push to main with:

```
Must provide --username with --password-stdin
```

— see [run 25133490213](https://github.com/sirixdb/sirix/actions/runs/25133490213/job/73666777671).

Cause: `docker_push.sh` runs its own `docker login` using `$DOCKER_USERNAME` / `$DOCKER_PASSWORD`. Those env vars are **not** exported by the workflow — authentication is already handled by the previous step (`docker/login-action@v3`, with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`). So the script's login runs without credentials and aborts.

This PR removes the redundant login and adds `set -euo pipefail` so future build/push failures surface clearly.

## Test plan

- [ ] Push to main triggers the `Deploy to OSSRH and Docker Hub` job; the Docker Hub step now succeeds (`docker compose build` / `docker compose push` run with the credentials established by `docker/login-action`).
- [x] Local `bash -n docker_push.sh` parses cleanly.