### PR TITLE
Consolidate duplicated mechanisms from the hardening pass

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -601,8 +601,9 @@ final class JsonNodeTrxImpl extends
         //  - repairBulkInsertHashes = true: per-insert adaptation OFF uniformly; ONE postorder
         //    repair over the imported subtree at the end. Correct for ANY import size; costs a
         //    full subtree walk after the import (opt-in for exactly that reason).
-        final boolean repairAtEnd = isAutoCommitting && resourceSession.getResourceConfig().repairBulkInsertHashes;
-        if (isAutoCommitting && !repairAtEnd) {
+        final boolean perInsertHashAdaptation =
+            isAutoCommitting && !resourceSession.getResourceConfig().repairBulkInsertHashes;
+        if (perInsertHashAdaptation) {
           nodeHashing.setAutoCommit(true);
         }
         final long nodeKey = getNodeKey();
@@ -623,10 +624,10 @@ final class JsonNodeTrxImpl extends
 
         adaptUpdateOperationsForInsert(getDeweyID(), getNodeKey());
 
-        // Non-auto-committing bulk inserts always repair at the end (single-trx scope, upstream
-        // semantics — per-insert adaptation was skipped above via bulkInsert). Auto-committing
-        // ones repair only in the opt-in end-repair mode (see the mode comment above).
-        if (!isAutoCommitting || repairAtEnd) {
+        // Exactly one of the two modes runs (see the mode comment above): per-insert adaptation
+        // during the shred, or one postorder repair at the end (always for non-auto-committing
+        // bulk inserts — single-trx scope, upstream semantics — and opt-in for auto-committing).
+        if (!perInsertHashAdaptation) {
           adaptHashesInPostorderTraversal();
         }
 
@@ -647,6 +648,23 @@ final class JsonNodeTrxImpl extends
     return this;
   }
 
+  /**
+   * A bare (nameless) object/array can only be inserted under the document root, an array, or a
+   * fused OBJECT_NAMED_ARRAY (array role). Under fusion an OBJECT_NAMED_OBJECT's children are its
+   * inner object's NAMED fields, so a nameless child is invalid — and the legacy OBJECT_KEY
+   * special-casing either force-NULLed both sibling keys (ORPHANING the existing fields — silent
+   * data loss + childCount divergence) or chained the fields after the new node (a malformed
+   * object). Reject it, like the insertObjectRecordWith* and insertPrimitiveAsChild variants
+   * already do.
+   */
+  private static void rejectBareChildUnderObjectField(final NodeKind kind, final String what) {
+    if (kind == NodeKind.OBJECT_NAMED_OBJECT) {
+      throw new SirixUsageException(
+          "Inserting a bare " + what + " as the child of an object field is not supported. "
+              + "Use insertObjectRecordAs*/insertObjectRecordWith* to emit a named (fused) record.");
+    }
+  }
+
   @Override
   public JsonNodeTrx insertObjectAsFirstChild() {
     if (lock != null) {
@@ -656,17 +674,7 @@ final class JsonNodeTrxImpl extends
     try {
       final NodeKind kind = getKind();
 
-      // A bare (nameless) object can only be inserted under the document root, an array, or a
-      // fused OBJECT_NAMED_ARRAY (array role). Under fusion an OBJECT_NAMED_OBJECT's children are
-      // its inner object's NAMED fields, so a nameless object child is invalid — and the legacy
-      // OBJECT_KEY "set value" special-casing below force-NULLed both sibling keys, ORPHANING the
-      // existing fields (silent data loss + childCount divergence). Reject it, like
-      // insertObjectRecordWith*/insertPrimitiveAsChild already do.
-      if (kind == NodeKind.OBJECT_NAMED_OBJECT) {
-        throw new SirixUsageException(
-            "Inserting a bare object as the child of an object field is not supported. "
-                + "Use insertObjectRecordAs*/insertObjectRecordWith* to emit a named (fused) record.");
-      }
+      rejectBareChildUnderObjectField(kind, "object");
       if (kind != NodeKind.JSON_DOCUMENT && kind != NodeKind.ARRAY
           && kind != NodeKind.OBJECT_NAMED_ARRAY)
         throw new SirixUsageException(
@@ -720,17 +728,7 @@ final class JsonNodeTrxImpl extends
     try {
       final NodeKind kind = getKind();
 
-      // A bare (nameless) object can only be inserted under the document root, an array, or a
-      // fused OBJECT_NAMED_ARRAY (array role). Under fusion an OBJECT_NAMED_OBJECT's children are
-      // its inner object's NAMED fields, so a nameless object child is invalid — and the legacy
-      // OBJECT_KEY "set value" special-casing below force-NULLed both sibling keys, ORPHANING the
-      // existing fields (silent data loss + childCount divergence). Reject it, like
-      // insertObjectRecordWith*/insertPrimitiveAsChild already do.
-      if (kind == NodeKind.OBJECT_NAMED_OBJECT) {
-        throw new SirixUsageException(
-            "Inserting a bare object as the child of an object field is not supported. "
-                + "Use insertObjectRecordAs*/insertObjectRecordWith* to emit a named (fused) record.");
-      }
+      rejectBareChildUnderObjectField(kind, "object");
       if (kind != NodeKind.JSON_DOCUMENT && kind != NodeKind.ARRAY
           && kind != NodeKind.OBJECT_NAMED_ARRAY)
         throw new SirixUsageException(
@@ -1585,13 +1583,7 @@ final class JsonNodeTrxImpl extends
       final NodeKind kind = getKind();
       // OBJECT_NAMED_ARRAY plays the ARRAY role under fusion — its
       // first/last-child slot is the array body, exactly like ARRAY. Accept it.
-      // An OBJECT_NAMED_OBJECT's children are NAMED fields, so a bare array child is invalid
-      // (the old code chained the existing fields after the array — a malformed object). Reject.
-      if (kind == NodeKind.OBJECT_NAMED_OBJECT) {
-        throw new SirixUsageException(
-            "Inserting a bare array as the child of an object field is not supported. "
-                + "Use insertObjectRecordAs*/insertObjectRecordWith* to emit a named (fused) record.");
-      }
+      rejectBareChildUnderObjectField(kind, "array");
       if (kind != NodeKind.JSON_DOCUMENT && kind != NodeKind.ARRAY
           && kind != NodeKind.OBJECT_NAMED_ARRAY)
         throw new SirixUsageException(
@@ -1652,13 +1644,7 @@ final class JsonNodeTrxImpl extends
       final NodeKind kind = getKind();
       // OBJECT_NAMED_ARRAY plays the ARRAY role under fusion — its
       // first/last-child slot is the array body, exactly like ARRAY. Accept it.
-      // An OBJECT_NAMED_OBJECT's children are NAMED fields, so a bare array child is invalid
-      // (the old code chained the existing fields after the array — a malformed object). Reject.
-      if (kind == NodeKind.OBJECT_NAMED_OBJECT) {
-        throw new SirixUsageException(
-            "Inserting a bare array as the child of an object field is not supported. "
-                + "Use insertObjectRecordAs*/insertObjectRecordWith* to emit a named (fused) record.");
-      }
+      rejectBareChildUnderObjectField(kind, "array");
       if (kind != NodeKind.JSON_DOCUMENT && kind != NodeKind.ARRAY
           && kind != NodeKind.OBJECT_NAMED_ARRAY)
         throw new SirixUsageException(

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -188,9 +188,6 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    */
   private volatile java.util.concurrent.CompletableFuture<Void> pendingFsync;
 
-  /** Captured async-fsync failure from close(), rethrown after teardown (H3). */
-  private Throwable deferredCloseFailure;
-
   /**
    * {@link XmlIndexController} instance.
    */
@@ -1173,6 +1170,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
   @Override
   public void close() {
+    // Captured async-fsync failure, rethrown after teardown (H3) — see below.
+    Throwable deferredCloseFailure = null;
     if (!isClosed) {
       storageEngineReader.assertNotClosed();
 
@@ -1245,10 +1244,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // After completing teardown, surface a durability failure from the pending async fsync
     // (captured above) so the application learns the last commit may not be durable.
     if (deferredCloseFailure != null) {
-      final var failure = deferredCloseFailure;
-      deferredCloseFailure = null;
       throw new SirixIOException("Pending async fsync failed during close; last commit may not be durable",
-          failure);
+          deferredCloseFailure);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/PageCache.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/PageCache.java
@@ -121,15 +121,25 @@ public final class PageCache implements Cache<PageReference, Page> {
 
   @Override
   public Page get(PageReference key, BiFunction<? super PageReference, ? super Page, ? extends Page> mappingFunction) {
-    final Page page = cache.asMap().compute(key, mappingFunction);
-    // Enforce the same type policy as put(): revision-root/path-summary/path/CAS/name pages are
-    // mutable metadata that must not be shared via this cache — the compute path silently
-    // bypassed put()'s filter and cached exactly the kinds it refuses.
-    if (page instanceof RevisionRootPage || page instanceof PathSummaryPage || page instanceof PathPage
-        || page instanceof CASPage || page instanceof NamePage) {
-      cache.asMap().remove(key, page);
-    }
-    return page;
+    // Enforce the same type policy as put() without the old insert-then-remove churn: a
+    // disallowed page never enters the map, but the computed page is still returned.
+    final Page[] computed = new Page[1];
+    final Page cached = cache.asMap().compute(key, (k, v) -> {
+      final Page page = mappingFunction.apply(k, v);
+      computed[0] = page;
+      return isCacheablePageType(page) ? page : null;
+    });
+    return cached != null ? cached : computed[0];
+  }
+
+  /**
+   * Revision-root/path-summary/path/CAS/name pages are mutable metadata that must not be shared
+   * via this cache — ONE policy consulted by both {@link #put} and the compute path of
+   * {@link #get(PageReference, BiFunction)}.
+   */
+  private static boolean isCacheablePageType(final Page page) {
+    return page != null && !(page instanceof RevisionRootPage) && !(page instanceof PathSummaryPage)
+        && !(page instanceof PathPage) && !(page instanceof CASPage) && !(page instanceof NamePage);
   }
 
   @Override
@@ -169,8 +179,7 @@ public final class PageCache implements Cache<PageReference, Page> {
           "KeyValueLeafPages must not be stored in PageCache! Use RecordPageCache instead.");
     }
 
-    if (!(value instanceof RevisionRootPage) && !(value instanceof PathSummaryPage) && !(value instanceof PathPage)
-        && !(value instanceof CASPage) && !(value instanceof NamePage)) {
+    if (isCacheablePageType(value)) {
       assert key.getKey() != Constants.NULL_ID_LONG;
       cache.put(key, value);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
@@ -60,6 +60,24 @@ public interface IOStorage {
   int OTHER_BEACON = Integer.BYTES;
 
   /**
+   * Size in bytes of one revisions-file record (revision-root offset + timestamp, a long each).
+   */
+  int REVISIONS_FILE_RECORD_SIZE = 2 * Long.BYTES;
+
+  /**
+   * The revisions file is a fixed-slot array: record for {@code revision} lives at this offset.
+   * The SINGLE definition of the on-disk layout — every reader and writer must use it; a
+   * diverging hand-expanded formula is exactly the slot-shift corruption class the deterministic
+   * slots were introduced to prevent.
+   *
+   * @param revision revision number (0-based)
+   * @return byte offset of the revision's record in the revisions file
+   */
+  static long revisionsFileOffset(final int revision) {
+    return FIRST_BEACON + (long) revision * REVISIONS_FILE_RECORD_SIZE;
+  }
+
+  /**
    * Getting a writer.
    *
    * @return an {@link Writer} instance

--- a/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
@@ -529,8 +529,9 @@ public final class FFILz4Compressor implements ByteHandler {
           "Corrupt compressed page: payload shorter than its size header (" + compressed.byteSize() + " bytes)");
     }
     int sizeHeader = compressed.get(JAVA_INT_UNALIGNED, 0);
-    final long declaredSize = sizeHeader == Integer.MIN_VALUE ? -1L : Math.abs((long) sizeHeader);
-    if (declaredSize < 0 || declaredSize > MAX_DECOMPRESSED_SIZE) {
+    // abs over the WIDENED long is total (Integer.MIN_VALUE becomes +2^31, which the cap rejects).
+    final long declaredSize = Math.abs((long) sizeHeader);
+    if (declaredSize > MAX_DECOMPRESSED_SIZE) {
       throw new io.sirix.exception.SirixIOException(
           "Corrupt compressed page: implausible decompressed size " + sizeHeader);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/file/FileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/file/FileReader.java
@@ -274,7 +274,7 @@ public final class FileReader implements Reader {
   @Override
   public RevisionFileData getRevisionFileData(int revision) {
     try {
-      final var fileOffset = revision * 8 * 2 + IOStorage.FIRST_BEACON;
+      final var fileOffset = IOStorage.revisionsFileOffset(revision);
       revisionsOffsetFile.seek(fileOffset);
       final long offset = revisionsOffsetFile.readLong();
       revisionsOffsetFile.seek(fileOffset + 8);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/file/FileWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/file/FileWriter.java
@@ -143,7 +143,7 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
 
       // Drop revisions-file records beyond the target + stale cache entries (populated at
       // write time, before durability).
-      final long revisionsKeep = IOStorage.FIRST_BEACON + 16L * (revision + 1);
+      final long revisionsKeep = IOStorage.revisionsFileOffset(revision + 1);
       if (revisionsFile.length() > revisionsKeep) {
         revisionsFile.getChannel().truncate(revisionsKeep);
       }
@@ -230,10 +230,10 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
 
       if (type == SerializationType.DATA) {
         if (page instanceof RevisionRootPage revisionRootPage) {
-          // DETERMINISTIC slot matching the reader's formula (revision*16 + FIRST_BEACON):
-          // append-at-length shifted every later slot after a failed commit or a partial
-          // record from power loss (see FileChannelWriter for the full analysis).
-          revisionsFile.seek(IOStorage.FIRST_BEACON + (long) revisionRootPage.getRevision() * 16);
+          // DETERMINISTIC slot (the shared layout formula): append-at-length shifted every
+          // later slot after a failed commit or a partial record from power loss (see
+          // FileChannelWriter for the full analysis).
+          revisionsFile.seek(IOStorage.revisionsFileOffset(revisionRootPage.getRevision()));
           revisionsFile.writeLong(offset);
           final long currTimestamp = revisionRootPage.getRevisionTimestamp();
           revisionsFile.writeLong(currTimestamp);
@@ -278,10 +278,28 @@ public final class FileWriter extends AbstractForwardingReader implements Writer
   @Override
   public Writer writeUberPageReference(final ResourceConfiguration resourceConfiguration,
       final PageReference pageReference, final Page page, final BytesOut<?> bufferedBytes) {
-    isFirstUberPage = true;
-    writePageReference(resourceConfiguration, pageReference, page, 0);
-    isFirstUberPage = false;
-    writePageReference(resourceConfiguration, pageReference, page, 100);
+    try {
+      // WRITE-AHEAD BARRIER (durability parity with FileChannelWriter): make the revision data
+      // durable BEFORE any uber copy points at it — power loss otherwise persists an uber page
+      // referencing data that never reached disk.
+      dataFile.getFD().sync();
+
+      isFirstUberPage = true;
+      writePageReference(resourceConfiguration, pageReference, page, 0);
+
+      // ORDERED dual-copy (parity with FileChannelWriter): make the first copy (and its
+      // revisions-file beacons) durable before the second copy is touched, so at every instant
+      // at least one intact copy exists. The second copy is forced by the commit-end forceAll().
+      dataFile.getFD().sync();
+      if (revisionsFile != null) {
+        revisionsFile.getFD().sync();
+      }
+
+      isFirstUberPage = false;
+      writePageReference(resourceConfiguration, pageReference, page, 100);
+    } catch (final IOException e) {
+      throw new SirixIOException(e);
+    }
     return this;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -297,7 +297,7 @@ public final class FileChannelReader extends AbstractReader {
   @Override
   public RevisionFileData getRevisionFileData(int revision) {
     try {
-      final var fileOffset = revision * 8 * 2 + IOStorage.FIRST_BEACON;
+      final var fileOffset = IOStorage.revisionsFileOffset(revision);
       final ByteBuffer buffer = ByteBuffer.allocateDirect(16).order(ByteOrder.nativeOrder());
       revisionsOffsetFileChannel.read(buffer, fileOffset);
       buffer.position(8);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -174,7 +174,7 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       // leftover records from failed/rolled-back commits otherwise shift or shadow later
       // lookups — and drop now-stale cache entries (they were populated at WRITE time, before
       // durability).
-      final long revisionsKeep = IOStorage.FIRST_BEACON + 16L * (revision + 1);
+      final long revisionsKeep = IOStorage.revisionsFileOffset(revision + 1);
       if (revisionsFileChannel.size() > revisionsKeep) {
         revisionsFileChannel.truncate(revisionsKeep);
       }
@@ -358,15 +358,14 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
           buffer.position(8);
           buffer.putLong(revisionRootPage.getRevisionTimestamp());
           buffer.position(0);
-          // DETERMINISTIC slot, matching the readers' formula (revision*16 + FIRST_BEACON).
-          // The old append-at-file-size positioning agreed with that formula only while the
-          // file held exactly one record per committed revision: a commit that failed AFTER
-          // appending its record (rollback/truncateTo never touched this file), or a partial
-          // record from power loss, shifted EVERY later slot — all subsequent revision lookups
-          // returned garbage offsets, permanently. Writing at the formula's offset is identical
-          // in the happy path and self-healing after a failed attempt (the retry overwrites).
-          final long revisionsFileOffset =
-              IOStorage.FIRST_BEACON + (long) revisionRootPage.getRevision() * 16;
+          // DETERMINISTIC slot (the shared layout formula). The old append-at-file-size
+          // positioning agreed with it only while the file held exactly one record per
+          // committed revision: a commit that failed AFTER appending its record
+          // (rollback/truncateTo never touched this file), or a partial record from power
+          // loss, shifted EVERY later slot — all subsequent revision lookups returned garbage
+          // offsets, permanently. Writing at the formula's offset is identical in the happy
+          // path and self-healing after a failed attempt (the retry overwrites).
+          final long revisionsFileOffset = IOStorage.revisionsFileOffset(revisionRootPage.getRevision());
           while (buffer.hasRemaining()) {
             revisionsFileChannel.write(buffer, revisionsFileOffset + buffer.position());
           }

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonLimitedSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonLimitedSerializer.java
@@ -794,8 +794,9 @@ public final class JsonLimitedSerializer implements Callable<Void> {
     // named-member query result (`.products[0].id`) would serialize as the invalid bare fragment
     // `"revision":"id":"A"`. That is safe ONLY because the sole XQuery-result caller
     // (JsonDBSerializer) sets no maxLevel/maxChildren/maxNodes, so JsonSerializer.call() never
-    // delegates here for a result sequence. If a limited XQuery-result path is ever added, port the
-    // wrap from JsonSerializer#emitRevisionStartNode (+ its start-node bracket suppression).
+    // delegates here for a result sequence — and the delegation chokepoint now THROWS on that
+    // combination. To support it, port the wrap from JsonSerializer#emitRevisionStartNode
+    // (+ its start-node bracket suppression) and drop the guard.
     if (emitXQueryResultSequence || revisions.length > 1) {
       appendObjectStart(rtx.hasChildren())
                                           .appendObjectKeyValue(quote("revisionNumber"),

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -168,6 +168,15 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
     boolean hasNodeLimit = maxNodesLimit != Long.MAX_VALUE;
 
     if (hasLevelLimit || hasChildLimit || hasNodeLimit) {
+      // JsonLimitedSerializer has no wrapRevisionResultInObject step, so a LIMITED XQuery-result
+      // serialization would emit invalid JSON for single fused named-member results. No caller
+      // combines the two today — fail fast here (the delegation chokepoint) instead of silently
+      // producing an invalid document if one ever does.
+      if (emitXQueryResultSequence) {
+        throw new IllegalStateException(
+            "XQuery-result serialization with maxLevel/maxChildren/maxNodes limits is not supported: "
+                + "JsonLimitedSerializer lacks the named-member result wrap (see emitRevisionStartNode).");
+      }
       // Use JsonLimitedSerializer for proper limit handling
       JsonLimitedSerializer.Builder limitedBuilder =
           new JsonLimitedSerializer.Builder(resourceSession, out, revisions).startNodeKey(startNodeKey)

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/StringValue.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/StringValue.java
@@ -19,9 +19,19 @@ public final class StringValue {
 
   public static String escape(final String value) {
     final int len = value.length();
-    final StringBuilder sb = new StringBuilder(len + (len >> 3));
+    // Fast path: most strings need no escaping — return the SAME instance, zero allocation
+    // (this sits on the per-string-value serialization hot path).
+    int first = 0;
+    while (first < len && !needsEscape(value.charAt(first))) {
+      first++;
+    }
+    if (first == len) {
+      return value;
+    }
 
-    for (int i = 0; i < len; i++) {
+    final StringBuilder sb = new StringBuilder(len + (len >> 3));
+    sb.append(value, 0, first);
+    for (int i = first; i < len; i++) {
       final char ch = value.charAt(i);
       if (ch < 128) {
         final String replacement = ESCAPE_TABLE[ch];
@@ -39,6 +49,13 @@ public final class StringValue {
       }
     }
     return sb.toString();
+  }
+
+  private static boolean needsEscape(final char ch) {
+    if (ch < 128) {
+      return ESCAPE_TABLE[ch] != null || ch <= '\u001F';
+    }
+    return (ch >= '\u007F' && ch <= '\u009F') || (ch >= '\u2000' && ch <= '\u20FF');
   }
 
   private static void appendUnicodeEscape(final StringBuilder sb, final char ch) {

--- a/bundles/sirix-core/src/main/java/io/sirix/service/xml/shredder/XmlShredder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/xml/shredder/XmlShredder.java
@@ -249,8 +249,8 @@ public final class XmlShredder extends AbstractShredder implements Callable<Long
             // CDATA is handled here too — event readers that report distinct CDATA events
             // otherwise dropped the content entirely.
             sBuilder.append(event.asCharacters().getData());
-            if (reader.peek().getEventType() != XMLStreamConstants.CHARACTERS
-                && reader.peek().getEventType() != XMLStreamConstants.CDATA) {
+            final int nextEventType = reader.peek().getEventType();
+            if (nextEventType != XMLStreamConstants.CHARACTERS && nextEventType != XMLStreamConstants.CDATA) {
               processText(sBuilder.toString().trim());
               sBuilder.setLength(0);
             }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/JsonDBSerializer.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/JsonDBSerializer.java
@@ -38,6 +38,7 @@ import io.brackit.query.util.serialize.Serializer;
 import io.brackit.query.util.serialize.StringSerializer;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.serialize.StringValue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -111,7 +112,7 @@ public final class JsonDBSerializer implements Serializer, AutoCloseable {
               if (((Atomic) item).type() == Type.STR) {
                 // Escape the string value — a computed/literal string containing a quote or a
                 // control character would otherwise produce invalid JSON.
-                out.append("\"").append(escapeJson(item.toString())).append("\"");
+                out.append("\"").append(StringValue.escape(item.toString())).append("\"");
               } else {
                 out.append(item.toString());
               }
@@ -138,30 +139,6 @@ public final class JsonDBSerializer implements Serializer, AutoCloseable {
     }
   }
 
-  /** Escape {@code "}, {@code \} and C0 control characters for a JSON string. */
-  private static String escapeJson(final String s) {
-    final StringBuilder sb = new StringBuilder(s.length() + 8);
-    for (int i = 0; i < s.length(); i++) {
-      final char c = s.charAt(i);
-      switch (c) {
-        case '"' -> sb.append("\\\"");
-        case '\\' -> sb.append("\\\\");
-        case '\n' -> sb.append("\\n");
-        case '\r' -> sb.append("\\r");
-        case '\t' -> sb.append("\\t");
-        case '\b' -> sb.append("\\b");
-        case '\f' -> sb.append("\\f");
-        default -> {
-          if (c < 0x20) {
-            sb.append(String.format("\\u%04x", (int) c));
-          } else {
-            sb.append(c);
-          }
-        }
-      }
-    }
-    return sb.toString();
-  }
 
   private Item printCommaIfNextItemExists(Iter it) throws IOException {
     Item item = null;

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/sdb/trx/IsDeleted.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/sdb/trx/IsDeleted.java
@@ -8,9 +8,8 @@ import io.brackit.query.jdm.Sequence;
 import io.brackit.query.jdm.Signature;
 import io.brackit.query.module.StaticContext;
 import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.axis.temporal.RecordRevisionsLookup;
 import io.sirix.api.ResourceSession;
-import io.sirix.index.IndexType;
-import io.sirix.node.RevisionReferencesNode;
 import io.sirix.query.StructuredDBItem;
 import io.sirix.query.function.sdb.SDBFun;
 
@@ -52,15 +51,16 @@ public final class IsDeleted extends AbstractFunction {
     // a long-lived session when sdb:is-deleted was called repeatedly (ItemHistory closes
     // correctly; this function didn't).
     try (final NodeReadOnlyTrx rtxInMostRecentRevision = getTrx(resourceSession, mostRecentRevisionNumber)) {
-      final RevisionReferencesNode node =
-          rtxInMostRecentRevision.getStorageEngineReader().getRecord(item.getNodeKey(), IndexType.RECORD_TO_REVISIONS, 0);
+      // RecordRevisionsLookup owns the storeNodeHistory/stale-record guards — the previous raw
+      // getRecord + unchecked assignment threw a ClassCastException on resources without
+      // storeNodeHistory (the shared trie can return an unrelated record kind).
+      final int[] revisions = RecordRevisionsLookup.revisionsFor(rtxInMostRecentRevision, item.getNodeKey());
 
-      if (node == null) {
+      if (revisions == null) {
         return rtxInMostRecentRevision.moveTo(item.getNodeKey())
             ? Bool.FALSE
             : Bool.TRUE;
       } else {
-        final var revisions = node.getRevisions();
         final var mostRecentRevisionOfItem = revisions[revisions.length - 1];
         try (final NodeReadOnlyTrx rtxInMostRecentRevisionOfItem = getTrx(resourceSession, mostRecentRevisionOfItem)) {
           return rtxInMostRecentRevisionOfItem.moveTo(item.getNodeKey())

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/sdb/trx/ItemHistory.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/sdb/trx/ItemHistory.java
@@ -9,10 +9,9 @@ import io.brackit.query.jdm.Signature;
 import io.brackit.query.module.StaticContext;
 import io.brackit.query.sequence.ItemSequence;
 import io.sirix.api.NodeReadOnlyTrx;
+import io.sirix.axis.temporal.RecordRevisionsLookup;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.xml.XmlNodeReadOnlyTrx;
-import io.sirix.index.IndexType;
-import io.sirix.node.RevisionReferencesNode;
 import io.sirix.query.StructuredDBItem;
 import io.sirix.query.function.sdb.SDBFun;
 import io.sirix.query.json.JsonDBItem;
@@ -63,24 +62,16 @@ public final class ItemHistory extends AbstractFunction {
     final var resourceSession = rtx.getResourceSession();
     final NodeReadOnlyTrx rtxInMostRecentRevision = resourceSession.beginNodeReadOnlyTrx();
 
-    final RevisionReferencesNode node;
+    // RecordRevisionsLookup owns the storeNodeHistory/stale-record guards for the
+    // RECORD_TO_REVISIONS index — null means "no usable index entry", fall back to the scan.
+    final int[] indexedRevisions;
     try {
-      // Guarded like RecordRevisionsLookup.revisionsFor: resources without storeNodeHistory have
-      // no RECORD_TO_REVISIONS index, and the shared trie can return a stale/unrelated record —
-      // the unchecked cast then 500'd with a ClassCastException instead of falling back to the
-      // scan path below.
-      if (!resourceSession.getResourceConfig().storeNodeHistory()) {
-        node = null;
-      } else {
-        final var record = rtxInMostRecentRevision.getStorageEngineReader()
-            .getRecord(item.getNodeKey(), IndexType.RECORD_TO_REVISIONS, 0);
-        node = record instanceof RevisionReferencesNode rrn ? rrn : null;
-      }
+      indexedRevisions = RecordRevisionsLookup.revisionsFor(rtxInMostRecentRevision, item.getNodeKey());
     } finally {
       rtxInMostRecentRevision.close();
     }
 
-    if (node == null) {
+    if (indexedRevisions == null) {
       final Deque<Item> sequences = new ArrayDeque<>();
       final var itemResourceSession = item.getTrx().getResourceSession();
       int revision = itemResourceSession.getMostRecentRevisionNumber();
@@ -107,7 +98,7 @@ public final class ItemHistory extends AbstractFunction {
     } else {
       // Fast path: use RECORD_TO_REVISIONS index for the revision list,
       // then open all transactions concurrently using virtual threads.
-      final int[] revisions = node.getRevisions();
+      final int[] revisions = indexedRevisions;
       final long nodeKey = item.getNodeKey();
       final boolean isJson = item instanceof JsonDBItem;
       final JsonItemFactory jsonItemFactory = isJson ? new JsonItemFactory() : null;

--- a/bundles/sirix-rest-api/sirix-logs.txt
+++ b/bundles/sirix-rest-api/sirix-logs.txt
@@ -1,3 +1,5 @@
+ Network sirix-test_auth-network Creating 
+ Network sirix-test_auth-network Created 
  Container sirix-test-keycloak-1 Creating 
  Container sirix-test-keycloak-1 Created 
  Container sirix-test-keycloak-1 Starting 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractCreateHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractCreateHandler.kt
@@ -16,6 +16,8 @@ import io.sirix.access.trx.node.HashType
 import io.sirix.access.Databases
 import io.sirix.api.Database
 import io.sirix.api.ResourceSession
+import io.sirix.utils.LogWrapper
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -25,6 +27,7 @@ abstract class AbstractCreateHandler<T : ResourceSession<*, *>>(
 ) : Handler {
     companion object {
         protected const val MAX_NODES_TO_SERIALIZE = 5000
+        private val logger = LogWrapper(LoggerFactory.getLogger(AbstractCreateHandler::class.java))
     }
 
     override suspend fun handle(ctx: RoutingContext): Route {
@@ -65,7 +68,33 @@ abstract class AbstractCreateHandler<T : ResourceSession<*, *>>(
         }
     }
 
+    /**
+     * Runs [block] (the resource shred + serialization); on failure removes the just-created,
+     * half-built resource — which would otherwise stay listed and could 500 on GET — and rethrows
+     * so the client still sees the original failure. Shared failure-path policy for all create
+     * handlers.
+     */
+    protected suspend fun <R> withCleanupOnFailedShred(
+        database: Database<T>,
+        resPathName: String,
+        dispatcher: CoroutineDispatcher,
+        block: suspend () -> R
+    ): R {
+        try {
+            return block()
+        } catch (e: Exception) {
+            try {
+                withContext(dispatcher) { database.removeResource(resPathName) }
+            } catch (cleanup: Exception) {
+                logger.warn("Failed to clean up resource '$resPathName' after failed shred: ${cleanup.message}")
+            }
+            throw e
+        }
+    }
+
+
     suspend fun prepareDatabasePath(dbFile: Path, context: Context): DatabaseConfiguration? {
+
         return context.executeBlocking {
             val dbExists = Files.exists(dbFile)
 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractDeleteHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractDeleteHandler.kt
@@ -129,30 +129,17 @@ abstract class AbstractDeleteHandler(protected val location: Path) {
                 val wtx = manager.beginNodeTrx()
 
                 wtx.use {
-                    if (wtx.moveTo(nodeId)) {
-                        if (hashType(manager) != HashType.NONE && !wtx.isDocumentRoot) {
-                            // Standard "If-Match" accepted (preferred); legacy ETag header kept.
-                            val rawHash = routingCtx.request().getHeader("If-Match")
-                                ?: routingCtx.request().getHeader(HttpHeaders.ETAG)
-                                ?: throw IllegalStateException("Hash code is missing in If-Match (or legacy ETag) HTTP-Header.")
-                            val hashCode = rawHash.trim().removeSurrounding("\"")
+                    // Deleting a nonexistent node used to silently return success (204) — a client
+                    // whose target was already removed/replaced by a concurrent commit never
+                    // learned its precondition was stale.
+                    wtx.moveToOrNotFound(nodeId)
 
-                            if (wtx.hash != (hashCode.toLongOrNull()
-                                    ?: throw IllegalArgumentException("If-Match/ETag header must be the node hash (a long): '$rawHash'"))
-                            ) {
-                                throw IllegalArgumentException("Someone might have changed the resource in the meantime.")
-                            }
-                        }
-
-                        wtx.remove()
-                        wtx.commit()
-                    } else {
-                        // Deleting a nonexistent node silently returned success (204) — a client
-                        // whose target was already removed/replaced by a concurrent commit never
-                        // learned its precondition was stale (the ETag check above is unreachable
-                        // for an absent node).
-                        throw IllegalStateException("Node with ID $nodeId not found.")
+                    if (hashType(manager) != HashType.NONE && !wtx.isDocumentRoot) {
+                        checkNodeHashPrecondition(routingCtx, wtx.hash)
                     }
+
+                    wtx.remove()
+                    wtx.commit()
                 }
             }
         }.coAwait()

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractGetHandler.kt
@@ -166,13 +166,10 @@ abstract class AbstractGetHandler<T : ResourceSession<*, *>,
                         if (nodeId == null) {
                             rtx.moveToFirstChild()
                         } else {
-                            // moveTo on a nonexistent key returns false and leaves the cursor on
-                            // the document root — the context item then binds there: the JSON
-                            // path throws AssertionError (no doc-root case → HTTP 500) and the
-                            // XML path silently evaluates the query against the WRONG context.
-                            if (!rtx.moveTo(nodeId.toLong())) {
-                                throw IllegalStateException("Node with ID $nodeId not found.")
-                            }
+                            // An unchecked moveTo would bind the context item to the document
+                            // root: the JSON path throws AssertionError (HTTP 500) and the XML
+                            // path silently evaluates the query against the WRONG context.
+                            rtx.moveToOrNotFound(nodeId.toLong())
                         }
 
                         handleQueryExtra(rtx, dbCollection, queryCtx, jsonDBStore)

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractHeadHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractHeadHandler.kt
@@ -85,8 +85,7 @@ abstract class AbstractHeadHandler< T : ResourceSession<*, *>> (
     }
     private fun getRevisionNumber(rev: String?, revTimestamp: String?, manager: T): Int {
         return if (rev != null) {
-            // Bare toInt() turned "?revision=abc" into a generic 500 — it's a 400.
-            rev.toIntOrNull() ?: throw IllegalArgumentException("revision must be an integer: '$rev'")
+            requireIntParam("revision", rev)
         } else if (revTimestamp != null) {
             var revision = getRevisionNumber(manager, revTimestamp)
             if (revision == 0) {

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractUpdateHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/AbstractUpdateHandler.kt
@@ -24,9 +24,7 @@ abstract class AbstractUpdateHandler(protected val location: Path) {
 
         // A non-numeric nodeId must be a client error — toLongOrNull silently degraded
         // "?nodeId=abc" to "no nodeId", redirecting the update to the document root.
-        val nodeIdAsLong = nodeId?.let {
-            it.toLongOrNull() ?: throw IllegalArgumentException("nodeId must be a long: '$it'")
-        }
+        val nodeIdAsLong = nodeId?.let { requireLongParam("nodeId", it) }
 
         update(databaseName, resource, nodeIdAsLong, insertionMode, body, ctx)
 
@@ -58,18 +56,7 @@ abstract class AbstractUpdateHandler(protected val location: Path) {
      */
     protected fun checkHashCode(ctx: RoutingContext, wtx: NodeTrx, resourceConfig: ResourceConfiguration) {
         if (resourceConfig.hashType != HashType.NONE && !wtx.isDocumentRoot) {
-            // Standard "If-Match" is now accepted (preferred); the legacy use of the request
-            // "ETag" header stays for compatibility. Strip the optional RFC 7232 quotes.
-            val rawHash = ctx.request().getHeader("If-Match")
-                ?: ctx.request().getHeader(HttpHeaders.ETAG)
-                ?: throw IllegalStateException("Hash code is missing in If-Match (or legacy ETag) HTTP-Header.")
-            val hashCode = rawHash.trim().removeSurrounding("\"")
-
-            if (wtx.hash != (hashCode.toLongOrNull()
-                    ?: throw IllegalArgumentException("If-Match/ETag header must be the node hash (a long): '$rawHash'"))
-            ) {
-                throw IllegalArgumentException("Someone might have changed the resource in the meantime.")
-            }
+            checkNodeHashPrecondition(ctx, wtx.hash)
         }
     }
 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/DiffHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/DiffHandler.kt
@@ -69,10 +69,8 @@ class DiffHandler(private val location: Path, private val authz: AuthorizationPr
                         // Validate revision numbers and ordering up front: non-numeric input would
                         // 500 on toInt(), and a reversed pair silently produced a "backwards" diff
                         // (old=second, new=first) instead of an error.
-                        val firstRevisionNumber = firstRevision.toIntOrNull()
-                            ?: throw IllegalArgumentException("first-revision must be an integer.")
-                        val secondRevisionNumber = secondRevision.toIntOrNull()
-                            ?: throw IllegalArgumentException("second-revision must be an integer.")
+                        val firstRevisionNumber = requireIntParam("first-revision", firstRevision)
+                        val secondRevisionNumber = requireIntParam("second-revision", secondRevision)
                         if (firstRevisionNumber < 1 || secondRevisionNumber < 1) {
                             throw IllegalArgumentException("Revisions must be >= 1.")
                         }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HandlerPreconditions.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HandlerPreconditions.kt
@@ -1,0 +1,49 @@
+package io.sirix.rest.crud
+
+import io.sirix.api.NodeCursor
+import io.vertx.core.http.HttpHeaders
+import io.vertx.ext.web.RoutingContext
+
+/**
+ * Shared parse-and-precondition helpers for the REST handlers. The failure handler maps
+ * [IllegalArgumentException] to 400 and [IllegalStateException] to a client-visible error, so a
+ * malformed parameter or stale precondition never surfaces as a 500.
+ */
+
+/** Parse-or-400 for integer params — `toInt()` on user input 500s on garbage. */
+fun requireIntParam(name: String, value: String): Int =
+    value.toIntOrNull() ?: throw IllegalArgumentException("$name must be an integer: '$value'")
+
+/** Parse-or-400 for long params. */
+fun requireLongParam(name: String, value: String): Long =
+    value.toLongOrNull() ?: throw IllegalArgumentException("$name must be a long: '$value'")
+
+/**
+ * Optimistic-concurrency precondition shared by the update and delete paths: the standard
+ * "If-Match" header (preferred) or the legacy request-"ETag" header must carry the node hash
+ * (RFC 7232 quotes are stripped). Callers gate on hashType/document-root themselves — see the
+ * design-gap note on AbstractUpdateHandler.checkHashCode.
+ */
+fun checkNodeHashPrecondition(ctx: RoutingContext, actualHash: Long) {
+    val rawHash = ctx.request().getHeader("If-Match")
+        ?: ctx.request().getHeader(HttpHeaders.ETAG)
+        ?: throw IllegalStateException("Hash code is missing in If-Match (or legacy ETag) HTTP-Header.")
+    val hashCode = rawHash.trim().removeSurrounding("\"")
+
+    if (actualHash != (hashCode.toLongOrNull()
+            ?: throw IllegalArgumentException("If-Match/ETag header must be the node hash (a long): '$rawHash'"))
+    ) {
+        throw IllegalArgumentException("Someone might have changed the resource in the meantime.")
+    }
+}
+
+/**
+ * Move the cursor to the node or fail with a client-visible "not found": moveTo on a missing key
+ * returns false and LEAVES THE CURSOR ON THE DOCUMENT ROOT, so an unchecked call silently
+ * operates on an unrelated position (the bug class every handler used to have independently).
+ */
+fun NodeCursor.moveToOrNotFound(nodeId: Long) {
+    if (!moveTo(nodeId)) {
+        throw IllegalStateException("Node with ID $nodeId not found.")
+    }
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HistoryHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/HistoryHandler.kt
@@ -57,15 +57,14 @@ class HistoryHandler(private val location: Path, private val authz: Authorizatio
                         if (startRevision.isEmpty() && endRevision.isEmpty()) {
                             manager.history
                         } else {
-                            val startRevisionAsInt = startRevision.getOrNull(0)?.toIntOrNull()
-                                ?: throw IllegalArgumentException("startRevision must be an integer.")
-                            val endRevisionAsInt = endRevision.getOrNull(0)?.toIntOrNull()
-                                ?: throw IllegalArgumentException("endRevision must be an integer.")
+                            val startRevisionAsInt =
+                                requireIntParam("startRevision", startRevision.getOrNull(0) ?: "")
+                            val endRevisionAsInt =
+                                requireIntParam("endRevision", endRevision.getOrNull(0) ?: "")
                             manager.getHistory(startRevisionAsInt, endRevisionAsInt)
                         }
                     } else {
-                        val revisions = numberOfRevisions[0].toIntOrNull()
-                            ?: throw IllegalArgumentException("revisions must be an integer.")
+                        val revisions = requireIntParam("revisions", numberOfRevisions[0])
                         manager.getHistory(revisions)
                     }
 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/PathSummaryHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/PathSummaryHandler.kt
@@ -45,9 +45,7 @@ class PathSummaryHandler(private val location: Path, private val authz: Authoriz
                         val revision = ctx.queryParam("revision").getOrNull(0)
 
                         val pathSummary = if (revision != null) {
-                            // Bare toInt() turned "?revision=abc" into a generic 500 — it's a 400.
-                            val revisionNumber = revision.toIntOrNull()
-                                ?: throw IllegalArgumentException("revision must be an integer: '$revision'")
+                            val revisionNumber = requireIntParam("revision", revision)
                             manager.openPathSummary(revisionNumber)
                         } else {
                             manager.openPathSummary()

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/Revisions.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/Revisions.kt
@@ -41,8 +41,7 @@ class Revisions {
                 // Validate instead of bare toInt(): "?revision=abc" previously threw a
                 // NumberFormatException mapped to a generic 500, and out-of-range numbers
                 // surfaced as low-level transaction errors. Both are client errors (400).
-                val revisionNumber = rev.toIntOrNull()
-                    ?: throw IllegalArgumentException("revision must be an integer: '$rev'")
+                val revisionNumber = requireIntParam("revision", rev)
                 if (revisionNumber < 1 || revisionNumber > manager.mostRecentRevisionNumber) {
                     throw IllegalArgumentException(
                         "revision $revisionNumber out of range [1, ${manager.mostRecentRevisionNumber}]"
@@ -120,24 +119,26 @@ class Revisions {
             if (firstRevisionNumber == 0) ++firstRevisionNumber
             if (lastRevisionNumber == 0) ++lastRevisionNumber
 
-            return (firstRevisionNumber..lastRevisionNumber).toSet().toIntArray()
+            return ascendingRevisionArray(firstRevisionNumber, lastRevisionNumber)
         }
+
+        /** An ascending int range is already distinct and ordered — no boxing/Set detour needed. */
+        private fun ascendingRevisionArray(start: Int, end: Int): IntArray =
+            if (end < start) IntArray(0) else IntArray(end - start + 1) { start + it }
 
         private fun parseIntRevisions(startRevision: String, endRevision: String): IntArray {
             // Validate: non-numeric input 500'd, an inverted range silently produced an empty set,
             // and a huge end allocated an enormous IntArray. The range is clamped by the CALLER's
             // semantics (revisions beyond mostRecent fail downstream), so just bound the basics.
-            val start = startRevision.toIntOrNull()
-                ?: throw IllegalArgumentException("start-revision must be an integer: '$startRevision'")
-            val end = endRevision.toIntOrNull()
-                ?: throw IllegalArgumentException("end-revision must be an integer: '$endRevision'")
+            val start = requireIntParam("start-revision", startRevision)
+            val end = requireIntParam("end-revision", endRevision)
             if (start < 1 || end < start) {
                 throw IllegalArgumentException("invalid revision range [$start, $end]")
             }
             if (end - start > 1_000_000) {
                 throw IllegalArgumentException("revision range too large: ${end - start + 1} revisions")
             }
-            return (start..end).toSet().toIntArray()
+            return ascendingRevisionArray(start, end)
         }
 
         private fun parseTimestampRevisions(

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
@@ -20,14 +20,11 @@ import io.sirix.rest.crud.Revisions
 import io.sirix.rest.crud.SirixDBUser
 import io.sirix.service.json.serialize.JsonSerializer
 import io.sirix.service.json.shredder.JsonShredder
-import io.sirix.utils.LogWrapper
-import org.slf4j.LoggerFactory
 import java.io.File
 import java.io.StringWriter
 import java.nio.file.Path
 
 
-private val logger = LogWrapper(LoggerFactory.getLogger(JsonCreate::class.java))
 
 class JsonCreate(
     location: Path,
@@ -104,7 +101,7 @@ class JsonCreate(
 
                 createOrRemoveAndCreateResource(database, resConfig, resPathName, dispatcher)
 
-                try {
+                withCleanupOnFailedShred(database, resPathName, dispatcher) {
                     val manager = database.beginResourceSession(resPathName)
 
                     manager.use {
@@ -116,17 +113,6 @@ class JsonCreate(
                             ctx.response().setStatusCode(200)
                         }
                     }
-                } catch (e: Exception) {
-                    // The resource was created above but the body shred failed (malformed JSON,
-                    // client disconnect mid-stream, ...). Without cleanup the empty half-built
-                    // resource stays listed and a GET of it can 500. Remove it and rethrow so the
-                    // client still sees the failure.
-                    try {
-                        withContext(dispatcher) { database.removeResource(resPathName) }
-                    } catch (cleanup: Exception) {
-                        logger.warn("Failed to clean up resource '$resPathName' after failed shred: ${cleanup.message}")
-                    }
-                    throw e
                 }
             }
 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonUpdate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonUpdate.kt
@@ -18,6 +18,7 @@ import java.io.StringWriter
 import java.nio.file.Path
 import java.time.Instant
 import java.util.*
+import io.sirix.rest.crud.moveToOrNotFound
 
 
 @Suppress("unused")
@@ -316,12 +317,7 @@ class JsonUpdate(location: Path) :
                     val revision = wtx.revisionNumber
                     val (maxNodeKey, hash) = wtx.use {
                         if (nodeId != null) {
-                            // moveTo on a nonexistent key returns false and LEAVES THE CURSOR ON THE
-                            // DOCUMENT ROOT — the fallback below would then silently commit the
-                            // payload at the root's first child (an unrelated position) with a 200.
-                            if (!wtx.moveTo(nodeId)) {
-                                throw IllegalStateException("Node with ID $nodeId not found.")
-                            }
+                            wtx.moveToOrNotFound(nodeId)
                         }
 
                         if (wtx.isDocumentRoot && wtx.hasFirstChild()) {

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlCreate.kt
@@ -19,15 +19,12 @@ import io.sirix.rest.crud.Revisions
 import io.sirix.rest.crud.SirixDBUser
 import io.sirix.service.xml.serialize.XmlSerializer
 import io.sirix.service.xml.shredder.XmlShredder
-import io.sirix.utils.LogWrapper
-import org.slf4j.LoggerFactory
 import java.io.ByteArrayOutputStream
 import java.io.FileInputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.*
 
-private val logger = LogWrapper(LoggerFactory.getLogger(XmlCreate::class.java))
 
 class XmlCreate(
     location: Path,
@@ -68,28 +65,20 @@ class XmlCreate(
                         .customCommitTimestamps(commitTimestampAsString != null).build()
                 createOrRemoveAndCreateResource(database, resConfig, resPathName, dispatcher)
                 try {
-                    val manager = database.beginResourceSession(resPathName)
+                    withCleanupOnFailedShred(database, resPathName, dispatcher) {
+                        val manager = database.beginResourceSession(resPathName)
 
-                    manager.use {
-                        val maxNodeKey =
-                            insertResourceSubtreeAsFirstChild(manager, tempFilePath.toAbsolutePath(), ctx)
+                        manager.use {
+                            val maxNodeKey =
+                                insertResourceSubtreeAsFirstChild(manager, tempFilePath.toAbsolutePath(), ctx)
 
-                        if (maxNodeKey < MAX_NODES_TO_SERIALIZE) {
-                            body = serializeResource(manager, ctx)
-                        } else {
-                            ctx.response().setStatusCode(200)
+                            if (maxNodeKey < MAX_NODES_TO_SERIALIZE) {
+                                body = serializeResource(manager, ctx)
+                            } else {
+                                ctx.response().setStatusCode(200)
+                            }
                         }
                     }
-                } catch (e: Exception) {
-                    // The resource was created above but the shred failed (malformed XML, ...) —
-                    // remove the empty half-built resource instead of leaving it listed (a GET of
-                    // it could 500), then rethrow so the client still sees the failure.
-                    try {
-                        withContext(dispatcher) { database.removeResource(resPathName) }
-                    } catch (cleanup: Exception) {
-                        logger.warn("Failed to clean up resource '$resPathName' after failed shred: ${cleanup.message}")
-                    }
-                    throw e
                 } finally {
                     // Delete the temp upload file on success AND failure (previously success-only,
                     // leaking a temp file per failed upload).

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlUpdate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlUpdate.kt
@@ -15,6 +15,7 @@ import java.nio.file.Path
 import java.time.Instant
 import java.util.*
 import javax.xml.stream.XMLEventReader
+import io.sirix.rest.crud.moveToOrNotFound
 
 enum class XmlInsertionMode {
     ASFIRSTCHILD {
@@ -86,11 +87,7 @@ class XmlUpdate(location: Path) : AbstractUpdateHandler(location) {
                     val wtx = manager.beginNodeTrx()
                     val (maxNodeKey, hash) = wtx.use {
                         if (nodeId != null) {
-                            // moveTo on a nonexistent key leaves the cursor on the document root —
-                            // the fallback below would silently commit at an unrelated position.
-                            if (!wtx.moveTo(nodeId)) {
-                                throw IllegalStateException("Node with ID $nodeId not found.")
-                            }
+                            wtx.moveToOrNotFound(nodeId)
                         }
 
                         if (wtx.isDocumentRoot && wtx.hasFirstChild())


### PR DESCRIPTION
Follow-up cleanup to #1024 — consolidation only, no semantic changes except where noted. Full local gates: **sirix-core 9141/0, sirix-query 789/0, sirix-rest-api 161/0**.

## Storage layout
- `IOStorage.revisionsFileOffset(revision)` is now the single definition of the revisions-file slot layout; both writers and both readers used four hand-expanded spellings of the same formula.
- **`FileWriter` gains the write-ahead barrier and ordered dual-copy fsync sequencing** that `FileChannelWriter` already had — the FILE backend previously had neither, so power loss could tear both uber copies at once. (Behavioral: strictly stronger durability.)

## REST API
- `HandlerPreconditions.kt`: one home for parse-or-400 params (~11 hand-rolled copies), the If-Match/legacy-ETag precondition (the delete path carried a fresh inline copy), and `moveToOrNotFound` (4 pasted sites).
- `AbstractCreateHandler.withCleanupOnFailedShred`: shared failure-path policy for both create handlers.

## Caches/serialization
- `PageCache`: one `isCacheablePageType` predicate for `put()` + the `get()` compute path; no more insert-then-remove churn for disallowed kinds.
- `StringValue.escape`: zero-allocation fast path (returns the same instance when nothing needs escaping); `JsonDBSerializer` now delegates to it instead of carrying a second, weaker escaper — query results and stored-resource reads emit identical string escapes.
- `JsonSerializer` fails fast on limited XQuery-result serialization (previously guarded only by a comment).

## Misc
- `JsonNodeTrxImpl`: one named `perInsertHashAdaptation` boolean; shared `rejectBareChildUnderObjectField` guard (was pasted 4×).
- `ItemHistory`/`IsDeleted` route `RECORD_TO_REVISIONS` lookups through `RecordRevisionsLookup` — `IsDeleted` still had the unguarded cast that CCE'd on resources without `storeNodeHistory`.
- `deferredCloseFailure` demoted to a `close()` local; FFILz4 drops an unreachable special case; `XmlShredder` hoists a duplicate `peek()`; `Revisions.kt` builds ranges as `IntArray` (no boxed Set detour).