### PR TITLE
release: 1.0.0-alpha11 — fix Dockerfile jar glob for release builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,12 @@ RUN gradle build --refresh-dependencies -x test -x javadoc
 
 FROM eclipse-temurin:25-jre AS server
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
-ENV VERTICLE_FILE sirix-rest-api-*-SNAPSHOT-fat.jar
+# Match the fat jar for ANY project version. A `*-SNAPSHOT-fat.jar` glob silently
+# matched nothing for real releases (e.g. 1.0.0-alpha10): the COPY below copied no
+# jar and the runtime `-jar` glob resolved to a missing file, yielding a jar-less
+# image that fails with "Unable to access jarfile". `*-fat.jar` covers snapshots and
+# releases alike (exactly one *-fat.jar artifact exists per build).
+ENV VERTICLE_FILE sirix-rest-api-*-fat.jar
 # Set the location of the verticles
 ENV VERTICLE_HOME /opt/sirix
 WORKDIR /opt/sirix

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha10
+version=1.0.0-alpha11
 vertxVersion=5.0.5
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## Problem

`sirixdb/sirix:latest` is published **jar-less**, so the backend can't start — it exits with `Unable to access jarfile /opt/sirix/sirix-rest-api-*-SNAPSHOT-fat.jar`. This silently broke this repo's e2e CI and the cloud demo, both of which pull `:latest`.

## Cause

The server image's `VERTICLE_FILE` was hardcoded to `sirix-rest-api-*-SNAPSHOT-fat.jar`. Once the project moved to release versions (`1.0.0-alphaN`), the fat jar is `sirix-rest-api-1.0.0-alphaN-fat.jar` — no `-SNAPSHOT` — so the glob matched nothing. The `COPY` (build time) copied no jar, and the runtime `-jar $VERTICLE_FILE` glob resolved to a missing file. No build-time error; just a broken image.

## Fix

Widen the glob to `sirix-rest-api-*-fat.jar`, which matches snapshots **and** releases (exactly one `*-fat.jar` artifact exists per build — `archiveClassifier='fat'`). Bump version to `1.0.0-alpha11`.

## Verification

Building the image from this branch and confirming the jar is baked in, the container boots on 9443, and a JSON shred succeeds — results posted before merge.
