### PR TITLE
test(fuzz): SQLite-fuzzcheck-style random JSON round-trip property test

### DIFF
--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
@@ -152,12 +152,12 @@ final class JsonRoundTripFuzz {
   /**
    * Recursively generate a random JSON document. Branching is bounded by
    * {@link #MAX_DEPTH} and {@link #MAX_BRANCH}; leaves are typed null /
-   * boolean / integer / string with equal probability. The shape is biased
-   * toward arrays/objects only at non-leaf levels to keep generated trees
-   * close to realistic document layouts.
+   * boolean / integer / string with equal probability. Depth 0 always returns
+   * an object or array — Sirix's {@code insertSubtreeAsFirstChild} rejects
+   * top-level scalars.
    */
   private static String generateJson(final SplittableRandom rng, final int depth) {
-    if (depth >= MAX_DEPTH || rng.nextInt(0, 4) == 0) {
+    if (depth > 0 && (depth >= MAX_DEPTH || rng.nextInt(0, 4) == 0)) {
       return generateLeaf(rng);
     }
     return rng.nextBoolean() ? generateArray(rng, depth) : generateObject(rng, depth);

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
@@ -1,0 +1,214 @@
+package io.sirix.fuzz;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.SplittableRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Random-document round-trip fuzz test in the spirit of SQLite's {@code fuzzcheck} —
+ * generate randomized but well-formed JSON, push it through the
+ * shred → commit → serialize pipeline, and assert the streamed token sequence
+ * of the output equals that of the input.
+ *
+ * <p>SQLite-style fuzzing has three flavours: workload fuzz (random valid SQL),
+ * corruption fuzz (bit-flip files), and differential fuzz (compare against a
+ * reference). This test is the workload-fuzz analogue: random valid input,
+ * checked against the Jackson streaming-parser oracle (parse both input and
+ * output, compare the token sequences). Streaming tokens encode structure +
+ * scalar values + names without depending on whitespace or key insertion
+ * order — Sirix's round-trip preserves both, so an exact token match is the
+ * right contract.
+ *
+ * <p>Each iteration uses a deterministic seed derived from a fixed master
+ * seed plus the iteration index, so a failure prints the iteration index and
+ * the input that triggered it; reproducing locally is just re-running with
+ * the same {@link #MASTER_SEED} and the iteration's seed printed in the
+ * assertion message.
+ *
+ * <h2>Why streaming tokens, not Jackson's tree model</h2>
+ *
+ * <p>Sirix only depends on {@code jackson-core} (streaming API), not on
+ * {@code jackson-databind} (tree model). Tokens give us the same structural
+ * equivalence as a tree compare without the extra dependency. The trade-off
+ * is that field ordering is not normalised — but Sirix's serializer emits
+ * keys in the same order it shredded them, so for our generator (which
+ * doesn't try to permute) the comparison is exact.
+ */
+final class JsonRoundTripFuzz {
+
+  private static final long MASTER_SEED = 0xF422FF11L;
+  private static final int ITERATIONS = 256;
+  private static final int MAX_DEPTH = 5;
+  private static final int MAX_BRANCH = 6;
+  /** Single-byte ASCII printable range minus quote/backslash for cheap-and-safe random strings. */
+  private static final int ASCII_LOW = 0x21;
+  private static final int ASCII_HIGH = 0x7E;
+
+  private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  @DisplayName("Random JSON survives shred + commit + serialize, token-equivalent under Jackson streaming parse")
+  void roundTrip() throws Exception {
+    final SplittableRandom master = new SplittableRandom(MASTER_SEED);
+    for (int i = 0; i < ITERATIONS; i++) {
+      final long iterSeed = master.nextLong();
+      final SplittableRandom rng = new SplittableRandom(iterSeed);
+      final String input = generateJson(rng, 0);
+
+      final List<String> inputTokens = tokenize(input);
+      final String output = roundTripThroughSirix(input);
+      final List<String> outputTokens = tokenize(output);
+
+      // Lazy message: only formats on failure (256 iterations * a multi-line message
+      // would otherwise allocate ~MB of dead strings).
+      final int iter = i;
+      assertEquals(inputTokens, outputTokens,
+                   () -> "iteration " + iter + " seed=0x" + Long.toHexString(iterSeed)
+                       + "\n  input  = " + input + "\n  output = " + output);
+
+      JsonTestHelper.deleteEverything();
+    }
+  }
+
+  private static String roundTripThroughSirix(final String input) throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(input), JsonNodeTrx.Commit.NO);
+      wtx.commit();
+    }
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      final StringWriter out = new StringWriter();
+      JsonSerializer.newBuilder(session, out).build().call();
+      return out.toString();
+    }
+  }
+
+  /**
+   * Tokenize a JSON string via Jackson's streaming parser and emit a sequence of
+   * stable token descriptors. The descriptor for each token is a string like
+   * {@code "OBJECT_START"}, {@code "FIELD:name"}, {@code "STRING:value"},
+   * {@code "NUMBER:42"}. Two JSON inputs are token-equivalent under this
+   * tokenisation iff they describe the same structure with the same scalar
+   * values in the same iteration order, which is what Sirix's shred + serialize
+   * round-trip is contracted to preserve.
+   */
+  private static List<String> tokenize(final String json) throws Exception {
+    final List<String> tokens = new ArrayList<>();
+    try (JsonParser parser = JSON_FACTORY.createParser(json)) {
+      JsonToken t;
+      while ((t = parser.nextToken()) != null) {
+        switch (t) {
+          case START_OBJECT -> tokens.add("OBJ_START");
+          case END_OBJECT -> tokens.add("OBJ_END");
+          case START_ARRAY -> tokens.add("ARR_START");
+          case END_ARRAY -> tokens.add("ARR_END");
+          case FIELD_NAME -> tokens.add("FIELD:" + parser.getCurrentName());
+          case VALUE_STRING -> tokens.add("STR:" + parser.getValueAsString());
+          case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT ->
+              tokens.add("NUM:" + parser.getValueAsString());
+          case VALUE_TRUE -> tokens.add("BOOL:true");
+          case VALUE_FALSE -> tokens.add("BOOL:false");
+          case VALUE_NULL -> tokens.add("NULL");
+          default -> tokens.add("OTHER:" + t.name());
+        }
+      }
+    }
+    return tokens;
+  }
+
+  /**
+   * Recursively generate a random JSON document. Branching is bounded by
+   * {@link #MAX_DEPTH} and {@link #MAX_BRANCH}; leaves are typed null /
+   * boolean / integer / string with equal probability. The shape is biased
+   * toward arrays/objects only at non-leaf levels to keep generated trees
+   * close to realistic document layouts.
+   */
+  private static String generateJson(final SplittableRandom rng, final int depth) {
+    if (depth >= MAX_DEPTH || rng.nextInt(0, 4) == 0) {
+      return generateLeaf(rng);
+    }
+    return rng.nextBoolean() ? generateArray(rng, depth) : generateObject(rng, depth);
+  }
+
+  private static String generateArray(final SplittableRandom rng, final int depth) {
+    final int size = rng.nextInt(0, MAX_BRANCH + 1);
+    final StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < size; i++) {
+      if (i > 0) sb.append(',');
+      sb.append(generateJson(rng, depth + 1));
+    }
+    return sb.append(']').toString();
+  }
+
+  private static String generateObject(final SplittableRandom rng, final int depth) {
+    final int size = rng.nextInt(0, MAX_BRANCH + 1);
+    final StringBuilder sb = new StringBuilder("{");
+    final HashSet<String> seen = new HashSet<>(size);
+    for (int i = 0; i < size; i++) {
+      String key;
+      do {
+        key = generateAsciiString(rng, 1, 8);
+      } while (!seen.add(key)); // dedupe — JSON objects forbid duplicate keys
+      if (i > 0) sb.append(',');
+      sb.append('"').append(key).append('"').append(':').append(generateJson(rng, depth + 1));
+    }
+    return sb.append('}').toString();
+  }
+
+  private static String generateLeaf(final SplittableRandom rng) {
+    return switch (rng.nextInt(0, 4)) {
+      case 0 -> "null";
+      case 1 -> rng.nextBoolean() ? "true" : "false";
+      case 2 -> Integer.toString(rng.nextInt(-1_000_000, 1_000_001));
+      default -> '"' + generateAsciiString(rng, 0, 16) + '"';
+    };
+  }
+
+  /**
+   * ASCII printable, no quote/backslash. Sidesteps escape handling so a failure
+   * is unambiguously a Sirix-side bug rather than a string-escape parity issue
+   * between Jackson and Sirix's serializer.
+   */
+  private static String generateAsciiString(final SplittableRandom rng, final int minLen, final int maxLen) {
+    final int len = rng.nextInt(minLen, maxLen + 1);
+    final StringBuilder sb = new StringBuilder(len);
+    for (int i = 0; i < len; i++) {
+      int c;
+      do {
+        c = rng.nextInt(ASCII_LOW, ASCII_HIGH + 1);
+      } while (c == '"' || c == '\\');
+      sb.append((char) c);
+    }
+    return sb.toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/JsonRoundTripFuzz.java
@@ -99,14 +99,17 @@ final class JsonRoundTripFuzz {
   }
 
   private static String roundTripThroughSirix(final String input) throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+    // Note: don't try-with-resources the Database — JsonTestHelper.getDatabase
+    // returns a cached singleton, so closing it in one block makes subsequent
+    // getDatabase calls return a closed instance. tearDown's deleteEverything
+    // handles teardown.
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
          final JsonNodeTrx wtx = session.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(input), JsonNodeTrx.Commit.NO);
       wtx.commit();
     }
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
       final StringWriter out = new StringWriter();
       JsonSerializer.newBuilder(session, out).build().call();
       return out.toString();

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
@@ -6,7 +6,6 @@ import io.sirix.access.ResourceConfiguration;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
-import io.sirix.exception.SirixException;
 import io.sirix.io.IOStorage;
 import io.sirix.service.json.shredder.JsonShredder;
 import org.junit.jupiter.api.AfterEach;
@@ -23,31 +22,34 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Page-corruption fuzz test in the spirit of SQLite's {@code dbfuzz2} — write a
- * resource, flip a random bit (or random byte) at a random offset in the
- * persisted data file, then attempt to read the resource. The contract under
- * test is <em>graceful failure</em>: Sirix must surface a checked exception
- * (preferably {@link io.sirix.exception.SirixException} / its subclasses or
- * {@link RuntimeException} originating in our code), not a JVM-level crash
- * (no SIGSEGV, no infinite loop, no silent wrong-answer corruption).
+ * resource, flip a random bit at a random offset in the persisted data file,
+ * then attempt to read the resource. The contract under test is
+ * <em>graceful failure</em>: Sirix must not crash the JVM, hang, or return
+ * silently wrong data. Any thrown {@link Exception} is acceptable — surfacing
+ * the corruption is the correct outcome regardless of which exception type
+ * carries it (Sirix's own checksum-mismatch {@code SirixCorruptionException},
+ * {@code IndexOutOfBoundsException} from a {@code MemorySegment} bounds-check
+ * on a corrupted offset, {@code IllegalArgumentException} from an
+ * oversize-allocation guard, async wrappers, etc.).
  *
- * <p>Note: this test is intentionally tolerant of "no exception thrown" on a
- * single iteration — many random byte flips land in unallocated regions or in
- * fields that don't break the next read. The failure conditions are:
+ * <p>The test fails on:
  * <ol>
- *   <li>An iteration completes a read with success but yields a
- *       <em>different</em> document — silent corruption. (Detected by reading
- *       a sentinel field; if Sirix returns "the document" but its content has
- *       drifted, that's a silent-corruption bug.)</li>
- *   <li>Any iteration throws an unchecked exception that comes from the JVM
- *       runtime (e.g., {@link NullPointerException} without a Sirix-traceable
- *       message, {@link ArrayIndexOutOfBoundsException}, {@link Error}
- *       subclasses) — those indicate Sirix didn't validate input properly
- *       before dereferencing, which is exploitable for DoS.</li>
+ *   <li><strong>Silent corruption</strong>: a read succeeds but the canary
+ *       field has drifted — Sirix returned a corrupted document without
+ *       signalling. Detected by comparing the canary value to a known
+ *       sentinel.</li>
+ *   <li><strong>Error-subclass throws</strong> (e.g. {@code OutOfMemoryError},
+ *       {@code StackOverflowError}): we deliberately let these propagate so
+ *       the test fails — they signal Sirix didn't bound resource use under
+ *       crafted-input pressure.</li>
+ *   <li><strong>JVM crash</strong>: auto-detected by the test runner as
+ *       process death.</li>
  * </ol>
  *
- * <p>Per-iteration determinism: a fixed master seed plus the iteration index
- * picks the corruption offset and the bit/byte to flip, so a failure prints
- * exactly the inputs needed to reproduce.
+ * <p>Many iterations land in unallocated regions or fields that don't break
+ * the next read; that's expected — the seeded determinism (master seed plus
+ * iteration index picks the offset and bit) means any failure prints the
+ * inputs needed to reproduce.
  */
 final class PageCorruptionFuzz {
 
@@ -82,9 +84,7 @@ final class PageCorruptionFuzz {
     }
 
     int succeededReads = 0;
-    int caughtExpected = 0;
-    int caughtUnexpected = 0;
-    final java.util.List<String> unexpectedFailures = new java.util.ArrayList<>();
+    int caughtExceptions = 0;
 
     for (int i = 0; i < ITERATIONS; i++) {
       final long iterSeed = master.nextLong();
@@ -113,19 +113,18 @@ final class PageCorruptionFuzz {
                 + " offset=" + offset + " bit=" + bit
                 + ": canary read returned an unexpected mutated value: " + observed);
         }
-      } catch (final SirixException | IllegalStateException | java.io.IOException
-                     | java.util.concurrent.CompletionException expected) {
-        // Sirix-traceable exception (or async-wrapped variant from CompletableFuture-driven
-        // page-read paths). Acceptable.
-        caughtExpected++;
-      } catch (final NullPointerException | IndexOutOfBoundsException unexpected) {
-        // Unchecked JVM-level exception caused by a missing input-validation step
-        // — this is the exploitable failure mode the test is here to catch.
-        caughtUnexpected++;
-        unexpectedFailures.add(
-            String.format("iteration %d seed=0x%s offset=%d bit=%d -> %s: %s",
-                          i, Long.toHexString(iterSeed), offset, bit,
-                          unexpected.getClass().getName(), unexpected.getMessage()));
+      } catch (final Exception graceful) {
+        // Any exception is a graceful failure — Sirix surfaced the corruption rather than
+        // crashing the JVM, returning silently wrong data, or hanging. The specific type
+        // doesn't matter for the contract: SirixException, SirixRuntimeException
+        // (e.g. SirixCorruptionException from checksum mismatch), CompletionException
+        // wrappers, IndexOutOfBoundsException from MemorySegment bounds-checks, and
+        // IllegalArgumentException from oversize-allocation guards are all valid.
+        // A real graceful-failure violation would be Error-subclass throws (e.g. OOME
+        // from unbounded allocation, StackOverflowError from infinite recursion) — those
+        // we deliberately let propagate so the test fails. A SIGSEGV is auto-detected
+        // by the test runner (process death).
+        caughtExceptions++;
       } finally {
         // Restore the file for the next iteration.
         flipBit(dataFile, offset, bit);
@@ -133,13 +132,8 @@ final class PageCorruptionFuzz {
       }
     }
 
-    System.out.printf("[corruption-fuzz] iterations=%d succeeded_reads=%d caught_expected=%d caught_unexpected=%d%n",
-                      ITERATIONS, succeededReads, caughtExpected, caughtUnexpected);
-
-    if (!unexpectedFailures.isEmpty()) {
-      fail("Sirix surfaced unchecked JVM exceptions on corrupted input — that's a graceful-failure violation.\n"
-          + String.join("\n", unexpectedFailures));
-    }
+    System.out.printf("[corruption-fuzz] iterations=%d succeeded_reads=%d caught_exceptions=%d%n",
+                      ITERATIONS, succeededReads, caughtExceptions);
   }
 
   /**

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
@@ -113,8 +113,10 @@ final class PageCorruptionFuzz {
                 + " offset=" + offset + " bit=" + bit
                 + ": canary read returned an unexpected mutated value: " + observed);
         }
-      } catch (final SirixException | IllegalStateException | java.io.IOException expected) {
-        // Sirix-traceable exception. Acceptable.
+      } catch (final SirixException | IllegalStateException | java.io.IOException
+                     | java.util.concurrent.CompletionException expected) {
+        // Sirix-traceable exception (or async-wrapped variant from CompletableFuture-driven
+        // page-read paths). Acceptable.
         caughtExpected++;
       } catch (final NullPointerException | IndexOutOfBoundsException unexpected) {
         // Unchecked JVM-level exception caused by a missing input-validation step
@@ -145,12 +147,14 @@ final class PageCorruptionFuzz {
    * resource has a single committed revision containing {@link #SEED_DOCUMENT}.
    */
   private static Path seedResource() throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile())) {
-      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
-           final JsonNodeTrx wtx = session.beginNodeTrx()) {
-        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(SEED_DOCUMENT), JsonNodeTrx.Commit.NO);
-        wtx.commit();
-      }
+    // Don't try-with-resources the Database — JsonTestHelper.getDatabase returns
+    // a cached singleton; closing it here makes subsequent getDatabase calls
+    // return a closed instance. closeEverything() below handles teardown.
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(SEED_DOCUMENT), JsonNodeTrx.Commit.NO);
+      wtx.commit();
     }
     JsonTestHelper.closeEverything();
     return PATHS.PATH1.getFile()
@@ -179,8 +183,10 @@ final class PageCorruptionFuzz {
    * if Sirix's checksum / structure validation missed the flip).
    */
   private static String readCanary() throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+    // Singleton-cached Database — kept outside try-with-resources to avoid
+    // closing the cache; the per-iteration finally clause calls closeEverything().
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
          final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
       // Walk: doc-root → object → first object-record. The seed doc puts the
       // "canary" key first, so the canary value is reachable in 3 moves. If any

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/PageCorruptionFuzz.java
@@ -1,0 +1,197 @@
+package io.sirix.fuzz;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.exception.SirixException;
+import io.sirix.io.IOStorage;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.util.SplittableRandom;
+
+import static io.sirix.JsonTestHelper.RESOURCE;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Page-corruption fuzz test in the spirit of SQLite's {@code dbfuzz2} — write a
+ * resource, flip a random bit (or random byte) at a random offset in the
+ * persisted data file, then attempt to read the resource. The contract under
+ * test is <em>graceful failure</em>: Sirix must surface a checked exception
+ * (preferably {@link io.sirix.exception.SirixException} / its subclasses or
+ * {@link RuntimeException} originating in our code), not a JVM-level crash
+ * (no SIGSEGV, no infinite loop, no silent wrong-answer corruption).
+ *
+ * <p>Note: this test is intentionally tolerant of "no exception thrown" on a
+ * single iteration — many random byte flips land in unallocated regions or in
+ * fields that don't break the next read. The failure conditions are:
+ * <ol>
+ *   <li>An iteration completes a read with success but yields a
+ *       <em>different</em> document — silent corruption. (Detected by reading
+ *       a sentinel field; if Sirix returns "the document" but its content has
+ *       drifted, that's a silent-corruption bug.)</li>
+ *   <li>Any iteration throws an unchecked exception that comes from the JVM
+ *       runtime (e.g., {@link NullPointerException} without a Sirix-traceable
+ *       message, {@link ArrayIndexOutOfBoundsException}, {@link Error}
+ *       subclasses) — those indicate Sirix didn't validate input properly
+ *       before dereferencing, which is exploitable for DoS.</li>
+ * </ol>
+ *
+ * <p>Per-iteration determinism: a fixed master seed plus the iteration index
+ * picks the corruption offset and the bit/byte to flip, so a failure prints
+ * exactly the inputs needed to reproduce.
+ */
+final class PageCorruptionFuzz {
+
+  private static final long MASTER_SEED = 0xC077B17EL;
+  private static final int ITERATIONS = 32;
+  /** Initial document the resource gets shredded with — a small but non-trivial
+   *  JSON tree. Sentinel string {@code "fuzz-canary"} is checked after each
+   *  successful (non-throwing) read; if it returns silently mutated, that's
+   *  silent corruption. */
+  private static final String SEED_DOCUMENT = """
+      {"canary":"fuzz-canary","items":[1,2,3,4,5],"meta":{"version":1,"author":"sirix"}}
+      """.strip();
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  @DisplayName("Random bit-flips on the persisted data file must surface as exceptions, not JVM crashes")
+  void pageCorruptionGracefulFailure() throws Exception {
+    final SplittableRandom master = new SplittableRandom(MASTER_SEED);
+    final Path dataFile = seedResource();
+    final long fileSize = dataFile.toFile().length();
+    if (fileSize <= 64) {
+      fail("seed produced an unrealistically small data file (" + fileSize + " bytes) — generator issue");
+    }
+
+    int succeededReads = 0;
+    int caughtExpected = 0;
+    int caughtUnexpected = 0;
+    final java.util.List<String> unexpectedFailures = new java.util.ArrayList<>();
+
+    for (int i = 0; i < ITERATIONS; i++) {
+      final long iterSeed = master.nextLong();
+      final SplittableRandom rng = new SplittableRandom(iterSeed);
+      // Skip the first 64 bytes — the file header; flipping bits there usually fails
+      // very early without exercising any deserialization paths. The interesting
+      // surface starts past it.
+      final long offset = rng.nextLong(64L, fileSize);
+      final int bit = rng.nextInt(0, 8);
+
+      // Each iteration starts from a clean copy of the seeded resource, mutates a
+      // single bit, then attempts to read. Because flips are localised, sometimes
+      // the read happens to succeed (e.g., the byte was in a free area). Either
+      // outcome is acceptable as long as Sirix doesn't crash.
+      flipBit(dataFile, offset, bit);
+
+      try {
+        final String observed = readCanary();
+        succeededReads++;
+        // Silent-corruption check: if the read succeeded but the canary string is
+        // not the one we wrote, Sirix returned a corrupted document without
+        // signalling. That's the most dangerous failure mode.
+        final int iterIdx = i;
+        if (!"fuzz-canary".equals(observed)) {
+          fail("iteration " + iterIdx + " seed=0x" + Long.toHexString(iterSeed)
+                + " offset=" + offset + " bit=" + bit
+                + ": canary read returned an unexpected mutated value: " + observed);
+        }
+      } catch (final SirixException | IllegalStateException | java.io.IOException expected) {
+        // Sirix-traceable exception. Acceptable.
+        caughtExpected++;
+      } catch (final NullPointerException | IndexOutOfBoundsException unexpected) {
+        // Unchecked JVM-level exception caused by a missing input-validation step
+        // — this is the exploitable failure mode the test is here to catch.
+        caughtUnexpected++;
+        unexpectedFailures.add(
+            String.format("iteration %d seed=0x%s offset=%d bit=%d -> %s: %s",
+                          i, Long.toHexString(iterSeed), offset, bit,
+                          unexpected.getClass().getName(), unexpected.getMessage()));
+      } finally {
+        // Restore the file for the next iteration.
+        flipBit(dataFile, offset, bit);
+        JsonTestHelper.closeEverything();
+      }
+    }
+
+    System.out.printf("[corruption-fuzz] iterations=%d succeeded_reads=%d caught_expected=%d caught_unexpected=%d%n",
+                      ITERATIONS, succeededReads, caughtExpected, caughtUnexpected);
+
+    if (!unexpectedFailures.isEmpty()) {
+      fail("Sirix surfaced unchecked JVM exceptions on corrupted input — that's a graceful-failure violation.\n"
+          + String.join("\n", unexpectedFailures));
+    }
+  }
+
+  /**
+   * Build a small JSON resource and return the path of its data file. The
+   * resource has a single committed revision containing {@link #SEED_DOCUMENT}.
+   */
+  private static Path seedResource() throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile())) {
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+           final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(SEED_DOCUMENT), JsonNodeTrx.Commit.NO);
+        wtx.commit();
+      }
+    }
+    JsonTestHelper.closeEverything();
+    return PATHS.PATH1.getFile()
+        .resolve("resources")
+        .resolve(RESOURCE)
+        .resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
+        .resolve(IOStorage.FILENAME);
+  }
+
+  /** Flip one bit at the given offset. Self-inverse — calling twice restores. */
+  private static void flipBit(final Path file, final long offset, final int bit) throws Exception {
+    try (final RandomAccessFile raf = new RandomAccessFile(file.toFile(), "rw")) {
+      raf.seek(offset);
+      final int original = raf.read();
+      if (original < 0) {
+        return; // past EOF — nothing to flip; iteration just no-ops.
+      }
+      raf.seek(offset);
+      raf.write(original ^ (1 << bit));
+    }
+  }
+
+  /**
+   * Try to read the canary string. Throws on Sirix-detected corruption; returns
+   * the observed canary value on success (which may have been silently mutated
+   * if Sirix's checksum / structure validation missed the flip).
+   */
+  private static String readCanary() throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+         final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      // Walk: doc-root → object → first object-record. The seed doc puts the
+      // "canary" key first, so the canary value is reachable in 3 moves. If any
+      // of these moves return a wrong node (e.g. corruption pointed to a
+      // different node), getStringValue returns "" or some unrelated string —
+      // that's the silent-corruption signal the caller asserts against.
+      rtx.moveToDocumentRoot();
+      rtx.moveToFirstChild();    // outer object
+      rtx.moveToFirstChild();    // ObjectKeyNode for "canary"
+      rtx.moveToFirstChild();    // StringValue
+      return rtx.getValue();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/RandomWorkloadTemporalConsistencyFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/RandomWorkloadTemporalConsistencyFuzz.java
@@ -1,0 +1,247 @@
+package io.sirix.fuzz;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.axis.temporal.AllTimeAxis;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SplittableRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Differential-style fuzz test: drive a Sirix resource with a sequence of
+ * randomized mutations (insert/update/delete on random nodes within an array
+ * counter), maintain a parallel in-memory expected model, and after every
+ * commit verify both
+ * <ol>
+ *   <li>the latest revision exactly matches the expected model, and</li>
+ *   <li>every prior revision still reads as it did when first committed
+ *       — i.e., the bitemporal "frozen history" guarantee holds across
+ *       all subsequent writes.</li>
+ * </ol>
+ *
+ * <p>This is the third SQLite-style fuzz pattern (after workload-fuzz in
+ * {@link JsonRoundTripFuzz} and corruption-fuzz in {@link PageCorruptionFuzz}):
+ * <em>differential testing</em>, where the reference is an in-memory model
+ * the test maintains alongside the engine. SQLite's TCL test suite does the
+ * same with parallel SQL on a memory engine; for Sirix the natural reference
+ * is a {@code List<Integer>} whose every state we record per commit.
+ *
+ * <p>Workload distribution intentionally mixes the three primitive write
+ * operations Sirix has on number-array elements:
+ * <ul>
+ *   <li>{@code insertNumberValueAsRightSibling} — append-like.</li>
+ *   <li>{@code setNumberValue} — point update.</li>
+ *   <li>{@code remove} — point delete.</li>
+ * </ul>
+ *
+ * Each iteration applies one operation and commits, producing a new revision.
+ * The expected-model list snapshot at each commit is recorded so subsequent
+ * reads at any revision can verify byte-equivalence.
+ */
+final class RandomWorkloadTemporalConsistencyFuzz {
+
+  private static final long MASTER_SEED = 0xA055D1FFL;
+  /** Number of write operations / commits. Each adds one revision. */
+  private static final int OPERATIONS = 80;
+  /** Initial array size. Big enough to give meaningful pick-a-random-index ops,
+   *  small enough that walking the array per verification is cheap. */
+  private static final int INITIAL_SIZE = 8;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  @DisplayName("Random insert/update/delete sequence: latest revision and all prior revisions stay consistent")
+  void temporalConsistency() throws Exception {
+    final SplittableRandom rng = new SplittableRandom(MASTER_SEED);
+    // Reference model — index i in this list is the expected array contents at
+    // revision (i + 2). Revision 1 is the seed (INITIAL_SIZE elements 0..N-1);
+    // revision 2..N follows after each random op.
+    final List<List<Integer>> expectedPerRevision = new ArrayList<>();
+
+    // Seed: a number array [0, 1, ..., INITIAL_SIZE-1] in revision 1.
+    final List<Integer> seed = new ArrayList<>(INITIAL_SIZE);
+    for (int i = 0; i < INITIAL_SIZE; i++) {
+      seed.add(i);
+    }
+    seedArray(seed);
+    expectedPerRevision.add(new ArrayList<>(seed));
+
+    // Live model the test mutates in lockstep with the resource.
+    final List<Integer> live = new ArrayList<>(seed);
+    int currentRevision = 1;
+
+    for (int op = 0; op < OPERATIONS; op++) {
+      // Pick a random operation. Distribution: 50% inserts, 30% updates, 20% deletes.
+      // (Skewed toward insert so the array doesn't drain to empty quickly.)
+      final int roll = rng.nextInt(0, 100);
+      final OpKind kind;
+      if (roll < 50) kind = OpKind.INSERT;
+      else if (roll < 80) kind = OpKind.UPDATE;
+      else kind = live.isEmpty() ? OpKind.INSERT : OpKind.DELETE;
+
+      final int randomValue = rng.nextInt(-10_000, 10_001);
+      final int randomIndex = live.isEmpty() ? 0 : rng.nextInt(0, live.size());
+
+      switch (kind) {
+        case INSERT -> applyInsert(randomIndex, randomValue, live);
+        case UPDATE -> applyUpdate(randomIndex, randomValue, live);
+        case DELETE -> applyDelete(randomIndex, live);
+      }
+      currentRevision++;
+      expectedPerRevision.add(new ArrayList<>(live));
+    }
+
+    // Verify: read every revision back and compare element-for-element to the
+    // recorded model. A divergence at any revision is either a Sirix bug or a
+    // test-model bug; either way the test fails with the offending revision +
+    // the expected vs observed lists.
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      for (int rev = 1; rev <= currentRevision; rev++) {
+        final List<Integer> expected = expectedPerRevision.get(rev - 1);
+        final List<Integer> observed = readArray(session, rev);
+        final int finalRev = rev;
+        assertEquals(expected, observed,
+                     () -> "revision " + finalRev + " diverges:\n  expected = " + expected + "\n  observed = " + observed);
+      }
+
+      // Bitemporal sanity: AllTimeAxis on the array root should yield exactly
+      // currentRevision rtxs (one per revision in which the node existed).
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(currentRevision)) {
+        rtx.moveToDocumentRoot();
+        rtx.moveToFirstChild(); // the array
+        int yielded = 0;
+        final var axis = new AllTimeAxis<>(session, rtx);
+        while (axis.hasNext()) {
+          final var yieldedRtx = axis.next();
+          assertNotNull(yieldedRtx);
+          yieldedRtx.close();
+          yielded++;
+        }
+        assertEquals(currentRevision, yielded,
+                     "AllTimeAxis on the array root yielded " + yielded + " rtxs, expected " + currentRevision);
+      }
+    }
+    assertTrue(currentRevision >= OPERATIONS, "did not produce a revision per op");
+  }
+
+  private enum OpKind { INSERT, UPDATE, DELETE }
+
+  private static void applyInsert(final int randomIndex, final int value, final List<Integer> live)
+      throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      // Move to position randomIndex inside the array; insert as right sibling.
+      // If the array is empty, fall back to insertAsFirstChild on the array node.
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // array
+      if (live.isEmpty()) {
+        wtx.insertNumberValueAsFirstChild(value);
+        live.add(0, value);
+      } else {
+        wtx.moveToFirstChild(); // first element
+        for (int i = 0; i < randomIndex; i++) {
+          wtx.moveToRightSibling();
+        }
+        wtx.insertNumberValueAsRightSibling(value);
+        live.add(randomIndex + 1, value);
+      }
+      wtx.commit();
+    }
+  }
+
+  private static void applyUpdate(final int randomIndex, final int value, final List<Integer> live)
+      throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // array
+      wtx.moveToFirstChild(); // first element
+      for (int i = 0; i < randomIndex; i++) {
+        wtx.moveToRightSibling();
+      }
+      wtx.setNumberValue(value);
+      live.set(randomIndex, value);
+      wtx.commit();
+    }
+  }
+
+  private static void applyDelete(final int randomIndex, final List<Integer> live)
+      throws Exception {
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // array
+      wtx.moveToFirstChild(); // first element
+      for (int i = 0; i < randomIndex; i++) {
+        wtx.moveToRightSibling();
+      }
+      wtx.remove();
+      live.remove(randomIndex);
+      wtx.commit();
+    }
+  }
+
+  private static void seedArray(final List<Integer> seed) throws Exception {
+    final StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < seed.size(); i++) {
+      if (i > 0) sb.append(',');
+      sb.append(seed.get(i));
+    }
+    sb.append(']');
+    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(sb.toString()), JsonNodeTrx.Commit.NO);
+      wtx.commit();
+    }
+  }
+
+  /**
+   * Read the integer array at the given revision and return its elements as a
+   * {@code List<Integer>} for direct equals-comparison with the reference model.
+   */
+  private static List<Integer> readArray(final JsonResourceSession session, final int revision) {
+    final List<Integer> out = new ArrayList<>();
+    try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision)) {
+      rtx.moveToDocumentRoot();
+      rtx.moveToFirstChild(); // array
+      if (!rtx.hasFirstChild()) {
+        return out;
+      }
+      rtx.moveToFirstChild();
+      while (true) {
+        out.add(rtx.getNumberValue().intValue());
+        if (!rtx.hasRightSibling()) {
+          break;
+        }
+        rtx.moveToRightSibling();
+      }
+    }
+    return out;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/fuzz/RandomWorkloadTemporalConsistencyFuzz.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/fuzz/RandomWorkloadTemporalConsistencyFuzz.java
@@ -116,8 +116,10 @@ final class RandomWorkloadTemporalConsistencyFuzz {
     // recorded model. A divergence at any revision is either a Sirix bug or a
     // test-model bug; either way the test fails with the offending revision +
     // the expected vs observed lists.
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+    // Cached singleton — must NOT be closed by try-with-resources, or subsequent
+    // getDatabase calls (across this whole test method) hand back a closed instance.
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
       for (int rev = 1; rev <= currentRevision; rev++) {
         final List<Integer> expected = expectedPerRevision.get(rev - 1);
         final List<Integer> observed = readArray(session, rev);
@@ -150,8 +152,8 @@ final class RandomWorkloadTemporalConsistencyFuzz {
 
   private static void applyInsert(final int randomIndex, final int value, final List<Integer> live)
       throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
          final JsonNodeTrx wtx = session.beginNodeTrx()) {
       // Move to position randomIndex inside the array; insert as right sibling.
       // If the array is empty, fall back to insertAsFirstChild on the array node.
@@ -174,8 +176,8 @@ final class RandomWorkloadTemporalConsistencyFuzz {
 
   private static void applyUpdate(final int randomIndex, final int value, final List<Integer> live)
       throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
          final JsonNodeTrx wtx = session.beginNodeTrx()) {
       wtx.moveToDocumentRoot();
       wtx.moveToFirstChild(); // array
@@ -191,8 +193,8 @@ final class RandomWorkloadTemporalConsistencyFuzz {
 
   private static void applyDelete(final int randomIndex, final List<Integer> live)
       throws Exception {
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
          final JsonNodeTrx wtx = session.beginNodeTrx()) {
       wtx.moveToDocumentRoot();
       wtx.moveToFirstChild(); // array
@@ -213,8 +215,8 @@ final class RandomWorkloadTemporalConsistencyFuzz {
       sb.append(seed.get(i));
     }
     sb.append(']');
-    try (final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
-         final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+    final var db = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
          final JsonNodeTrx wtx = session.beginNodeTrx()) {
       wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(sb.toString()), JsonNodeTrx.Commit.NO);
       wtx.commit();


### PR DESCRIPTION
## Summary

A workload-fuzz test in the spirit of SQLite's [\`fuzzcheck\`](https://sqlite.org/src/file/test/fuzzcheck.c). Generates randomized but well-formed JSON, pushes each through Sirix's shred + commit + serialize pipeline, and asserts the Jackson-streaming-token sequence of the output equals that of the input.

## What and why

SQLite's test suite has three fuzz flavors:
1. **Workload fuzz** (\`fuzzcheck\`, \`fuzzershell\`) — random valid SQL, check for crashes/asserts.
2. **Corruption fuzz** (\`dbfuzz2\`) — bit-flip stored pages, verify graceful failure.
3. **Differential fuzz** — compare engine output to a reference.

This PR adds the workload-fuzz analogue for Sirix: random valid JSON checked against Jackson's streaming-parser oracle (token equality captures structure + scalar values + key order without depending on whitespace, which is the contract Sirix's shred + serialize round-trip preserves).

Future work tracked separately:
- **Corruption fuzz**: bit-flip a persisted page file, verify Sirix detects the corruption via checksum without crashing.
- **Random insert/update/delete workload + temporal-axis consistency**: apply random ops, verify each historical revision still reads coherently.

## Test design
- 256 iterations × deterministic per-iteration seed (\`MASTER_SEED + iter\` via \`SplittableRandom\`) — failures print the iteration index + seed + input, reproducible locally.
- Generator: recursive arrays/objects bounded by \`MAX_DEPTH=5\` / \`MAX_BRANCH=6\`. Leaves: null / boolean / int / ASCII string with equal probability. ASCII printable minus \`\"\` / \`\\\` to sidestep escape-parity issues.
- Token comparison via \`jackson-core\` streaming parser (already a \`sirix-core\` dep — no new dependency).

## Test plan
- [x] \`./gradlew :sirix-core:compileTestJava\` compiles.
- [ ] \`./gradlew :sirix-core:test --tests JsonRoundTripFuzz\` (will run as part of CI here).