### PR TITLE
Robustness wave: crash-window fixes, auto-commit read race, REST Error mapping, recovery self-heal

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/Databases.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/Databases.java
@@ -280,6 +280,10 @@ public final class Databases {
     }
     AbstractResourceSession.clearRevisionInfoCache();
     SuperblockValidator.clear();
+    // Path-keyed revision metadata (the RevisionFileData cache + the revision-index holders) is
+    // populated at write time and survives session closes — a fresh process has neither, and a
+    // warm copy completely masks out-of-band revisions-file damage from the next open.
+    io.sirix.io.StorageType.clearRevisionMetadataCaches();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -74,8 +74,22 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
 
   /**
    * State of transaction including all cached stuff.
+   *
+   * <p>Volatile because auto-commit swaps the engine from the commit-timer thread
+   * ({@code reInstantiate()} closes the old engine, then publishes the new one via
+   * {@link #setPageReadTransaction(StorageEngineReader)}) while the owning thread may
+   * concurrently read — a plain field could pin a stale (closed) engine forever.
    */
-  protected StorageEngineReader storageEngineReader;
+  protected volatile StorageEngineReader storageEngineReader;
+
+  /**
+   * The revision this transaction works on, cached from the engine at every engine handoff.
+   * The value is immutable per engine instance, so reading it here instead of dereferencing
+   * {@link #storageEngineReader} keeps {@link #getRevisionNumber()} safe against the
+   * post-auto-commit swap window in which the field is momentarily {@code null} or still
+   * points at the just-closed engine (auto-commit explicitly invites such cross-thread reads).
+   */
+  private volatile int revisionNumber;
 
   /**
    * The current node.
@@ -168,6 +182,7 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     this.resourceSession = requireNonNull(resourceSession);
     this.id = trxId;
     this.storageEngineReader = requireNonNull(pageReadTransaction);
+    this.revisionNumber = pageReadTransaction.getActualRevisionRootPage().getRevision();
     this.currentNode = requireNonNull(documentNode);
     this.isClosed = false;
     this.resourceConfig = resourceSession.getResourceConfig();
@@ -373,7 +388,10 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
   @Override
   public int getRevisionNumber() {
     assertNotClosed();
-    return storageEngineReader.getActualRevisionRootPage().getRevision();
+    // Served from the cached value instead of the engine: during the post-commit engine swap
+    // (KEEP_OPEN auto-commit) the engine reference is transiently null or already closed, and
+    // dereferencing it from another thread raced into "Transaction is already closed!" errors.
+    return revisionNumber;
   }
 
   @Override
@@ -1120,6 +1138,12 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
    */
   public final void setPageReadTransaction(@Nullable final StorageEngineReader pageReadTransaction) {
     assertNotClosed();
+    if (pageReadTransaction != null) {
+      // Refresh BEFORE publishing the engine so a concurrent getRevisionNumber() never sees the
+      // new engine paired with the old revision. While the engine reference is null (the swap
+      // window) the previous revision stays readable — it was the true value an instant ago.
+      revisionNumber = pageReadTransaction.getActualRevisionRootPage().getRevision();
+    }
     storageEngineReader = pageReadTransaction;
     cachedNodeReader = resolveNodeReader(pageReadTransaction);
     cachedWriter = (pageReadTransaction instanceof StorageEngineWriter w) ? w : null;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -1593,20 +1593,25 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // truncated away — discard them before touching the files.
     bufferBytes.clear();
 
-    storagePageReaderWriter.truncateTo(this, revision);
-
     // An explicit rollback truncates AWAY the revision both uber beacons advertise — unlike
     // crash recovery, where one slot still matches the target and the io-layer repairs the
-    // other. Dying before the next commit would leave the resource unopenable (beacons
-    // referencing truncated offsets). The serialized uber page carries only the revision
-    // count, so the rolled-back page is fully reconstructible here and written through the
-    // regular dual-beacon protocol.
+    // other. The serialized uber page carries only the revision count, so the rolled-back
+    // page is fully reconstructible here and written through the regular dual-beacon
+    // protocol. ORDER MATTERS: the beacons must be downgraded durably BEFORE the files are
+    // truncated — truncating first opened a crash window in which a (still checksum-valid)
+    // beacon advertised the truncated-away revision, so recovery dereferenced truncated
+    // offsets and the resource was unopenable ("Truncated revisions record"). With
+    // beacons-first, a crash at any instant leaves the resource at either the original or
+    // the target revision: the target's revision record and pages lie BELOW the truncation
+    // point, so they satisfy pre-written beacons even when the truncates themselves are lost.
     final var resourceSession = getResourceSession();
     final var rolledBackUberPage = new UberPage(revision + 1);
     storagePageReaderWriter.writeUberPageReference(resourceSession.getResourceConfig(), new PageReference(),
         rolledBackUberPage, Bytes.elasticOffHeapByteBuffer());
     ((io.sirix.access.trx.node.InternalResourceSession<?, ?>) resourceSession).setLastCommittedUberPage(
         rolledBackUberPage);
+
+    storagePageReaderWriter.truncateTo(this, revision);
 
     // The truncated range's offsets are reused by the next commit — drop this database's
     // cached pages so nothing pre-truncation can be served.

--- a/bundles/sirix-core/src/main/java/io/sirix/io/InterruptedFirstCommitRecovery.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/InterruptedFirstCommitRecovery.java
@@ -1,9 +1,14 @@
 package io.sirix.io;
 
 import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.exception.SirixIOException;
+import io.sirix.io.bytepipe.ByteHandlerPipeline;
+import io.sirix.io.filechannel.FileChannelReader;
+import io.sirix.page.PagePersister;
 import io.sirix.page.PageReference;
+import io.sirix.page.SerializationType;
 import io.sirix.page.UberPage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,22 +25,36 @@ import java.nio.file.StandardOpenOption;
  * Open-time bootstrap-vs-load decision for a resource's storage, including the conservative
  * auto-heal for a crash during the resource's FIRST commit (layout-F5 gap).
  *
- * <p><b>The gap:</b> the superblock and both uber-page beacon slots of {@code sirix.data} are
- * only written at the END of the first commit (by {@code Writer.writeUberPageReference}); until
- * then the header region {@code [0, DATA_REGION_START)} is a sparse hole while the buffered page
- * writer may already have flushed &ge; 64 KiB of data pages past {@link IOStorage#DATA_REGION_START}.
- * A process crash in that window leaves a NON-EMPTY data file with an all-zero header (or, dying
- * between the superblock write and the beacon writes, a valid superblock with all-zero beacon
- * slots). {@link IOStorage#exists()} is size-based, so the next open takes the "load" path and
- * fails on superblock/beacon validation — permanently, although nothing was ever committed and a
- * fresh bootstrap is provably safe.
+ * <p><b>The gap, variant one (interrupted header write):</b> the superblock and both uber-page
+ * beacon slots of {@code sirix.data} are only written at the END of the first commit (by
+ * {@code Writer.writeUberPageReference}); until then the header region
+ * {@code [0, DATA_REGION_START)} is a sparse hole while the buffered page writer may already have
+ * flushed &ge; 64 KiB of data pages past {@link IOStorage#DATA_REGION_START}. A process crash in
+ * that window leaves a NON-EMPTY data file with an all-zero header (or, dying between the
+ * superblock write and the beacon writes, a valid superblock with all-zero beacon slots).
+ * {@link IOStorage#exists()} is size-based, so the next open takes the "load" path and fails on
+ * superblock/beacon validation — permanently, although nothing was ever committed and a fresh
+ * bootstrap is provably safe.
+ *
+ * <p><b>The gap, variant two (lost revision record of the bootstrap commit):</b> resource
+ * creation itself runs the EMPTY bootstrap commit (revision 0). Its 32-byte revision record is
+ * the ONLY path from the (durably written) uber beacons to the revision's root page, and the
+ * record lives in a DIFFERENT, just-created file — an environment-level loss (e.g. the new
+ * {@code sirix.revisions} directory entry dropped by a power cut, or the file truncated by
+ * filesystem repair) leaves checksum-valid beacons advertising revision 0 with no record to
+ * dereference. The next open then fails with "Truncated revisions record for revision 0" —
+ * permanently, although the only revision ever acknowledged is the empty bootstrap one and
+ * nothing on disk is reachable.
  *
  * <p><b>The heal:</b> when the open fails, the resource is re-initialized empty if and only if
- * the on-disk state PROVES no commit ever completed (see
- * {@link #provesNoCommitEverCompleted(Path, Path)}). Both files are truncated to zero and the
- * open is retried — which then runs the EXACT fresh-resource bootstrap path
- * ({@code exists() == false} → {@code new UberPage()}), not a duplicate of it. When the state is
- * not provable, the original exception (with its existing actionable message) is rethrown
+ * the on-disk state PROVES that at most the empty bootstrap revision was ever committed AND no
+ * checksum-valid revision record survives — i.e. nothing recoverable exists (see
+ * {@link #provesAtMostEmptyBootstrapCommitted(ResourceConfiguration, Path, Path)}). Both files
+ * are truncated to zero and the open is retried — which then runs the EXACT fresh-resource
+ * bootstrap path ({@code exists() == false} → {@code new UberPage()}), not a duplicate of it.
+ * When the state is not provable — any beacon advertising a revision past the bootstrap one, any
+ * torn/garbage beacon bytes, any checksum-valid revision record, any foreign superblock bytes —
+ * data may exist and the original exception (with its existing actionable message) is rethrown
  * unchanged.
  *
  * @author Johannes Lichtenberger
@@ -58,8 +77,9 @@ public final class InterruptedFirstCommitRecovery {
    * XML resource-session factories.
    *
    * <p>Any step of the open can surface the interrupted-first-commit state: storage creation
-   * pre-loads revision metadata (reading the uber page reference), and the uber-page load
-   * re-reads it. On failure the on-disk bytes are probed; a provably-uncommitted resource is
+   * pre-loads revision metadata (reading the uber page reference AND every revision record),
+   * and the uber-page load re-reads the beacons. On failure the on-disk bytes are probed; a
+   * resource provably holding nothing but (at most) the unreachable empty bootstrap revision is
    * re-initialized empty (with a WARN log) and the open retried through the fresh-bootstrap
    * path, everything else rethrows the original failure.
    *
@@ -73,13 +93,14 @@ public final class InterruptedFirstCommitRecovery {
     } catch (final RuntimeException openFailure) {
       final Path dataFile = dataFilePath(resourceConfig);
       final Path revisionsFile = revisionsFilePath(resourceConfig);
-      if (!provesNoCommitEverCompleted(dataFile, revisionsFile)) {
+      if (!provesAtMostEmptyBootstrapCommitted(resourceConfig, dataFile, revisionsFile)) {
         // Not provable — keep the existing actionable failure untouched.
         throw openFailure;
       }
-      LOGGER.warn("Interrupted FIRST commit detected for {}: the data file is non-empty (uncommitted flushed "
-              + "pages) but carries no superblock/uber-page beacon and the revisions file holds no checksum-valid "
-              + "revision record — no commit ever completed. Re-initializing the resource empty.",
+      LOGGER.warn("Interrupted FIRST commit detected for {}: the data file is non-empty but its uber-page "
+              + "beacons either were never written or advertise only the EMPTY bootstrap revision, and the "
+              + "revisions file holds no checksum-valid revision record — no commit carrying data ever became "
+              + "durable and nothing on disk is reachable. Re-initializing the resource empty.",
           dataFile, openFailure);
       reinitializeEmpty(resourceConfig, dataFile, revisionsFile);
       // Retry: with both files truncated to zero, exists() is false and the SAME code path that
@@ -110,9 +131,10 @@ public final class InterruptedFirstCommitRecovery {
   }
 
   /**
-   * Probes the raw on-disk bytes for PROOF that no commit ever completed on this resource. All
-   * of the following must hold (anything else — including any probe I/O error — is "not
-   * provable" and the open failure must be rethrown):
+   * Probes the raw on-disk bytes for PROOF that at most the EMPTY bootstrap revision was ever
+   * committed and that nothing on disk is reachable. All of the following must hold (anything
+   * else — including any probe I/O error — is "not provable" and the open failure must be
+   * rethrown):
    *
    * <ol>
    *   <li>{@code sirix.data} is non-empty (otherwise the open would have bootstrapped anyway —
@@ -121,16 +143,24 @@ public final class InterruptedFirstCommitRecovery {
    *       {@code writeUberPageReference} wrote anything) or a checksum-valid
    *       {@link Superblock#ROLE_DATA} superblock followed by zeros (crash between the
    *       superblock write and the beacon writes);</li>
-   *   <li>BOTH beacon slots {@code [PRIMARY_BEACON_OFFSET, DATA_REGION_START)} are entirely
-   *       zero — any nonzero byte (a length prefix, a torn payload, a checksum-valid slot)
-   *       means a commit may have completed;</li>
+   *   <li>EACH beacon slot in {@code [PRIMARY_BEACON_OFFSET, DATA_REGION_START)} is either
+   *       entirely zero (never written — no commit was ever acknowledged) or a checksum-valid
+   *       uber beacon advertising the BOOTSTRAP revision (revision number 0 — only the empty
+   *       commit that resource creation itself runs was ever acknowledged). Torn/garbage slot
+   *       bytes or any slot advertising a later revision mean data may exist;</li>
    *   <li>{@code sirix.revisions} holds no checksum-valid revision record in any slot (the
    *       bootstrap commit writes revision 0's record at slot 0 — and the first user commit
    *       revision 1's at slot 1 — BEFORE the beacons go out; a valid record means a commit got
-   *       far enough that data may exist).</li>
+   *       far enough that data may exist, and it also means whatever failed the open was not
+   *       the missing-record gap this recovery is for).</li>
    * </ol>
+   *
+   * <p>Under these conditions the only acknowledged state is (at most) the empty bootstrap
+   * revision whose record is gone — every byte past the header is unreachable, so re-running
+   * the fresh bootstrap loses nothing.
    */
-  static boolean provesNoCommitEverCompleted(final Path dataFile, final Path revisionsFile) {
+  static boolean provesAtMostEmptyBootstrapCommitted(final ResourceConfiguration resourceConfig, final Path dataFile,
+      final Path revisionsFile) {
     try {
       if (!Files.isRegularFile(dataFile) || Files.size(dataFile) == 0) {
         return false;
@@ -139,12 +169,8 @@ public final class InterruptedFirstCommitRecovery {
       if (!superblockRegionProvesNoCommit(header, dataFile)) {
         return false;
       }
-      // Both beacon slots must be entirely zero (a file ending before DATA_REGION_START reads
-      // as zeros — no beacon was ever written there either).
-      for (int i = (int) IOStorage.PRIMARY_BEACON_OFFSET; i < header.length; i++) {
-        if (header[i] != 0) {
-          return false;
-        }
+      if (!beaconSlotsProveAtMostBootstrapRevision(resourceConfig, header, dataFile)) {
+        return false;
       }
       return hasNoChecksumValidRevisionRecord(revisionsFile);
     } catch (final IOException | RuntimeException probeFailure) {
@@ -152,6 +178,46 @@ public final class InterruptedFirstCommitRecovery {
           probeFailure);
       return false;
     }
+  }
+
+  /**
+   * Each beacon slot must be entirely zero (a file ending before {@code DATA_REGION_START}
+   * reads as zeros — never written) or a checksum-valid beacon advertising revision number 0,
+   * the empty bootstrap revision committed by resource creation itself. The slot is parsed by
+   * the canonical verifier ({@code AbstractReader#beaconRevisionOrMinusOne}); the beacon-slot
+   * format is identical across the file-based storage backends, so the {@link FileChannelReader}
+   * parser is authoritative for all of them. The reader's revisions-channel parameter is only
+   * used for revision-record reads, which the beacon parse never performs — the data channel is
+   * passed in both positions so the probe cannot require {@code sirix.revisions} to exist (its
+   * loss may be exactly what is being probed).
+   */
+  private static boolean beaconSlotsProveAtMostBootstrapRevision(final ResourceConfiguration resourceConfig,
+      final byte[] header, final Path dataFile) throws IOException {
+    final boolean primaryAllZero =
+        isAllZero(header, (int) IOStorage.PRIMARY_BEACON_OFFSET, (int) IOStorage.SECONDARY_BEACON_OFFSET);
+    final boolean secondaryAllZero =
+        isAllZero(header, (int) IOStorage.SECONDARY_BEACON_OFFSET, (int) IOStorage.DATA_REGION_START);
+    if (primaryAllZero && secondaryAllZero) {
+      return true;
+    }
+    try (final FileChannel dataChannel = FileChannel.open(dataFile, StandardOpenOption.READ)) {
+      final FileChannelReader reader = new FileChannelReader(dataChannel, dataChannel,
+          new ByteHandlerPipeline(resourceConfig.byteHandlePipeline), SerializationType.DATA, new PagePersister(),
+          Caffeine.newBuilder().build());
+      if (!primaryAllZero && reader.beaconRevisionOrMinusOne(IOStorage.PRIMARY_BEACON_OFFSET) != 0) {
+        return false;
+      }
+      return secondaryAllZero || reader.beaconRevisionOrMinusOne(IOStorage.SECONDARY_BEACON_OFFSET) == 0;
+    }
+  }
+
+  private static boolean isAllZero(final byte[] bytes, final int from, final int to) {
+    for (int i = from; i < to; i++) {
+      if (bytes[i] != 0) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /** Reads {@code [0, DATA_REGION_START)} of the data file; bytes past EOF stay zero. */

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -219,6 +219,21 @@ public enum StorageType {
    */
   public static final ConcurrentMap<Path, RevisionIndexHolder> REVISION_INDEX_REPOSITORY = new ConcurrentHashMap<>();
 
+  /**
+   * Drops every per-path revision-metadata entry (the global {@code RevisionFileData} cache,
+   * the per-resource cache views, and the revision-index holders). NOT part of normal
+   * operation — these caches are populated at write time and kept consistent by the writers;
+   * this exists for {@code Databases.clearGlobalCaches()}'s cold-process simulation, where
+   * tests mutate the on-disk files out-of-band and the next open must re-read EVERYTHING from
+   * disk like a freshly started process would (a warm revision index otherwise masks
+   * revisions-file damage entirely).
+   */
+  public static void clearRevisionMetadataCaches() {
+    GLOBAL_REVISION_FILE_DATA_CACHE.synchronous().invalidateAll();
+    CACHE_REPOSITORY.clear();
+    REVISION_INDEX_REPOSITORY.clear();
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(StorageType.class);
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
@@ -245,6 +245,35 @@ public final class MMFileReader extends AbstractReader {
   }
 
   @Override
+  public RevisionFileData[] getRevisionFileData(final int fromRevision, final int count) {
+    if (count <= 0) {
+      return new RevisionFileData[0];
+    }
+    // Mapped reads need no syscalls or staging buffers, so unlike FileChannelReader the bulk
+    // path is not about I/O batching — it only hoists the truncation check out of the
+    // per-record loop (the revision-index load calls this with the full history).
+    final long lastRecordOffset = IOStorage.revisionsFileOffset(fromRevision + count - 1);
+    if (lastRecordOffset + 3L * Long.BYTES > revisionsOffsetFileSegment.byteSize()) {
+      final long tail = revisionsOffsetFileSegment.byteSize() - IOStorage.REVISIONS_RECORDS_START - 3L * Long.BYTES;
+      final long firstTruncated = tail < 0 ? 0 : tail / IOStorage.REVISIONS_FILE_RECORD_SIZE + 1;
+      throw new SirixIOException("Truncated revisions record for revision " + Math.max(fromRevision, firstTruncated));
+    }
+    final RevisionFileData[] result = new RevisionFileData[count];
+    for (int i = 0; i < count; i++) {
+      final long base = IOStorage.revisionsFileOffset(fromRevision + i);
+      final long revisionOffset = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base);
+      final long timestampMillis = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base + 8);
+      final long storedChecksum = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base + 16);
+      if (storedChecksum != IOStorage.revisionRecordChecksum(revisionOffset, timestampMillis)) {
+        throw new io.sirix.exception.SirixIOException("Corrupt revisions record for revision " + (fromRevision + i)
+            + " (checksum mismatch) — torn write or storage corruption");
+      }
+      result[i] = new RevisionFileData(revisionOffset, Instant.ofEpochMilli(timestampMillis));
+    }
+    return result;
+  }
+
+  @Override
   protected java.nio.ByteBuffer readBeaconSlot(final long offset) {
     final long available = dataFileSegment.byteSize() - offset;
     if (available < Integer.BYTES) {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
@@ -89,7 +89,10 @@ public final class ReferencesPage4 implements Page {
       pageReference.setDatabaseId(pageReferenceToClone.getDatabaseId());
       pageReference.setResourceId(pageReferenceToClone.getResourceId());
       pageReference.setPage(pageReferenceToClone.getPage());
-      pageReference.setPageFragments(pageReferenceToClone.getPageFragments());
+      // Copy the list, never alias it: the clone lives in a new revision and its fragment list
+      // must be able to diverge from the committed page's (FullReferencesPage and
+      // BitmapReferencesPage already copy).
+      pageReference.setPageFragments(new ArrayList<>(pageReferenceToClone.getPageFragments()));
       references.add(pageReference);
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/access/InterruptedFirstCommitRecoveryTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/InterruptedFirstCommitRecoveryTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -211,6 +212,127 @@ final class InterruptedFirstCommitRecoveryTest {
     Databases.clearGlobalCaches(); // cold-process simulation
 
     assertOpensEmptyAcceptsCommitAndReadsBack(dbPath);
+  }
+
+  /**
+   * Variant two of the gap: resource creation's bootstrap commit COMPLETED (checksum-valid
+   * beacons advertising the empty revision 0), but the just-created {@code sirix.revisions} was
+   * lost/truncated by the environment (directory entry dropped on power cut, filesystem repair)
+   * before anything else committed. The open then fails with "Truncated revisions record for
+   * revision 0" although the only acknowledged revision is the empty bootstrap one and nothing
+   * on disk is reachable — must self-heal exactly like the zero-header variant.
+   */
+  @ParameterizedTest(name = "storageType={0}, revisionsFileDamage={1}")
+  @MethodSource("revisionsFileDamageVariants")
+  @DisplayName("bootstrap-only resource with truncated/empty/partial revisions file re-bootstraps empty")
+  void truncatedRevisionsRecordAtRevisionZero_isRebootstrappedEmpty(final StorageType storageType,
+      final String damage, final long truncateToSize) throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    createDbAndResource(dbPath, storageType);
+
+    truncate(revisionsFilePath(dbPath, RESOURCE), truncateToSize);
+    Databases.clearGlobalCaches(); // cold-process simulation
+
+    assertOpensEmptyAcceptsCommitAndReadsBack(dbPath);
+  }
+
+  private static java.util.stream.Stream<org.junit.jupiter.params.provider.Arguments> revisionsFileDamageVariants() {
+    final long recordStart = IOStorage.REVISIONS_RECORDS_START;
+    return java.util.stream.Stream.of(StorageType.FILE_CHANNEL, StorageType.MEMORY_MAPPED)
+        .flatMap(storageType -> java.util.stream.Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of(storageType, "lost (size 0)", 0L),
+            org.junit.jupiter.params.provider.Arguments.of(storageType, "header only (record 0 gone)", recordStart),
+            org.junit.jupiter.params.provider.Arguments.of(storageType, "torn mid-record 0", recordStart + 4)));
+  }
+
+  /**
+   * NEGATIVE control for variant two: a truncated record for a revision PAST the bootstrap one
+   * on a resource WITH committed data is REAL CORRUPTION — earlier records are checksum-valid
+   * and the beacons advertise the later revision, so data exists. The open must keep failing
+   * with the existing actionable error and the files must be left untouched.
+   */
+  @Test
+  @DisplayName("committed resource with truncated revisions record at revision N>0 fails without re-bootstrap")
+  void truncatedRevisionsRecordAtLaterRevision_failsWithoutRebootstrap() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    createDbAndResource(dbPath, StorageType.FILE_CHANNEL);
+
+    // One real commit beyond the bootstrap revision (data!), then cut its record off.
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath);
+         final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(DOC));
+        wtx.commit();
+      }
+    }
+
+    final Path dataFile = dataFilePath(dbPath, RESOURCE);
+    final Path revisionsFile = revisionsFilePath(dbPath, RESOURCE);
+    truncate(revisionsFile, IOStorage.revisionsFileOffset(1)); // record 0 survives, record 1 cut
+    final long dataSize = Files.size(dataFile);
+    final long revisionsSize = Files.size(revisionsFile);
+
+    Databases.clearGlobalCaches(); // cold-process simulation
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      final RuntimeException failure = assertThrows(RuntimeException.class, () -> {
+        try (final JsonResourceSession ignored = db.beginResourceSession(RESOURCE)) {
+          // must not be reached
+        }
+      });
+      assertTrue(messageChain(failure).contains("Truncated revisions record for revision 1"),
+          "expected the existing truncated-record failure, got: " + messageChain(failure));
+    }
+
+    // NO re-bootstrap: the files (committed data!) must be byte-count identical.
+    assertEquals(dataSize, Files.size(dataFile), "data file must not be truncated/re-initialized");
+    assertEquals(revisionsSize, Files.size(revisionsFile), "revisions file must not be truncated further");
+  }
+
+  /**
+   * NEGATIVE control for variant two: losing the WHOLE revisions file of a resource whose
+   * beacons advertise a revision past the bootstrap one means committed data exists but is
+   * unreachable — corruption to surface loudly, never to auto-wipe (the no-valid-record check
+   * alone would pass here; the beacon-advertised-revision check is what must refuse).
+   */
+  @Test
+  @DisplayName("committed resource with lost revisions file fails without re-bootstrap")
+  void lostRevisionsFileWithCommittedData_failsWithoutRebootstrap() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    createDbAndResource(dbPath, StorageType.FILE_CHANNEL);
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath);
+         final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(DOC));
+        wtx.commit();
+      }
+    }
+
+    final Path dataFile = dataFilePath(dbPath, RESOURCE);
+    truncate(revisionsFilePath(dbPath, RESOURCE), 0);
+    final long dataSize = Files.size(dataFile);
+
+    Databases.clearGlobalCaches(); // cold-process simulation
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      final RuntimeException failure = assertThrows(RuntimeException.class, () -> {
+        try (final JsonResourceSession ignored = db.beginResourceSession(RESOURCE)) {
+          // must not be reached
+        }
+      });
+      assertTrue(messageChain(failure).contains("Truncated revisions record"),
+          "expected the existing truncated-record failure, got: " + messageChain(failure));
+    }
+
+    assertEquals(dataSize, Files.size(dataFile), "data file must not be truncated/re-initialized");
+  }
+
+  private static void truncate(final Path file, final long size) throws IOException {
+    try (final FileChannel ch = FileChannel.open(file, StandardOpenOption.WRITE)) {
+      ch.truncate(size);
+      ch.force(true);
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/xml/XmlResourceSessionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/xml/XmlResourceSessionTest.java
@@ -240,8 +240,29 @@ public class XmlResourceSessionTest {
   @Test
   public void testAutoCommitWithScheduler() throws InterruptedException {
     // After 500 milliseconds commit.
-    try (final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx(500, TimeUnit.MILLISECONDS)) {
-      TimeUnit.MILLISECONDS.sleep(1500);
+    final XmlResourceSession session = holder.getResourceSession();
+    try (final XmlNodeTrx wtx = session.beginNodeTrx(500, TimeUnit.MILLISECONDS)) {
+      // The timer fires on a background thread; sleeping a fixed 1500ms and expecting two
+      // commits already happened is a wall-clock race that flaked on loaded runners. Poll the
+      // session's committed revision instead and only assert that the scheduler commits
+      // repeatedly — bounded so a wedged timer fails loudly instead of hanging the test.
+      final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(60);
+      while (session.getMostRecentRevisionNumber() < 2) {
+        if (System.nanoTime() - deadlineNanos > 0) {
+          fail("Auto-commit scheduler did not commit two revisions within 60s (still at "
+              + session.getMostRecentRevisionNumber() + ")");
+        }
+        TimeUnit.MILLISECONDS.sleep(10);
+      }
+      // The transaction's own view advances a beat later (the timer thread is still inside
+      // commitInternal between publishing the committed uber page and re-instantiating the
+      // transaction) — give it the same bounded grace instead of asserting the instant value.
+      while (wtx.getRevisionNumber() < 3) {
+        if (System.nanoTime() - deadlineNanos > 0) {
+          break;
+        }
+        TimeUnit.MILLISECONDS.sleep(10);
+      }
       assertTrue(wtx.getRevisionNumber() >= 3);
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/AutoCommitRevisionReadStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/AutoCommitRevisionReadStressTest.java
@@ -1,0 +1,78 @@
+package io.sirix.access.trx.node;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Auto-commit ({@code beginNodeTrx(maxTime, timeUnit)}) commits from a TIMER thread while the
+ * owning thread keeps using the transaction — the documented usage explicitly invites this
+ * cross-thread interaction. The post-commit {@code reInstantiate()} swap (close old storage
+ * engine → create new → publish) left a multi-millisecond window in which
+ * {@code getRevisionNumber()} dereferenced a closed (or null) engine and died with
+ * {@code AssertionError: Transaction is already closed!} from
+ * {@code NodeStorageEngineReader.assertNotClosed}.
+ *
+ * <p>This stress test reproduced that race deterministically within roughly a second before the
+ * fix (revision number served from a volatile cached value instead of the swapping engine).
+ */
+final class AutoCommitRevisionReadStressTest {
+
+  /** Short cadence maximizes engine swaps per second; the window opens on every commit. */
+  private static final int AUTO_COMMIT_MILLIS = 5;
+
+  private static final long STRESS_DURATION_MILLIS = 3_000;
+
+  private Database<JsonResourceSession> database;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.closeEverything();
+  }
+
+  @Test
+  @Timeout(value = 120, unit = TimeUnit.SECONDS)
+  @DisplayName("getRevisionNumber() polled concurrently with timer auto-commits never observes a closed engine")
+  void pollingRevisionNumberWhileAutoCommitTimerSwapsEnginesIsSafe() {
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx(AUTO_COMMIT_MILLIS, TimeUnit.MILLISECONDS)) {
+      final int initialRevision = wtx.getRevisionNumber();
+
+      final long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(STRESS_DURATION_MILLIS);
+      int lastSeen = initialRevision;
+      long reads = 0;
+      while (System.nanoTime() < deadline) {
+        // Pre-fix this poll raced the timer thread's reInstantiate() into
+        // "AssertionError: Transaction is already closed!" (or an NPE in the null window).
+        final int revision = wtx.getRevisionNumber();
+        assertTrue(revision >= lastSeen,
+            "revision must never move backwards (read " + revision + " after " + lastSeen + ")");
+        lastSeen = revision;
+        reads++;
+        Thread.onSpinWait();
+      }
+
+      assertTrue(reads > 0, "the poll loop must have run");
+      assertTrue(lastSeen > initialRevision,
+          "the auto-commit timer must have committed at least once during the stress window (saw "
+              + lastSeen + ", started at " + initialRevision + ")");
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/crash/ExplicitRollbackCrashSimulationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/crash/ExplicitRollbackCrashSimulationTest.java
@@ -1,0 +1,394 @@
+package io.sirix.crash;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Crash-simulation gate for an EXPLICIT rollback ({@code StorageEngineWriter.truncateTo}): unlike
+ * crash recovery — where one uber-beacon slot still matches the truncated-to revision — a rollback
+ * truncates AWAY the revision both slots advertise, so the ordering between the file truncation
+ * and the dual-beacon downgrade is the whole crash-safety story. Truncating FIRST left a window in
+ * which a checksum-valid beacon advertised the truncated-away revision over truncated files: a
+ * crash there made recovery dereference truncated offsets ("Truncated revisions record") and the
+ * resource was permanently unopenable, silently resurrecting a rolled-back revision being the
+ * other possible outcome.
+ *
+ * <p>The gate records every channel write/force/truncate of a real rollback (three committed
+ * revisions, then {@code truncateTo(1)}) through {@link PowerLossRecordingStorage}, materializes a
+ * candidate post-power-loss state for every crash instant in the rollback window (with lost and
+ * torn in-flight variants, {@link CrashStateMaterializer} semantics), and verifies each state
+ * cold:
+ *
+ * <ol>
+ *   <li>the resource MUST open — never brick;</li>
+ *   <li>it must sit at either the ORIGINAL revision (3 — rollback not yet effective) or the
+ *       TARGET revision (1 — rollback effective): nothing in between, nothing beyond;</li>
+ *   <li>every surviving revision must serialize exactly to its golden JSON;</li>
+ *   <li>the resource must accept a new commit afterwards.</li>
+ * </ol>
+ *
+ * <p>Before the beacons-first ordering fix this failed at every instant between the truncates and
+ * the beacon rewrite with the exact production symptom (unopenable, "Truncated revisions record").
+ */
+public final class ExplicitRollbackCrashSimulationTest {
+
+  private static final String RESOURCE = "rollback-crash-resource";
+
+  private static final int ORIGINAL_REVISION = 3;
+
+  private static final int TARGET_REVISION = 1;
+
+  /** In-flight sets up to this size are enumerated exhaustively (the rollback window is small). */
+  private static final int EXHAUSTIVE_SUBSET_LIMIT = 6;
+
+  private record RollbackCandidate(long crashSeq, Set<Long> appliedInFlight, Map<Long, Integer> torn, String label) {
+  }
+
+  @Test
+  public void anyCrashInstantDuringExplicitRollbackLeavesOriginalOrTargetRevision() throws Exception {
+    final Path workRoot = Files.createTempDirectory("sirix-rollback-crash-");
+    try {
+      // ---------------- record the rollback under the real I/O stack ----------------
+      final PowerLossRecorder recorder = new PowerLossRecorder();
+      final Path recordDb = workRoot.resolve("record-db");
+      final Map<Integer, String> golden = new TreeMap<>();
+
+      PowerLossRecordingStorage.install(recordDb, recorder);
+      try {
+        Databases.createJsonDatabase(new DatabaseConfiguration(recordDb));
+        try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(recordDb)) {
+          database.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+                                                       .storageType(StorageType.FILE_CHANNEL)
+                                                       .versioningApproach(VersioningType.FULL)
+                                                       .hashKind(HashType.NONE)
+                                                       .buildPathSummary(false)
+                                                       .storeDiffs(false)
+                                                       .build());
+          try (final JsonResourceSession session = database.beginResourceSession(RESOURCE)) {
+            try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+              wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[\"r1\"]"), JsonNodeTrx.Commit.NO);
+              wtx.commit();
+            }
+            for (final String value : new String[] { "{\"r\":2}", "{\"r\":3}" }) {
+              try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+                wtx.moveToDocumentRoot();
+                wtx.moveToFirstChild();
+                wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(value), JsonNodeTrx.Commit.NO);
+                wtx.commit();
+              }
+            }
+            assertTrue(session.getMostRecentRevisionNumber() == ORIGINAL_REVISION,
+                "setup must produce " + ORIGINAL_REVISION + " revisions");
+            for (int revision = 1; revision <= ORIGINAL_REVISION; revision++) {
+              golden.put(revision, serializeRevision(session, revision));
+            }
+
+            recorder.mark("preRollback", ORIGINAL_REVISION);
+            try (final var storageEngineWriter = session.createStorageEngineWriter()) {
+              storageEngineWriter.truncateTo(TARGET_REVISION);
+            }
+            recorder.mark("rollback", TARGET_REVISION);
+          }
+        }
+      } finally {
+        PowerLossRecordingStorage.uninstall();
+      }
+
+      final Path templateDb = workRoot.resolve("template-db");
+      copyRecursive(recordDb, templateDb);
+      Files.deleteIfExists(commitMarkerPath(templateDb));
+
+      final List<PowerLossRecorder.Op> ops = recorder.snapshotOps();
+      final long rollbackWindowStart = recorder.snapshotMilestones()
+                                               .stream()
+                                               .filter(m -> m.name().equals("preRollback"))
+                                               .findFirst()
+                                               .orElseThrow()
+                                               .lastSeqInclusive();
+
+      // ---------------- enumerate crash states across the rollback window ----------------
+      final List<RollbackCandidate> candidates = enumerateCandidates(ops, rollbackWindowStart);
+      final LinkedHashMap<String, RollbackCandidate> uniqueStates = new LinkedHashMap<>();
+      final Map<String, byte[]> dataByKey = new LinkedHashMap<>();
+      final Map<String, byte[]> revisionsByKey = new LinkedHashMap<>();
+      for (final RollbackCandidate candidate : candidates) {
+        final byte[] data = CrashStateMaterializer.materialize(ops, PowerLossRecorder.TargetFile.DATA,
+            candidate.crashSeq(), candidate.appliedInFlight(), candidate.torn());
+        final byte[] revisions = CrashStateMaterializer.materialize(ops, PowerLossRecorder.TargetFile.REVISIONS,
+            candidate.crashSeq(), candidate.appliedInFlight(), candidate.torn());
+        final String key = java.util.Arrays.hashCode(data) + "/" + data.length + "|"
+            + java.util.Arrays.hashCode(revisions) + "/" + revisions.length;
+        if (uniqueStates.putIfAbsent(key, candidate) == null) {
+          dataByKey.put(key, data);
+          revisionsByKey.put(key, revisions);
+        }
+      }
+
+      // ---------------- verify each state cold ----------------
+      final List<String> failures = new ArrayList<>();
+      final Set<Integer> observedRevisions = new HashSet<>();
+      int stateIndex = 0;
+      for (final Map.Entry<String, RollbackCandidate> entry : uniqueStates.entrySet()) {
+        final Path stateDb = workRoot.resolve("state-" + stateIndex++);
+        copyRecursive(templateDb, stateDb);
+        Files.write(dataFilePath(stateDb), dataByKey.get(entry.getKey()));
+        Files.write(revisionsFilePath(stateDb), revisionsByKey.get(entry.getKey()));
+
+        final String failure = verifyState(stateDb, golden, observedRevisions);
+        if (failure != null) {
+          failures.add("crash state [" + entry.getValue().label() + "]: " + failure);
+        }
+        dropPerPathRegistryEntries(stateDb);
+        deleteRecursive(stateDb);
+      }
+
+      if (!failures.isEmpty()) {
+        fail(failures.size() + " of " + uniqueStates.size()
+            + " rollback crash state(s) violated the original-or-target contract:\n"
+            + String.join("\n---\n", failures));
+      }
+      // The enumeration must actually have exercised both outcomes, or the gate proves nothing.
+      assertTrue(observedRevisions.contains(ORIGINAL_REVISION),
+          "no crash state surfaced the pre-rollback revision — enumeration broken? saw " + observedRevisions);
+      assertTrue(observedRevisions.contains(TARGET_REVISION),
+          "no crash state surfaced the rolled-back revision — enumeration broken? saw " + observedRevisions);
+    } finally {
+      deleteRecursive(workRoot);
+    }
+  }
+
+  /**
+   * Crash instants from the first rollback-issued op through one past the final op (the fully
+   * completed rollback), each with exhaustive lost-in-flight subsets and content-aware torn
+   * variants for in-flight writes — the dual DSYNC beacon-slot writes are the interesting ones
+   * (covers a torn primary falling back to the secondary, i.e. both slot orderings). The
+   * pre-rollback boundary op itself (the final op of the LAST COMMIT, whose loss legitimately
+   * reverts to the commit-before-last — that commit was then never acknowledged) belongs to the
+   * general power-loss gate, not to this rollback-ordering one.
+   */
+  private static List<RollbackCandidate> enumerateCandidates(final List<PowerLossRecorder.Op> ops,
+      final long rollbackWindowStart) {
+    final List<RollbackCandidate> candidates = new ArrayList<>();
+    for (long instant = rollbackWindowStart + 1; instant <= ops.size(); instant++) {
+      final String prefix = "i" + instant;
+      final List<PowerLossRecorder.Op> inFlight = inFlightOps(ops, instant);
+      final int k = inFlight.size();
+      assertTrue(k <= EXHAUSTIVE_SUBSET_LIMIT,
+          "rollback window has " + k + " in-flight ops at instant " + instant
+              + " — raise the exhaustive limit or sample: " + inFlight);
+      for (int mask = 0; mask < (1 << k); mask++) {
+        final Set<Long> applied = new HashSet<>();
+        for (int bit = 0; bit < k; bit++) {
+          if ((mask & (1 << bit)) != 0) {
+            applied.add(inFlight.get(bit).seq);
+          }
+        }
+        candidates.add(new RollbackCandidate(instant, applied, Map.of(), prefix + ":mask" + mask));
+      }
+      for (final PowerLossRecorder.Op op : inFlight) {
+        if (op.kind != PowerLossRecorder.OpKind.WRITE || op.bytes.length < 2) {
+          continue;
+        }
+        final Set<Integer> tornLengths = new LinkedHashSet<>();
+        tornLengths.add(op.bytes.length / 2);
+        int contentEnd = op.bytes.length;
+        while (contentEnd > 0 && op.bytes[contentEnd - 1] == 0) {
+          contentEnd--;
+        }
+        if (contentEnd >= 2) {
+          tornLengths.add(contentEnd / 2);
+          tornLengths.add(contentEnd - 1);
+        }
+        tornLengths.removeIf(keep -> keep <= 0 || keep >= op.bytes.length);
+        final Set<Long> others = new HashSet<>();
+        for (final PowerLossRecorder.Op other : inFlight) {
+          if (other.seq != op.seq) {
+            others.add(other.seq);
+          }
+        }
+        for (final int keep : tornLengths) {
+          candidates.add(new RollbackCandidate(instant, others, Map.of(op.seq, keep),
+              prefix + ":torn#" + op.seq + "@" + keep + "+rest"));
+          candidates.add(new RollbackCandidate(instant, Set.of(), Map.of(op.seq, keep),
+              prefix + ":torn#" + op.seq + "@" + keep + "+only"));
+        }
+      }
+    }
+    return candidates;
+  }
+
+  /** Content-mutating ops issued at or before {@code crashSeq} but past their file's last completed force. */
+  private static List<PowerLossRecorder.Op> inFlightOps(final List<PowerLossRecorder.Op> ops, final long crashSeq) {
+    final Map<PowerLossRecorder.TargetFile, Long> lastBarrier =
+        new java.util.EnumMap<>(PowerLossRecorder.TargetFile.class);
+    for (final PowerLossRecorder.Op op : ops) {
+      if (op.seq > crashSeq) {
+        break;
+      }
+      if (op.kind == PowerLossRecorder.OpKind.FORCE) {
+        lastBarrier.put(op.file, op.seq);
+      }
+    }
+    final List<PowerLossRecorder.Op> inFlight = new ArrayList<>();
+    for (final PowerLossRecorder.Op op : ops) {
+      if (op.seq > crashSeq) {
+        break;
+      }
+      if (op.kind == PowerLossRecorder.OpKind.FORCE) {
+        continue;
+      }
+      // Write-through (DSYNC/SYNC) writes that RETURNED (a later op was issued) are durable at
+      // return — only the boundary op can still be in flight.
+      if (op.kind == PowerLossRecorder.OpKind.WRITE && op.durability != PowerLossRecorder.WriteDurability.NONE
+          && op.seq < crashSeq) {
+        continue;
+      }
+      if (op.seq > lastBarrier.getOrDefault(op.file, -1L)) {
+        inFlight.add(op);
+      }
+    }
+    return inFlight;
+  }
+
+  /** @return a failure description, or {@code null} if the state honors the contract. */
+  private static String verifyState(final Path stateDb, final Map<Integer, String> golden,
+      final Set<Integer> observedRevisions) {
+    Databases.clearGlobalCaches();
+    final int mostRecent;
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(stateDb);
+         final JsonResourceSession session = database.beginResourceSession(RESOURCE)) {
+      mostRecent = session.getMostRecentRevisionNumber();
+      observedRevisions.add(mostRecent);
+      if (mostRecent != ORIGINAL_REVISION && mostRecent != TARGET_REVISION) {
+        return "opened at revision " + mostRecent + " but only " + ORIGINAL_REVISION + " (rollback not effective) or "
+            + TARGET_REVISION + " (rollback effective) are permitted";
+      }
+      for (int revision = 1; revision <= mostRecent; revision++) {
+        final String json = serializeRevision(session, revision);
+        final String expected = golden.get(revision);
+        if (!json.equals(expected)) {
+          return "revision " + revision + " read back '" + json + "' but golden is '" + expected + "'";
+        }
+      }
+    } catch (final Throwable t) {
+      return "resource UNOPENABLE after rollback crash (the beacon/truncate ordering bug):\n" + stackTrace(t);
+    }
+
+    // The resource must accept a writer again — offsets and revision-record slots are reused.
+    Databases.clearGlobalCaches();
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(stateDb);
+         final JsonResourceSession session = database.beginResourceSession(RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.moveToDocumentRoot();
+        wtx.moveToFirstChild();
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"recovered\":true}"), JsonNodeTrx.Commit.NO);
+        wtx.commit();
+      }
+      final int afterRecovery = session.getMostRecentRevisionNumber();
+      if (afterRecovery != mostRecent + 1) {
+        return "recovery commit produced revision " + afterRecovery + " instead of " + (mostRecent + 1);
+      }
+      for (int revision = 1; revision <= mostRecent; revision++) {
+        final String json = serializeRevision(session, revision);
+        final String expected = golden.get(revision);
+        if (!json.equals(expected)) {
+          return "after the recovery commit, revision " + revision + " read back '" + json + "' but golden is '"
+              + expected + "'";
+        }
+      }
+    } catch (final Throwable t) {
+      return "resource rejected a writer after the rollback crash:\n" + stackTrace(t);
+    }
+    return null;
+  }
+
+  private static String serializeRevision(final JsonResourceSession session, final int revision) {
+    final StringWriter out = new StringWriter();
+    JsonSerializer.newBuilder(session, out, revision).build().call();
+    return out.toString();
+  }
+
+  private static Path resourceDir(final Path dbPath) {
+    return dbPath.resolve(DatabaseConfiguration.DatabasePaths.DATA.getFile()).resolve(RESOURCE);
+  }
+
+  private static Path dataFilePath(final Path dbPath) {
+    return resourceDir(dbPath).resolve(ResourceConfiguration.ResourcePaths.DATA.getPath()).resolve("sirix.data");
+  }
+
+  private static Path revisionsFilePath(final Path dbPath) {
+    return resourceDir(dbPath).resolve(ResourceConfiguration.ResourcePaths.DATA.getPath()).resolve("sirix.revisions");
+  }
+
+  private static Path commitMarkerPath(final Path dbPath) {
+    return resourceDir(dbPath).resolve(ResourceConfiguration.ResourcePaths.TRANSACTION_INTENT_LOG.getPath())
+                              .resolve(".commit");
+  }
+
+  /** Drop the per-path repository entries a verified scratch state registered, keeping the JVM tidy. */
+  private static void dropPerPathRegistryEntries(final Path stateDb) {
+    final Path cacheKey = dataFilePath(stateDb);
+    StorageType.CACHE_REPOSITORY.remove(cacheKey);
+    StorageType.REVISION_INDEX_REPOSITORY.remove(cacheKey);
+  }
+
+  private static String stackTrace(final Throwable t) {
+    final StringWriter out = new StringWriter();
+    t.printStackTrace(new PrintWriter(out));
+    final String full = out.toString();
+    return full.length() > 4000 ? full.substring(0, 4000) + "\n  ... (truncated)" : full;
+  }
+
+  private static void copyRecursive(final Path source, final Path target) throws IOException {
+    try (var paths = Files.walk(source)) {
+      for (final Path path : (Iterable<Path>) paths::iterator) {
+        final Path destination = target.resolve(source.relativize(path));
+        if (Files.isDirectory(path)) {
+          Files.createDirectories(destination);
+        } else {
+          Files.createDirectories(destination.getParent());
+          Files.copy(path, destination, StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    }
+  }
+
+  private static void deleteRecursive(final Path root) {
+    if (root == null || !Files.exists(root)) {
+      return;
+    }
+    try (var paths = Files.walk(root)) {
+      paths.sorted(java.util.Comparator.reverseOrder()).forEach(p -> p.toFile().delete());
+    } catch (final IOException ignored) {
+      // Best-effort temp cleanup.
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/ReferencesPage4Test.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/ReferencesPage4Test.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import io.sirix.page.delegates.ReferencesPage4;
 import io.sirix.page.interfaces.PageFragmentKey;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,5 +76,27 @@ public final class ReferencesPage4Test {
 
     assertEquals(pageFragmentKeys.get(0).key(), copiedPageFragmentKeys.get(0).key());
     assertEquals(pageFragmentKeys.get(1).key(), copiedPageFragmentKeys.get(1).key());
+  }
+
+  @Test
+  public void testCloneConstructorDoesNotAliasPageFragments() {
+    final var referencesPage4 = new ReferencesPage4();
+
+    final var pageReference = referencesPage4.getOrCreateReference(0);
+    assert pageReference != null;
+    final List<PageFragmentKey> mutableFragments = new ArrayList<>();
+    mutableFragments.add(new PageFragmentKeyImpl(1, 200, 1, 1));
+    pageReference.setPageFragments(mutableFragments);
+
+    final var clonedPage = new ReferencesPage4(referencesPage4);
+    final var clonedReference = clonedPage.getOrCreateReference(0);
+    assert clonedReference != null;
+
+    assertNotSame(pageReference.getPageFragments(), clonedReference.getPageFragments(),
+        "the clone must own its fragment list (FullReferencesPage/BitmapReferencesPage semantics)");
+
+    mutableFragments.add(new PageFragmentKeyImpl(2, 763, 1, 1));
+    assertEquals(1, clonedReference.getPageFragments().size(),
+        "mutating the committed page's fragment list must not leak into the clone");
   }
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/RequestFailureHandling.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/RequestFailureHandling.kt
@@ -1,0 +1,133 @@
+package io.sirix.rest
+
+import io.brackit.query.QueryException
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.vertx.core.Handler
+import io.vertx.core.http.HttpHeaders
+import io.vertx.core.http.HttpServerResponse
+import io.vertx.ext.web.Route
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.HttpException
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Request-scoped failure plumbing shared by every route of [SirixVerticle] — extracted so the
+ * coroutine bridge and the failure-to-HTTP mapping are testable as the exact production units.
+ */
+private val logger = LoggerFactory.getLogger(SirixVerticle::class.java)
+
+/**
+ * Bridges a suspending handler onto a route, routing EVERY failure of the request body — checked,
+ * unchecked, and [java.lang.Error] alike — into the router's failure handler so the client gets a
+ * clean status code and the worker/event-loop threads are never killed or poisoned.
+ *
+ * `catch (e: Exception)` used to let an [AssertionError] thrown during a request (e.g. inside a
+ * serializer on an executeBlocking worker, rethrown here by `coAwait`) escape to the event-loop
+ * thread's uncaught handler: the stack went to stderr and the request hung until the client
+ * timeout instead of becoming a 500.
+ *
+ * [VirtualMachineError]s (OutOfMemoryError & friends) are NOT swallowed: the request is failed
+ * best-effort (cheap — it only schedules the failure handler), then the error is rethrown so the
+ * platform-level uncaught handling and any crash-on-OOM policy still see it.
+ */
+internal fun Route.coroutineHandler(scope: CoroutineScope, fn: suspend (RoutingContext) -> Unit): Route {
+    return handler { ctx ->
+        scope.launch(ctx.vertx().dispatcher()) {
+            try {
+                fn(ctx)
+            } catch (t: Throwable) {
+                if (t is VirtualMachineError) {
+                    runCatching { ctx.fail(t) }
+                    throw t
+                }
+                ctx.fail(t)
+            }
+        }
+    }
+}
+
+/**
+ * The router-wide failure handler: logs full details server-side and maps the failure to a safe
+ * client response (no internal details). [Throwable]s without a dedicated mapping — including
+ * [java.lang.Error]s — become a generic 500.
+ */
+internal fun routerFailureHandler(): Handler<RoutingContext> = Handler { failureRoutingContext ->
+    val statusCode = failureRoutingContext.statusCode()
+    val failure = failureRoutingContext.failure()
+    val request = failureRoutingContext.request()
+
+    // Log full details server-side (stack traces never sent to client)
+    if (failure != null) {
+        if (failure is CancellationException) {
+            logger.debug(
+                "Request cancelled (shutdown): {} {} (statusCode={})",
+                request.method(),
+                request.uri(),
+                statusCode
+            )
+        } else {
+            logger.error(
+                "Request failed: {} {} (statusCode={})",
+                request.method(),
+                request.uri(),
+                statusCode,
+                failure
+            )
+        }
+    } else {
+        logger.error(
+            "Request failed: {} {} (statusCode={}, no exception)",
+            request.method(),
+            request.uri(),
+            statusCode
+        )
+    }
+
+    // Vert.x's RoutingContext.fail(Throwable) stamps statusCode 500 BEFORE this handler runs
+    // (only HttpException carries its own code), so a blanket "statusCode > 0 wins" rule made
+    // the type-based client-error branches below unreachable and every QueryException /
+    // IllegalArgumentException surfaced as a 500. An explicit non-500 code still wins.
+    val resolvedStatus = when {
+        statusCode > 0 && statusCode != HttpResponseStatus.INTERNAL_SERVER_ERROR.code() -> statusCode
+        failure is HttpException -> failure.statusCode
+        // A query evaluation/type error (err:XPTY..., err:XQDY..., FO...) is a CLIENT
+        // error: the query came from the request. Masking it as a generic 500 hid the
+        // actionable message (e.g. "array() expected" for an object-rooted resource).
+        failure is QueryException -> HttpResponseStatus.BAD_REQUEST.code()
+        // The HandlerPreconditions contract: malformed parameters/preconditions throw
+        // IllegalArgumentException — a client error. Only the message branch below
+        // existed, so these still surfaced with a 500 status.
+        failure is IllegalArgumentException -> HttpResponseStatus.BAD_REQUEST.code()
+        statusCode > 0 -> statusCode
+        else -> HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
+    }
+
+    // Return a safe error message without internal details
+    val safeMessage = when {
+        failure is HttpException && failure.payload != null -> failure.payload
+        failure is QueryException -> failure.message ?: "Query error"
+        failure is IllegalArgumentException -> failure.message ?: "Bad request"
+        resolvedStatus == 404 -> "Not found"
+        resolvedStatus == 401 -> "Unauthorized"
+        resolvedStatus == 403 -> "Forbidden"
+        resolvedStatus in 400..499 -> failure?.message ?: "Bad request"
+        else -> "Internal server error"
+    }
+
+    endWithErrorResponse(failureRoutingContext.response(), resolvedStatus, safeMessage)
+}
+
+internal fun endWithErrorResponse(response: HttpServerResponse, statusCode: Int, message: String?) {
+    if (response.ended() || response.headWritten()) {
+        return
+    }
+    response.setStatusCode(statusCode)
+        .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+    val safeMessage = message ?: "An error occurred"
+    val escapedMessage = safeMessage.replace("\\", "\\\\").replace("\"", "\\\"")
+    response.end("""{"statusCode":$statusCode,"message":"$escapedMessage"}""")
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
@@ -5,7 +5,6 @@ import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpHeaders
 import io.vertx.core.http.HttpMethod
 import io.vertx.core.http.HttpServer
-import io.vertx.core.http.HttpServerResponse
 import io.vertx.core.json.DecodeException
 import io.vertx.core.json.JsonObject
 import io.vertx.core.net.PemKeyCertOptions
@@ -22,17 +21,13 @@ import io.vertx.ext.auth.oauth2.providers.KeycloakAuth
 import io.vertx.ext.web.Route
 import io.vertx.ext.web.Router
 import io.vertx.ext.web.RoutingContext
-import io.brackit.query.QueryException
 import io.vertx.ext.web.handler.BodyHandler
 import io.vertx.ext.web.handler.CorsHandler
 import io.vertx.ext.web.handler.HttpException
 import io.vertx.kotlin.core.http.httpServerOptionsOf
 import io.vertx.kotlin.coroutines.CoroutineVerticle
 import io.vertx.kotlin.coroutines.coAwait
-import io.vertx.kotlin.coroutines.dispatcher
-import kotlin.coroutines.cancellation.CancellationException
 import io.vertx.kotlin.ext.auth.oauth2.oAuth2OptionsOf
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.HttpURLConnection
 import io.sirix.access.DatabasesInternals
@@ -528,66 +523,7 @@ class SirixVerticle : CoroutineVerticle() {
             ctx.fail(HttpException(HttpResponseStatus.NOT_FOUND.code()))
         }
 
-        route().failureHandler { failureRoutingContext ->
-            val statusCode = failureRoutingContext.statusCode()
-            val failure = failureRoutingContext.failure()
-            val request = failureRoutingContext.request()
-
-            // Log full details server-side (stack traces never sent to client)
-            if (failure != null) {
-                if (failure is CancellationException) {
-                    logger.debug(
-                        "Request cancelled (shutdown): {} {} (statusCode={})",
-                        request.method(),
-                        request.uri(),
-                        statusCode
-                    )
-                } else {
-                    logger.error(
-                        "Request failed: {} {} (statusCode={})",
-                        request.method(),
-                        request.uri(),
-                        statusCode,
-                        failure
-                    )
-                }
-            } else {
-                logger.error(
-                    "Request failed: {} {} (statusCode={}, no exception)",
-                    request.method(),
-                    request.uri(),
-                    statusCode
-                )
-            }
-
-            val resolvedStatus = when {
-                statusCode > 0 -> statusCode
-                failure is HttpException -> failure.statusCode
-                // A query evaluation/type error (err:XPTY..., err:XQDY..., FO...) is a CLIENT
-                // error: the query came from the request. Masking it as a generic 500 hid the
-                // actionable message (e.g. "array() expected" for an object-rooted resource).
-                failure is QueryException -> HttpResponseStatus.BAD_REQUEST.code()
-                // The HandlerPreconditions contract: malformed parameters/preconditions throw
-                // IllegalArgumentException — a client error. Only the message branch below
-                // existed, so these still surfaced with a 500 status.
-                failure is IllegalArgumentException -> HttpResponseStatus.BAD_REQUEST.code()
-                else -> HttpResponseStatus.INTERNAL_SERVER_ERROR.code()
-            }
-
-            // Return a safe error message without internal details
-            val safeMessage = when {
-                failure is HttpException && failure.payload != null -> failure.payload
-                failure is QueryException -> failure.message ?: "Query error"
-                failure is IllegalArgumentException -> failure.message ?: "Bad request"
-                resolvedStatus == 404 -> "Not found"
-                resolvedStatus == 401 -> "Unauthorized"
-                resolvedStatus == 403 -> "Forbidden"
-                resolvedStatus in 400..499 -> failure?.message ?: "Bad request"
-                else -> "Internal server error"
-            }
-
-            response(failureRoutingContext.response(), resolvedStatus, safeMessage)
-        }
+        route().failureHandler(routerFailureHandler())
     }
 
     /**
@@ -657,29 +593,11 @@ class SirixVerticle : CoroutineVerticle() {
         }
     }
 
-    private fun response(response: HttpServerResponse, statusCode: Int, message: String?) {
-        if (response.ended() || response.headWritten()) {
-            return
-        }
-        response.setStatusCode(statusCode)
-            .putHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-        val safeMessage = message ?: "An error occurred"
-        val escapedMessage = safeMessage.replace("\\", "\\\\").replace("\"", "\\\"")
-        response.end("""{"statusCode":$statusCode,"message":"$escapedMessage"}""")
-    }
-
     /**
-     * An extension method for simplifying coroutines usage with Vert.x Web routers.
+     * An extension method for simplifying coroutines usage with Vert.x Web routers. Delegates to
+     * the shared bridge in RequestFailureHandling.kt, which maps EVERY failure (Errors included)
+     * to the request's failure handler.
      */
-    private fun Route.coroutineHandler(fn: suspend (RoutingContext) -> Unit): Route {
-        return handler { ctx ->
-            launch(ctx.vertx().dispatcher()) {
-                try {
-                    fn(ctx)
-                } catch (e: Exception) {
-                    ctx.fail(e)
-                }
-            }
-        }
-    }
+    private fun Route.coroutineHandler(fn: suspend (RoutingContext) -> Unit): Route =
+        coroutineHandler(this@SirixVerticle, fn)
 }

--- a/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/RouteErrorMappingTest.kt
+++ b/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/RouteErrorMappingTest.kt
@@ -1,0 +1,106 @@
+package io.sirix.rest
+
+import io.vertx.core.Vertx
+import io.vertx.ext.web.Router
+import io.vertx.ext.web.client.WebClient
+import io.vertx.junit5.Timeout
+import io.vertx.junit5.VertxExtension
+import io.vertx.junit5.VertxTestContext
+import io.vertx.kotlin.coroutines.coAwait
+import io.vertx.kotlin.coroutines.dispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.concurrent.TimeUnit
+
+/**
+ * Verifies the request-scoped failure mapping against [java.lang.Error]s using the EXACT
+ * production units ([coroutineHandler] + [routerFailureHandler], the ones SirixVerticle's router
+ * is built from — no Keycloak/TLS needed for that).
+ *
+ * An [AssertionError] thrown while serving a request (observed in production from
+ * JsonLimitedSerializer during a GET, surfacing via an executeBlocking future awaited on the
+ * event loop) used to escape the `catch (e: Exception)` bridge to the event-loop thread's
+ * uncaught handler: the client got NO response (hang until timeout) and the failure bypassed the
+ * failure handler entirely. It must map to a clean 500 — and the server must keep serving.
+ */
+@ExtendWith(VertxExtension::class)
+@DisplayName("Route error mapping for java.lang.Error")
+class RouteErrorMappingTest {
+
+    @Test
+    @Timeout(value = 30, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("AssertionError in a request handler maps to 500 and the event loop keeps serving")
+    fun assertionErrorMapsTo500AndServerSurvives(vertx: Vertx, testContext: VertxTestContext) {
+        val router = Router.router(vertx)
+        val scope = CoroutineScope(vertx.dispatcher())
+        router.get("/boom").coroutineHandler(scope) {
+            throw AssertionError("injected: serializer invariant violated")
+        }
+        router.get("/ok").coroutineHandler(scope) { ctx ->
+            ctx.response().end("ok")
+        }
+        router.route().failureHandler(routerFailureHandler())
+
+        GlobalScope.launch(vertx.dispatcher()) {
+            try {
+                val server = vertx.createHttpServer().requestHandler(router).listen(0).coAwait()
+                val client = WebClient.create(vertx)
+
+                val boomResponse = client.get(server.actualPort(), "localhost", "/boom").send().coAwait()
+                testContext.verify {
+                    assertEquals(500, boomResponse.statusCode(), "an Error must map to a 500, not a hang")
+                    val body = boomResponse.bodyAsJsonObject()
+                    assertEquals(500, body.getInteger("statusCode"))
+                    assertEquals("Internal server error", body.getString("message"))
+                }
+
+                // The same event loop must still serve requests — the Error must not have killed
+                // or poisoned it.
+                val okResponse = client.get(server.actualPort(), "localhost", "/ok").send().coAwait()
+                testContext.verify {
+                    assertEquals(200, okResponse.statusCode())
+                    assertEquals("ok", okResponse.bodyAsString())
+                    testContext.completeNow()
+                }
+            } catch (t: Throwable) {
+                testContext.failNow(t)
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 30, timeUnit = TimeUnit.SECONDS)
+    @DisplayName("Exception mapping is unchanged: IllegalArgumentException stays a 400")
+    fun illegalArgumentStillMapsTo400(vertx: Vertx, testContext: VertxTestContext) {
+        val router = Router.router(vertx)
+        val scope = CoroutineScope(vertx.dispatcher())
+        router.get("/bad").coroutineHandler(scope) {
+            throw IllegalArgumentException("database names must not contain path separators")
+        }
+        router.route().failureHandler(routerFailureHandler())
+
+        GlobalScope.launch(vertx.dispatcher()) {
+            try {
+                val server = vertx.createHttpServer().requestHandler(router).listen(0).coAwait()
+                val client = WebClient.create(vertx)
+
+                val response = client.get(server.actualPort(), "localhost", "/bad").send().coAwait()
+                testContext.verify {
+                    assertEquals(400, response.statusCode())
+                    assertEquals(
+                        "database names must not contain path separators",
+                        response.bodyAsJsonObject().getString("message")
+                    )
+                    testContext.completeNow()
+                }
+            } catch (t: Throwable) {
+                testContext.failNow(t)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Seven fixes, each with a test demonstrated to fail pre-fix (stash-and-rerun verified by the implementing run). Suites on the branch pre-rebase: `:sirix-core:test` 9,198/0, `:sirix-rest-api:test` 163/0, `:sirix-query:test` 817/0; rebased cleanly onto current main (post #1029/#1031/#1032) with targeted reruns green.

## 1. Explicit-rollback crash window (`ae7ce1e5f`)
`truncateTo` truncated the files **before** rewriting the uber beacons — a crash in between left a checksum-valid beacon advertising the truncated-away revision over truncated files: permanently unopenable ("Truncated revisions record"). A power-loss simulation across every crash instant in the rollback window found **9 of 16 states unopenable**. Beacons are now durably downgraded (secondary-then-primary, DSYNC) *before* truncation, so every crash instant lands on original-or-target. All 16 states now recover cold.

## 2. Interrupted-first-commit self-heal: lost revisions record (`ec7bbf2f7`)
A bootstrap whose 32-byte revision-0 record was lost (file dropped on power cut) left checksum-valid beacons pointing at nothing — every open failed `Truncated revisions record for revision 0` until manual deletion. The recovery provability gate now also covers this variant: heal iff the superblock is valid-or-zero, every beacon slot is zero or advertises revision 0, and zero checksum-valid revision records exist. Negative controls keep a truncated record at revision N>0 (real corruption) failing loudly. 6 heal variants × 2 backends tested.

## 3. Auto-commit read race (`b4e2c1a8b`)
`getRevisionNumber()` on an auto-commit transaction raced the post-commit engine swap ("Transaction is already closed!"). Volatile engine handoff + a volatile cached revision number; reads never touch the swapped-out engine, no locking added. Stress test (5ms commit cadence, 3s polling) failed in ~1s pre-fix.

## 4. REST: `java.lang.Error` → HTTP 500 (`8444ae200`)
An `AssertionError` inside a handler bypassed the `catch (Exception)` bridge — request hung, stack to the uncaught handler. The bridge now catches `Throwable` (`VirtualMachineError` is failed best-effort then rethrown, never swallowed). The new test also exposed a dead branch: Vert.x 5's `fail(Throwable)` pre-stamps statusCode 500, so the documented QueryException/IllegalArgumentException→400 mappings never fired — resolution order fixed, 400 mapping restored.

## 5. Flaky `testAutoCommitWithScheduler` (`e7192b839`)
Same wall-clock race family as #1029; now polls `getMostRecentRevisionNumber()` with a bounded deadline.

## 6. `ReferencesPage4` clone aliased `pageFragments` (`cac976efe`)
Deep-copies now, matching every sibling reference-page class.

## 7. `MMFileReader` bulk revision-record read (`8285f91a1`)
Follow-up to #1031's bulk interface: the mapped reader needs no I/O batching, so the override just hoists the truncation check out of the full-history loop and keeps error messages consistent.

Also investigated, no change needed: the historical `UberPageCorruptionTest` timeout flake — its root cause (corrupt length header driving a multi-GB allocation) is already fixed on main via `checkDataLength`, with preemptive timeouts already guarding the formerly-flaky cases.