### PR TITLE
fix(query): array deref in =>> operator + serializer stack guard

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -685,7 +685,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
           : revisions.length;
 
       if (emitXQueryResultSequence || length > 1) {
-        if (rtx.moveToDocumentRoot() && rtx.hasFirstChild())
+        if (rtx.moveToDocumentRoot() && rtx.hasFirstChild() && !stack.isEmpty())
           stack.popLong();
         appendObjectEnd(rtx.hasChildren());
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/translator/DerefDescendantExpr.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/translator/DerefDescendantExpr.java
@@ -168,7 +168,7 @@ class DerefDescendantExpr implements Expr {
 
             // Match at the next level (single child-path).
             if (matchLevel == startLevel + 1) {
-              if (reader.getPathNode().getKind() == NodeKind.ARRAY) {
+              if (reader.getPathNode().getPathKind() == NodeKind.ARRAY) {
                 return getLazySequence(new SirixJsonStream(new ChildAxis(rtx), jsonDBItem.getCollection()));
               }
               if (nodeKind == NodeKind.ARRAY) {
@@ -289,7 +289,7 @@ class DerefDescendantExpr implements Expr {
                 newConcurrentRtx.moveTo(nodeKey);
                 final var newConcurrentRtx1 = resourceSession.beginNodeReadOnlyTrx(revisionNumber);
 
-                if (reader.getPathNode().getKind() == NodeKind.ARRAY) {
+                if (reader.getPathNode().getPathKind() == NodeKind.ARRAY) {
                   axisQueue.addLast(new ConcurrentAxis<>(newConcurrentRtx1, new ChildAxis(rtx)));
                 } else {
                   final FilterAxis<JsonNodeReadOnlyTrx> filterAxis;


### PR DESCRIPTION
## Summary

- **Fix dead array-path detection in `DerefDescendantExpr`**: `PathNode.getKind()` always returns `NodeKind.PATH` (the path-summary node's own kind), making the `== NodeKind.ARRAY` checks at lines 171 and 292 always false — the array deref branch was dead code. Changed to `getPathKind()` which returns the actual data-tree node kind.
- **Guard `stack.popLong()` in `JsonSerializer.emitRevisionEndNode()`**: When serializing XQuery result items that are leaf nodes, `emitRevisionStartNode` skips pushing the sentinel (no children), but `emitRevisionEndNode` unconditionally popped — causing `NoSuchElementException`. Added `!stack.isEmpty()` guard.

## Test plan

- [x] `JsonIntegrationTest` full suite passes (all `=>>` descendant deref tests)
- [ ] Manual test on demo.sirix.io: `jn:doc("demo-db","products", 1)==>id` should return results instead of internal server error
- [ ] Verify array descendant deref queries like `$array=>>fieldName` on array-typed paths