### PR TITLE
release: 1.0.0-alpha19 — jn:open/xml:open before first revision returns empty sequence

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollection.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollection.java
@@ -153,10 +153,13 @@ public final class JsonDBCollection extends AbstractJsonItemCollection<JsonDBIte
           trx.close();
 
           trx = resource.beginNodeReadOnlyTrx(revision - 1);
-        } else if (revision == 0) {
+        } else {
+          // Even the earliest revision was committed after the requested point
+          // in time, i.e. the resource did not exist yet. Return the empty
+          // sequence instead of anachronistically yielding the first revision.
           trx.close();
-
-          trx = resource.beginNodeReadOnlyTrx(1);
+          resource.close();
+          return null;
         }
       }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollection.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollection.java
@@ -153,10 +153,14 @@ public final class XmlDBCollection extends AbstractNodeCollection<AbstractTempor
             trx.close();
 
             trx = resource.beginNodeReadOnlyTrx(revision - 1);
-          } else if (revision == 0) {
+          } else {
+            // Even the earliest revision was committed after the requested point
+            // in time, i.e. the resource did not exist yet. Return the empty
+            // sequence instead of anachronistically yielding the first revision.
+            // (Returning null from computeIfAbsent leaves the cache untouched.)
             trx.close();
-
-            trx = resource.beginNodeReadOnlyTrx(1);
+            resource.close();
+            return null;
           }
         }
 

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/DocByPointInTimeJsonTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/DocByPointInTimeJsonTest.java
@@ -1,0 +1,85 @@
+package io.sirix.query.function.jn.temporal;
+
+import io.brackit.query.Query;
+import io.brackit.query.util.io.IOUtils;
+import io.brackit.query.util.serialize.StringSerializer;
+import io.sirix.JsonTestHelper;
+import io.sirix.query.SirixCompileChain;
+import io.sirix.query.SirixQueryContext;
+import io.sirix.query.json.BasicJsonDBStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@code jn:open($db, $resource, $pointInTime)} — opening a JSON resource as of a
+ * wall-clock instant ({@link io.sirix.query.function.jn.io.DocByPointInTime}).
+ */
+public final class DocByPointInTimeJsonTest {
+
+  private static final Path SIRIX_DB_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  @BeforeEach
+  void setup() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  private static String run(final SirixQueryContext ctx, final SirixCompileChain chain, final String query)
+      throws IOException {
+    final var seq = new Query(chain, query).execute(ctx);
+    final var buf = IOUtils.createBuffer();
+    try (final var serializer = new StringSerializer(buf)) {
+      serializer.setFormat(true).serialize(seq);
+    }
+    return buf.toString().trim();
+  }
+
+  /**
+   * A point in time before the resource's first revision must yield the empty sequence — the
+   * resource did not exist yet, so there is nothing to return (regression: previously the first
+   * revision's data was returned anachronistically).
+   */
+  @Test
+  public void test_whenPointInTimeBeforeFirstRevision_thenEmpty() throws IOException {
+    try (final var store = BasicJsonDBStore.newBuilder().location(SIRIX_DB_PATH.getParent()).build();
+        final var ctx = SirixQueryContext.createWithJsonStore(store);
+        final var chain = SirixCompileChain.createWithJsonStore(store)) {
+
+      SetupRevisions.setupRevisions(ctx, chain);
+
+      // The revisions above are committed "now"; 2000-01-01 predates all of them.
+      final var result = run(ctx, chain, "jn:open('json-path1','mydoc.jn', xs:dateTime('2000-01-01T00:00:00Z'))");
+
+      assertEquals("", result);
+    }
+  }
+
+  /**
+   * A point in time after the first revision must still return the document (here a far-future
+   * instant resolves to the most recent revision).
+   */
+  @Test
+  public void test_whenPointInTimeAfterFirstRevision_thenDocument() throws IOException {
+    try (final var store = BasicJsonDBStore.newBuilder().location(SIRIX_DB_PATH.getParent()).build();
+        final var ctx = SirixQueryContext.createWithJsonStore(store);
+        final var chain = SirixCompileChain.createWithJsonStore(store)) {
+
+      SetupRevisions.setupRevisions(ctx, chain);
+
+      final var result = run(ctx, chain, "jn:open('json-path1','mydoc.jn', xs:dateTime('2100-01-01T00:00:00Z'))");
+
+      assertFalse(result.isEmpty(), "expected the resource document, got the empty sequence");
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha18
+version=1.0.0-alpha19
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## Problem

`jn:open($db, $resource, $pointInTime)` — and the XML twin `xml:open` — clamped a point in time that **predates the resource's first revision** to revision 1, anachronistically returning the first revision's data for a moment when the resource did not exist:

```xquery
(: resource created 2026-06-09; query asks about 2024 :)
jn:open('demo-db', 'products', xs:dateTime('2024-01-15T15:00:00Z'))
(: returned the full rev-1 document — expected: empty sequence :)
```

## Fix

`JsonDBCollection#getDocumentInternal(String, Instant)` / `XmlDBCollection#getDocumentInternal(String, Instant)`: when even the earliest revision's commit timestamp is after the requested instant, close the transaction/session and return the empty sequence instead of falling through to revision 1. Timestamps at/after the first commit are unaffected (verified: far-future timestamps still resolve to the most recent revision).

## Tests

- New `DocByPointInTimeJsonTest`: pre-creation instant → empty sequence; far-future instant → document.
- Existing `xml.io.DocByPointInTimeTest` and the whole `jn.temporal` suite (FirstExisting/LastExisting/Bitemporal incl. stress tests) pass unchanged.

## Release

Bumps `gradle.properties` to `1.0.0-alpha19`; tag `sirix-1.0.0-alpha19` to follow on the merge commit.