### PR TITLE
fix(query): sequentialize jn:store multi-fragment create + skip empty…

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -586,20 +586,21 @@ public final class BasicJsonDBStore implements JsonDBStore {
       Databases.createJsonDatabase(dbConf);
       final var database = Databases.openJsonDatabase(dbConf.getDatabaseFile());
       databases.add(database);
-      final var resourceFutures = new ArrayList<CompletableFuture<Void>>();
+      final Object emptyOptions = new ArrayObject(new QNm[0], new Sequence[0]);
       int i = database.listResources().size() + 1;
       try (jsonStrings) {
         Str string;
         while ((string = jsonStrings.next()) != null) {
           final String currentString = string.stringValue();
+          if (currentString == null || currentString.isEmpty()) {
+            continue;
+          }
           final String resourceName = "resource" + i;
-          resourceFutures.add(CompletableFuture.runAsync(
-              () -> createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName,
-                  new ArrayObject(new QNm[0], new Sequence[0]))));
+          createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName,
+              emptyOptions);
           i++;
         }
       }
-      CompletableFuture.allOf(resourceFutures.toArray(new CompletableFuture[0])).join();
       return new JsonDBCollection(collName, database, this);
     } catch (final SirixRuntimeException e) {
       throw new DocumentException(e.getCause());


### PR DESCRIPTION
… strings

BasicJsonDBStore.createFromJsonStrings submitted resource creation to CompletableFuture.runAsync on the shared ForkJoinPool.commonPool() and joined the futures. The catch SirixRuntimeException clause did NOT catch CompletionException, so any future failure escaped wrapped in a double-wrapped chain (matched the observed flaky CI output: SirixIOException ... CompletionException ... SirixIOException ... EOFException).

database.createResource is already synchronized in LocalDatabase, so the old parallelism only parallelized the JSON insert phase. For the typical 1-2 small-fragment jn:store call that is pure ForkJoinPool overhead, and preceding heavy tests can leave the common pool warm with scheduling jitter that surfaces here.

Make the loop sequential, reuse the empty ArrayObject options, and skip null/empty input strings defensively (the only input shape that lets JsonReader raise an EOF at line 1 column 1).