### PR TITLE
test: tighten fusion-era assertions + PathSummary fusion correctness suite

### DIFF
--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonNodeTrxCopyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonNodeTrxCopyTest.java
@@ -281,34 +281,17 @@ public final class JsonNodeTrxCopyTest {
         wtx.moveToFirstChild(); // copied object
 
         assertEquals(NodeKind.OBJECT, wtx.getKind());
-        wtx.moveToFirstChild(); // first key "name" — fused OBJECT_NAMED_STRING when fusion on, else OBJECT_KEY
-        final NodeKind firstKeyKind = wtx.getKind();
-        assertTrue(firstKeyKind.playsObjectKeyRole(),
-            "expected OBJECT_KEY or fused OBJECT_NAMED_STRING but was: " + firstKeyKind);
+        wtx.moveToFirstChild(); // first key "name" — string value → OBJECT_NAMED_STRING under default fusion
+        assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind(),
+            "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
         assertEquals("name", wtx.getName().getLocalName());
+        assertEquals("Alice", wtx.getValue()); // fused leaf — read inline primitive directly
 
-        if (firstKeyKind.isFusedObjectNamed()) {
-          // Option B: fused leaf — read the inline primitive directly.
-          assertEquals("Alice", wtx.getValue());
-        } else {
-          // Legacy: descend into OBJECT_STRING_VALUE child.
-          wtx.moveToFirstChild();
-          assertEquals("Alice", wtx.getValue());
-          wtx.moveToParent(); // back to "name" key
-        }
-
-        wtx.moveToRightSibling(); // "age" key — fused OBJECT_NAMED_NUMBER or legacy OBJECT_KEY
-        final NodeKind secondKeyKind = wtx.getKind();
-        assertTrue(secondKeyKind.playsObjectKeyRole(),
-            "expected OBJECT_KEY or fused OBJECT_NAMED_NUMBER but was: " + secondKeyKind);
+        wtx.moveToRightSibling(); // "age" key — number value → OBJECT_NAMED_NUMBER under default fusion
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, wtx.getKind(),
+            "number-valued field must produce OBJECT_NAMED_NUMBER under default fusion");
         assertEquals("age", wtx.getName().getLocalName());
-
-        if (secondKeyKind.isFusedObjectNamed()) {
-          assertEquals(30, wtx.getNumberValue().intValue());
-        } else {
-          wtx.moveToFirstChild(); // 30
-          assertEquals(30, wtx.getNumberValue().intValue());
-        }
+        assertEquals(30, wtx.getNumberValue().intValue());
       }
 
       wtx.commit();
@@ -561,10 +544,9 @@ public final class JsonNodeTrxCopyTest {
 
         // Verify the copied object's internal structure: key "key" -> value "value"
         wtx.moveTo(copiedObjKey);
-        wtx.moveToFirstChild(); // "key" field record — fused when fusion on, legacy OBJECT_KEY when off
-        final NodeKind fieldKind = wtx.getKind();
-        assertTrue(fieldKind.playsObjectKeyRole(),
-            "expected OBJECT_KEY or fused OBJECT_NAMED_STRING but was: " + fieldKind);
+        wtx.moveToFirstChild(); // "key" field record — string value → OBJECT_NAMED_STRING
+        assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind(),
+            "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
         assertEquals("key", wtx.getName().getLocalName());
         assertEquals(copiedObjKey, wtx.getParentKey());
 
@@ -618,33 +600,20 @@ public final class JsonNodeTrxCopyTest {
         rtx.moveToFirstChild(); // first object (the copy)
         assertEquals(NodeKind.OBJECT, rtx.getKind());
 
-        rtx.moveToFirstChild(); // "x" field record — fused OBJECT_NAMED_NUMBER when fusion on, legacy OBJECT_KEY when off
-        final NodeKind xKind = rtx.getKind();
-        assertTrue(xKind.playsObjectKeyRole(),
-            "expected OBJECT_KEY or fused OBJECT_NAMED_NUMBER but was: " + xKind);
+        rtx.moveToFirstChild(); // "x" field record — number value → OBJECT_NAMED_NUMBER
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, rtx.getKind(),
+            "number-valued field must produce OBJECT_NAMED_NUMBER under default fusion");
         assertEquals("x", rtx.getName().getLocalName());
+        assertEquals(10, rtx.getNumberValue().intValue());
+        rtx.moveToParent(); // back to first object
 
-        if (xKind.isFusedObjectNamed()) {
-          // Option B: fused leaf — read inline and hop straight back to OBJECT.
-          assertEquals(10, rtx.getNumberValue().intValue());
-          rtx.moveToParent(); // back to first object
-        } else {
-          rtx.moveToFirstChild(); // 10
-          assertEquals(10, rtx.getNumberValue().intValue());
-          rtx.moveToParent(); // back to "x" key
-          rtx.moveToParent(); // back to first object
-        }
         rtx.moveToRightSibling(); // second object (original)
         assertEquals(NodeKind.OBJECT, rtx.getKind());
 
-        rtx.moveToFirstChild(); // "x" key — fused or legacy
-        final NodeKind origXKind = rtx.getKind();
-        if (origXKind.isFusedObjectNamed()) {
-          assertEquals(10, rtx.getNumberValue().intValue());
-        } else {
-          rtx.moveToFirstChild(); // 10
-          assertEquals(10, rtx.getNumberValue().intValue());
-        }
+        rtx.moveToFirstChild(); // "x" key on the original
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, rtx.getKind(),
+            "original object's number-valued field must also be OBJECT_NAMED_NUMBER");
+        assertEquals(10, rtx.getNumberValue().intValue());
       }
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/PathSummaryFusionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/PathSummaryFusionTest.java
@@ -1,0 +1,263 @@
+package io.sirix.access.node.json;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.api.Axis;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.node.NodeKind;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * PathSummary correctness under default-on iter#30 + iter#32 fusion.
+ *
+ * <p>Verifies the design contracts captured in {@code PathSummaryWriter}:
+ * <ul>
+ *   <li>Fused {@code OBJECT_NAMED_*} primitive leaves register exactly one path-summary entry
+ *       under the canonical {@code OBJECT_NAMED_OBJECT} pathKind, reusing the slot that an
+ *       unfused {@code OBJECT_KEY} would have populated.</li>
+ *   <li>Fused {@code OBJECT_NAMED_ARRAY} structural records bump the path-summary entry for
+ *       <em>both</em> the field-name level and the underlying array level (Phase 2 mirror).</li>
+ *   <li>Reference counts increment on duplicate-field insert and decrement on remove; when the
+ *       last reference goes away the entry is gone too.</li>
+ *   <li>{@code setObjectKeyName} on a fused record correctly migrates references between the
+ *       old and new path-summary entries.</li>
+ * </ul>
+ */
+public final class PathSummaryFusionTest {
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  /**
+   * Walk the path summary and snapshot {@code (qname → references)} for level-1 entries.
+   * Asserts each is registered with the canonical fused pathKind {@link NodeKind#OBJECT_NAMED_OBJECT}.
+   */
+  private static Map<String, Integer> level1Refs(final PathSummaryReader summary) {
+    final Map<String, Integer> out = new HashMap<>();
+    final Axis axis = new DescendantAxis(summary);
+    while (axis.hasNext()) {
+      axis.nextLong();
+      if (summary.getLevel() != 1) {
+        continue;
+      }
+      final NodeKind pathKind = summary.getPathKind();
+      assertTrue(pathKind == NodeKind.OBJECT_NAMED_OBJECT || pathKind == NodeKind.ARRAY,
+          "level-1 path-summary entries must use the canonical fused pathKind "
+              + "OBJECT_NAMED_OBJECT (or ARRAY for array-typed children); got: " + pathKind);
+      final QNm name = summary.getName();
+      assertNotNull(name, "level-1 path-summary entry has null name at nodeKey="
+          + summary.getNodeKey());
+      out.put(name.getLocalName(), summary.getReferences());
+    }
+    return out;
+  }
+
+  @Test
+  void fusedPrimitiveLeaves_registerCanonicalOBJECT_NAMED_OBJECT_pathKind() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"s\":\"v\",\"n\":42,\"b\":true,\"z\":null}"));
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        final Map<String, Integer> refs = level1Refs(summary);
+        assertEquals(4, refs.size(),
+            "expected exactly 4 level-1 path entries for the 4 fused primitive fields, got: " + refs);
+        assertEquals(1, refs.get("s"), "string-valued field 's' refcount");
+        assertEquals(1, refs.get("n"), "number-valued field 'n' refcount");
+        assertEquals(1, refs.get("b"), "boolean-valued field 'b' refcount");
+        assertEquals(1, refs.get("z"), "null-valued field 'z' refcount");
+      }
+    }
+  }
+
+  @Test
+  void duplicateFieldName_acrossSiblingObjects_increments_references() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("[{\"name\":\"a\"},{\"name\":\"b\"}]"));
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        final Axis axis = new DescendantAxis(summary);
+        int nameRefs = -1;
+        while (axis.hasNext()) {
+          axis.nextLong();
+          final QNm name = summary.getName();
+          if (name != null && "name".equals(name.getLocalName())) {
+            assertEquals(NodeKind.OBJECT_NAMED_OBJECT, summary.getPathKind(),
+                "fused string field's path entry must use OBJECT_NAMED_OBJECT");
+            nameRefs = summary.getReferences();
+          }
+        }
+        assertEquals(2, nameRefs,
+            "two fused OBJECT_NAMED_STRING records sharing the same field path must register references=2");
+      }
+    }
+  }
+
+  @Test
+  void removingFusedField_decrements_pathSummaryReferences() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("[{\"k\":1},{\"k\":2}]"));
+        wtx.commit();
+        // doc(0) → array(1) → first object(2) → fused "k=1"(3).
+        wtx.moveTo(2);
+        wtx.moveToFirstChild();
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, wtx.getKind());
+        wtx.remove();
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        int kRefs = -1;
+        final Axis axis = new DescendantAxis(summary);
+        while (axis.hasNext()) {
+          axis.nextLong();
+          final QNm name = summary.getName();
+          if (name != null && "k".equals(name.getLocalName())) {
+            kRefs = summary.getReferences();
+          }
+        }
+        assertEquals(1, kRefs,
+            "after removing one of two fused OBJECT_NAMED_NUMBER records, references must drop to 1");
+      }
+    }
+  }
+
+  @Test
+  void removingLastFusedField_collapses_pathSummaryEntry() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"only\":\"once\"}"));
+        wtx.commit();
+        wtx.moveTo(2);
+        assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind());
+        wtx.remove();
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        final Axis axis = new DescendantAxis(summary);
+        while (axis.hasNext()) {
+          axis.nextLong();
+          final QNm name = summary.getName();
+          if (name != null && "only".equals(name.getLocalName())) {
+            // PathSummaryWriter contract: when references drops to 0 the entry should be
+            // removed. If it ever resurfaces with refs=0, the path-summary garbage-collection
+            // path is broken — fail loudly.
+            throw new AssertionError(
+                "path-summary entry for 'only' should have been removed when its last reference "
+                    + "went away; instead found refs=" + summary.getReferences());
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void fusedStructural_OBJECT_NAMED_ARRAY_registers_pathSummaryEntries_onBothLevels() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        // Phase 2 structural fusion produces an OBJECT_NAMED_ARRAY for {"items": [...]}.
+        // The path summary must mirror the entry at BOTH the field-name level (OBJECT_NAMED_OBJECT
+        // pathKind under "items") AND the underlying array level (ARRAY pathKind for elements).
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"items\":[1,2,3]}"));
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        final Axis axis = new DescendantAxis(summary);
+        boolean sawItemsField = false;
+        boolean sawArrayLevel = false;
+        while (axis.hasNext()) {
+          axis.nextLong();
+          final QNm name = summary.getName();
+          if (name != null && "items".equals(name.getLocalName())) {
+            assertEquals(NodeKind.OBJECT_NAMED_OBJECT, summary.getPathKind(),
+                "field 'items' must be registered under canonical OBJECT_NAMED_OBJECT pathKind");
+            assertTrue(summary.getReferences() >= 1,
+                "field 'items' must have at least one reference, got: " + summary.getReferences());
+            sawItemsField = true;
+          }
+          if (summary.getPathKind() == NodeKind.ARRAY && summary.getLevel() == 2) {
+            // Level-2 ARRAY entry below "items" field — the structural-fusion mirror.
+            sawArrayLevel = true;
+          }
+        }
+        assertTrue(sawItemsField, "path-summary lacks field-level entry for fused 'items'");
+        assertTrue(sawArrayLevel,
+            "path-summary lacks the array-level mirror entry that Phase 2 structural fusion must "
+                + "register under OBJECT_NAMED_ARRAY");
+      }
+    }
+  }
+
+  @Test
+  void renamingFusedField_migrates_pathSummaryReferences() {
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"oldName\":\"v\"}"));
+        wtx.commit();
+        wtx.moveTo(2);
+        assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind());
+        wtx.setObjectKeyName("newName");
+        wtx.commit();
+      }
+      try (final var summary = session.openPathSummary()) {
+        final Axis axis = new DescendantAxis(summary);
+        Integer oldRefs = null;
+        Integer newRefs = null;
+        while (axis.hasNext()) {
+          axis.nextLong();
+          final QNm name = summary.getName();
+          if (name == null) {
+            continue;
+          }
+          if ("oldName".equals(name.getLocalName())) {
+            oldRefs = summary.getReferences();
+          } else if ("newName".equals(name.getLocalName())) {
+            newRefs = summary.getReferences();
+            assertEquals(NodeKind.OBJECT_NAMED_OBJECT, summary.getPathKind(),
+                "renamed field 'newName' must register under canonical fused pathKind");
+          }
+        }
+        assertNull(oldRefs,
+            "after setObjectKeyName, the old 'oldName' path entry must be gone, but found refs="
+                + oldRefs);
+        assertEquals(Integer.valueOf(1), newRefs,
+            "after setObjectKeyName, the new 'newName' path entry must hold the migrated reference");
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/FlyweightCursorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/FlyweightCursorTest.java
@@ -238,10 +238,9 @@ class FlyweightCursorTest {
         count++;
       }
 
-      // Legacy (unfused): object, key "nested", object, key "deep", number 42 = 5 descendants.
-      // iter#32 fusion (primitive + structural): object, OBJECT_NAMED_OBJECT "nested", fused
-      // "deep=42" (OBJECT_NAMED_NUMBER) = 3 descendants.
-      assertTrue(count >= 3, "Should have at least 3 descendants, got: " + count);
+      // iter#32 fusion (primitive + structural) is default ON: the descendant axis from doc root
+      // visits exactly OBJECT, OBJECT_NAMED_OBJECT "nested", OBJECT_NAMED_NUMBER "deep"=42 → 3.
+      assertEquals(3, count, "fused descendant count for {nested:{deep:42}} must be exactly 3");
     }
   }
 
@@ -389,12 +388,11 @@ class FlyweightCursorTest {
       final long firstNodeKey = firstSnapshot.getNodeKey();
       final NodeKind firstKind = firstSnapshot.getKind();
 
-      // Verify we have a valid snapshot
+      // Verify we have a valid snapshot. Source is {"first": 1, "second": 2}; first key has a
+      // number value so default fusion produces OBJECT_NAMED_NUMBER.
       assertNotNull(firstSnapshot);
-      // Under legacy mode first is OBJECT_KEY; under fuseNamedPrimitives it becomes an
-      // OBJECT_NAMED_* kind. Both play the "object key" role.
-      assertTrue(firstKind.playsObjectKeyRole(),
-          "Expected OBJECT_KEY or fused OBJECT_NAMED_* kind, got: " + firstKind);
+      assertEquals(NodeKind.OBJECT_NAMED_NUMBER, firstKind,
+          "first key with number value must produce OBJECT_NAMED_NUMBER under default fusion");
 
       // Move to the next sibling (different node)
       assertTrue(rtx.moveToRightSibling());
@@ -547,9 +545,9 @@ class FlyweightCursorTest {
       wtx.moveToDocumentRoot();
       wtx.moveToFirstChild(); // Object
       wtx.moveToFirstChild(); // "a" key
-      wtx.moveToRightSibling(); // "b" key
-      assertTrue(wtx.getKind().playsObjectKeyRole(),
-          "Expected OBJECT_KEY or fused OBJECT_NAMED_* kind, got: " + wtx.getKind());
+      wtx.moveToRightSibling(); // "b" key — string value → OBJECT_NAMED_STRING under default fusion
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind(),
+          "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
       assertEquals("b", wtx.getName().getLocalName());
 
       // This was the buggy operation — the cursor would end up at parent instead of "b"
@@ -587,9 +585,9 @@ class FlyweightCursorTest {
     try (final var session = database.beginResourceSession(RESOURCE); final var wtx = session.beginNodeTrx()) {
       wtx.moveToDocumentRoot();
       wtx.moveToFirstChild(); // Object
-      wtx.moveToFirstChild(); // "a" key
-      assertTrue(wtx.getKind().playsObjectKeyRole(),
-          "Expected OBJECT_KEY or fused OBJECT_NAMED_* kind, got: " + wtx.getKind());
+      wtx.moveToFirstChild(); // "a" key — string value → OBJECT_NAMED_STRING under default fusion
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, wtx.getKind(),
+          "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
       assertEquals("a", wtx.getName().getLocalName());
 
       wtx.insertObjectRecordAsRightSibling("inserted", new StringValue("new"));
@@ -624,13 +622,13 @@ class FlyweightCursorTest {
 
     try (final var session = database.beginResourceSession(RESOURCE); final var rtx = session.beginNodeReadOnlyTrx()) {
 
-      // Navigate to "first" object key
+      // Navigate to "first" object key. Source is {"first": "hello", "second": "world"} — both
+      // string values, so default fusion produces OBJECT_NAMED_STRING for each.
       rtx.moveToDocumentRoot();
       rtx.moveToFirstChild(); // Object
       rtx.moveToFirstChild(); // "first" key
-      // Under legacy mode OBJECT_KEY; under fuseNamedPrimitives it becomes OBJECT_NAMED_STRING.
-      assertTrue(rtx.getKind().playsObjectKeyRole(),
-          "Expected OBJECT_KEY or fused OBJECT_NAMED_* kind, got: " + rtx.getKind());
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, rtx.getKind(),
+          "string-valued field 'first' must produce OBJECT_NAMED_STRING under default fusion");
 
       // Get immutable snapshot at "first"
       final var firstNode = rtx.getNode();
@@ -639,8 +637,8 @@ class FlyweightCursorTest {
 
       // Move cursor to "second" key
       assertTrue(rtx.moveToRightSibling());
-      assertTrue(rtx.getKind().playsObjectKeyRole(),
-          "Expected OBJECT_KEY or fused OBJECT_NAMED_* kind, got: " + rtx.getKind());
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, rtx.getKind(),
+          "string-valued field 'second' must produce OBJECT_NAMED_STRING under default fusion");
 
       // Get immutable snapshot at "second"
       final var secondNode = rtx.getNode();

--- a/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/LdjsonShredderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/LdjsonShredderTest.java
@@ -256,18 +256,24 @@ public final class LdjsonShredderTest {
       assertEquals(NodeKind.OBJECT, trx.getKind());
       final long firstObjKey = trx.getNodeKey();
 
-      // First object has child object key "k" — fused into OBJECT_NAMED_STRING in iter#32.
+      // First object has child object key "k" with string value → OBJECT_NAMED_STRING under default fusion.
       trx.moveToFirstChild();
-      assertTrue(trx.getKind().playsObjectKeyRole(), "expected OBJECT_KEY-role kind, got: " + trx.getKind());
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, trx.getKind(),
+          "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
+      assertEquals("k", trx.getName().getLocalName());
+      assertEquals("v", trx.getValue());
 
       // Right sibling of first object: second object
       trx.moveTo(firstObjKey);
       trx.moveToRightSibling();
       assertEquals(NodeKind.OBJECT, trx.getKind());
 
-      // Second object has child object key "k2" — fused into OBJECT_NAMED_STRING in iter#32.
+      // Second object has child object key "k2" with string value → OBJECT_NAMED_STRING.
       trx.moveToFirstChild();
-      assertTrue(trx.getKind().playsObjectKeyRole(), "expected OBJECT_KEY-role kind, got: " + trx.getKind());
+      assertEquals(NodeKind.OBJECT_NAMED_STRING, trx.getKind(),
+          "string-valued field must produce OBJECT_NAMED_STRING under default fusion");
+      assertEquals("k2", trx.getName().getLocalName());
+      assertEquals("v2", trx.getValue());
 
       // No more siblings after second object
       trx.moveToParent(); // back to second object


### PR DESCRIPTION
## Summary

During the iter#28→32 fusion rollout (PRs landing the `OBJECT_NAMED_*` family) several existing tests were relaxed to accept *either* the legacy `OBJECT_KEY` shape or the post-fusion `OBJECT_NAMED_*` shape. Now that fusion is default ON, the legacy branch is unreachable — those OR/role-predicate assertions are silently weaker than they look. Per the project rule \"do not relax tests,\" tighten them back to the exact fused kind dictated by each test's JSON shape.

Also add a new `PathSummaryFusionTest` because the user asked specifically: **make sure that with fused nodes, the PathSummary is still valid**.

## Tightenings (3 files)

### `JsonNodeTrxCopyTest.java`
4 assertion sites switched from `assertTrue(kind.playsObjectKeyRole(), …)` (accepts any of the 6 fused kinds) to `assertEquals(NodeKind.OBJECT_NAMED_<TYPE>, kind)` per JSON value type. Removed the unreachable legacy `if/else` descent branches whose else-arm walks an extra `OBJECT_STRING_VALUE`/etc. child that fusion no longer emits.

### `FlyweightCursorTest.java`
- 5 assertion sites tightened the same way (`OBJECT_NAMED_STRING` for string-valued fields, `OBJECT_NAMED_NUMBER` for numeric).
- Descendant-count assertion was `assertTrue(count >= 3, …)` (accepts both the 3-fused and 5-legacy answer); now `assertEquals(3, count, …)`.

### `LdjsonShredderTest.java`
2 sites at `testTreeStructure` tightened to `OBJECT_NAMED_STRING` and now also assert the inline value (`\"v\"` / `\"v2\"`) — a legitimate strengthening since the fused leaf carries the value directly.

## New: `PathSummaryFusionTest` (6 tests, all passing)

Pins down the contracts in `PathSummaryWriter`:

1. **`fusedPrimitiveLeaves_registerCanonicalOBJECT_NAMED_OBJECT_pathKind`** — `{s,n,b,z}` of all four primitive flavours each produces one level-1 entry under the canonical `OBJECT_NAMED_OBJECT` pathKind with `references=1`.
2. **`duplicateFieldName_acrossSiblingObjects_increments_references`** — `[{name:\"a\"},{name:\"b\"}]` collapses into one path entry with `references=2`.
3. **`removingFusedField_decrements_pathSummaryReferences`** — removing one of two fused `OBJECT_NAMED_NUMBER` records drops refs from 2 → 1.
4. **`removingLastFusedField_collapses_pathSummaryEntry`** — removing the sole instance of a field eliminates the entry entirely (no orphan refs=0 entry).
5. **`fusedStructural_OBJECT_NAMED_ARRAY_registers_pathSummaryEntries_onBothLevels`** — Phase 2 structural fusion of `{items:[1,2,3]}` mirrors at both the field-name level (`OBJECT_NAMED_OBJECT` pathKind for `items`) AND the underlying array level (`ARRAY` pathKind for elements).
6. **`renamingFusedField_migrates_pathSummaryReferences`** — `setObjectKeyName(\"oldName\" → \"newName\")` migrates the reference; old entry gone, new entry refs=1, registered under the canonical pathKind.

## Test plan

- [x] `./gradlew :sirix-core:test --tests \"io.sirix.access.node.json.JsonNodeTrxCopyTest\"` — 14 tests, 0 failures.
- [x] `./gradlew :sirix-core:test --tests \"io.sirix.access.trx.node.FlyweightCursorTest\"` — 15 tests, 0 failures.
- [x] `./gradlew :sirix-core:test --tests \"io.sirix.service.json.shredder.LdjsonShredderTest\"` — 23 tests, 0 failures.
- [x] `./gradlew :sirix-core:test --tests \"io.sirix.access.node.json.PathSummaryFusionTest\"` — 6 tests, 0 failures.

## Notes

- Five other tests (`HOTSplitIntegrationTest`, `HOTVersioningIntegrationTest`, `JsonStructuralFuzzTest`, `HOTHeightOptimalTest`, `HOTIndexManyRevisionsTest`, etc.) use `playsObjectKeyRole()` as **dispatch** (`if (kind.playsObjectKeyRole()) { … }`), not as an assertion. Those are legitimate flow-control predicates, not relaxations — left alone.
- `ProductionReadinessTest` uses `playsObjectKeyRole()` inside walker dispatch and one comment says \"accept either kind via NodeKind#playsObjectKeyRole().\" That comment is stale (fusion default ON), but the predicate is still a dispatch usage, not a weakened assertion. Left alone.