### PR TITLE
chore(deps): bump jline 3.30.13 -> 4.1.3

### DIFF
--- a/libraries.gradle
+++ b/libraries.gradle
@@ -6,7 +6,7 @@ ext {
 
 implLibraries = [
         jacksonCore                 : 'com.fasterxml.jackson.core:jackson-core:2.22.0',
-        jline                       : 'org.jline:jline:3.30.13',
+        jline                       : 'org.jline:jline:4.1.3',
         slf4jApi                    : 'org.slf4j:slf4j-api:2.0.18',
         xmlunit                     : 'xmlunit:xmlunit:1.6',
         logbackClassic              : 'ch.qos.logback:logback-classic:1.5.34',


### PR DESCRIPTION
Major upgrade #3 of 4 (one-by-one). 3 -> 4; the REPL's LineReader/Terminal API is unchanged. jline 4 bundles its own GraalVM metadata. Verified locally: sirix-query compiles and the native image builds + runs. No code changes.