### PR TITLE
fix(json): wrap fused OBJECT_NAMED_OBJECT children in array for metadata serialization (alpha12)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonLimitedSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonLimitedSerializer.java
@@ -508,6 +508,16 @@ public final class JsonLimitedSerializer implements Callable<Void> {
           appendObjectKey(quote(rtx.getName().stringValue()));
         }
 
+        // In metadata mode a named OBJECT whose children are actually visited renders them as an
+        // array of child records (`[{...}]`, matching the unbounded JsonSerializer). When the
+        // children are pruned by a limit (maxLevel/maxNodes/maxChildren) or there are none, the
+        // value is the bare empty placeholder object `{}` — which the client reads as "children
+        // not loaded". A named ARRAY always opens `[`. Without metadata the value is bare.
+        final boolean wrapNamedObjectChildren =
+            isNamedObject && withMetaDataField() && willVisitChildren && innerHasChildren;
+        if (wrapNamedObjectChildren) {
+          appendArrayStart(true);
+        }
         if (isNamedObject) {
           appendObjectStart(willVisitChildren && innerHasChildren);
         } else {
@@ -673,7 +683,8 @@ public final class JsonLimitedSerializer implements Callable<Void> {
         final boolean isStartNode =
             startNodeKey != Fixed.NULL_NODE_KEY.getStandardProperty() && rtx.getNodeKey() == startNodeKey;
         if (withMetaDataField()) {
-          appendObjectEnd(true);
+          // Close the value array `]` (children live in it), then the metadata wrapper `}`.
+          appendArrayEnd(true);
           if (!isStartNode || hadToAddBracket) {
             appendObjectEnd(true);
           }

--- a/bundles/sirix-core/src/test/java/io/sirix/service/json/serialize/JsonSerializerTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/json/serialize/JsonSerializerTest.java
@@ -51,6 +51,58 @@ public final class JsonSerializerTest {
     JsonTestHelper.deleteEverything();
   }
 
+  @Test
+  public void metadataSerializationAlwaysProducesValidJson() throws Exception {
+    // The Explorer fetches every resource WITH metadata and a maxLevel (delegating to
+    // JsonLimitedSerializer). Regression sweep: nested objects, objects-in-arrays, empties,
+    // mixed primitives and array roots must all serialize to VALID JSON across both metadata
+    // modes and every depth — not just the unbounded JsonSerializer path.
+    final String[] docs = {
+        "{\"store\":{\"name\":\"Test Store\",\"products\":[{\"id\":1}],\"metadata\":{\"version\":\"1.0\"}}}",
+        "{\"a\":{\"b\":{\"c\":{\"d\":1}}}}",
+        "{\"arr\":[{\"x\":1},{\"y\":{\"z\":2}}]}",
+        "{\"empty\":{},\"emptyArr\":[],\"mixed\":[1,\"two\",true,null,{\"k\":\"v\"}]}",
+        "[{\"obj\":{\"nested\":{}}},[1,2],{}]",
+        "{\"o\":{\"p\":{\"q\":[{\"r\":{\"s\":\"t\"}}]}}}",
+        "{\"users\":[{\"name\":\"a\",\"roles\":[\"x\",\"y\"],\"meta\":{\"active\":true}}]}"
+    };
+    int caseNum = 0;
+    for (final String json : docs) {
+      caseNum++;
+      JsonTestHelper.deleteEverything();
+      final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+      try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+          final var trx = manager.beginNodeTrx()) {
+        new JsonShredder.Builder(trx, JsonShredder.createStringReader(json),
+            InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+
+        for (final boolean nodeKeyAndChildCount : new boolean[] {true, false}) {
+          for (final int level : new int[] {1, 2, 3, 4, 5, Integer.MAX_VALUE}) {
+            final Writer w = new StringWriter();
+            final JsonSerializer ser = nodeKeyAndChildCount
+                ? new JsonSerializer.Builder(manager, w).maxLevel(level)
+                      .withNodeKeyAndChildCountMetaData(true).build()
+                : new JsonSerializer.Builder(manager, w).maxLevel(level).withMetaData(true).build();
+            ser.call();
+            final String actual = w.toString();
+            try {
+              if (actual.trim().startsWith("[")) {
+                new org.json.JSONArray(actual);
+              } else {
+                new org.json.JSONObject(actual);
+              }
+            } catch (final Exception e) {
+              throw new AssertionError("INVALID JSON  case=" + caseNum + "  mode="
+                  + (nodeKeyAndChildCount ? "nodeKeyAndChildCount" : "metaData") + "  maxLevel=" + level
+                  + "\n  doc: " + json + "\n  out: " + actual + "\n  err: " + e.getMessage());
+            }
+          }
+        }
+      }
+    }
+    System.out.println(">>> SWEEP PASSED: " + caseNum + " docs x 2 modes x 6 levels all valid JSON");
+  }
+
   /**
    * Resolves the expected-JSON fixture for the current shredder fusion mode.
    *

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha11
+version=1.0.0-alpha12
 vertxVersion=5.0.5
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## Problem

When the REST API serializes a resource **with metadata** and **any limit** set (`maxLevel` / `maxChildren` / `maxNodes`), it delegates to `JsonLimitedSerializer`. For a fused `OBJECT_NAMED_OBJECT` node (a `OBJECT_KEY` fused with its inner `OBJECT`, introduced in bb5f14bab) whose children are actually visited, the serializer emitted the children as a bare object:

```json
"value":{ {"key":"a", ...}, {"key":"b", ...} }
```

instead of an array:

```json
"value":[ {"key":"a", ...}, {"key":"b", ...} ]
```

The first form is **invalid JSON** — a sequence of `{key,metadata,value}` records must live in an array. Every nested object in metadata mode produced unparseable output, which is exactly what the SirixDB Web GUI Explorer requests for every resource (it always sets a `maxLevel`). This is the root cause of the web-gui e2e failures.

## Fix

In `JsonLimitedSerializer`, wrap a named object's children in an array **only** when they are actually visited and present (`willVisitChildren && innerHasChildren`). When the children are pruned by a limit, or the object is empty, the value stays the bare `{}` placeholder the client reads as "children not loaded" — unchanged. The close side mirrors this (`appendArrayEnd` + the metadata-wrapper `appendObjectEnd`), keeping enter/exit brackets symmetric. This matches the unbounded `JsonSerializer`'s handling of the same fused kind.

`OBJECT_NAMED_ARRAY` was already correct (a named array always opens `[`); only the named-object case was missing the wrapper.

## Other serializers — audited, clean

Swept every JSON serializer for the same bug class:

- **`JsonSerializer`** (unbounded) — already correct and symmetric.
- **`JsonRecordSerializer`** — has no `OBJECT_NAMED_*` cases; delegates each child's body to `JsonSerializer`/`JsonLimitedSerializer` and only emits the outer wrapper itself (always `[...]` for value arrays). Cannot reproduce the bug.
- **`JsonDiffSerializer`** — serializes embedded `insert`/`replace` data in **non-metadata mode**, so the bug class is unreachable.

The only two metadata-mode REST entry points (`JsonGet.kt:156` and `:189`) both flow through the audited/fixed serializers.

## Tests

- Existing `JsonSerializerTest` suite: 24/24 green.
- New `metadataSerializationAlwaysProducesValidJson` regression test: asserts valid JSON across 7 documents (nested objects, objects-in-arrays, empties, mixed primitives, array roots, deep nesting) × both metadata modes × maxLevels `{1,2,3,4,5,MAX_VALUE}` — 84 assertions, all valid.

Bumps version to `1.0.0-alpha12` so the `Deploy` job republishes `sirixdb/sirix:latest` with the fix.
