### PR TITLE
chore(deps): bump zero-allocation-hashing 0.16 -> 2026.0

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -33,7 +33,7 @@ implLibraries = [
         fastUtil                    : 'it.unimi.dsi:fastutil:8.5.18',
         iouring                     : 'one.jasyncfio:jasyncfio:0.0.8:linux-amd64',
         roaringbitmap               : 'org.roaringbitmap:RoaringBitmap:0.9.49',
-        zeroAllocationHashing       : 'net.openhft:zero-allocation-hashing:0.16',
+        zeroAllocationHashing       : 'net.openhft:zero-allocation-hashing:2026.0',
         micrometerCore              : 'io.micrometer:micrometer-core:1.16.5',
         micrometerRegistryPrometheus: 'io.micrometer:micrometer-registry-prometheus:1.16.5'
 ]


### PR DESCRIPTION
Major upgrade #1 of 4 (one-by-one). The project switched to CalVer (0.16 -> 2026.0). Only `LongHashFunction.xx3()` is used, which is unchanged -> no code changes; sirix-core compiles locally. XXH3 is a fixed algorithm so stored hashes are unaffected. CI verifies tests + native images.