### PR TITLE
docs(readme): point primary docs link in-repo so it can't 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-<a href="https://sirix.io/docs/index.html"><b>Documentation</b></a> · <a href="https://discord.gg/yC33wVpv7t"><b>Discord</b></a> · <a href="https://sirix.discourse.group/"><b>Forum</b></a> · <a href="https://github.com/sirixdb/sirixdb-web-gui"><b>Web UI</b></a>
+<a href="docs/README.md"><b>Docs</b></a> · <a href="https://sirix.io"><b>Website</b></a> · <a href="https://discord.gg/yC33wVpv7t"><b>Discord</b></a> · <a href="https://sirix.discourse.group/"><b>Forum</b></a> · <a href="https://github.com/sirixdb/sirixdb-web-gui"><b>Web UI</b></a>
 </p>
 
 <p align="center"><i>Status: <b>1.0.0-alpha</b> — usable today and actively developed. The on-disk format and public APIs are stabilizing toward a 1.0 release; feedback from real use is exactly what we're looking for.</i></p>


### PR DESCRIPTION
Defensive hardening so the README has no link that can 404 for a first-time visitor (e.g. from a Show HN), independent of whether the external docs site is up.

**Change:** the top-nav primary docs link pointed at `https://sirix.io/docs/index.html`. Since the GitHub repo doubles as the landing page, a dead external link there is a poor first impression. The primary **Docs** link now targets the in-repo [`docs/README.md`](docs/README.md) index (always renders on GitHub), and the website is linked separately as **Website** → `https://sirix.io`.

**Why in-repo:** all in-repo README links were verified to resolve; the README is a self-contained quickstart, so even if the external docs site lags, newcomers always have a working path.

**Not changed:** the two inline "for the full reference" links still point at the canonical site (supplementary detail; low risk). Once the external docs are confirmed live, those can stay as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqMrDkiomS9ENs6RdfnHRa)_