### PR TITLE
release: 1.0.0-alpha17 — metrics, JSON-perf, crash-recovery + version-pinned Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish to Maven Central
     if: ${{ github.repository_owner == 'sirixdb' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,3 +42,17 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push version-pinned Docker image
+        run: |
+          VERSION="$(grep '^version=' gradle.properties | cut -d= -f2)"
+          echo "Building and pushing sirixdb/sirix:${VERSION}"
+          docker compose build server
+          docker tag sirixdb/sirix:latest "sirixdb/sirix:${VERSION}"
+          docker push "sirixdb/sirix:${VERSION}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha16
+version=1.0.0-alpha17
 vertxVersion=5.0.5
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## Release 1.0.0-alpha17

Cuts `1.0.0-alpha17` to publish the work merged in #1008, which landed on `main` **after** `alpha16` was tagged — so it isn't in any Maven Central release yet:

- **feat(metrics)** — Prometheus counters (`TransactionMetrics`, `SirixMetricsRegistry`, cache-size metrics)
- **perf(json)** — O(n²) array-unbox fix + installable prefetch-axis seam
- **fix(til)** — cross-generation `logKey` guard in `TransactionIntentLog.put`
- **test/docs** — crash-recovery coverage, re-enabled `@Disabled` tests, `KNOWN_LIMITATIONS.md`
- **test(benchmarks)** — JMH benchmark for `HOTIndirectPage.findChildIndex`
- **docs(roadmap)** — sharding → `sirix-enterprise`

### Changes in this PR
- `gradle.properties`: `1.0.0-alpha16` → `1.0.0-alpha17`
- `.github/workflows/release.yml`: also build + push a **version-pinned** `sirixdb/sirix:<version>` image alongside the Maven Central publish (previously only `:latest` was published, by the per-`main`-push job). Release-job timeout raised to 45 min to accommodate the from-source Docker build.

Merging this, then pushing tag `sirix-1.0.0-alpha17`, triggers the Central publish + GitHub Release + version-pinned Docker image.
