### PR TITLE
chore(deps): bump RoaringBitmap 0.9.49 -> 1.6.14

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -32,7 +32,7 @@ implLibraries = [
         integercompression          : 'me.lemire.integercompression:JavaFastPFOR:0.3.11',
         fastUtil                    : 'it.unimi.dsi:fastutil:8.5.18',
         iouring                     : 'one.jasyncfio:jasyncfio:0.0.8:linux-amd64',
-        roaringbitmap               : 'org.roaringbitmap:RoaringBitmap:0.9.49',
+        roaringbitmap               : 'org.roaringbitmap:RoaringBitmap:1.6.14',
         zeroAllocationHashing       : 'net.openhft:zero-allocation-hashing:0.16',
         micrometerCore              : 'io.micrometer:micrometer-core:1.16.5',
         micrometerRegistryPrometheus: 'io.micrometer:micrometer-registry-prometheus:1.16.5'


### PR DESCRIPTION
Major upgrade #2 of 4 (one-by-one). 0.9 -> 1.x; the used APIs (RoaringBitmap, Roaring64*, Long iterators) are unchanged. Verified locally: sirix-core + sirix-query compile, and the native image builds + runs. CI confirms tests + all native images.