### PR TITLE
fix(build): declare sourcesJar dependency on buildNativeLz77

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -192,6 +192,14 @@ test {
 // processResources should rebuild the .so if the .c source changed.
 processResources.dependsOn 'buildNativeLz77'
 
+// The sources jar (added by the maven-publish plugin) also packages src/main/resources,
+// into which buildNativeLz77 generates the native .so — so it consumes that task's output
+// too. Declare the dependency or Gradle 9.x task-validation fails the build during a
+// release. Lazily configured and tolerant of the task being absent in non-publishing builds.
+tasks.matching { it.name == 'sourcesJar' }.configureEach {
+    dependsOn 'buildNativeLz77'
+}
+
 // Detect gcc availability at configuration time. The Docker deploy image has no
 // gcc; runtime degrades gracefully to the pure-Java LZ77 decoder when the .so is
 // absent, so the native compile is best-effort.


### PR DESCRIPTION
buildNativeLz77 generates libsirix_lz77.so into src/main/resources, which the maven-publish sourcesJar also packages. Without a declared dependency, Gradle 9.x task-validation fails the build (':sirix-core:sourcesJar uses this output of :sirix-core:buildNativeLz77 without declaring ... a dependency'), breaking the Maven Central release. processResources already declares this dependency; mirror it for sourcesJar. Reproduced and verified via 'assemble --rerun-tasks' (FAILED before, SUCCESSFUL after).