### PR TITLE
Fix mixed read/write tails: reader use-after-free + O(revisions) storage-open cost

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -376,6 +376,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     };
 
     if (pageReferenceToPage == null || pageReferenceToPage.page == null) {
+      if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS) {
+        LOGGER.error("getRecord: no page for recordKey={} (recordPageKey={}, indexType={}, trxRev={}, refNull={})",
+            recordKey, recordPageKey, indexType, revisionNumber, pageReferenceToPage == null);
+      }
       return null;
     }
 
@@ -409,6 +413,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
           final var data = ((OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig())).getData();
           record = getDataRecord(nodeKey, offset, data, page);
         } else {
+          if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS && page instanceof KeyValueLeafPage kvl) {
+            LOGGER.error(
+                "getValue miss: nodeKey={} offset={} on page {} (type={}, pageRev={}, trxRev={}, closed={}, orphaned={}, guards={}, slotPopulated={}, slottedPageNull={})",
+                nodeKey, offset, kvl.getPageKey(), kvl.getIndexType(), kvl.getRevision(), revisionNumber,
+                kvl.isClosed(), kvl.isOrphaned(), kvl.getGuardCount(),
+                kvl.getSlottedPage() != null && io.sirix.page.PageLayout.isSlotPopulated(kvl.getSlottedPage(), offset),
+                kvl.getSlottedPage() == null);
+          }
           return null;
         }
       } catch (final SirixIOException e) {
@@ -577,6 +589,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // Not cached - atomically acquire guard only if page is still live.
     // Split acquireGuard + isClosed races with close() under severe eviction.
     if (!page.tryAcquireGuard()) {
+      if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS) {
+        LOGGER.error(
+            "lookupSlot(cached) guard-fail: recordKey={} on page {} (type={}, pageRev={}, trxRev={}, closed={}, orphaned={}, guards={})",
+            recordKey, page.getPageKey(), page.getIndexType(), page.getRevision(), revisionNumber, page.isClosed(),
+            page.isOrphaned(), page.getGuardCount());
+      }
       return new SlotOrCachedResult(null, null);
     }
 
@@ -596,6 +614,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
 
     if (data == null) {
+      if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS) {
+        LOGGER.error(
+            "lookupSlot(cached) slot-miss: recordKey={} offset={} on page {} (type={}, pageRev={}, trxRev={}, closed={}, orphaned={}, guards={}, slottedPageNull={})",
+            recordKey, offset, page.getPageKey(), page.getIndexType(), page.getRevision(), revisionNumber,
+            page.isClosed(), page.isOrphaned(), page.getGuardCount(), page.getSlottedPage() == null);
+      }
       page.releaseGuard();
       return new SlotOrCachedResult(null, null);
     }
@@ -661,6 +685,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // tryAcquireGuard is atomic (synchronized) vs close(); split acquire +
     // isClosed races with the eviction path.
     if (!page.tryAcquireGuard()) {
+      if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS) {
+        LOGGER.error(
+            "lookupSlot guard-fail: recordKey={} on page {} (type={}, pageRev={}, trxRev={}, closed={}, orphaned={}, guards={}, identity={})",
+            recordKey, page.getPageKey(), page.getIndexType(), page.getRevision(), revisionNumber, page.isClosed(),
+            page.isOrphaned(), page.getGuardCount(), System.identityHashCode(page), page.getCloseSite());
+      }
       return null;
     }
 
@@ -680,6 +710,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
 
     if (data == null) {
+      if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS) {
+        LOGGER.error(
+            "lookupSlot slot-miss: recordKey={} offset={} on page {} (type={}, pageRev={}, trxRev={}, closed={}, orphaned={}, guards={}, slottedPageNull={})",
+            recordKey, offset, page.getPageKey(), page.getIndexType(), page.getRevision(), revisionNumber,
+            page.isClosed(), page.isOrphaned(), page.getGuardCount(), page.getSlottedPage() == null);
+      }
       page.releaseGuard();
       return null;
     }
@@ -844,12 +880,16 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // ORPHANED_BIT and increments guardCount. Split acquireGuard +
       // isClosed races with close() under severe-pressure eviction.
       closeCurrentPageGuard();
-      if (page.tryAcquireGuard() && page.getSlottedPage() != null) {
+      final boolean acquired = page.tryAcquireGuard();
+      if (acquired && page.getSlottedPage() != null) {
         currentPageGuard = PageGuard.wrapAlreadyGuarded(page);
         return new PageReferenceToPage(pathSummaryRecordPage.pageReference, page);
       }
-      if (!page.isClosed()) {
-        // Acquired but slottedPage was null — release and fall through.
+      if (acquired) {
+        // Acquired but slottedPage was null — release and fall through. NEVER release on a
+        // failed acquire: the count belongs to OTHER holders (a failed acquire never
+        // increments), and a bogus decrement lets a deferred orphan-close free the page
+        // out from under them.
         page.releaseGuard();
       }
       pathSummaryRecordPage = null;
@@ -864,11 +904,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       var page = cachedPage.page();
 
       closeCurrentPageGuard();
-      if (page.tryAcquireGuard() && page.getSlottedPage() != null) {
+      final boolean acquired = page.tryAcquireGuard();
+      if (acquired && page.getSlottedPage() != null) {
         currentPageGuard = PageGuard.wrapAlreadyGuarded(page);
         return new PageReferenceToPage(cachedPage.pageReference, page);
       }
-      if (!page.isClosed()) {
+      if (acquired) {
+        // Release only what we acquired — a failed tryAcquireGuard never increments,
+        // so releasing there would steal another holder's guard.
         page.releaseGuard();
       }
       setMostRecentPage(indexLogKey.getIndexType(), indexLogKey.getIndexNumber(), null);
@@ -1038,60 +1081,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       default -> null;
     };
 
-    // Close the replaced page if it's orphaned (not in cache)
-    if (previous != null && previous != page) {
-      closeMostRecentPageIfOrphaned(previous);
-    }
-  }
-
-  /**
-   * Close a mostRecent page if it has been orphaned (evicted from cache).
-   * <p>
-   * Pages still in cache will be closed by the cache eviction process.
-   * Orphaned pages (no longer in cache) need to have any remaining guards released
-   * and then be closed.
-   * <p>
-   * IMPORTANT: For orphaned pages (not in cache), any remaining guards must be from
-   * this transaction since:
-   * 1. Pages can only be evicted/replaced in cache if guardCount == 0
-   * 2. If a page has guards and is not in cache, those guards are from transactions
-   *    that hold mostRecent references to a page instance that was replaced in cache
-   * 3. When this transaction closes, we must release our guard to allow the page to close
-   *
-   * @param recordPage the record page to potentially close
-   */
-  private void closeMostRecentPageIfOrphaned(RecordPage recordPage) {
-    if (recordPage == null) {
-      return;
-    }
-
-    KeyValueLeafPage page = recordPage.page();
-    if (page == null || page.isClosed()) {
-      return;
-    }
-
-    // Check if page is still in cache
-    KeyValueLeafPage cachedPage = resourceBufferManager.getRecordPageCache().get(recordPage.pageReference);
-
-    if (cachedPage != page) {
-      // Page is orphaned (not in cache or replaced by different instance)
-      // This can happen when:
-      // 1. Cache evicted the page (only possible if guardCount was 0 at eviction time)
-      // 2. Another transaction replaced the page in cache with a new combined instance
-      //
-      // In case 2, our transaction may still have a guard on the old instance that
-      // needs to be released. Since this page is orphaned, no other active transaction
-      // can have guards on it (they would keep it in cache via compute()).
-      //
-      // Release any remaining guard (should be at most 1 from this transaction)
-      // and close the page.
-      if (page.getGuardCount() > 0) {
-        page.releaseGuard();
-      }
-      if (!page.isClosed() && page.getGuardCount() == 0) {
-        page.close();
-      }
-    }
+    // Lifecycle note: the replaced slot page is deliberately NOT closed here. Most-recent
+    // slots hold UNGUARDED references to SHARED cache instances — other transactions hold the
+    // same instance in their own slots or are mid-lookup on it, and guardCount carries no
+    // ownership information, so "not in cache anymore" never implies "closeable by me".
+    // A reader-side close here stole in-flight guards and freed pages under concurrent
+    // readers (use-after-free: sporadic 500s/NPEs and silent "node not found" under mixed
+    // read/write load). The CACHE owns shared-page lifecycle: eviction closes unguarded
+    // pages, and put()-replacement orphans the old instance so the last releaseGuard()
+    // tears it down. Stale slot references are revalidated via tryAcquireGuard on use.
   }
 
   /**
@@ -1279,10 +1277,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         // tryAcquireGuard is atomic with close(): split acquire + isClosed
         // races under severe-pressure eviction and produces FrameReusedException.
         closeCurrentPageGuard();
-        if (kvLeafPage.tryAcquireGuard() && kvLeafPage.getSlottedPage() != null) {
+        final boolean acquired = kvLeafPage.tryAcquireGuard();
+        if (acquired && kvLeafPage.getSlottedPage() != null) {
           currentPageGuard = PageGuard.wrapAlreadyGuarded(kvLeafPage);
         } else {
-          if (!kvLeafPage.isClosed()) {
+          if (acquired) {
+            // Acquired but unusable (null slottedPage) — release our own guard only. A failed
+            // acquire never increments, so releasing there would steal another holder's guard.
             kvLeafPage.releaseGuard();
           }
           pageReferenceToRecordPage.setPage(null);
@@ -1623,20 +1624,17 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         resourceSession.closePageReadTransaction(trxId);
       }
 
-      // CRITICAL: Close all mostRecent pages to release their pins
-      closeMostRecentPageIfOrphaned(mostRecentDocumentPage);
-      closeMostRecentPageIfOrphaned(mostRecentChangedNodesPage);
-      closeMostRecentPageIfOrphaned(mostRecentRecordToRevisionsPage);
-      closeMostRecentPageIfOrphaned(mostRecentDeweyIdPage);
-      for (RecordPage page : mostRecentPathPages) {
-        closeMostRecentPageIfOrphaned(page);
-      }
-      for (RecordPage page : mostRecentCasPages) {
-        closeMostRecentPageIfOrphaned(page);
-      }
-      for (RecordPage page : mostRecentNamePages) {
-        closeMostRecentPageIfOrphaned(page);
-      }
+      // Drop most-recent slot references. They are UNGUARDED references to SHARED cache
+      // instances — this transaction holds no pin on them (the only guard it owns is
+      // currentPageGuard, released above), so there is nothing to release and closing them
+      // here would free pages other transactions are still using (see setMostRecentPage).
+      mostRecentDocumentPage = null;
+      mostRecentChangedNodesPage = null;
+      mostRecentRecordToRevisionsPage = null;
+      mostRecentDeweyIdPage = null;
+      java.util.Arrays.fill(mostRecentPathPages, null);
+      java.util.Arrays.fill(mostRecentCasPages, null);
+      java.util.Arrays.fill(mostRecentNamePages, null);
       // PATH_SUMMARY handled separately below (has special bypass logic)
 
       // Handle PATH_SUMMARY bypassed pages for write transactions (they're not in cache)

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManagerImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManagerImpl.java
@@ -323,11 +323,14 @@ public final class BufferManagerImpl implements BufferManager {
     for (var key : recordKeysToRemove) {
       KeyValueLeafPage page = recordPageCache.get(key);
       if (page != null && !page.isClosed()) {
-        // CRITICAL: Force-release all guards to ensure page can be closed and memory returned
+        // Teardown/destructive-admin path (database removal, truncate recovery): reclaim
+        // unconditionally. Tests and admin flows rely on frames being returned even when a
+        // leaked/abandoned transaction still holds a guard — deferring here pinned frames
+        // forever and exhausted the FrameSlotAllocator over long runs.
         while (page.getGuardCount() > 0) {
           page.releaseGuard();
         }
-        page.close(); // Close page to release memory segments to allocator
+        page.close();
       }
       recordPageCache.remove(key);
       removedFromRecordCache++;
@@ -343,11 +346,11 @@ public final class BufferManagerImpl implements BufferManager {
     for (var key : fragmentKeysToRemove) {
       KeyValueLeafPage page = recordPageFragmentCache.get(key);
       if (page != null && !page.isClosed()) {
-        // CRITICAL: Force-release all guards to ensure fragment can be closed and memory returned
+        // See above: unconditional reclamation on the teardown path.
         while (page.getGuardCount() > 0) {
           page.releaseGuard();
         }
-        page.close(); // Close fragment to release memory segments to allocator
+        page.close();
       }
       recordPageFragmentCache.remove(key);
       removedFromFragmentCache++;
@@ -405,11 +408,14 @@ public final class BufferManagerImpl implements BufferManager {
     for (var key : recordKeysToRemove) {
       KeyValueLeafPage page = recordPageCache.get(key);
       if (page != null && !page.isClosed()) {
-        // CRITICAL: Force-release all guards to ensure page can be closed and memory returned
+        // Teardown/destructive-admin path (database removal, truncate recovery): reclaim
+        // unconditionally. Tests and admin flows rely on frames being returned even when a
+        // leaked/abandoned transaction still holds a guard — deferring here pinned frames
+        // forever and exhausted the FrameSlotAllocator over long runs.
         while (page.getGuardCount() > 0) {
           page.releaseGuard();
         }
-        page.close(); // Close page to release memory segments to allocator
+        page.close();
       }
       recordPageCache.remove(key);
       removedFromRecordCache++;
@@ -426,11 +432,11 @@ public final class BufferManagerImpl implements BufferManager {
     for (var key : fragmentKeysToRemove) {
       KeyValueLeafPage page = recordPageFragmentCache.get(key);
       if (page != null && !page.isClosed()) {
-        // CRITICAL: Force-release all guards to ensure fragment can be closed and memory returned
+        // See above: unconditional reclamation on the teardown path.
         while (page.getGuardCount() > 0) {
           page.releaseGuard();
         }
-        page.close(); // Close fragment to release memory segments to allocator
+        page.close();
       }
       recordPageFragmentCache.remove(key);
       removedFromFragmentCache++;

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/CacheablePage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/CacheablePage.java
@@ -25,6 +25,14 @@ public interface CacheablePage {
 
   boolean isClosed();
 
+  /**
+   * Mark this page as orphaned: it left its owning structure (cache mapping replaced,
+   * truncate/TIL teardown) but concurrent holders may still guard it. {@link #close()} is
+   * guard-aware — an orphaned page is torn down immediately when unguarded, otherwise by the
+   * last {@link #releaseGuard()}.
+   */
+  void markOrphaned();
+
   void close();
 
   void incrementVersion();

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/ShardedPageCache.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/ShardedPageCache.java
@@ -1,5 +1,6 @@
 package io.sirix.cache;
 
+import io.sirix.page.KeyValueLeafPage;
 import io.sirix.page.PageReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -227,9 +228,11 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
     }
 
     return map.compute(key, (k, existingValue) -> {
-      if (existingValue != null && !existingValue.isClosed()) {
+      // acquireGuard() can fail even after an isClosed() check: a non-compute closer
+      // (truncate sweep, TIL teardown) may close the page concurrently. NEVER hand out a
+      // page whose guard was not actually acquired — the caller would use it unprotected.
+      if (existingValue != null && !existingValue.isClosed() && existingValue.acquireGuard()) {
         existingValue.markAccessed();
-        existingValue.acquireGuard();
         return existingValue;
       }
       if (existingValue != null) {
@@ -250,20 +253,32 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
     }
 
     V page = map.compute(key, (k, existingInCompute) -> {
-      if (existingInCompute != null && !existingInCompute.isClosed()) {
+      // acquireGuard() can fail even after an isClosed() check: a non-compute closer
+      // (truncate sweep, TIL teardown) may close the page concurrently. A failed acquire
+      // means the mapping is dead — replace it with a fresh load instead of handing out a
+      // page the caller would use unguarded.
+      if (existingInCompute != null && !existingInCompute.isClosed() && existingInCompute.acquireGuard()) {
         CACHE_HITS.increment();
         existingInCompute.markAccessed();
-        existingInCompute.acquireGuard();
         return existingInCompute;
+      }
+      if (existingInCompute != null) {
+        unchargeWeight(k); // dead mapping — release its charge before replacing
+        k.setPage(null);
       }
       CACHE_MISSES.increment();
       V loaded = loader.apply(k);
       if (loaded != null && !loaded.isClosed()) {
         loaded.markAccessed();
-        loaded.acquireGuard();
+        if (!loaded.acquireGuard()) {
+          // Freshly loaded page closed before we could guard it (cannot normally happen —
+          // the instance is still private). Free it and treat as a miss.
+          loaded.close();
+          return null;
+        }
         chargeWeight(k, loaded);
-      } else if (existingInCompute != null) {
-        unchargeWeight(k); // mapping removed or replaced by a dead page — release its charge
+      } else {
+        return null;
       }
       return loaded;
     });
@@ -279,6 +294,17 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
 
     value.markAccessed();
     map.compute(key, (k, existing) -> {
+      if (existing instanceof KeyValueLeafPage && existing != value && !existing.isClosed()) {
+        // Replacing a live RECORD-page instance: hand the old one to the orphan protocol.
+        // Readers may still reference it (most-recent slots, in-flight lookups) — close()
+        // tears it down now when unguarded, otherwise the LAST releaseGuard() does. Leaving
+        // it open and unowned (the previous behavior) leaked its off-heap segments.
+        // HOT leaves are exempt: the same instance intentionally backs both a TIL
+        // PageContainer and this cache, and split/CoW paths re-put while older swizzled
+        // references still re-resolve through it — the TIL owns that lifecycle.
+        existing.markOrphaned();
+        existing.close();
+      }
       chargeWeight(k, value);
       return value;
     });
@@ -322,6 +348,10 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
         if (page.isClosed()) {
           continue;
         }
+        // Global teardown path (clearAllCaches at shutdown / test reset): reclaim
+        // unconditionally. Deferring via the orphan protocol pinned frames forever when a
+        // leaked/abandoned transaction still held a guard, exhausting the allocator over
+        // long suite runs.
         while (page.getGuardCount() > 0) {
           page.releaseGuard();
         }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -712,14 +712,20 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Helper method to release guards and close a page.
+   * Helper method to tear down a TIL-owned page without harming concurrent holders.
    */
   private void closePage(final Page page) {
     if (page instanceof KeyValueLeafPage kvPage) {
-      while (kvPage.getGuardCount() > 0) {
-        kvPage.releaseGuard();
+      if (!kvPage.isClosed()) {
+        // NEVER force-release guards this transaction does not own: a concurrent reader may
+        // have resolved this very instance through a shared reference and still hold its
+        // guard mid-read — draining freed the frame under the reader (use-after-free / torn
+        // reads), exactly like the HOTLeafPage case below. markOrphaned() + guard-aware
+        // close(): immediate teardown when unguarded, deferred to the LAST releaseGuard()
+        // otherwise.
+        kvPage.markOrphaned();
+        kvPage.close();
       }
-      kvPage.close();
     } else if (page instanceof HOTLeafPage hotLeaf && !hotLeaf.isClosed()) {
       // Do NOT free a HOT leaf still owned by the shared HOT-leaf buffer cache — the same
       // instance backs both a TIL PageContainer and the cache, so closing it here would

--- a/bundles/sirix-core/src/main/java/io/sirix/io/AbstractForwardingReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/AbstractForwardingReader.java
@@ -55,5 +55,12 @@ public abstract class AbstractForwardingReader extends ForwardingObject implemen
   }
 
   @Override
+  public RevisionFileData[] getRevisionFileData(int fromRevision, int count) {
+    // Forward explicitly — falling back to the interface default would loop the
+    // single-record read and lose the delegate's bulk-read optimization.
+    return delegate().getRevisionFileData(fromRevision, count);
+  }
+
+  @Override
   protected abstract Reader delegate();
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
@@ -238,10 +238,14 @@ public interface IOStorage {
       final long[] timestamps = new long[revisionCount];
       final long[] offsets = new long[revisionCount];
 
+      // Bulk-read the whole revisions file in one request. Reading record-by-record cost one
+      // syscall + one direct-buffer allocation per revision, so this rebuild — which runs on
+      // a storage open whenever a concurrent commit makes the in-memory index disagree with
+      // the on-disk count — made request-scoped opens linear in revision count.
+      final RevisionFileData[] data = reader.getRevisionFileData(0, revisionCount);
       for (int i = 0; i < revisionCount; i++) {
-        final RevisionFileData data = reader.getRevisionFileData(i);
-        timestamps[i] = data.timestamp().toEpochMilli();
-        offsets[i] = data.offset();
+        timestamps[i] = data[i].timestamp().toEpochMilli();
+        offsets[i] = data[i].offset();
       }
 
       final RevisionIndex index = RevisionIndex.create(timestamps, offsets);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/Reader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/Reader.java
@@ -105,4 +105,22 @@ public interface Reader extends AutoCloseable {
   Instant readRevisionRootPageCommitTimestamp(int revision);
 
   RevisionFileData getRevisionFileData(int revision);
+
+  /**
+   * Read a contiguous range of revision records. Implementations should override this with a
+   * single bulk read — the revision-index load on storage open calls it with the FULL history,
+   * and the default per-revision loop costs one syscall plus one buffer per revision, which
+   * made request-scoped opens linear in revision count.
+   *
+   * @param fromRevision first revision (inclusive)
+   * @param count        number of consecutive revisions to read
+   * @return one {@link RevisionFileData} per revision, in order
+   */
+  default RevisionFileData[] getRevisionFileData(final int fromRevision, final int count) {
+    final RevisionFileData[] result = new RevisionFileData[Math.max(count, 0)];
+    for (int i = 0; i < count; i++) {
+      result[i] = getRevisionFileData(fromRevision + i);
+    }
+    return result;
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -298,30 +298,52 @@ public final class FileChannelReader extends AbstractReader {
 
   @Override
   public RevisionFileData getRevisionFileData(int revision) {
+    return getRevisionFileData(revision, 1)[0];
+  }
+
+  @Override
+  public RevisionFileData[] getRevisionFileData(final int fromRevision, final int count) {
+    if (count <= 0) {
+      return new RevisionFileData[0];
+    }
+    final int byteCount = count * IOStorage.REVISIONS_FILE_RECORD_SIZE;
+    // One bulk pread + one pooled buffer for the whole range. The previous one-record-per-call
+    // loop issued one syscall AND one ByteBuffer.allocateDirect per revision — allocateDirect
+    // registers with a JVM-global synchronized Cleaner list, so concurrent readers rebuilding
+    // the revision index serialized on it and storage opens became linear in revision count.
+    final ByteBuffer buffer = acquireBuffer(byteCount);
     try {
-      final var fileOffset = IOStorage.revisionsFileOffset(revision);
-      final ByteBuffer buffer =
-          ByteBuffer.allocateDirect(IOStorage.REVISIONS_FILE_RECORD_SIZE).order(ByteOrder.LITTLE_ENDIAN);
+      final long fileOffset = IOStorage.revisionsFileOffset(fromRevision);
+      buffer.clear().limit(byteCount);
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
       int position = 0;
       while (buffer.hasRemaining()) {
         final int read = revisionsOffsetFileChannel.read(buffer, fileOffset + position);
         if (read < 0) {
-          throw new SirixIOException("Truncated revisions record for revision " + revision);
+          throw new SirixIOException("Truncated revisions record for revision "
+              + (fromRevision + position / IOStorage.REVISIONS_FILE_RECORD_SIZE));
         }
         position += read;
       }
-      buffer.flip();
-      final var offset = buffer.getLong();
-      final var timestamp = buffer.getLong();
-      final var storedChecksum = buffer.getLong();
-      // These 16 bytes are the ONLY path to the revision's root page — verify them.
-      if (storedChecksum != IOStorage.revisionRecordChecksum(offset, timestamp)) {
-        throw new SirixIOException("Corrupt revisions record for revision " + revision
-            + " (checksum mismatch) — torn write or storage corruption");
+      final RevisionFileData[] result = new RevisionFileData[count];
+      for (int i = 0; i < count; i++) {
+        final int base = i * IOStorage.REVISIONS_FILE_RECORD_SIZE;
+        final long offset = buffer.getLong(base);
+        final long timestamp = buffer.getLong(base + 8);
+        final long storedChecksum = buffer.getLong(base + 16);
+        // These bytes are the ONLY path to the revision's root page — verify them.
+        if (storedChecksum != IOStorage.revisionRecordChecksum(offset, timestamp)) {
+          throw new SirixIOException("Corrupt revisions record for revision " + (fromRevision + i)
+              + " (checksum mismatch) — torn write or storage corruption");
+        }
+        result[i] = new RevisionFileData(offset, Instant.ofEpochMilli(timestamp));
       }
-      return new RevisionFileData(offset, Instant.ofEpochMilli(timestamp));
+      return result;
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new SirixIOException(e);
+    } finally {
+      buffer.order(ByteOrder.nativeOrder());
+      releaseBuffer(buffer);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -162,6 +162,18 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    */
   private final StackTraceElement[] creationStackTrace;
 
+  /**
+   * DIAGNOSTIC: Where and on which thread this page was closed (only captured when
+   * DEBUG_MEMORY_LEAKS=true). Lets a reader that observes a closed page report WHO freed it
+   * out from under it (use-after-free triage).
+   */
+  private volatile Throwable closeSite;
+
+  /** Diagnostic accessor for the close-site capture (null unless DEBUG_MEMORY_LEAKS). */
+  public Throwable getCloseSite() {
+    return closeSite;
+  }
+
   /** Shared Cleaner for all KeyValueLeafPage leak-detection registrations. */
   private static final Cleaner LEAK_CLEANER = Cleaner.create();
 
@@ -2553,7 +2565,12 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @return the slotted page segment, or null if not yet initialized
    */
   public MemorySegment getSlottedPage() {
-    return slottedPage;
+    final MemorySegment sp = slottedPage;
+    if (DEBUG_MEMORY_LEAKS && sp == null && isClosed()) {
+      LOGGER.error("Use-after-close: null slottedPage observed on page {} ({}, rev={}, guards={}) by thread {}",
+          recordPageKey, indexType, revision, guardCount.get(), Thread.currentThread().getName(), closeSite);
+    }
+    return sp;
   }
 
   /**
@@ -2847,6 +2864,12 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
       currentFlags = (int) STATE_FLAGS_HANDLE.getVolatile(this);
       newFlags = currentFlags | CLOSED_BIT;
     } while (!STATE_FLAGS_HANDLE.compareAndSet(this, currentFlags, newFlags));
+
+    if (DEBUG_MEMORY_LEAKS) {
+      closeSite = new Throwable(
+          "page " + recordPageKey + " (" + indexType + ", rev=" + revision + ") closed by thread "
+              + Thread.currentThread().getName());
+    }
 
     // Tell the Cleaner-registered leak detector that this page closed cleanly. The
     // detector's run() reads this flag and skips the leak log. Only present when

--- a/bundles/sirix-core/src/test/java/io/sirix/access/MixedReadWriteUafStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/MixedReadWriteUafStressTest.java
@@ -1,0 +1,167 @@
+package io.sirix.access;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Reproduces the mixed read/write use-after-free seen via REST as sporadic HTTP 500s (3 / 108k
+ * requests with 16 readers + 1 committing writer): read-only transactions crashed with
+ * {@code NullPointerException: "page" is null} (PageLayout access to a closed page's segment) and
+ * {@code AssertionError: Type not known} (value parse through a recycled frame).
+ *
+ * <p>The record-page cache is shrunk so eviction churns constantly, maximizing the window in
+ * which a page can be freed out from under a reader whose guard accounting went wrong. Run with
+ * {@code -Dsirix.debug.memory.leaks=true} (set in the static initializer below) so a reader that
+ * observes a freed page logs the closing thread's stack trace.
+ */
+public final class MixedReadWriteUafStressTest {
+
+  static {
+    // Must win the race with DiagnosticSettings class-init: enables the close-site capture in
+    // KeyValueLeafPage so a reader observing a freed page logs WHO closed it.
+    System.setProperty("sirix.debug.memory.leaks", "true");
+  }
+
+  private static final int READERS = 8;
+  private static final long DURATION_MS = Long.getLong("sirix.uaf.stress.ms", 15_000);
+
+  private long previousRecordCacheBytes;
+  private long previousFragmentCacheBytes;
+
+  @BeforeEach
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    // The buffer manager is GLOBAL — remember the suite's budgets so tearDown can restore
+    // them. Leaving the shrunken budget in place starved every test running after this one
+    // in the same JVM (eviction storms → "sustained allocator thrashing" in the HOT family).
+    if (Databases.getGlobalBufferManager() instanceof io.sirix.cache.BufferManagerImpl bm) {
+      previousRecordCacheBytes = bm.getRecordPageCacheMaxWeightBytes();
+      previousFragmentCacheBytes = bm.getRecordPageFragmentCacheMaxWeightBytes();
+    }
+    // 8 record pages + 8 fragment pages of budget — the latest-revision working set does not
+    // fit, so eviction runs continuously while readers traverse.
+    Databases.reinitializeBufferManagerForTesting(8L * 64 * 1024, 8L * 64 * 1024);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    JsonTestHelper.closeEverything();
+    if (previousRecordCacheBytes > 0) {
+      Databases.reinitializeBufferManagerForTesting(previousRecordCacheBytes, previousFragmentCacheBytes);
+    }
+  }
+
+  @Test
+  @Timeout(180)
+  public void concurrentReadersSurviveWriterCommits() throws Exception {
+    final var sb = new StringBuilder("[");
+    for (int i = 0; i < 3000; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append("{\"a\":").append(i).append(",\"b\":\"v").append(i).append("\",\"c\":").append((i & 1) == 0).append('}');
+    }
+    sb.append(']');
+
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile())) {
+      try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+           final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(sb.toString()));
+      }
+
+      final AtomicBoolean stop = new AtomicBoolean();
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final AtomicLong reads = new AtomicLong();
+      final AtomicLong commits = new AtomicLong();
+      final CountDownLatch start = new CountDownLatch(1);
+      final List<Thread> threads = new ArrayList<>();
+
+      try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        for (int r = 0; r < READERS; r++) {
+          final Thread t = new Thread(() -> {
+            try {
+              start.await();
+              while (!stop.get() && failure.get() == null) {
+                try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+                  final var axis = new DescendantAxis(rtx);
+                  while (axis.hasNext()) {
+                    axis.nextLong();
+                    switch (rtx.getKind()) {
+                      case STRING_VALUE, OBJECT_NAMED_STRING -> rtx.getValue();
+                      case NUMBER_VALUE, OBJECT_NAMED_NUMBER -> rtx.getNumberValue();
+                      case BOOLEAN_VALUE, OBJECT_NAMED_BOOLEAN -> rtx.getBooleanValue();
+                      default -> {
+                      }
+                    }
+                  }
+                }
+                reads.incrementAndGet();
+              }
+            } catch (final Throwable e) {
+              failure.compareAndSet(null, e);
+            }
+          }, "uaf-reader-" + r);
+          t.setDaemon(true);
+          threads.add(t);
+          t.start();
+        }
+
+        final Thread writer = new Thread(() -> {
+          try {
+            start.await();
+            int i = 0;
+            while (!stop.get() && failure.get() == null) {
+              try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+                wtx.moveToDocumentRoot();
+                wtx.moveToFirstChild();
+                wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"w\":" + i + "}"));
+              }
+              commits.incrementAndGet();
+              i++;
+            }
+          } catch (final Throwable e) {
+            failure.compareAndSet(null, e);
+          }
+        }, "uaf-writer");
+        writer.setDaemon(true);
+        threads.add(writer);
+        writer.start();
+
+        start.countDown();
+        final long deadline = System.currentTimeMillis() + DURATION_MS;
+        while (System.currentTimeMillis() < deadline && failure.get() == null) {
+          Thread.sleep(100);
+        }
+        stop.set(true);
+        for (final Thread t : threads) {
+          t.join(60_000);
+        }
+      }
+
+      final Throwable t = failure.get();
+      if (t != null) {
+        t.printStackTrace();
+        fail("concurrent reader/writer failed after " + reads.get() + " reads / " + commits.get() + " commits: " + t);
+      }
+      System.out.println("UAF stress survived: " + reads.get() + " reads, " + commits.get() + " commits");
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/ShardedPageCacheTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/ShardedPageCacheTest.java
@@ -102,6 +102,7 @@ class ShardedPageCacheTest {
     private final long pageKey;
     private volatile boolean hot;
     private volatile boolean closed;
+    private volatile boolean orphaned;
     private final AtomicInteger guards = new AtomicInteger();
 
     FakePage(long pageKey) {
@@ -130,8 +131,16 @@ class ShardedPageCacheTest {
 
     @Override
     public boolean acquireGuard() {
+      if (closed || (orphaned && guards.get() <= 0)) {
+        return false;
+      }
       guards.incrementAndGet();
       return true;
+    }
+
+    @Override
+    public void markOrphaned() {
+      orphaned = true;
     }
 
     @Override


### PR DESCRIPTION
## Problem

Under mixed read/write load (REST: 16 readers + 1 committing writer), readers sporadically crashed or returned wrong results, and both reader and writer latency collapsed as revisions accumulated:

1. **Sporadic HTTP 500s / wrong results** (3 per ~108k requests in a 30s run): `NullPointerException: "page" is null` in `PageLayout` reads, `AssertionError: Type not known` parsing values through a recycled frame, and silent `Failed to move to nodeKey` for nodes that exist in the reader's pinned revision.
2. **Revision-count scaling collapse**: with ~9k revisions, reader throughput dropped from 3,650 to 361 req/s, reader p99 from 22ms to 334ms, writer p99 to 471ms — the long-standing "mixed read/write tail".

## Root cause 1: reader-side guard theft (use-after-free)

Captured by a new DEBUG close-site diagnostic (`-Dsirix.debug.memory.leaks=true` makes a page record who closed it): on most-recent-slot replacement and at trx close, `closeMostRecentPageIfOrphaned()` saw "page not in cache anymore", **released a guard it never acquired, and closed the page when the count hit zero** — stealing the guard another reader had just taken on the same shared instance and freeing the page under it. `guardCount` carries no ownership, and most-recent slots are unguarded references to shared cache instances by design, so the method's premise ("orphaned pages can't have foreign guards") was false.

Fix — shared-page lifecycle belongs to the cache, never to readers:

- `NodeStorageEngineReader`: slot replacement and trx close just drop references (stale references already revalidate via `tryAcquireGuard` on use). Release-only-what-you-acquired at every `tryAcquireGuard` site (a failed acquire never increments, so releasing there stole a foreign guard).
- `ShardedPageCache.put()`: replacing a live **record-page** instance now `markOrphaned()` + guard-aware `close()` — immediate teardown when unguarded, deferred to the last `releaseGuard()` otherwise. This also closes the leak the reader-side close was (incorrectly) compensating for. HOT leaves are exempt: the same instance intentionally backs both a TIL container and the cache (that lifecycle is owned by the TIL — see #1030 for the HOT-side fix).
- `ShardedPageCache.getAndGuard()/getOrLoadAndGuard()`: honor `acquireGuard()` results — a failed acquire is a dead mapping (reload), never a handout of an unguarded page.
- `TransactionIntentLog.closePage` (KeyValueLeafPage branch): orphan + guard-aware close instead of force-draining guards the transaction does not own — the HOTLeafPage branch of the same method already did exactly this.
- Teardown/destructive-admin paths (`clearAllCaches`, database/resource removal sweeps) keep unconditional reclamation: deferring there pinned frames forever when tests/admin flows abandon transactions.

## Root cause 2: O(revisions) revision-index rebuild on storage open

A `jstack` profile of the degraded aged-DB run put ~95% of busy reader samples in `FileChannelReader.getRevisionFileData` under `IOStorage.loadRevisionIndex`: whenever a concurrent commit makes the in-memory revision index disagree with the on-disk count, the next storage open rebuilt it by issuing **one 16-byte pread + one `ByteBuffer.allocateDirect` per revision**. `allocateDirect` registers with a JVM-global synchronized `Cleaner` list, so 16 concurrent readers serialized on it — request-scoped opens became linear in revision count (14k revisions ⇒ ~14k syscalls + 14k global-lock acquisitions per open).

Fix: a bulk `Reader.getRevisionFileData(from, count)` (single pread through the existing pooled buffer, per-record checksums still verified), used by `loadRevisionIndex`; the single-record path delegates to it. `AbstractForwardingReader` forwards the bulk method so wrappers keep the optimization.

## Verification

- New regression gate `MixedReadWriteUafStressTest` (8 readers full descendant traversals with value reads vs 1 insert+commit writer on an 8-page record-cache budget): pre-fix it failed 5/6 runs within seconds, including the exact production NPE signature; post-fix 5/5 × 45s runs green (~3.2k commits, ~18k traversals each). It restores the global buffer-manager budgets in `tearDown`.
- Full `:sirix-core:test`: **9,188 tests, 0 failures, 0 errors**.
- End-to-end REST mixed bench (16 readers + 1 writer):

| | fresh DB, before | aged DB (~9k revs), before | aged DB (~12.8k revs), **after** |
|---|---|---|---|
| reader throughput | 3,650 req/s | 361 req/s | **11,198 req/s** |
| reader p99 | 22–36 ms | 334 ms | **4.8 ms** (max 9.4 ms) |
| writer p99 | 222 ms | 471 ms | **13.1 ms** |
| reader errors | 3 × HTTP 500 | 0 | **0** |

The aged database now outperforms the pre-fix fresh database: even low-revision opens were paying per-record syscalls plus the global `Cleaner` lock.
