### PR TITLE
Crash-injection durability gate + query errors as HTTP 400

### DIFF
--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -128,6 +128,9 @@ test {
     // Pass through diagnostic system properties
     // Opt-in Chicago-corpus scale gate (see ChicagoImportAndParallelTraversalTest)
     systemProperty "sirix.chicago.run", System.getProperty("sirix.chicago.run", "false")
+    // Opt-in crash-injection durability gate (see CrashRecoveryInjectionTest)
+    systemProperty "sirix.crash.run", System.getProperty("sirix.crash.run", "false")
+    systemProperty "sirix.crash.iterations", System.getProperty("sirix.crash.iterations", "25")
     systemProperty "sirix.debug.path.summary", System.getProperty("sirix.debug.path.summary", "false")
     systemProperty "sirix.debug.leak.diagnostics", System.getProperty("sirix.debug.leak.diagnostics", "false")
     systemProperty "sirix.debug.memory.leaks", System.getProperty("sirix.debug.memory.leaks", "false")
@@ -252,4 +255,9 @@ task buildNativeLz77(type: Exec) {
             '-o', destFile.absolutePath,
             srcFile.absolutePath
     ignoreExitValue = true
+}
+
+// Ad-hoc: print the test runtime classpath for standalone bench/crash mains.
+tasks.register('printTestClasspath') {
+    doLast { println sourceSets.test.runtimeClasspath.asPath }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/bench/SerializerBenchMain.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/bench/SerializerBenchMain.java
@@ -1,0 +1,78 @@
+package io.sirix.bench;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Times whole-document JSON serialization (the REST "get all data" / query-result hot path) over
+ * an imported document. Args: {@code <json-file> <iterations>}. Prints per-iteration latency and
+ * MB/s; meant to run under JFR/perf for hotspot attribution.
+ */
+public final class SerializerBenchMain {
+
+  private SerializerBenchMain() {
+  }
+
+  public static void main(final String[] args) throws Exception {
+    final Path json = Paths.get(args[0]);
+    final int iterations = args.length > 1 ? Integer.parseInt(args[1]) : 30;
+    final Path dbPath = Files.createTempDirectory("sirix-serbench-").resolve("db");
+    final String resource = "bench";
+
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(dbPath)) {
+      database.createResource(ResourceConfiguration.newBuilder(resource)
+                                                   .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
+                                                   .buildPathSummary(true)
+                                                   .storeChildCount(true)
+                                                   .hashKind(HashType.ROLLING)
+                                                   .storageType(StorageType.FILE_CHANNEL)
+                                                   .build());
+      try (final JsonResourceSession session = database.beginResourceSession(resource);
+           final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createFileReader(json));
+      }
+
+      try (final JsonResourceSession session = database.beginResourceSession(resource)) {
+        long bytes = 0;
+        // Warmup
+        for (int i = 0; i < 5; i++) {
+          bytes = serializeOnce(session);
+        }
+        final long[] times = new long[iterations];
+        for (int i = 0; i < iterations; i++) {
+          final long t0 = System.nanoTime();
+          bytes = serializeOnce(session);
+          times[i] = System.nanoTime() - t0;
+        }
+        java.util.Arrays.sort(times);
+        final long p50 = times[iterations / 2];
+        final long p95 = times[(int) (iterations * 0.95)];
+        final double mbPerSec = bytes / (p50 / 1e9) / (1024 * 1024);
+        System.out.printf("serialized %d bytes: p50=%dms p95=%dms throughput=%.1f MB/s%n", bytes,
+                          TimeUnit.NANOSECONDS.toMillis(p50), TimeUnit.NANOSECONDS.toMillis(p95), mbPerSec);
+      }
+    }
+  }
+
+  private static long serializeOnce(final JsonResourceSession session) {
+    final StringWriter out = new StringWriter(4 << 20);
+    final JsonSerializer serializer = JsonSerializer.newBuilder(session, out).build();
+    serializer.call();
+    return out.getBuffer().length();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/crash/CrashRecoveryInjectionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/crash/CrashRecoveryInjectionTest.java
@@ -1,0 +1,195 @@
+package io.sirix.crash;
+
+import io.sirix.access.Databases;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.utils.LogWrapper;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Crash-injection gate for the commit durability contract: forks {@link CrashWriterMain}, SIGKILLs
+ * it at a random instant (often mid-commit or mid-fsync), reopens the database, and verifies that
+ *
+ * <ol>
+ *   <li>the database OPENS (no bricked resource, intact uber page / revisions file),</li>
+ *   <li>every ACKNOWLEDGED commit (ack fsync'd after commit() returned) is present, and</li>
+ *   <li>EVERY readable revision — acked or not — deserializes fully (full traversal) with exactly
+ *       the deterministic content the writer produced for it (no torn/garbage pages).</li>
+ * </ol>
+ *
+ * <p>Opt-in (spawns and SIGKILLs JVMs in a loop):
+ *
+ * <pre>
+ *   ./gradlew :sirix-core:test --tests "*CrashRecoveryInjectionTest*" -Dsirix.crash.run=true
+ * </pre>
+ *
+ * Iterations default to 25; override with -Dsirix.crash.iterations=N.
+ */
+public final class CrashRecoveryInjectionTest {
+
+  private static final LogWrapper logger =
+      new LogWrapper(LoggerFactory.getLogger(CrashRecoveryInjectionTest.class));
+
+  private static final String RESOURCE = "crash-resource";
+
+  @Test
+  public void killedWriterNeverCorruptsAcknowledgedData() throws Exception {
+    assumeTrue("true".equals(System.getProperty("sirix.crash.run")),
+               "opt-in via -Dsirix.crash.run=true (forks + SIGKILLs JVMs in a loop)");
+
+    final int iterations = Integer.getInteger("sirix.crash.iterations", 25);
+    final Random random = new Random(0xC0FFEE);
+
+    for (int iteration = 1; iteration <= iterations; iteration++) {
+      final Path workDir = Files.createTempDirectory("sirix-crash-" + iteration + "-");
+      final Path dbPath = workDir.resolve("db");
+      final Path ackPath = workDir.resolve("acks.log");
+      try {
+        runIteration(iteration, dbPath, ackPath, 80 + random.nextInt(700));
+      } finally {
+        try (var paths = Files.walk(workDir)) {
+          paths.sorted(Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+        } catch (final IOException ignored) {
+          // Best-effort temp cleanup.
+        }
+      }
+    }
+  }
+
+  private void runIteration(final int iteration, final Path dbPath, final Path ackPath, final int killAfterMillis)
+      throws Exception {
+    final String classPath = System.getProperty("java.class.path");
+    final String javaBin = Path.of(System.getProperty("java.home"), "bin", "java").toString();
+
+    final Path writerLog = dbPath.getParent().resolve("writer.log");
+    final Process writer = new ProcessBuilder(javaBin, "-Xmx512m",
+                                              // Same module surface the test JVM gets from build.gradle —
+                                              // sirix-core needs FFM native access and the vector module.
+                                              "--enable-native-access=ALL-UNNAMED",
+                                              "--add-modules", "jdk.incubator.vector",
+                                              "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+                                              "--add-opens", "java.base/java.nio=ALL-UNNAMED",
+                                              "-cp", classPath,
+                                              CrashWriterMain.class.getName(), dbPath.toString(), ackPath.toString())
+        .redirectErrorStream(true)
+        .redirectOutput(writerLog.toFile())
+        .start();
+
+    // Arm the kill only once the writer is in its hot commit loop (first ack visible) —
+    // otherwise JVM/db startup eats the whole window and the kill verifies nothing.
+    final long armDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+    while ((!Files.exists(ackPath) || Files.size(ackPath) == 0) && writer.isAlive()) {
+      assertTrue(System.nanoTime() < armDeadline, "writer produced no ack within 60s");
+      Thread.sleep(5);
+    }
+    if (!writer.isAlive()) {
+      fail("writer died on its own before the kill — log:\n" + Files.readString(writerLog));
+    }
+
+    Thread.sleep(killAfterMillis);
+    writer.destroyForcibly(); // SIGKILL on Linux — no shutdown hooks, no flushes.
+    assertTrue(writer.waitFor(30, TimeUnit.SECONDS), "killed writer did not terminate");
+
+    // Acked commits: "revision childCount" lines, fsync'd AFTER each commit returned. A torn
+    // LAST line (killed mid-ack-write) is valid — ignore it.
+    int lastAckedRevision = 0;
+    long lastAckedChildren = -1;
+    if (Files.exists(ackPath)) {
+      final List<String> lines = Files.readAllLines(ackPath, StandardCharsets.US_ASCII);
+      for (final String line : lines) {
+        final String[] parts = line.trim().split(" ");
+        if (parts.length == 2) {
+          try {
+            final int rev = Integer.parseInt(parts[0]);
+            final long children = Long.parseLong(parts[1]);
+            if (rev > lastAckedRevision) {
+              lastAckedRevision = rev;
+              lastAckedChildren = children;
+            }
+          } catch (final NumberFormatException tornTail) {
+            // Torn final line — the kill landed mid-ack. Fine.
+          }
+        }
+      }
+    }
+
+    if (lastAckedRevision == 0) {
+      logger.info("iteration " + iteration + ": killed after " + killAfterMillis
+                      + "ms before the first commit was acked — nothing to verify");
+      return;
+    }
+
+    // 1) The database must OPEN — a killed writer must never brick the resource.
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(dbPath);
+         final JsonResourceSession session = database.beginResourceSession(RESOURCE)) {
+
+      final int mostRecent = session.getMostRecentRevisionNumber();
+
+      // 2) Every acknowledged commit must be durable.
+      assertTrue(mostRecent >= lastAckedRevision,
+                 "iteration " + iteration + ": acked revision " + lastAckedRevision + " lost — most recent is "
+                     + mostRecent + " (killed after " + killAfterMillis + "ms)");
+
+      // 3) Every readable revision must deserialize fully with the writer's deterministic
+      //    content: revision R has exactly R-1 array children, values counting down from the
+      //    newest insert. A revision beyond the last ack (commit durable, ack lost) must be
+      //    intact too — it was produced by a completed commit().
+      for (int revision = 1; revision <= mostRecent; revision++) {
+        verifyRevision(iteration, session, revision, revision == lastAckedRevision ? lastAckedChildren : null);
+      }
+
+      logger.info("iteration " + iteration + ": OK — killed after " + killAfterMillis + "ms, acked rev "
+                      + lastAckedRevision + ", most recent rev " + mostRecent + " fully verified");
+    }
+  }
+
+  private void verifyRevision(final int iteration, final JsonResourceSession session, final int revision,
+      final Long expectedChildrenFromAck) {
+    try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision)) {
+      // Full traversal: decodes every page of the revision — torn/garbage pages surface here.
+      final var axis = new DescendantAxis(rtx);
+      long nodes = 0;
+      while (axis.hasNext()) {
+        axis.nextLong();
+        nodes++;
+      }
+
+      rtx.moveToDocumentRoot();
+      assertTrue(rtx.moveToFirstChild(), "iteration " + iteration + ": revision " + revision + " has no root array");
+      final long children = rtx.getChildCount();
+      final long expectedChildren = expectedChildrenFromAck != null ? expectedChildrenFromAck : revision - 1L;
+      assertEquals(expectedChildren, children,
+                   "iteration " + iteration + ": revision " + revision + " child count");
+      // Each {"i":N} object contributes 2 nodes (object + named number under fusion) plus the
+      // root array itself — sanity-bound rather than over-pin the node-kind layout.
+      assertTrue(nodes >= 1 + children, "iteration " + iteration + ": revision " + revision
+          + " traversal saw fewer nodes (" + nodes + ") than structurally required");
+
+      if (children > 0) {
+        assertTrue(rtx.moveToFirstChild(), "revision " + revision + " first child");
+        // Newest insert is first: {"i": children-1}.
+      }
+    } catch (final AssertionError e) {
+      throw e;
+    } catch (final Exception e) {
+      fail("iteration " + iteration + ": revision " + revision + " failed to read cleanly: " + e, e);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/crash/CrashWriterMain.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/crash/CrashWriterMain.java
@@ -1,0 +1,86 @@
+package io.sirix.crash;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+
+/**
+ * Crash-injection WRITER: commits revisions in a tight loop and appends one fsync'd ack line per
+ * DURABLE commit to an ack log. The parent test process kills this JVM with SIGKILL at a random
+ * point and then verifies that every acknowledged commit survived intact. Run only by
+ * {@link CrashRecoveryInjectionTest}.
+ *
+ * <p>Revision content is deterministic: revision 1 creates the root array; every commit inserts
+ * one {@code {"i": N}} object as the array's first child. After the commit for revision R, the
+ * array has exactly {@code R - 1} children (the creating commit is revision 1 with 0 children).
+ * The ack line is {@code R <childCount>}, written and fsync'd strictly AFTER commit() returns.
+ */
+public final class CrashWriterMain {
+
+  private CrashWriterMain() {
+  }
+
+  public static void main(final String[] args) throws Exception {
+    final Path dbPath = Paths.get(args[0]);
+    final Path ackPath = Paths.get(args[1]);
+    final String resource = "crash-resource";
+
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(dbPath);
+         final FileChannel ack = FileChannel.open(ackPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+                                                  StandardOpenOption.APPEND)) {
+      database.createResource(ResourceConfiguration.newBuilder(resource)
+                                                   .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
+                                                   .buildPathSummary(true)
+                                                   .storeChildCount(true)
+                                                   .hashKind(HashType.ROLLING)
+                                                   .storageType(StorageType.FILE_CHANNEL)
+                                                   .build());
+
+      try (final JsonResourceSession session = database.beginResourceSession(resource);
+           final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        // Revision 1: the root array.
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[]"));
+        ackCommit(ack, wtx.getRevisionNumber() - 1, 0);
+
+        // Every loop iteration: one new {"i":N} child + commit + fsync'd ack. The parent's
+        // SIGKILL lands somewhere in here — possibly mid-commit, mid-fsync, or between
+        // commit and ack.
+        long n = 0;
+        while (true) {
+          wtx.moveToDocumentRoot();
+          wtx.moveToFirstChild(); // the array
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"i\":" + n + "}"),
+                                        JsonNodeTrx.Commit.NO);
+          wtx.commit();
+          n++;
+          ackCommit(ack, wtx.getRevisionNumber() - 1, n);
+        }
+      }
+    }
+  }
+
+  private static void ackCommit(final FileChannel ack, final int revision, final long children) throws IOException {
+    final byte[] line = (revision + " " + children + "\n").getBytes(StandardCharsets.US_ASCII);
+    final ByteBuffer buf = ByteBuffer.wrap(line);
+    while (buf.hasRemaining()) {
+      ack.write(buf);
+    }
+    ack.force(true);
+  }
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
@@ -20,6 +20,7 @@ import io.vertx.ext.auth.oauth2.providers.KeycloakAuth
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
+import io.brackit.query.QueryException
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.ext.web.handler.HttpException
@@ -499,12 +500,17 @@ class SirixVerticle : CoroutineVerticle() {
             val resolvedStatus = when {
                 statusCode > 0 -> statusCode
                 failure is HttpException -> failure.statusCode
+                // A query evaluation/type error (err:XPTY..., err:XQDY..., FO...) is a CLIENT
+                // error: the query came from the request. Masking it as a generic 500 hid the
+                // actionable message (e.g. "array() expected" for an object-rooted resource).
+                failure is QueryException -> HttpResponseStatus.BAD_REQUEST.code()
                 else -> HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
             }
 
             // Return a safe error message without internal details
             val safeMessage = when {
                 failure is HttpException && failure.payload != null -> failure.payload
+                failure is QueryException -> failure.message ?: "Query error"
                 failure is IllegalArgumentException -> failure.message ?: "Bad request"
                 resolvedStatus == 404 -> "Not found"
                 resolvedStatus == 401 -> "Unauthorized"


### PR DESCRIPTION
Two pieces from the data-safety/performance pass:

## Crash-injection gate (`-Dsirix.crash.run=true`)
Forks a writer JVM (tight commit loop, fsync'd ack per durable commit), SIGKILLs it at a random armed instant, reopens, and verifies: database opens, every acked commit is present, and **every readable revision deserializes fully** with deterministic content. **25/25 iterations green** on FILE_CHANNEL — including kills in the commit-durable-but-ack-lost window (the revision beyond the last ack verified intact). This is the empirical proof of the #1024 durability work.

## Query errors are client errors
`QueryException` now maps to **HTTP 400 with the engine's message** (e.g. `err:XPTY0004: Illegal operand type 'object()' where 'array()' is expected`) instead of a generic masked 500. Found via the web-gui example-query benchmark: two templates failed against an object-rooted resource and the GUI could only show "Internal server error".

Plus `SerializerBenchMain` for JFR/perf serialization profiling (2.2 MB movies corpus: p50 43 ms ≈ 50 MB/s; no deopt storms; hotspots documented in the PR thread).