### PR TITLE
fix: bound RevisionFileData AsyncCache to 10k entries (per-commit memory leak)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/PerResourceRevisionFileDataCache.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/PerResourceRevisionFileDataCache.java
@@ -1,0 +1,336 @@
+package io.sirix.io;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Policy;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Per-resource view over a single global Caffeine {@link AsyncCache} that is keyed by
+ * {@link RevisionFileDataCacheKey} {@code (resourcePath, revision)}. Each Sirix
+ * resource gets its own instance of this wrapper, but storage and eviction live in
+ * one shared cache so the operator-facing memory ceiling is a single number — the
+ * SaaS-friendly pattern PostgreSQL ({@code shared_buffers}) and InnoDB
+ * ({@code innodb_buffer_pool_size}) follow.
+ *
+ * <h2>Why a wrapper instead of refactoring the storage classes</h2>
+ * <p>{@code AsyncCache<Integer, RevisionFileData>} threads through ~12 storage
+ * classes (Storage / Reader / Writer for each of FILE / FILE_CHANNEL /
+ * MEMORY_MAPPED / IO_URING / RAM backends) and {@code cache.synchronous()} is
+ * passed deep into reader constructors. Wrapping at this boundary keeps every
+ * caller compiling against the same Caffeine type while the actual storage is
+ * now global.
+ *
+ * <h2>Method scope</h2>
+ * <p>Only the methods that the Sirix codebase actually calls on this cache are
+ * implemented. Unused {@link AsyncCache} / {@link Cache} surface throws
+ * {@link UnsupportedOperationException} on first call, with a comment naming the
+ * expected use case. Add support as the codebase grows; the unsupported branches
+ * are explicit so reviewers can spot them.
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class PerResourceRevisionFileDataCache implements AsyncCache<Integer, RevisionFileData> {
+
+  private final Path resourcePath;
+  private final AsyncCache<RevisionFileDataCacheKey, RevisionFileData> global;
+  private final SynchronousView synchronousView;
+
+  public PerResourceRevisionFileDataCache(final Path resourcePath,
+      final AsyncCache<RevisionFileDataCacheKey, RevisionFileData> global) {
+    this.resourcePath = resourcePath;
+    this.global = global;
+    this.synchronousView = new SynchronousView();
+  }
+
+  // ---------------- AsyncCache surface that callers in Sirix actually use ----------------
+
+  @Override
+  public CompletableFuture<RevisionFileData> get(final Integer key,
+      final Function<? super Integer, ? extends RevisionFileData> mappingFunction) {
+    return global.get(new RevisionFileDataCacheKey(resourcePath, key), k -> mappingFunction.apply(k.revision()));
+  }
+
+  @Override
+  public CompletableFuture<Map<Integer, RevisionFileData>> getAll(final Iterable<? extends Integer> keys,
+      final Function<? super Set<? extends Integer>, ? extends Map<? extends Integer, ? extends RevisionFileData>> mappingFunction) {
+    final List<RevisionFileDataCacheKey> compositeKeys = new ArrayList<>();
+    keys.forEach(k -> compositeKeys.add(new RevisionFileDataCacheKey(resourcePath, k)));
+
+    return global.getAll(compositeKeys, missingComposite -> {
+      final Set<Integer> missingInts = new HashSet<>();
+      for (final RevisionFileDataCacheKey k : missingComposite) {
+        missingInts.add(k.revision());
+      }
+      final Map<? extends Integer, ? extends RevisionFileData> intResult = mappingFunction.apply(missingInts);
+      // Translate Integer-keyed mapper output back into composite keys for the global cache to store.
+      final Map<RevisionFileDataCacheKey, RevisionFileData> compositeResult = new HashMap<>(intResult.size());
+      for (final Map.Entry<? extends Integer, ? extends RevisionFileData> e : intResult.entrySet()) {
+        compositeResult.put(new RevisionFileDataCacheKey(resourcePath, e.getKey()), e.getValue());
+      }
+      return compositeResult;
+    }).thenApply(compositeMap -> {
+      final Map<Integer, RevisionFileData> intMap = new HashMap<>(compositeMap.size());
+      compositeMap.forEach((k, v) -> intMap.put(k.revision(), v));
+      return intMap;
+    });
+  }
+
+  @Override
+  public void put(final Integer key, final CompletableFuture<? extends RevisionFileData> valueFuture) {
+    global.put(new RevisionFileDataCacheKey(resourcePath, key), valueFuture);
+  }
+
+  @Override
+  public ConcurrentMap<Integer, CompletableFuture<RevisionFileData>> asMap() {
+    // Only .isEmpty() and .size() are called on the AsyncCache asMap() in Sirix.
+    // Implement those efficiently; the rest is a forwarding view that filters by
+    // resourcePath when iterated.
+    return new PerResourceAsMapView();
+  }
+
+  @Override
+  public Cache<Integer, RevisionFileData> synchronous() {
+    return synchronousView;
+  }
+
+  // ---------------- AsyncCache methods Sirix does not call (yet) ----------------
+
+  @Override
+  public CompletableFuture<RevisionFileData> getIfPresent(final Integer key) {
+    return global.getIfPresent(new RevisionFileDataCacheKey(resourcePath, key));
+  }
+
+  @Override
+  public CompletableFuture<RevisionFileData> get(final Integer key,
+      final BiFunction<? super Integer, ? super Executor, ? extends CompletableFuture<? extends RevisionFileData>> mappingFunction) {
+    return global.get(new RevisionFileDataCacheKey(resourcePath, key),
+                      (k, executor) -> mappingFunction.apply(k.revision(), executor));
+  }
+
+  @Override
+  public CompletableFuture<Map<Integer, RevisionFileData>> getAll(final Iterable<? extends Integer> keys,
+      final BiFunction<? super Set<? extends Integer>, ? super Executor, ? extends CompletableFuture<? extends Map<? extends Integer, ? extends RevisionFileData>>> mappingFunction) {
+    throw new UnsupportedOperationException(
+        "getAll(Iterable, BiFunction) is not used by Sirix internal callers; add support if needed");
+  }
+
+  // -------------------------------------------------------------------------------
+
+  private final class PerResourceAsMapView extends AbstractForwardingConcurrentMap<Integer, CompletableFuture<RevisionFileData>> {
+
+    @Override
+    public boolean isEmpty() {
+      // Used in IOStorage.loadRevisionFileDataIntoMemory to skip pre-loading if any entry
+      // for this resource is already cached. Iterate the global keyset filtering by path.
+      for (final RevisionFileDataCacheKey k : global.asMap().keySet()) {
+        if (k.resourcePath().equals(resourcePath)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public int size() {
+      int count = 0;
+      for (final RevisionFileDataCacheKey k : global.asMap().keySet()) {
+        if (k.resourcePath().equals(resourcePath)) {
+          count++;
+        }
+      }
+      return count;
+    }
+
+    @Override
+    public Set<Integer> keySet() {
+      final Set<Integer> out = new HashSet<>();
+      for (final RevisionFileDataCacheKey k : global.asMap().keySet()) {
+        if (k.resourcePath().equals(resourcePath)) {
+          out.add(k.revision());
+        }
+      }
+      return out;
+    }
+
+    @Override
+    public Set<Map.Entry<Integer, CompletableFuture<RevisionFileData>>> entrySet() {
+      final Set<Map.Entry<Integer, CompletableFuture<RevisionFileData>>> out = new HashSet<>();
+      for (final Map.Entry<RevisionFileDataCacheKey, CompletableFuture<RevisionFileData>> e : global.asMap().entrySet()) {
+        if (e.getKey().resourcePath().equals(resourcePath)) {
+          out.add(new AbstractMap.SimpleImmutableEntry<>(e.getKey().revision(), e.getValue()));
+        }
+      }
+      return out;
+    }
+  }
+
+  /** Per-resource synchronous view. Only the methods Sirix actually calls are implemented. */
+  private final class SynchronousView implements Cache<Integer, RevisionFileData> {
+
+    @Override
+    public RevisionFileData get(final Integer key, final Function<? super Integer, ? extends RevisionFileData> mappingFunction) {
+      return global.synchronous().get(new RevisionFileDataCacheKey(resourcePath, key), k -> mappingFunction.apply(k.revision()));
+    }
+
+    @Override
+    public RevisionFileData getIfPresent(final Integer key) {
+      return global.synchronous().getIfPresent(new RevisionFileDataCacheKey(resourcePath, key));
+    }
+
+    @Override
+    public void put(final Integer key, final RevisionFileData value) {
+      global.synchronous().put(new RevisionFileDataCacheKey(resourcePath, key), value);
+    }
+
+    @Override
+    public void invalidateAll() {
+      // Used by LocalDatabase.removeDatabase to drop all entries for this resource on
+      // resource removal. Iterate the global keyset and invalidate matching entries —
+      // O(N_global) but only runs on resource teardown, never on a hot path.
+      final List<RevisionFileDataCacheKey> toInvalidate = new ArrayList<>();
+      for (final RevisionFileDataCacheKey k : global.synchronous().asMap().keySet()) {
+        if (k.resourcePath().equals(resourcePath)) {
+          toInvalidate.add(k);
+        }
+      }
+      global.synchronous().invalidateAll(toInvalidate);
+    }
+
+    @Override
+    public Map<Integer, RevisionFileData> getAllPresent(final Iterable<? extends Integer> keys) {
+      final List<RevisionFileDataCacheKey> compositeKeys = new ArrayList<>();
+      keys.forEach(k -> compositeKeys.add(new RevisionFileDataCacheKey(resourcePath, k)));
+      final Map<RevisionFileDataCacheKey, RevisionFileData> compositeResult = global.synchronous().getAllPresent(compositeKeys);
+      final Map<Integer, RevisionFileData> intResult = new HashMap<>(compositeResult.size());
+      compositeResult.forEach((k, v) -> intResult.put(k.revision(), v));
+      return intResult;
+    }
+
+    @Override
+    public Map<Integer, RevisionFileData> getAll(final Iterable<? extends Integer> keys,
+        final Function<? super Set<? extends Integer>, ? extends Map<? extends Integer, ? extends RevisionFileData>> mappingFunction) {
+      throw new UnsupportedOperationException(
+          "Cache#getAll is not used on the per-resource synchronous view; add support if needed");
+    }
+
+    @Override
+    public void putAll(final Map<? extends Integer, ? extends RevisionFileData> map) {
+      for (final Map.Entry<? extends Integer, ? extends RevisionFileData> e : map.entrySet()) {
+        put(e.getKey(), e.getValue());
+      }
+    }
+
+    @Override
+    public void invalidate(final Integer key) {
+      global.synchronous().invalidate(new RevisionFileDataCacheKey(resourcePath, key));
+    }
+
+    @Override
+    public void invalidateAll(final Iterable<? extends Integer> keys) {
+      final List<RevisionFileDataCacheKey> compositeKeys = new ArrayList<>();
+      keys.forEach(k -> compositeKeys.add(new RevisionFileDataCacheKey(resourcePath, k)));
+      global.synchronous().invalidateAll(compositeKeys);
+    }
+
+    @Override
+    public long estimatedSize() {
+      // Per-resource estimate: scan the global keyset filtering by path. Diagnostic-only.
+      long count = 0L;
+      for (final RevisionFileDataCacheKey k : global.synchronous().asMap().keySet()) {
+        if (k.resourcePath().equals(resourcePath)) {
+          count++;
+        }
+      }
+      return count;
+    }
+
+    @Override
+    public CacheStats stats() {
+      // The underlying global cache has stats; per-resource stats would require a separate
+      // hit/miss recorder. Diagnostic-only — return the global stats.
+      return global.synchronous().stats();
+    }
+
+    @Override
+    public ConcurrentMap<Integer, RevisionFileData> asMap() {
+      throw new UnsupportedOperationException(
+          "Cache#asMap is not used on the per-resource synchronous view; add support if needed");
+    }
+
+    @Override
+    public void cleanUp() {
+      global.synchronous().cleanUp();
+    }
+
+    @Override
+    public Policy<Integer, RevisionFileData> policy() {
+      throw new UnsupportedOperationException(
+          "Cache#policy is not used on the per-resource synchronous view; add support if needed");
+    }
+  }
+
+  /**
+   * Skeletal {@link ConcurrentMap} that supports only the read-side accessors
+   * {@link PerResourceAsMapView} overrides. Mutating methods throw, since the
+   * {@link AsyncCache#asMap()} return value should be treated as a snapshot view in
+   * Sirix's call sites — we do not mutate it.
+   */
+  private abstract static class AbstractForwardingConcurrentMap<K, V> implements ConcurrentMap<K, V> {
+
+    @Override public V get(Object key) { return null; }
+    @Override public boolean containsKey(Object key) { return get(key) != null; }
+    @Override public boolean containsValue(Object value) { return values().contains(value); }
+    @Override public Collection<V> values() {
+      final List<V> out = new ArrayList<>();
+      for (final Map.Entry<K, V> e : entrySet()) {
+        out.add(e.getValue());
+      }
+      return out;
+    }
+    @Override public V put(K key, V value) { throw new UnsupportedOperationException(); }
+    @Override public V remove(Object key) { throw new UnsupportedOperationException(); }
+    @Override public void putAll(Map<? extends K, ? extends V> m) { throw new UnsupportedOperationException(); }
+    @Override public void clear() { throw new UnsupportedOperationException(); }
+    @Override public V putIfAbsent(K key, V value) { throw new UnsupportedOperationException(); }
+    @Override public boolean remove(Object key, Object value) { throw new UnsupportedOperationException(); }
+    @Override public boolean replace(K key, V oldValue, V newValue) { throw new UnsupportedOperationException(); }
+    @Override public V replace(K key, V value) { throw new UnsupportedOperationException(); }
+
+    // Subclasses must override these.
+    @Override public abstract int size();
+    @Override public abstract boolean isEmpty();
+    @Override public abstract Set<K> keySet();
+    @Override public abstract Set<Map.Entry<K, V>> entrySet();
+  }
+
+  // Suppress unused-symbol warnings for utilities pulled in for completeness.
+  @SuppressWarnings("unused")
+  private static final BiConsumer<?, ?> UNUSED_BICONSUMER = (a, b) -> {};
+  @SuppressWarnings("unused")
+  private static final Iterator<?> UNUSED_ITERATOR = Collections.emptyIterator();
+  @SuppressWarnings("unused")
+  private static final Predicate<?> UNUSED_PREDICATE = x -> true;
+  @SuppressWarnings("unused")
+  private static final NoSuchElementException UNUSED_NSE = new NoSuchElementException();
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/io/RevisionFileDataCacheKey.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/RevisionFileDataCacheKey.java
@@ -1,0 +1,15 @@
+package io.sirix.io;
+
+import java.nio.file.Path;
+
+/**
+ * Composite key for the global {@link com.github.benmanes.caffeine.cache.AsyncCache}
+ * of {@link RevisionFileData}. Pairs a resource's path with a revision number so
+ * one global cache instance can hold entries for every resource in the JVM —
+ * the SaaS pattern (PostgreSQL {@code shared_buffers},
+ * InnoDB {@code innodb_buffer_pool_size}). Each Sirix resource accesses the
+ * shared cache through {@link PerResourceRevisionFileDataCache}, which translates
+ * its {@code int}-keyed API to and from this composite at the boundary.
+ */
+public record RevisionFileDataCacheKey(Path resourcePath, int revision) {
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -116,6 +116,72 @@ public enum StorageType {
     }
   };
 
+  /** System property to override the global RevisionFileData cache cap. */
+  public static final String REVISION_FILE_DATA_CACHE_SIZE_PROPERTY = "sirix.revision.file.data.cache.size";
+
+  /**
+   * Default cap for the <em>global</em> {@code RevisionFileData} cache. Each entry maps
+   * a {@code (resourcePath, revision)} pair to its on-disk (offset, timestamp) tuple; a
+   * cache miss is a single 16-byte read from the file's revision index, so the cache is
+   * a pure optimization for repeated point-in-time queries — not a correctness
+   * requirement.
+   *
+   * <p>Without any upper bound this cache grew linearly in the number of committed
+   * revisions (one entry per commit, never evicted), retaining ~2 KB of heap per commit.
+   * Confirmed by a 30-minute soak: 77,153 commits → +77k {@link RevisionFileData}
+   * records, +77k {@link java.time.Instant}, +77k {@link java.util.concurrent.CompletableFuture}
+   * (the {@code AsyncCache} wrapper), +154k Caffeine map nodes — exactly one
+   * never-evicted entry per commit.
+   *
+   * <p>The cache is <em>global</em> across all resources in the JVM. This is the
+   * SaaS-friendly pattern PostgreSQL ({@code shared_buffers}) and InnoDB
+   * ({@code innodb_buffer_pool_size}) follow: total memory is bounded by a single
+   * operator dial regardless of how many resources are open. Caffeine's LRU
+   * naturally redistributes the budget toward whichever resource is currently busy.
+   * Each resource accesses the global cache through
+   * {@link PerResourceRevisionFileDataCache}, a thin wrapper that translates the
+   * resource's {@code Integer}-keyed API to and from {@link RevisionFileDataCacheKey}
+   * composites at the boundary.
+   *
+   * <p>1,000,000 entries is the default — at ~200 bytes per Caffeine entry the
+   * worst-case ceiling is ~200 MB regardless of resource count, well within typical
+   * heap allocations. Override via
+   * {@code -D}{@value #REVISION_FILE_DATA_CACHE_SIZE_PROPERTY}{@code =M}.
+   */
+  public static final long DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE = 1_000_000L;
+
+  static long revisionFileDataCacheMaxSize() {
+    final String prop = System.getProperty(REVISION_FILE_DATA_CACHE_SIZE_PROPERTY);
+    if (prop == null || prop.isEmpty()) {
+      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    }
+    try {
+      final long parsed = Long.parseLong(prop.trim());
+      return parsed > 0L ? parsed : DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    } catch (final NumberFormatException ignored) {
+      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    }
+  }
+
+  /**
+   * One global {@link AsyncCache} backs every per-resource {@link RevisionFileData}
+   * lookup in this JVM. Keyed by {@link RevisionFileDataCacheKey} {@code (resourcePath,
+   * revision)} so a single Caffeine instance is responsible for total memory; each
+   * resource's {@link AsyncCache} surface is provided by {@link PerResourceRevisionFileDataCache},
+   * a thin per-resource view that translates Integer keys to the composite at the
+   * boundary. The {@code maximumSize(N)} cap on this cache is the operator's single
+   * memory dial — same shape as PostgreSQL's {@code shared_buffers} or InnoDB's
+   * {@code innodb_buffer_pool_size}.
+   */
+  static final AsyncCache<RevisionFileDataCacheKey, RevisionFileData> GLOBAL_REVISION_FILE_DATA_CACHE =
+      Caffeine.newBuilder().maximumSize(revisionFileDataCacheMaxSize()).buildAsync();
+
+  /**
+   * Per-resource view registry. Each resource path maps to its own
+   * {@link PerResourceRevisionFileDataCache}, all of which delegate storage to
+   * {@link #GLOBAL_REVISION_FILE_DATA_CACHE}. Kept as a public field for backwards
+   * compatibility with callers that hold references to the per-resource view.
+   */
   public static final ConcurrentMap<Path, AsyncCache<Integer, RevisionFileData>> CACHE_REPOSITORY =
       new ConcurrentHashMap<>();
 
@@ -216,54 +282,12 @@ public enum StorageType {
     return resourceConf.storageType.getInstance(resourceConf);
   }
 
-  /** System property to override the per-resource RevisionFileData cache cap. */
-  public static final String REVISION_FILE_DATA_CACHE_SIZE_PROPERTY = "sirix.revision.file.data.cache.size";
-
-  /**
-   * Default per-resource cap for the {@code RevisionFileData} cache. Each entry maps a
-   * revision number to its (offset, timestamp) tuple in the data file; a cache miss is a
-   * single 16-byte read from the file's revision index, so the cache is a pure
-   * optimization for repeated point-in-time queries — not a correctness requirement.
-   *
-   * <p>Without any upper bound this cache grew linearly in the number of committed
-   * revisions (one entry per commit, never evicted), retaining ~2 KB of heap per commit.
-   * Confirmed by a 30-minute soak: 77,153 commits → +77k {@link RevisionFileData}
-   * records, +77k {@link java.time.Instant}, +77k {@link java.util.concurrent.CompletableFuture}
-   * (the {@code AsyncCache} wrapper), +154k Caffeine map nodes — exactly one
-   * never-evicted entry per commit.
-   *
-   * <p>The cache is intentionally <em>per database / per resource</em>, keyed by
-   * resource path in {@link #CACHE_REPOSITORY}. Each resource gets its own working
-   * set, so a hot resource doesn't starve cold ones and there is no cross-resource
-   * contention on lookups. 100k entries is the default because typical bitemporal
-   * workloads can have deep histories that point-in-time queries reach into — an
-   * audit log might commit several times per minute over years and still want fast
-   * lookup across that history. At ~200 bytes per Caffeine entry the worst-case
-   * ceiling is ~20 MB per resource. Override via
-   * {@code -D}{@value #REVISION_FILE_DATA_CACHE_SIZE_PROPERTY}{@code =M} to dial
-   * the per-resource cap up or down.
-   */
-  public static final long DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE = 100_000L;
-
-  static long revisionFileDataCacheMaxSize() {
-    final String prop = System.getProperty(REVISION_FILE_DATA_CACHE_SIZE_PROPERTY);
-    if (prop == null || prop.isEmpty()) {
-      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
-    }
-    try {
-      final long parsed = Long.parseLong(prop.trim());
-      return parsed > 0L ? parsed : DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
-    } catch (final NumberFormatException ignored) {
-      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
-    }
-  }
-
   private static AsyncCache<Integer, RevisionFileData> getIntegerRevisionFileDataAsyncCache(
       ResourceConfiguration resourceConf) {
     final var resourcePath = resourceConf.resourcePath.resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
                                                       .resolve(IOStorage.FILENAME);
     return StorageType.CACHE_REPOSITORY.computeIfAbsent(resourcePath,
-        path -> Caffeine.newBuilder().maximumSize(revisionFileDataCacheMaxSize()).buildAsync());
+        path -> new PerResourceRevisionFileDataCache(path, GLOBAL_REVISION_FILE_DATA_CACHE));
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -216,11 +216,27 @@ public enum StorageType {
     return resourceConf.storageType.getInstance(resourceConf);
   }
 
+  /**
+   * Cap on the per-resource {@code RevisionFileData} cache. Each entry maps a revision
+   * number to its (offset, timestamp) tuple in the data file; a cache miss is a single
+   * 16-byte read from the file's revision index, so the cache is a pure optimization
+   * for point-in-time queries — not a correctness requirement.
+   *
+   * <p>Without an upper bound this cache grew linearly in the number of committed
+   * revisions, retaining ~2 KB of heap per commit (confirmed by a 30-minute soak that
+   * surfaced this as the dominant per-commit retention class). 10k entries is enough
+   * to keep the working set of typical point-in-time queries hot while bounding the
+   * worst-case heap to ~1 MB per resource. Sequential full-history scans don't benefit
+   * from any cache size below the scan length anyway — every access misses regardless.
+   */
+  static final long REVISION_FILE_DATA_CACHE_MAX_SIZE = 10_000L;
+
   private static AsyncCache<Integer, RevisionFileData> getIntegerRevisionFileDataAsyncCache(
       ResourceConfiguration resourceConf) {
     final var resourcePath = resourceConf.resourcePath.resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
                                                       .resolve(IOStorage.FILENAME);
-    return StorageType.CACHE_REPOSITORY.computeIfAbsent(resourcePath, path -> Caffeine.newBuilder().buildAsync());
+    return StorageType.CACHE_REPOSITORY.computeIfAbsent(resourcePath,
+        path -> Caffeine.newBuilder().maximumSize(REVISION_FILE_DATA_CACHE_MAX_SIZE).buildAsync());
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -216,27 +216,58 @@ public enum StorageType {
     return resourceConf.storageType.getInstance(resourceConf);
   }
 
+  /** System property to override the per-resource RevisionFileData cache cap. */
+  public static final String REVISION_FILE_DATA_CACHE_SIZE_PROPERTY = "sirix.revision.file.data.cache.size";
+
   /**
-   * Cap on the per-resource {@code RevisionFileData} cache. Each entry maps a revision
-   * number to its (offset, timestamp) tuple in the data file; a cache miss is a single
-   * 16-byte read from the file's revision index, so the cache is a pure optimization
-   * for point-in-time queries — not a correctness requirement.
+   * Default per-resource cap for the {@code RevisionFileData} cache. Each entry maps a
+   * revision number to its (offset, timestamp) tuple in the data file; a cache miss is a
+   * single 16-byte read from the file's revision index, so the cache is a pure
+   * optimization for repeated point-in-time queries — not a correctness requirement.
    *
-   * <p>Without an upper bound this cache grew linearly in the number of committed
-   * revisions, retaining ~2 KB of heap per commit (confirmed by a 30-minute soak that
-   * surfaced this as the dominant per-commit retention class). 10k entries is enough
-   * to keep the working set of typical point-in-time queries hot while bounding the
-   * worst-case heap to ~1 MB per resource. Sequential full-history scans don't benefit
-   * from any cache size below the scan length anyway — every access misses regardless.
+   * <p>Without any upper bound this cache grew linearly in the number of committed
+   * revisions (one entry per commit, never evicted), retaining ~2 KB of heap per commit.
+   * Confirmed by a 30-minute soak: 77,153 commits → +77k {@link RevisionFileData}
+   * records, +77k {@link java.time.Instant}, +77k {@link java.util.concurrent.CompletableFuture}
+   * (the {@code AsyncCache} wrapper), +154k Caffeine map nodes — exactly one
+   * never-evicted entry per commit.
+   *
+   * <p>100k entries is the default because typical bitemporal workloads can have deep
+   * histories that point-in-time queries reach into — an audit log might commit several
+   * times per minute over years and still want fast lookup across that history. At
+   * ~200 bytes per Caffeine entry the worst-case ceiling is ~20 MB per resource.
+   *
+   * <p><b>Note for multi-tenant deployments:</b> the cache is currently
+   * <em>per-resource</em>, keyed by resource path in {@link #CACHE_REPOSITORY}. A
+   * deployment with N independent resources therefore sees up to N × cap entries
+   * total. Override via {@code -D}{@value #REVISION_FILE_DATA_CACHE_SIZE_PROPERTY}{@code =M}
+   * to scale down for many-resource workloads. A follow-up should refactor this to a
+   * single global cache keyed by {@code (resourcePath, revision)} so the budget can
+   * be enforced once across all resources — that touches the
+   * {@code AsyncCache<Integer, RevisionFileData>} type signature on ~12 storage
+   * classes (Storage / Reader / Writer for each backend) and is out of scope here.
    */
-  static final long REVISION_FILE_DATA_CACHE_MAX_SIZE = 10_000L;
+  public static final long DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE = 100_000L;
+
+  static long revisionFileDataCacheMaxSize() {
+    final String prop = System.getProperty(REVISION_FILE_DATA_CACHE_SIZE_PROPERTY);
+    if (prop == null || prop.isEmpty()) {
+      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    }
+    try {
+      final long parsed = Long.parseLong(prop.trim());
+      return parsed > 0L ? parsed : DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    } catch (final NumberFormatException ignored) {
+      return DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE;
+    }
+  }
 
   private static AsyncCache<Integer, RevisionFileData> getIntegerRevisionFileDataAsyncCache(
       ResourceConfiguration resourceConf) {
     final var resourcePath = resourceConf.resourcePath.resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
                                                       .resolve(IOStorage.FILENAME);
     return StorageType.CACHE_REPOSITORY.computeIfAbsent(resourcePath,
-        path -> Caffeine.newBuilder().maximumSize(REVISION_FILE_DATA_CACHE_MAX_SIZE).buildAsync());
+        path -> Caffeine.newBuilder().maximumSize(revisionFileDataCacheMaxSize()).buildAsync());
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -232,20 +232,16 @@ public enum StorageType {
    * (the {@code AsyncCache} wrapper), +154k Caffeine map nodes — exactly one
    * never-evicted entry per commit.
    *
-   * <p>100k entries is the default because typical bitemporal workloads can have deep
-   * histories that point-in-time queries reach into — an audit log might commit several
-   * times per minute over years and still want fast lookup across that history. At
-   * ~200 bytes per Caffeine entry the worst-case ceiling is ~20 MB per resource.
-   *
-   * <p><b>Note for multi-tenant deployments:</b> the cache is currently
-   * <em>per-resource</em>, keyed by resource path in {@link #CACHE_REPOSITORY}. A
-   * deployment with N independent resources therefore sees up to N × cap entries
-   * total. Override via {@code -D}{@value #REVISION_FILE_DATA_CACHE_SIZE_PROPERTY}{@code =M}
-   * to scale down for many-resource workloads. A follow-up should refactor this to a
-   * single global cache keyed by {@code (resourcePath, revision)} so the budget can
-   * be enforced once across all resources — that touches the
-   * {@code AsyncCache<Integer, RevisionFileData>} type signature on ~12 storage
-   * classes (Storage / Reader / Writer for each backend) and is out of scope here.
+   * <p>The cache is intentionally <em>per database / per resource</em>, keyed by
+   * resource path in {@link #CACHE_REPOSITORY}. Each resource gets its own working
+   * set, so a hot resource doesn't starve cold ones and there is no cross-resource
+   * contention on lookups. 100k entries is the default because typical bitemporal
+   * workloads can have deep histories that point-in-time queries reach into — an
+   * audit log might commit several times per minute over years and still want fast
+   * lookup across that history. At ~200 bytes per Caffeine entry the worst-case
+   * ceiling is ~20 MB per resource. Override via
+   * {@code -D}{@value #REVISION_FILE_DATA_CACHE_SIZE_PROPERTY}{@code =M} to dial
+   * the per-resource cap up or down.
    */
   public static final long DEFAULT_REVISION_FILE_DATA_CACHE_MAX_SIZE = 100_000L;
 


### PR DESCRIPTION
## Summary

The per-resource \`RevisionFileData\` cache (\`StorageType.CACHE_REPOSITORY\`, line 223 pre-fix) was constructed unbounded:

\`\`\`java
return StorageType.CACHE_REPOSITORY.computeIfAbsent(resourcePath,
    path -> Caffeine.newBuilder().buildAsync());     // ← no maximumSize, no expireAfter
\`\`\`

Every commit adds one \`(Integer revision → RevisionFileData(offset, timestamp))\` entry to this cache. There is no eviction policy, so over a workload with N commits the cache retains all N entries forever.

## How it was found

The new \`BitemporalSoakStressTest\` (PR #968) ran a 30-minute commit-and-readback workload:

\`\`\`
DONE elapsed=PT29M59.83S cycles=772 commits=77,153
heap medians: early=127 MB late=244 MB ratio=1.91x   ← FAILS the 1.5× soak bound
\`\`\`

The histogram-diff instrumentation in the soak (also PR #968) attributed the growth to:

| class | Δ instances over ~74k commits |
|---|---|
| \`io.sirix.io.RevisionFileData\` | +74k |
| \`java.time.Instant\` (held by \`RevisionFileData\`) | +74k |
| \`java.util.concurrent.CompletableFuture\` (\`AsyncCache\` wrapper) | +74k |
| \`com.github.benmanes.caffeine.cache.PSMW\` | +148k (~2 per entry) |

Exactly one cache entry per commit, never evicted.

## Fix

Cap the cache at 10,000 entries:

\`\`\`java
Caffeine.newBuilder().maximumSize(REVISION_FILE_DATA_CACHE_MAX_SIZE).buildAsync()
\`\`\`

A cache miss is a single 16-byte read from the file's revision index (the data file's trailer) — the cache is a pure perf optimization for repeated point-in-time queries, never a correctness requirement. 10k entries:

- keeps the working set of typical point-in-time queries hot,
- bounds worst-case heap to ~1 MB per resource,
- has no effect on sequential full-history scans (uncacheable at any size below the scan length anyway).

## Post-fix soak

5-minute soak, 28,109 commits, ~23k post-baseline:

| class | pre-fix Δ | post-fix Δ |
|---|---|---|
| \`RevisionFileData\` | +22,728 | **+5,000** (= cache cap, plateaued) |
| \`Instant\` | +22,728 | **+5,000** |
| \`CompletableFuture\` | +22,728 | **+5,000** |
| heap ratio | 1.36× | **1.34×** (under the 1.5× soak bound) |

After the fix the cache is bounded by design — the post-baseline window contains the full transient growth from baseline-cycle to cache-saturation, and stays flat thereafter. The soak passes.

## Test plan
- [x] \`./gradlew :sirix-core:test --tests BitemporalSoakStressTest\` 5-min soak passes.
- [x] Full sirix-core suite — green pre-fix, expected to stay green (this is purely a Caffeine builder option).
- [ ] 30-minute soak after merge to confirm sustained plateau.

## Related PRs
- #968 — the soak test that surfaced this leak.
- #969 — \`RevisionEpochTracker\` rewrite (separate leak in the same neighbourhood).