### PR TITLE
chore(deps): bump caffeine 3.1.6 -> 3.2.4 (native FACTORY metadata)

### DIFF
--- a/bundles/sirix-core/src/main/resources/META-INF/native-image/io.sirix/sirix-core/reachability-metadata.json
+++ b/bundles/sirix-core/src/main/resources/META-INF/native-image/io.sirix/sirix-core/reachability-metadata.json
@@ -82,5 +82,119 @@
     {
       "type": "org.junit.platform.engine.UniqueId$SerializedForm"
     }
+  ],
+  "reflection": [
+    {
+      "type": "com.github.benmanes.caffeine.cache.PS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.PSA",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.PSAMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.PSMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.PSMW",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSLMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSLMSA",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSLMW",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSLSMW",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSMS",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSMSA",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSMSW",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.SSMW",
+      "fields": [
+        {
+          "name": "FACTORY"
+        }
+      ]
+    }
   ]
 }

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -14,7 +14,7 @@ implLibraries = [
         gson                        : 'com.google.code.gson:gson:2.14.0',
         jspecify                    : 'org.jspecify:jspecify:1.0.0',
         brackit                     : 'io.sirix:brackit:1.0-alpha2',
-        caffeine                    : 'com.github.ben-manes.caffeine:caffeine:3.1.6',
+        caffeine                    : 'com.github.ben-manes.caffeine:caffeine:3.2.4',
         tink                        : 'com.google.crypto.tink:tink:1.21.0',
         kotlinStdlib                : 'org.jetbrains.kotlin:kotlin-stdlib:2.4.0',
         kotlinxCoroutinesCore       : 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.11.0',


### PR DESCRIPTION
Unblocks the Caffeine major held during the dependency campaign. Caffeine 3.2.x reflectively reads a static FACTORY field on its generated cache classes; registers FACTORY on the 14 cache classes the project uses (curated set + SSMS) in sirix-core's native metadata. The GraalVM metadata repository (plugin 0.11.5) lacks Caffeine 3.2.x metadata, so targeted registration is used instead. Verified locally: compile + sirix-query native image; JVM tests already green on 3.2.4. CI confirms all 3 native images + tests.