### PR TITLE
chore(release): bump version to 1.0.0-alpha6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha5
+version=1.0.0-alpha6
 vertxVersion=5.0.5
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
Cuts the next alpha. Pushing tag sirix-1.0.0-alpha6 triggers release.yml to publish to Maven Central. Includes everything merged since 1.0.0-alpha5, notably the new StorageType.S3 (PR #987) for the sirix-enterprise-s3 provider.