### PR TITLE
fix(gradle): publish sirix-core test classes via testArtifacts configuration

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -40,6 +40,28 @@ jar {
     }
 }
 
+// Expose compiled test classes (Holder, JsonTestHelper, IteratorTester, ...) to sibling
+// modules. Gradle 9+ no longer lets you reach `project(':x').sourceSets.test.output`
+// via project() in another module's dependencies block, so the historical short form
+// breaks. Publish a classifier="tests" jar through a named consumable configuration
+// instead — works on Gradle 8/9/10 alike.
+configurations {
+    testArtifacts
+}
+
+tasks.register('testJar', Jar) {
+    archiveClassifier = 'tests'
+    // Only compiled test classes — not src/test/resources, which contains
+    // multi-GB benchmark datasets (cityofchicago.json) that would blow past
+    // the zip 4 GB limit and are not needed by downstream test consumers.
+    from sourceSets.test.output.classesDirs
+    dependsOn testClasses
+}
+
+artifacts {
+    testArtifacts tasks.named('testJar')
+}
+
 test {
     useJUnitPlatform()
     

--- a/bundles/sirix-kotlin-api/build.gradle
+++ b/bundles/sirix-kotlin-api/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation implLibraries.kotlinStdlibJdk8
     implementation implLibraries.kotlinxCoroutinesCore
 
-    testImplementation project(':sirix-core').sourceSets.test.output
+    testImplementation project(path: ':sirix-core', configuration: 'testArtifacts')
     testImplementation testLibraries.junitJupiterApi
     testImplementation testLibraries.junitJupiterEngine
     testImplementation testLibraries.junitVintageEngine

--- a/bundles/sirix-rest-api/build.gradle
+++ b/bundles/sirix-rest-api/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'org.graalvm.buildtools.native'
 dependencies {
     implementation project(':sirix-core')
     implementation project(':sirix-query')
-    testImplementation project(':sirix-core').sourceSets.test.output
+    testImplementation project(path: ':sirix-core', configuration: 'testArtifacts')
 
     implementation implLibraries.kotlinStdlib
     implementation implLibraries.kotlinxCoroutinesCore


### PR DESCRIPTION
## Summary

Restores Docker Hub deploy on \`main\` (CI run [25207884507](https://github.com/sirixdb/sirix/actions/runs/25207884507/job/73912580366) failed with \`Could not get unknown property 'sourceSets' for project ':sirix-core'\`).

The historical idiom \`project(':sirix-core').sourceSets.test.output\` reaches across module boundaries through the dependencies block — Gradle 9.x stopped supporting that because \`project(...)\` returns a \`DefaultProjectDependency\`, not the actual \`Project\`.

## Fix

Replace the cross-module test-class share with a named consumable configuration:

- \`sirix-core/build.gradle\` declares a \`testArtifacts\` configuration and a \`testJar\` task that publishes a tests-classified jar.
- \`sirix-kotlin-api\` and \`sirix-rest-api\` now consume it via \`project(path: ':sirix-core', configuration: 'testArtifacts')\`.

The testJar deliberately excludes \`src/test/resources\` because that tree contains the ~3.6 GB \`json/cityofchicago.json\` benchmark dataset which would blow past the zip 4 GB limit and is not needed by downstream consumers (they need \`Holder\` / \`JsonTestHelper\` / \`IteratorTester\` classes, not the bench input).

## Test plan
- [x] \`./gradlew :sirix-kotlin-api:compileTestKotlin\` succeeds locally.
- [x] \`./gradlew :sirix-rest-api:compileTestKotlin\` succeeds locally.
- [ ] Docker Hub deploy job re-runs green on this PR.