### PR TITLE
release: 1.0.0-alpha20 — node-history/query latency (event-loop blocking + uncached history)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha19
+version=1.0.0-alpha20
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
Version bump for the perf work merged in #1021:

- **rest-api**: `HistoryHandler`/`AbstractGetHandler` ran blocking I/O on the Vert.x event loop, so one slow history/get request queued every concurrent request behind it (query-editor calls included). Now on `Dispatchers.IO`.
- **core**: `getHistory` no longer opens a full `NodeReadOnlyTrx` per revision per call — commit metadata is read via a `StorageEngineReader` and cached per session (immutable once committed; new commits still appear since loop bounds come from `getMostRecentRevisionNumber()`).
- **core**: dropped a redundant double-close in `AllTimeAxis`.

Tag `sirix-1.0.0-alpha20` to follow on the merge commit.