### PR TITLE
chore(release): align version references to 1.0.0-alpha10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to SirixDB are documented in this file.
 
-## [1.0.0-alpha8]
+## [1.0.0-alpha10]
 
 The first 1.0 alpha series — the API is stabilizing toward a production 1.0 release.
 

--- a/README.md
+++ b/README.md
@@ -343,13 +343,13 @@ Add `--read-write` to the `args` to allow mutations (read-only is the default). 
 <dependency>
   <groupId>io.sirix</groupId>
   <artifactId>sirix-core</artifactId>
-  <version>1.0.0-alpha8</version>
+  <version>1.0.0-alpha10</version>
 </dependency>
 ```
 
 ```gradle
 // Gradle (Kotlin DSL)
-implementation("io.sirix:sirix-core:1.0.0-alpha8")
+implementation("io.sirix:sirix-core:1.0.0-alpha10")
 ```
 
 ```java

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -6,7 +6,7 @@ flags, cache budgets, OS limits, observability, backups — rather than on API
 usage. For API documentation, see the project README and JavaDoc; for storage-
 format internals, see `docs/ARCHITECTURE.md`.
 
-> **Status.** Sirix is currently at `1.0.0-alpha5`. The wire format is on
+> **Status.** Sirix is currently at `1.0.0-alpha10`. The wire format is on
 > `BinaryEncodingVersion.V0`; bumps are stamped into the page header and rejected
 > on read with a clear "version not known" error. There is **no migration tool
 > yet** — when V1 is introduced, a one-shot upgrader will ship alongside.
@@ -340,7 +340,7 @@ java \
   -XX:+UseZGC -XX:+AlwaysPreTouch -XX:MaxDirectMemorySize=1g \
   -Dsirix.cache.recordPage=4294967296 \
   -Dsirix.cache.recordPageFragment=1610612736 \
-  -jar bundles/sirix-rest-api/build/libs/sirix-rest-api-1.0.0-alpha5-fat.jar \
+  -jar bundles/sirix-rest-api/build/libs/sirix-rest-api-1.0.0-alpha10-fat.jar \
   -conf bundles/sirix-rest-api/src/main/resources/sirix-conf.json
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha8
+version=1.0.0-alpha10
 vertxVersion=5.0.5
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
Aligns all concrete version references to the latest published release, `1.0.0-alpha10` (verified present on Maven Central: `sirix-core-1.0.0-alpha10.jar`/`.pom`). The repo previously declared `alpha8` and the ops guide still referenced `alpha5`.

**Updated (concrete pins):**
- `gradle.properties` — `version=1.0.0-alpha10`
- `README.md` — Maven and Gradle dependency snippets
- `CHANGELOG.md` — heading
- `docs/operations.md` — status line and the example fat-jar name

**Left unchanged (intentionally generic or historical):**
- README status banner ("1.0.0-alpha series")
- `SECURITY.md` supported-versions table (version-agnostic)
- `ROADMAP.md` ("1.0.0-alpha series")
- `docs/operations.md` "Sirix 1.0.0-alpha5 onwards drops `synchronized`…" — records when the behavior landed, so it must stay `alpha5`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqMrDkiomS9ENs6RdfnHRa)_