### PR TITLE
fix(compose): probe HTTP health endpoint to match use.http=true default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,10 +54,12 @@ services:
     depends_on:
       keycloak:
         condition: service_healthy
-    # Probe the unauthenticated /health endpoint (self-signed cert, hence -k) so the
-    # container only reports healthy once the REST server is actually accepting requests.
+    # Probe the unauthenticated /health endpoint so the container only reports healthy
+    # once the REST server is actually accepting requests. The default config is
+    # use.http=true (HTTP), so probe over HTTP — otherwise the server serves fine but
+    # an https probe never succeeds and the container is wrongly marked unhealthy.
     healthcheck:
-      test: ["CMD-SHELL", "curl -kfs https://localhost:9443/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fs http://localhost:9443/health || exit 1"]
       interval: 10s
       timeout: 3s
       start_period: 30s


### PR DESCRIPTION
## Problem

The `server` healthcheck in `docker-compose.yml` probes `https://localhost:9443/health`, but the default `sirix-docker-conf.json` sets `use.http: true` — so the REST server listens over **HTTP**. The https probe never succeeds, so the container is permanently marked **unhealthy** even when serving correctly, and any `depends_on: { condition: service_healthy }` consumer hangs.

## Fix

Probe over HTTP to match the default config. (Switch back to `https://…-k` if you flip the server to HTTPS.)
