### PR TITLE
release: 1.0.0-alpha21 — flaky UberPage test + invalid-JSON named-projection fixes

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/file/FileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/file/FileReader.java
@@ -128,6 +128,25 @@ public final class FileReader implements Reader {
     this.cache = cache;
   }
 
+  /**
+   * Validate a page's declared data-length header before it is used to size an allocation.
+   *
+   * <p>The length is read straight from the file; on a corrupt or garbled beacon/page it can be any
+   * 32-bit value. A negative value would throw {@link NegativeArraySizeException}, but a large
+   * positive value (e.g. random bytes read as ~2 GiB) used in {@code new byte[dataLength]} triggers
+   * a multi-gigabyte allocation that OOMs or stalls the JVM in GC instead of failing fast — which is
+   * exactly what made {@code UberPageCorruptionTest} flaky (it timed out the CI worker on some
+   * machines). A page can never be longer than the file that contains it, so bound it by the file
+   * length and fail fast with a clear exception.
+   */
+  private void checkDataLength(final int dataLength) throws IOException {
+    final long fileLength = dataFile.length();
+    if (dataLength < 0 || dataLength > fileLength) {
+      throw new SirixIOException("Corrupt page reference: declared data length " + dataLength
+          + " is out of bounds for a data file of " + fileLength + " bytes.");
+    }
+  }
+
   @Override
   public Page read(final PageReference reference,
       final @Nullable ResourceConfiguration resourceConfiguration) {
@@ -135,7 +154,7 @@ public final class FileReader implements Reader {
       // Read page from file.
       dataFile.seek(reference.getKey());
       final int dataLength = dataFile.readInt();
-      // reference.setLength(dataLength + FileReader.OTHER_BEACON);
+      checkDataLength(dataLength);
       final byte[] page = new byte[dataLength];
       dataFile.read(page);
 
@@ -233,6 +252,7 @@ public final class FileReader implements Reader {
       dataFile.seek(offsetIntoDataFile);
 
       final int dataLength = dataFile.readInt();
+      checkDataLength(dataLength);
       final byte[] page = new byte[dataLength];
       dataFile.read(page);
 

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -158,6 +158,22 @@ public final class FileChannelReader extends AbstractReader {
     this.cache = cache;
   }
 
+  /**
+   * Validate a page's declared data-length header before it is used to size an allocation
+   * ({@link #acquireBuffer} / {@code new byte[dataLength]}). The length is read straight from the
+   * file, so a corrupt or garbled beacon/page can present any 32-bit value; a large positive one
+   * (e.g. random bytes read as ~2 GiB) would trigger a multi-gigabyte allocation that OOMs or
+   * stalls the JVM in GC instead of failing fast — the cause of {@code UberPageCorruptionTest}
+   * flakiness. A page can never be longer than the file that contains it, so bound it accordingly.
+   */
+  private void checkDataLength(final int dataLength) throws IOException {
+    final long fileSize = dataFileChannel.size();
+    if (dataLength < 0 || dataLength > fileSize) {
+      throw new SirixIOException("Corrupt page reference: declared data length " + dataLength
+          + " is out of bounds for a data file of " + fileSize + " bytes.");
+    }
+  }
+
   public Page read(final PageReference reference,
       final @Nullable ResourceConfiguration resourceConfiguration) {
     // First pread: 4-byte length header. Uses a pooled buffer so we can size the
@@ -170,6 +186,7 @@ public final class FileChannelReader extends AbstractReader {
       dataFileChannel.read(buffer, position);
       buffer.flip();
       final int dataLength = buffer.getInt();
+      checkDataLength(dataLength);
 
       // If the header-probe buffer is too small for the page body, swap it for a
       // right-sized one. The rare-extra-alloc branch returns the old buffer to the
@@ -245,6 +262,7 @@ public final class FileChannelReader extends AbstractReader {
       dataFileChannel.read(buffer, dataFileOffset);
       buffer.flip();
       final int dataLength = buffer.getInt();
+      checkDataLength(dataLength);
 
       if (buffer.capacity() < dataLength) {
         final ByteBuffer grown = acquireBuffer(dataLength);

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -92,6 +92,12 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
   private final boolean serializeTimestamp;
 
+  /**
+   * Set per revision-start when the result node is a single fused named member, so the matching
+   * revision-end closes the object we wrapped it in. See {@link #emitRevisionStartNode}.
+   */
+  private boolean wrapRevisionResultInObject;
+
   private final boolean withMetaData;
 
   private final boolean withNodeKeyMetaData;
@@ -668,6 +674,26 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
         appendObjectKey(quote("revision"));
 
+        // A query result that IS a single fused named member (e.g. `.products[1].id`, an
+        // OBJECT_NAMED_STRING) serializes inline as a bare `"name":value` fragment. Emitted
+        // straight after `"revision":` that produces invalid JSON (`"revision":"id":"…"`), so wrap
+        // such a result in an object → `"revision":{"id":"…"}`. Only in the non-metadata path:
+        // with metadata the named node already emits a full `{key,metadata,value}` object.
+        //
+        // The framework only moves rtx to the result node AFTER this callback (see
+        // AbstractSerializer), so peek at the start node's kind here and restore the cursor.
+        wrapRevisionResultInObject = false;
+        if (!withMetaDataField() && startNodeKey != Fixed.NULL_NODE_KEY.getStandardProperty()) {
+          final long cursorKey = rtx.getNodeKey();
+          if (rtx.moveTo(startNodeKey)) {
+            wrapRevisionResultInObject = isFusedNamedMember(rtx.getKind());
+          }
+          rtx.moveTo(cursorKey);
+        }
+        if (wrapRevisionResultInObject) {
+          appendObjectStart(true);
+        }
+
         if (rtx.hasFirstChild()) {
           stack.push(Constants.NULL_ID_LONG);
         }
@@ -675,6 +701,15 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
     } catch (final IOException e) {
       LOGWRAPPER.error(e.getMessage(), e);
     }
+  }
+
+  /** Fused records whose inline serialization begins with an object key (`"name":…`). */
+  private static boolean isFusedNamedMember(final NodeKind kind) {
+    return switch (kind) {
+      case OBJECT_NAMED_OBJECT, OBJECT_NAMED_ARRAY, OBJECT_NAMED_BOOLEAN, OBJECT_NAMED_NUMBER,
+           OBJECT_NAMED_STRING, OBJECT_NAMED_NULL -> true;
+      default -> false;
+    };
   }
 
   @Override
@@ -687,6 +722,12 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
       if (emitXQueryResultSequence || length > 1) {
         if (rtx.moveToDocumentRoot() && rtx.hasFirstChild() && !stack.isEmpty())
           stack.popLong();
+        // Close the object we wrapped a single named-member result in (see emitRevisionStartNode),
+        // before closing the outer revision-metadata object.
+        if (wrapRevisionResultInObject) {
+          appendObjectEnd(true);
+          wrapRevisionResultInObject = false;
+        }
         appendObjectEnd(rtx.hasChildren());
 
         if (hasMoreRevisionsToSerialize(rtx))

--- a/bundles/sirix-core/src/test/java/io/sirix/io/UberPageCorruptionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/UberPageCorruptionTest.java
@@ -23,12 +23,14 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -299,6 +301,26 @@ class UberPageCorruptionTest {
     }
 
     @Test
+    @DisplayName("Huge data length header on BOTH beacons is rejected fast (no OOM/hang)")
+    void hugeLengthHeaderBothBeaconsFailsFast() {
+      // Regression guard for the flakiness this fix addresses: a corrupt length header read as a
+      // huge positive int was used directly in new byte[dataLength] / a ByteBuffer allocation,
+      // triggering a multi-gigabyte allocation that OOM'd or stalled the JVM in GC and timed out
+      // the CI worker — instead of failing fast. The reader now bounds the length by the data-file
+      // size, so this must throw promptly. The preemptive timeout pins "promptly": if the bound
+      // ever regresses this test fails on its own instead of hanging the whole suite.
+      assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
+        writeValidUberPage();
+        final Path dataFile = getDataFilePath();
+        writeNativeInt(dataFile, 0, Integer.MAX_VALUE);
+        writeNativeInt(dataFile, SECOND_BEACON_OFFSET, Integer.MAX_VALUE);
+
+        assertThrows(Exception.class, () -> readUberPage(),
+            "A ~2 GiB declared data length on both beacons must be rejected, not allocated");
+      });
+    }
+
+    @Test
     @DisplayName("Shortened data length on BOTH beacons truncates compressed frame")
     void shortenedLengthHeaderBothBeacons() throws IOException {
       writeValidUberPage();
@@ -439,32 +461,43 @@ class UberPageCorruptionTest {
 
     @Test
     @DisplayName("Both beacons overwritten with zeros causes unrecoverable failure")
-    void bothBeaconsZeroed() throws IOException {
-      writeValidUberPage();
-      // Zero out the entire beacon area (both copies)
-      try (final RandomAccessFile raf = new RandomAccessFile(getDataFilePath().toFile(), "rw")) {
-        raf.seek(0);
-        raf.write(new byte[IOStorage.FIRST_BEACON]);
-      }
+    void bothBeaconsZeroed() {
+      // Bounded: a zeroed length header is benign, but keep the same timeout guard as the garbage
+      // case so neither beacon-area corruption test can ever hang the suite if a regression makes
+      // a header drive an unbounded allocation again.
+      assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
+        writeValidUberPage();
+        // Zero out the entire beacon area (both copies)
+        try (final RandomAccessFile raf = new RandomAccessFile(getDataFilePath().toFile(), "rw")) {
+          raf.seek(0);
+          raf.write(new byte[IOStorage.FIRST_BEACON]);
+        }
 
-      assertThrows(Exception.class, () -> readUberPage(),
-          "Both beacons zeroed must cause an unrecoverable read failure");
+        assertThrows(Exception.class, () -> readUberPage(),
+            "Both beacons zeroed must cause an unrecoverable read failure");
+      });
     }
 
     @Test
     @DisplayName("Both beacons overwritten with random garbage causes unrecoverable failure")
-    void bothBeaconsGarbage() throws IOException {
-      writeValidUberPage();
-      final byte[] garbage = new byte[IOStorage.FIRST_BEACON];
-      new Random(0xCAFE).nextBytes(garbage);
+    void bothBeaconsGarbage() {
+      // This is the test that was flaky: the fixed-seed garbage's first 4 bytes read as a large
+      // positive length header drove a multi-gigabyte allocation that OOM'd/stalled the JVM and
+      // timed out CI on lower-memory runners. With the reader now bounding the length, it must
+      // throw promptly; the preemptive timeout keeps a future regression from hanging the suite.
+      assertTimeoutPreemptively(Duration.ofSeconds(15), () -> {
+        writeValidUberPage();
+        final byte[] garbage = new byte[IOStorage.FIRST_BEACON];
+        new Random(0xCAFE).nextBytes(garbage);
 
-      try (final RandomAccessFile raf = new RandomAccessFile(getDataFilePath().toFile(), "rw")) {
-        raf.seek(0);
-        raf.write(garbage);
-      }
+        try (final RandomAccessFile raf = new RandomAccessFile(getDataFilePath().toFile(), "rw")) {
+          raf.seek(0);
+          raf.write(garbage);
+        }
 
-      assertThrows(Exception.class, () -> readUberPage(),
-          "Both beacons garbled must cause an unrecoverable read failure");
+        assertThrows(Exception.class, () -> readUberPage(),
+            "Both beacons garbled must cause an unrecoverable read failure");
+      });
     }
   }
 

--- a/bundles/sirix-query/src/test/java/io/sirix/query/NamedProjectionSerializationTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/NamedProjectionSerializationTest.java
@@ -1,0 +1,88 @@
+package io.sirix.query;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.brackit.query.Query;
+import io.sirix.JsonTestHelper;
+import io.sirix.query.json.BasicJsonDBStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for serializing a query result that IS a single fused named member through
+ * {@link JsonDBSerializer} (the REST path: {@code isXQueryResultSequence().serializeTimestamp(true)}).
+ *
+ * <p>The bug: a projection like {@code jn:doc(...).products[0].id} yields an {@code OBJECT_NAMED_*}
+ * node, which serializes inline as a bare {@code "name":value} fragment. Emitted directly after the
+ * {@code "revision":} key of the result-metadata wrapper that produced INVALID JSON —
+ * {@code {"revisionNumber":N,...,"revision":"id":"A"}} (two colons). The serializer now wraps such a
+ * result in an object: {@code "revision":{"id":"A"}}.
+ */
+public final class NamedProjectionSerializationTest {
+
+  private static final Path PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  private static final String STORE =
+      "jn:store('json-path1','mydoc.jn','"
+          + "{\"products\":[{\"id\":\"A\",\"price\":10},{\"id\":\"B\",\"price\":20}]}')";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  /** Serialize a query exactly as the REST API does (JsonDBSerializer wraps in {@code {"rest":[…]}}). */
+  private String serializeViaRest(final String query) throws IOException {
+    try (final var store = BasicJsonDBStore.newBuilder().location(PATH.getParent()).build();
+        final var ctx = SirixQueryContext.createWithJsonStore(store);
+        final var chain = SirixCompileChain.createWithJsonStore(store)) {
+      new Query(chain, STORE).evaluate(ctx);
+      final var sb = new StringBuilder();
+      new Query(chain, query).serialize(ctx, new JsonDBSerializer(sb, false));
+      return sb.toString();
+    }
+  }
+
+  private static JsonObject firstResult(final String serialized) {
+    final var rest = JsonParser.parseString(serialized).getAsJsonObject().getAsJsonArray("rest");
+    assertEquals(1, rest.size(), "expected exactly one result item");
+    return rest.get(0).getAsJsonObject();
+  }
+
+  @Test
+  void namedStringProjectionSerializesAsValidJson() throws IOException {
+    // Index is 0-based: products[0].id == "A".
+    final var item = firstResult(serializeViaRest("jn:doc('json-path1','mydoc.jn').products[0].id"));
+    assertTrue(item.get("revision").isJsonObject(),
+        "a named-member result must be wrapped in an object, not emitted as a bare member");
+    assertEquals("A", item.getAsJsonObject("revision").get("id").getAsString());
+  }
+
+  @Test
+  void namedNumberProjectionSerializesAsValidJson() throws IOException {
+    final var item = firstResult(serializeViaRest("jn:doc('json-path1','mydoc.jn').products[1].price"));
+    assertTrue(item.get("revision").isJsonObject());
+    assertEquals(20, item.getAsJsonObject("revision").get("price").getAsInt());
+  }
+
+  @Test
+  void wholeObjectProjectionStillSerializesAsValidJson() throws IOException {
+    // The non-named case (an unnamed object) must remain a plain object value, unchanged.
+    final var item = firstResult(serializeViaRest("jn:doc('json-path1','mydoc.jn').products[0]"));
+    final var revision = item.getAsJsonObject("revision");
+    assertEquals("A", revision.get("id").getAsString());
+    assertEquals(10, revision.get("price").getAsInt());
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-alpha20
+version=1.0.0-alpha21
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
Two fixes found during a Show-HN readiness pass on demo.sirix.io.

## 1. Flaky `UberPageCorruptionTest` (fix at the root)
`FileReader`/`FileChannelReader` used a 4-byte page data-length header read straight from the file to size `new byte[dataLength]` / a `ByteBuffer`. A corrupt beacon whose bytes read as a large positive int drove a multi-gigabyte allocation that OOM'd / GC-stalled the JVM rather than failing fast — timing out the CI worker on lower-memory runners (the flakiness). A page can't be longer than its file, so both readers now bound the length and throw fast. Tests: a deterministic huge-length case + `assertTimeoutPreemptively` guards so a regression fails fast instead of hanging the suite.

## 2. Invalid JSON on a single named-member projection
`jn:doc(...).products[1].id` (an `OBJECT_NAMED_STRING`) serialized as `{"revisionNumber":N,...,"revision":"id":"A"}` — invalid JSON (two colons), which the GUI query editor can't parse. `JsonSerializer` now wraps a single named-member result in an object → `"revision":{"id":"A"}`. Non-metadata path only; peeks at the start node's kind (the framework positions `rtx` on the result node only after `emitRevisionStartNode`). New `NamedProjectionSerializationTest` serializes via `JsonDBSerializer` like the REST API; correctness-sweep / diff / serializer fixtures unchanged.

Tag `sirix-1.0.0-alpha21` to follow on the merge commit.