### PR TITLE
chore(deps): bump JUnit 5.14.4 -> 6.1.0

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     testImplementation testLibraries.junitJupiterParams
     testImplementation testLibraries.junitVintageEngine
     testImplementation testLibraries.junitPlatformLauncher
-    testImplementation testLibraries.junitPlatformRunner
     testImplementation testLibraries.mockitoCore
     testImplementation testLibraries.byteBuddy
     testImplementation testLibraries.byteBuddyAgent

--- a/bundles/sirix-core/src/main/resources/META-INF/native-image/io.sirix/sirix-core/reachability-metadata.json
+++ b/bundles/sirix-core/src/main/resources/META-INF/native-image/io.sirix/sirix-core/reachability-metadata.json
@@ -3,19 +3,35 @@
     "downcalls": [
       {
         "returnType": "void*",
-        "parameterTypes": ["void*", "long", "int", "int", "int", "long"]
+        "parameterTypes": [
+          "void*",
+          "long",
+          "int",
+          "int",
+          "int",
+          "long"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "long"]
+        "parameterTypes": [
+          "void*",
+          "long"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "long", "int"]
+        "parameterTypes": [
+          "void*",
+          "long",
+          "int"
+        ]
       },
       {
         "returnType": "long",
-        "parameterTypes": ["int"]
+        "parameterTypes": [
+          "int"
+        ]
       },
       {
         "returnType": "void*",
@@ -23,24 +39,48 @@
       },
       {
         "returnType": "void*",
-        "parameterTypes": ["int"]
+        "parameterTypes": [
+          "int"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "void*", "int", "int"]
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "int",
+          "int"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "void*", "int", "int", "int"]
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "int",
+          "int",
+          "int"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["void*", "void*", "int"]
+        "parameterTypes": [
+          "void*",
+          "void*",
+          "int"
+        ]
       },
       {
         "returnType": "int",
-        "parameterTypes": ["int"]
+        "parameterTypes": [
+          "int"
+        ]
       }
     ]
-  }
+  },
+  "serialization": [
+    {
+      "type": "org.junit.platform.engine.UniqueId$SerializedForm"
+    }
+  ]
 }

--- a/bundles/sirix-kotlin-api/build.gradle
+++ b/bundles/sirix-kotlin-api/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     testImplementation testLibraries.junitJupiterEngine
     testImplementation testLibraries.junitVintageEngine
     testImplementation testLibraries.junitPlatformLauncher
-    testImplementation testLibraries.junitPlatformRunner
     testImplementation testLibraries.mockitoCore
     testImplementation testLibraries.testng
     testImplementation testLibraries.jsonassert

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -40,12 +40,11 @@ implLibraries = [
 
 testLibraries = [
         testng                   : 'org.testng:testng:7.12.0',
-        junitJupiterApi          : 'org.junit.jupiter:junit-jupiter-api:5.14.4',
-        junitJupiterEngine       : 'org.junit.jupiter:junit-jupiter-engine:5.14.4',
-        junitJupiterParams       : 'org.junit.jupiter:junit-jupiter-params:5.14.4',
-        junitVintageEngine       : 'org.junit.vintage:junit-vintage-engine:5.14.4',
-        junitPlatformLauncher    : 'org.junit.platform:junit-platform-launcher:1.14.4',
-        junitPlatformRunner      : 'org.junit.platform:junit-platform-runner:1.14.4',
+        junitJupiterApi          : 'org.junit.jupiter:junit-jupiter-api:6.1.0',
+        junitJupiterEngine       : 'org.junit.jupiter:junit-jupiter-engine:6.1.0',
+        junitJupiterParams       : 'org.junit.jupiter:junit-jupiter-params:6.1.0',
+        junitVintageEngine       : 'org.junit.vintage:junit-vintage-engine:6.1.0',
+        junitPlatformLauncher    : 'org.junit.platform:junit-platform-launcher:6.1.0',
         mockitoCore              : 'org.mockito:mockito-core:5.23.0',
         byteBuddy                : 'net.bytebuddy:byte-buddy:1.18.10',
         byteBuddyAgent           : 'net.bytebuddy:byte-buddy-agent:1.18.10',


### PR DESCRIPTION
Major upgrade #4 of 4 (one-by-one), the hardest. JUnit 6 unifies jupiter+platform at 6.x and drops junit-platform-runner (unused here, removed). Adds UniqueId$SerializedForm serialization to sirix-core native metadata (JUnit Platform 6 serializes UniqueId). Verified locally: compile + JVM tests + native smoke image. The one runtime compat CI confirms is vertx-junit5 (rest-api), which is built against JUnit 5.14.