### PR TITLE
perf: fix node-history and query latency (event-loop blocking + uncached history)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -107,6 +107,15 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   final ConcurrentMap<Integer, StorageEngineWriter> storageEngineWriterMap;
 
   /**
+   * Cache of revision → {@link RevisionInfo} (author, timestamp, commit message). A committed
+   * revision is immutable, so an entry never has to be invalidated for the lifetime of this
+   * session; repeated history calls (the REST {@code /history} endpoint, GUIs polling the
+   * revision list) only pay I/O for revisions committed since the last call instead of
+   * re-reading every {@code RevisionRootPage} each time.
+   */
+  private final ConcurrentMap<Integer, RevisionInfo> revisionInfoCache = new ConcurrentHashMap<>();
+
+  /**
    * Lock for blocking the commit.
    */
   private final Lock commitLock;
@@ -332,17 +341,33 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     final var revisionInfos = new ArrayList<CompletableFuture<RevisionInfo>>();
 
     for (int revision = fromRevision; revision > 0 && revision >= toRevision; revision--) {
-      int finalRevision = revision;
-      revisionInfos.add(CompletableFuture.supplyAsync(() -> {
-        try (final NodeReadOnlyTrx rtx = beginNodeReadOnlyTrx(finalRevision)) {
-          final CommitCredentials commitCredentials = rtx.getCommitCredentials();
-          return new RevisionInfo(commitCredentials.getUser(), rtx.getRevisionNumber(), rtx.getRevisionTimestamp(),
-              commitCredentials.getMessage());
-        }
-      }));
+      revisionInfos.add(revisionInfoFuture(revision));
     }
 
     return getResult(revisionInfos);
+  }
+
+  /**
+   * Resolve one revision's {@link RevisionInfo}, serving immutable, already-seen revisions from
+   * {@link #revisionInfoCache} without any I/O. A miss reads the commit metadata directly through
+   * a {@link StorageEngineReader} — the credentials and timestamp live on the
+   * {@code RevisionRootPage}, so the full node-transaction machinery (node cursor, item list,
+   * per-trx wiring) that {@code beginNodeReadOnlyTrx} sets up is unnecessary overhead here.
+   */
+  private CompletableFuture<RevisionInfo> revisionInfoFuture(int revision) {
+    final RevisionInfo cached = revisionInfoCache.get(revision);
+    if (cached != null) {
+      return CompletableFuture.completedFuture(cached);
+    }
+    return CompletableFuture.supplyAsync(() -> revisionInfoCache.computeIfAbsent(revision, rev -> {
+      try (final StorageEngineReader reader = createStorageEngineReader(rev)) {
+        final CommitCredentials commitCredentials = reader.getCommitCredentials();
+        return new RevisionInfo(commitCredentials.getUser(),
+                                rev,
+                                Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
+                                commitCredentials.getMessage());
+      }
+    }));
   }
 
   private List<RevisionInfo> getHistoryInformations(int revisions) {
@@ -353,14 +378,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
     for (int revision = lastCommittedRevision; revision > 0
         && revision > lastCommittedRevision - revisions; revision--) {
-      int finalRevision = revision;
-      revisionInfos.add(CompletableFuture.supplyAsync(() -> {
-        try (final NodeReadOnlyTrx rtx = beginNodeReadOnlyTrx(finalRevision)) {
-          final CommitCredentials commitCredentials = rtx.getCommitCredentials();
-          return new RevisionInfo(commitCredentials.getUser(), rtx.getRevisionNumber(), rtx.getRevisionTimestamp(),
-              commitCredentials.getMessage());
-        }
-      }));
+      revisionInfos.add(revisionInfoFuture(revision));
     }
 
     return getResult(revisionInfos);

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/AllTimeAxis.java
@@ -74,10 +74,8 @@ public final class AllTimeAxis<R extends NodeReadOnlyTrx & NodeCursor, W extends
       rtx.close();
       if (hasMoved) {
         return endOfData();
-      } else {
-        // Index might be missing (storeNodeHistory off) — keep scanning.
-        rtx.close();
       }
+      // Index might be missing (storeNodeHistory off) — keep scanning.
     }
 
     return endOfData();

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
@@ -439,6 +439,65 @@ public final class JsonMultiRevisionTest {
   }
 
   @Test
+  void testGetHistoryIsStableAcrossCallsAndSeesNewCommits() throws Exception {
+    // Committed revisions are immutable, so the session caches RevisionInfo per revision.
+    // This guards the two semantics the cache must preserve: repeated calls return identical
+    // metadata, and revisions committed AFTER a history call still show up in the next call.
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      for (int i = 1; i <= 3; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          if (i == 1) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[" + i + "]"),
+                JsonNodeTrx.Commit.NO);
+          } else {
+            wtx.moveToDocumentRoot();
+            wtx.moveToFirstChild();
+            wtx.moveToFirstChild();
+            wtx.setNumberValue(i);
+          }
+          wtx.commit();
+        }
+      }
+
+      final List<RevisionInfo> first = session.getHistory();
+      assertEquals(3, first.size());
+
+      // A second call (served from the cache) must return identical metadata.
+      final List<RevisionInfo> second = session.getHistory();
+      assertEquals(first.size(), second.size());
+      for (int i = 0; i < first.size(); i++) {
+        assertEquals(first.get(i).getRevision(), second.get(i).getRevision());
+        assertEquals(first.get(i).getRevisionTimestamp(), second.get(i).getRevisionTimestamp());
+        assertEquals(first.get(i).getUser(), second.get(i).getUser());
+        assertEquals(first.get(i).getCommitMessage(), second.get(i).getCommitMessage());
+      }
+
+      // Commits made after a history call must appear in the next call (no stale cache).
+      for (int i = 4; i <= 5; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.moveToDocumentRoot();
+          wtx.moveToFirstChild();
+          wtx.moveToFirstChild();
+          wtx.setNumberValue(i);
+          wtx.commit();
+        }
+      }
+
+      final List<RevisionInfo> afterNewCommits = session.getHistory();
+      assertEquals(5, afterNewCommits.size());
+      // Most recent first; the new head revision must be 5.
+      assertEquals(5, afterNewCommits.get(0).getRevision());
+
+      // A bounded call after caching still honors its limit and ordering.
+      final List<RevisionInfo> lastTwo = session.getHistory(2);
+      assertEquals(2, lastTwo.size());
+      assertEquals(5, lastTwo.get(0).getRevision());
+      assertEquals(4, lastTwo.get(1).getRevision());
+    }
+  }
+
+  @Test
   void testRevisionTimestamps() throws Exception {
     final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
     try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
@@ -16,7 +16,7 @@ import io.vertx.ext.auth.authorization.AuthorizationProvider
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.coroutines.coAwait
-import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayOutputStream
 import java.nio.file.Path
@@ -38,7 +38,12 @@ abstract class AbstractGetHandler<T : ResourceSession<*, *>,
         val query: String? = ctx.queryParam("query").getOrElse(0) {
             jsonBody?.getString("query")
         }
-        withContext(context.dispatcher()) {
+        // Database open + resource-session open + revision(-timestamp) resolution are blocking
+        // I/O (file reads, uber-page load, per-revision lookups). Run the whole request on a
+        // worker pool — previously this ran on the Vert.x event loop (only the query evaluation
+        // and serialization inside already offload via executeBlocking), so cold session opens
+        // stalled the loop and queued every concurrent request on it.
+        withContext(Dispatchers.IO) {
             get(databaseName, ctx, resource, query, context, ctx.get("user") as User, jsonBody)
         }
         return ctx.currentRoute()!!

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HistoryHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HistoryHandler.kt
@@ -6,6 +6,7 @@ import io.vertx.ext.auth.authorization.AuthorizationProvider
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.RoutingContext
 import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import io.sirix.access.DatabaseType
 import io.sirix.access.Databases.getDatabaseType
@@ -29,13 +30,18 @@ class HistoryHandler(private val location: Path, private val authz: Authorizatio
         val user = ctx.get<User>("user")!!
         Auth.checkIfAuthorized(user, databaseName, AuthRole.VIEW, authz)
 
-        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") val database: Database<*> =
-            when (getDatabaseType(location.resolve(databaseName).toAbsolutePath())) {
-                DatabaseType.JSON -> openJsonDatabase(location.resolve(databaseName))
-                DatabaseType.XML -> openXmlDatabase(location.resolve(databaseName))
-            }
+        // Database open + history retrieval + JSON assembly are blocking (file I/O, one
+        // RevisionRootPage read per uncached revision). Run them on a worker pool like every
+        // other handler does — previously this ran on the Vert.x event loop, stalling the loop
+        // for the whole duration and adding the history latency to every concurrent request
+        // (including query-editor calls) served by the same event loop.
+        val content = withContext(Dispatchers.IO) {
+            @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") val database: Database<*> =
+                when (getDatabaseType(location.resolve(databaseName).toAbsolutePath())) {
+                    DatabaseType.JSON -> openJsonDatabase(location.resolve(databaseName))
+                    DatabaseType.XML -> openXmlDatabase(location.resolve(databaseName))
+                }
 
-        withContext(ctx.vertx().dispatcher()) {
             val buffer = StringBuilder()
             database.use {
                 val manager = database.beginResourceSession(resourceName)
@@ -85,9 +91,10 @@ class HistoryHandler(private val location: Path, private val authz: Authorizatio
                     buffer.append("]}")
                 }
             }
+            buffer.toString()
+        }
 
-            val content = buffer.toString()
-
+        withContext(ctx.vertx().dispatcher()) {
             val res = ctx.response().setStatusCode(200)
                 .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .putHeader(HttpHeaders.CONTENT_LENGTH, content.toByteArray(StandardCharsets.UTF_8).size.toString())


### PR DESCRIPTION
## Summary

Fixes two user-visible latency problems in the GUI/REST path: **node history is slow** and **queries feel slow** — three root causes, each verified against the code:

### 1. `perf(core)`: history was O(revisions) full-trx opens, every call
`getHistory*` opened a **full `NodeReadOnlyTrx` per revision on every call** just to read four fields (revision, timestamp, author, message) off the `RevisionRootPage` — and re-did all of it on each subsequent call.

- **Session-scoped `revision → RevisionInfo` cache**: committed revisions are immutable, so entries never need invalidation. Repeated history calls only pay I/O for revisions committed since the last call. Loop bounds still come from `getMostRecentRevisionNumber()`, so new commits always appear.
- **Cache misses read via `StorageEngineReader`** instead of `beginNodeReadOnlyTrx` — credentials + timestamp live on the `RevisionRootPage`; the node-cursor machinery was pure overhead.

### 2. `perf(rest-api)`: blocking work ran ON the Vert.x event loop
- `HistoryHandler` ran the database open + per-revision retrieval + JSON assembly inside `withContext(vertx.dispatcher())` — **on the event loop**, unlike every other handler. A slow history request stalled the loop and queued **every concurrent request** behind it (including query-editor calls) — making everything feel slow, not just history.
- `AbstractGetHandler` had the same bug one level down: query evaluation/serialization already offload via `executeBlocking`, but the database open, resource-session open and revision(-timestamp) resolution ran on the event loop.

Both now run on `Dispatchers.IO` (the codebase's established pattern); responses are written back on the Vert.x context.

### 3. `fix(axis)`: redundant double-close in `AllTimeAxis` prefix scan (drive-by).

## Test evidence (local)
- New test `testGetHistoryIsStableAcrossCallsAndSeesNewCommits` — guards the two semantics the cache must preserve (identical metadata across calls; **new commits visible after a cached call**; bounded calls still ordered).
- `JsonMultiRevisionTest` 15/15 (incl. existing `getHistory` assertions), `UpdateTest` 40/40, `AllTimeAxisTest` 3/3, `PrefetchedAllTimeAxisTest` 5/5, `PastAxisTest` 4/4 — 0 failures.
- `sirix-core` + `sirix-rest-api` compile clean.