### PR TITLE
release: 1.0.0-alpha18 — dependency refresh

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha17
+version=1.0.0-alpha18
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## Release 1.0.0-alpha18 — dependency refresh

Cuts `1.0.0-alpha18` to release the dependency-update campaign merged in #1010–#1015. Nearly every direct dependency is now at its latest stable:

- **Kotlin 2.4** (+ coroutines/cli), **Vert.x 5.1**, **JUnit 6**, **Caffeine 3.2.4**, **jline 4**, **RoaringBitmap 1.x**, **zero-allocation-hashing 2026.0**
- jackson, gson, slf4j, logback, tink, fastutil, JavaFastPFOR, jasyncfio, micrometer, testng, mockito, byte-buddy, assertj, jsonassert

Held (no stable release yet): assertj 4.x, jsonassert 2.x. `brackit`/`xmlunit` pinned by design.

Merging this + pushing tag `sirix-1.0.0-alpha18` triggers the Maven Central publish + GitHub Release + the version-pinned `sirixdb/sirix:1.0.0-alpha18` image.
