### PR TITLE
Vectorized multi-key group-by: anchor the scan on a provably-dense group field

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -955,7 +955,38 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
   private Object2LongOpenHashMap<String> typedGroupKeyCounts(final String[] sourcePath,
       final PredicateNode predicateOrNull, final String[] groupFields) throws Exception {
     final PredicateNode effective = predicateOrNull == null ? PredicateNode.AlwaysTrue.INSTANCE : predicateOrNull;
-    final CompiledPredicate cp = compileWithExtraFields(effective, groupFields);
+    // DENSE-ANCHOR SELECTION (unpredicated multi-key only). The scan iterates
+    // the anchor field's slots, so records missing the anchor are never visited
+    // — fatal for a SPARSE anchor whose absent records carry the OTHER group
+    // keys. When a predicate is present its sound anchor (from compile()) already
+    // governs visibility, so this only concerns the unpredicated path, where the
+    // anchor defaults to groupFields[0]. If any group field is PROVABLY dense
+    // (present on every record — path-summary reference count == record total),
+    // anchor the slot walk on THAT field: every relevant record is then visited
+    // and the remaining (possibly sparse) keys fall out as values, including the
+    // 'm' missing bucket the encoder emits. If NONE is provably dense we keep the
+    // historical order and the loud bail below (never guess density).
+    final String[] anchorOrderedFields;
+    if (predicateOrNull == null && groupFields.length > 1) {
+      final int denseIdx = provablyDenseAnchor(sourcePath, groupFields);
+      if (denseIdx > 0) {
+        anchorOrderedFields = new String[groupFields.length];
+        anchorOrderedFields[0] = groupFields[denseIdx];
+        int w = 1;
+        for (int i = 0; i < groupFields.length; i++) {
+          if (i != denseIdx) anchorOrderedFields[w++] = groupFields[i];
+        }
+      } else {
+        anchorOrderedFields = groupFields;
+      }
+    } else {
+      anchorOrderedFields = groupFields;
+    }
+    // compileWithExtraFields appends fields in order, so fieldNames[0] (the scan
+    // anchor) is anchorOrderedFields[0]. The group-key encoding below uses the
+    // ORIGINAL groupFields order (via groupIdxs), so the emitted keys are
+    // independent of which field anchors the scan.
+    final CompiledPredicate cp = compileWithExtraFields(effective, anchorOrderedFields);
     final int[] groupIdxs = new int[groupFields.length];
     for (int i = 0; i < groupFields.length; i++) {
       groupIdxs[i] = indexOfStr(cp.fieldNames, groupFields[i]);
@@ -977,7 +1008,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
             allMissing.addTo("m", recordCount);
             return allMissing;
           }
-          requireDenseGroupField(sourcePath, groupFields[0], true, 0L);
+          // No provably-dense group field existed (else the anchor would not be
+          // absent) — name the chosen anchor in the loud error.
+          requireDenseGroupField(sourcePath, cp.fieldNames[0], true, 0L);
         }
       }
       // Predicate anchor unresolvable → no record satisfies the leaf → empty
@@ -1077,13 +1110,15 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       // over a top-level array source the unvisited remainder is exactly the
       // missing-key group — synthesize it instead of erroring out (the
       // interpreter groups those records under the empty key). Multi-key
-      // grouping cannot be reconstructed this way — stay LOUD on a gap.
+      // grouping cannot be reconstructed this way — stay LOUD on a gap (only
+      // reachable when no group field was provably dense: a dense anchor visits
+      // every record, so counted == recordCount and this fixup is a no-op).
       final long recordCount = topLevelRecordCountOrUnknown(sourcePath);
       if (recordCount >= 0 && counted < recordCount) {
         if (groupFields.length == 1) {
           merged.addTo("m", recordCount - counted);
         } else {
-          requireDenseGroupField(sourcePath, groupFields[0], true, counted);
+          requireDenseGroupField(sourcePath, cp.fieldNames[0], true, counted);
         }
       }
     }
@@ -1143,6 +1178,98 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     } catch (final Exception e) {
       return -1L;
     }
+  }
+
+  /**
+   * Number of records of a TOP-LEVEL ARRAY source that carry {@code field}, or
+   * {@code -1} when this cannot be PROVED cheaply and soundly. Used to choose a
+   * dense scan anchor among group-by fields (see {@link #provablyDenseAnchor}).
+   *
+   * <p>Density evidence comes from the PATH SUMMARY: an OBJECT_KEY path node's
+   * reference count is incremented once per node that references it
+   * ({@link io.sirix.index.path.summary.PathSummaryWriter#incrementReferenceCount}),
+   * so for a top-level array of objects — where a key occurs at most once per
+   * record — {@code getReferences()} is EXACTLY the count of records carrying
+   * the field at that path. {@link #resolveTargetPathNodeKey} already fails
+   * closed (returns {@code -1}) on an ambiguous or unresolvable path, so a
+   * non-negative path node key means the count is unambiguous and scoped to the
+   * query path (no nested same-name field can inflate it).
+   *
+   * <p>Returns {@code -1} (caller must NOT treat the field as dense) when the
+   * source is not a top-level array, the path summary is unavailable, the path
+   * is ambiguous/absent, or the reader cannot be read — never a guess.
+   */
+  private long recordsCarryingFieldOrUnknown(final String[] sourcePath, final String field) {
+    if (sourcePath == null || sourcePath.length != 1 || !"[]".equals(sourcePath[0])) {
+      return -1L;
+    }
+    if (!session.getResourceConfig().withPathSummary) {
+      return -1L;
+    }
+    final long pathNodeKey = resolveTargetPathNodeKey(sourcePath, field);
+    if (pathNodeKey < 0) {
+      return -1L;
+    }
+    try (var summary = session.openPathSummary(revision)) {
+      final PathNode pathNode = summary.getPathNodeForPathNodeKey(pathNodeKey);
+      if (pathNode == null) {
+        return -1L;
+      }
+      return pathNode.getReferences();
+    } catch (final Exception e) {
+      return -1L;
+    }
+  }
+
+  /**
+   * Index into {@code groupFields} of a field PROVABLY present on every record
+   * of a top-level array source, or {@code -1} when re-anchoring is unsafe or
+   * no field can be proved dense. Anchors the multi-key scan on a DENSE field so
+   * the slot walk visits EVERY relevant record; the remaining (possibly sparse)
+   * group keys then fall out as their per-record values — including the
+   * {@code 'm'} missing bucket the typed encoder already emits for absent
+   * fields. A field is dense iff the path summary proves its scoped occurrence
+   * count equals the array's record total (see
+   * {@link #recordsCarryingFieldOrUnknown}).
+   *
+   * <p><b>First-key collapse veto.</b> brackit's interpreter has an
+   * order-dependent quirk: when the FIRST grouping variable evaluates to the
+   * EMPTY SEQUENCE on EVERY tuple (the first group field is absent on every
+   * record), the whole grouping degenerates to a single all-null tuple
+   * (verified: {@code group by $ghost, $dept} yields one {@code {null,null}}
+   * group, while {@code group by $dept, $ghost} yields proper per-dept groups).
+   * A dense-anchored scan would visit every record and emit the per-group
+   * tuples — diverging from that collapse. So if {@code groupFields[0]} is
+   * entirely absent we REFUSE to re-anchor and let the existing loud bail fire
+   * (fail-closed, exactly the historical behavior). A first key present on only
+   * SOME records is fine — those rows group into the null/missing bucket
+   * normally, which the typed kernel reproduces.
+   *
+   * <p>Returns the FIRST provably-dense field (group-field order) so the choice
+   * is deterministic and stable across runs; never guesses density.
+   */
+  private int provablyDenseAnchor(final String[] sourcePath, final String[] groupFields) {
+    final long recordCount = topLevelRecordCountOrUnknown(sourcePath);
+    if (recordCount < 0) {
+      return -1;
+    }
+    if (recordCount == 0) {
+      // Empty source: zero output tuples either way; leave the order untouched.
+      return -1;
+    }
+    // First-key collapse veto: an entirely-absent FIRST group field makes the
+    // interpreter collapse the whole grouping — not reproducible by re-anchoring.
+    final long firstCarrying = recordsCarryingFieldOrUnknown(sourcePath, groupFields[0]);
+    if (firstCarrying == 0L || resolveFieldKey(groupFields[0]) == -1) {
+      return -1;
+    }
+    for (int i = 0; i < groupFields.length; i++) {
+      final long carrying = i == 0 ? firstCarrying : recordsCarryingFieldOrUnknown(sourcePath, groupFields[i]);
+      if (carrying == recordCount) {
+        return i;
+      }
+    }
+    return -1;
   }
 
   /**

--- a/bundles/sirix-query/src/test/java/io/sirix/query/scan/TypedGroupByDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/scan/TypedGroupByDifferentialTest.java
@@ -83,6 +83,12 @@ public final class TypedGroupByDifferentialTest {
       if (i % 3 != 0) {
         sb.append(",\"tier\":\"").append(TIERS[rng.nextInt(TIERS.length)]).append('"');
       }
+      // "region": a SECOND sparse string group key, present on ~half the records
+      // with sparsity DISJOINT from tier — a both-sparse multi-key combination
+      // (tier, region) anchored neither field densely.
+      if (i % 2 == 1) {
+        sb.append(",\"region\":\"").append(CITIES[rng.nextInt(CITIES.length)]).append("-r\"");
+      }
       // "flag": boolean, MISSING on half the records.
       if (i % 2 == 0) {
         sb.append(",\"flag\":").append(rng.nextBoolean());
@@ -433,16 +439,127 @@ public final class TypedGroupByDifferentialTest {
   }
 
   @Test
-  void multiKeySparseAnchorWithoutProjectionFailsLoud() {
-    // No projection installed: the typed slot-walk cannot reconstruct the
-    // secondary keys of records missing the sparse anchor — it must FAIL
-    // LOUDLY, never return silently-partial groups.
+  void multiKeySparseFirstKeyDenseSecondReAnchorsToScan() throws Exception {
+    // Sparse FIRST key (tier) + DENSE second key (dept): no projection installed.
+    // The scan re-anchors on the provably-dense `dept` (path-summary reference
+    // count == record total), visiting EVERY record, so the sparse `tier` —
+    // including its missing 'm' bucket — falls out exactly. No fallback, no bail.
+    assertDifferential("for $u in " + SRC + " let $t := $u.tier, $d := $u.dept group by $t, $d "
+        + "return {\"t\": $t, \"d\": $d, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeyDenseFirstSparseSecondScanPath() throws Exception {
+    // Mirror order: dense anchor already at index 0 — the existing happy path,
+    // verified on the SCAN path (no projection).
+    assertDifferential("for $u in " + SRC + " let $d := $u.dept, $t := $u.tier group by $d, $t "
+        + "return {\"d\": $d, \"t\": $t, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeySparseFirstDenseSecondNumericKeysScanPath() throws Exception {
+    // Sparse string first key (tier) + dense NUMERIC second key (age): re-anchor
+    // on the numeric dense field; the typed kernel encodes long + 'm' keys.
+    assertDifferential("for $u in " + SRC + " let $t := $u.tier, $a := $u.age group by $t, $a "
+        + "return {\"t\": $t, \"a\": $a, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeyDenseAnchorIsThirdKeyScanPath() throws Exception {
+    // Two sparse keys (tier, flag) FIRST, dense key (city) THIRD. The dense
+    // anchor is not at the front — the selector must scan it regardless of
+    // group-field position, and both sparse keys fall out (incl. 'm').
+    assertDifferential("for $u in " + SRC + " let $t := $u.tier, $f := $u.flag, $c := $u.city "
+        + "group by $t, $f, $c return {\"t\": $t, \"f\": $f, \"c\": $c, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeyAbsentFirstKeyFailsLoudEvenWithDenseSecond() {
+    // First key is absent on EVERY record (ghost). The interpreter has an
+    // order-dependent quirk: an empty FIRST grouping variable collapses the
+    // whole grouping to ONE all-null tuple ({g:null,d:null,n:N}) rather than
+    // per-dept groups. A dense-anchored scan would produce per-dept groups, so
+    // the dense-anchor selector VETOES re-anchoring here and the path fails
+    // LOUDLY (fail-closed) instead of returning a divergent result.
     final var ex = org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
-        () -> run("for $u in " + SRC + " let $t := $u.tier, $d := $u.dept group by $t, $d "
-            + "return {\"t\": $t, \"d\": $d, \"n\": count($u)}", true));
+        () -> run("for $u in " + SRC + " let $g := $u.ghost, $d := $u.dept group by $g, $d "
+            + "return {\"g\": $g, \"d\": $d, \"n\": count($u)}", true));
     final String msg = String.valueOf(ex.getMessage()) + " " + String.valueOf(ex.getCause());
-    org.junit.jupiter.api.Assertions.assertTrue(msg.contains("tier"),
-        "loud error should name the sparse group field, got: " + msg);
+    org.junit.jupiter.api.Assertions.assertTrue(msg.contains("ghost"),
+        "loud error should name the absent first group field, got: " + msg);
+  }
+
+  @Test
+  void multiKeyAbsentSecondKeyDenseFirstScanPath() throws Exception {
+    // Mirror: absent key SECOND, dense key FIRST. The interpreter does NOT
+    // collapse here (empty key is not first) — it yields proper per-dept groups
+    // with the absent key rendered null. The dense anchor (dept) is already
+    // first, so the scan visits every record and emits the all-'m' second
+    // segment, matching the interpreter exactly (no bail).
+    assertDifferential("for $u in " + SRC + " let $d := $u.dept, $g := $u.ghost group by $d, $g "
+        + "return {\"d\": $d, \"g\": $g, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeySparseFirstAbsentSecondDenseThirdScanPath() throws Exception {
+    // Sparse-but-present first key (tier), absent second key (ghost), dense
+    // third key (city). The first key is present on some records (no collapse),
+    // so re-anchoring on the dense city is sound; tier emits its missing bucket
+    // and ghost emits all-'m'.
+    assertDifferential("for $u in " + SRC + " let $t := $u.tier, $g := $u.ghost, $c := $u.city "
+        + "group by $t, $g, $c return {\"t\": $t, \"g\": $g, \"c\": $c, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeyBothSparseWithoutProjectionFailsLoud() {
+    // No group field is provably dense (tier ~67% present, region ~50% present,
+    // sparsity disjoint) and no projection is installed: the typed slot-walk
+    // cannot reconstruct the secondary keys of records missing whichever sparse
+    // field anchors the scan, so it must FAIL LOUDLY — never silently-partial.
+    final var ex = org.junit.jupiter.api.Assertions.assertThrows(Exception.class,
+        () -> run("for $u in " + SRC + " let $t := $u.tier, $r := $u.region group by $t, $r "
+            + "return {\"t\": $t, \"r\": $r, \"n\": count($u)}", true));
+    final String msg = String.valueOf(ex.getMessage()) + " " + String.valueOf(ex.getCause());
+    org.junit.jupiter.api.Assertions.assertTrue(msg.contains("tier") || msg.contains("region"),
+        "loud error should name the sparse anchor field, got: " + msg);
+  }
+
+  @Test
+  void multiKeyBothSparseFallbackViaProjectionStaysCorrect() throws Exception {
+    // The SAME both-sparse query that fails loud on the bare scan path returns
+    // the CORRECT (interpreter-identical) result once a covering projection is
+    // installed — proving the loud bail is a fail-closed gate, not a dead end.
+    // Both tier and region are sparse STRING_DICT columns in the projection.
+    assertDifferentialWithSparseProjection("for $u in " + SRC + " let $t := $u.tier, $r := $u.region "
+        + "group by $t, $r return {\"t\": $t, \"r\": $r, \"n\": count($u)}");
+  }
+
+  @Test
+  void multiKeySparseFirstDenseSecondMixedProvenanceScanPath() throws Exception {
+    // SHREDDER-built resource (genuine double rows): sparse first key (xtra,
+    // ~half present) + dense second key (dept). Re-anchor on dept; the missing
+    // first key emits 'm'. Exercises a different value provenance than jn:store.
+    shredExtraResource("provmix.jn", provMixJson());
+    assertDifferentialOn("provmix.jn",
+        "for $u in jn:doc('" + DB + "','provmix.jn')[] let $x := $u.xtra, $d := $u.dept group by $x, $d "
+            + "return {\"x\": $x, \"d\": $d, \"n\": count($u)}");
+  }
+
+  /** A small shredder corpus: dense `dept`, sparse `xtra` (present on ~half). */
+  private static String provMixJson() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append('[');
+    for (int i = 0; i < 200; i++) {
+      if (i > 0) sb.append(',');
+      sb.append("{\"id\":").append(i).append(",\"dept\":\"").append(DEPTS[i % DEPTS.length]).append('"');
+      if (i % 2 == 0) {
+        // genuine double via exponent form on the sparse key
+        sb.append(",\"xtra\":").append(1 + (i % 3)).append(".5e0");
+      }
+      sb.append('}');
+    }
+    sb.append(']');
+    return sb.toString();
   }
 
   @Test
@@ -858,11 +975,13 @@ public final class TypedGroupByDifferentialTest {
             io.brackit.query.util.path.Path.parse("/[]/bonus", io.brackit.query.util.path.PathParser.Type.JSON),
             io.brackit.query.util.path.Path.parse("/[]/age", io.brackit.query.util.path.PathParser.Type.JSON),
             io.brackit.query.util.path.Path.parse("/[]/nully", io.brackit.query.util.path.PathParser.Type.JSON),
-            io.brackit.query.util.path.Path.parse("/[]/mixed", io.brackit.query.util.path.PathParser.Type.JSON));
+            io.brackit.query.util.path.Path.parse("/[]/mixed", io.brackit.query.util.path.PathParser.Type.JSON),
+            io.brackit.query.util.path.Path.parse("/[]/region", io.brackit.query.util.path.PathParser.Type.JSON));
     final var def = io.sirix.index.IndexDefs.createProjectionIdxDef(rootPath, fieldPaths,
         java.util.List.of(io.brackit.query.jdm.Type.STR, io.brackit.query.jdm.Type.STR,
             io.brackit.query.jdm.Type.LON, io.brackit.query.jdm.Type.LON,
-            io.brackit.query.jdm.Type.STR, io.brackit.query.jdm.Type.STR),
+            io.brackit.query.jdm.Type.STR, io.brackit.query.jdm.Type.STR,
+            io.brackit.query.jdm.Type.STR),
         7, io.sirix.index.IndexDef.DbType.JSON);
     final java.util.List<byte[]> leaves = new java.util.ArrayList<>();
     final io.sirix.index.projection.ProjectionIndexBuilder builder;
@@ -874,7 +993,7 @@ public final class TypedGroupByDifferentialTest {
     }
     io.sirix.index.projection.ProjectionIndexRegistry.installWildcard(
         session.getResourceConfig().getResource().toString(),
-        new String[] { "dept", "tier", "bonus", "age", "nully", "mixed" },
+        new String[] { "dept", "tier", "bonus", "age", "nully", "mixed", "region" },
         leaves,
         builder.numericColumnNonIntegralFlags());
   }
@@ -928,6 +1047,13 @@ public final class TypedGroupByDifferentialTest {
         wtx.commit();
       }
     }
+  }
+
+  /** Differential harness ({@code run2On}-based) against an arbitrary resource. */
+  private void assertDifferentialOn(final String resource, final String query) throws Exception {
+    final String interpreted = normalize(run2On(resource, query, false));
+    final String vectorized = normalize(run2On(resource, query, true));
+    assertEquals(interpreted, vectorized, "vectorized result differs from interpreted for: " + query);
   }
 
   /** {@link #run2} against an arbitrary resource of the test database. */

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -121,6 +121,26 @@ else falls back to the generic (always correct) pipeline.
   publish/lookup guards exclude only the `-1` missing sentinel, so scans
   anchored on negative-hash fields populate and reuse the page-skip bitmap
   like everyone else (was: permanent full page sweeps).
+- **Multi-key group-by with a sparse anchor — re-anchor on a PROVABLY-DENSE
+  group field (scan path).** An anchor-based scan never visits a record missing
+  the anchor field, so a SPARSE anchor used to fail loudly even when another
+  group field was present on every record. The unpredicated multi-key kernel now
+  chooses the scan anchor among the group fields by PROVABLE density: a field is
+  dense iff the path summary's OBJECT_KEY reference count for its (unambiguously
+  resolved, query-scoped) path equals the top-level array's record total —
+  `getReferences()` is incremented once per referencing node, and for a
+  top-level array of objects a key occurs at most once per record, so equality
+  proves presence on every record. The scan then anchors on the dense field,
+  visits every record, and the remaining (possibly sparse) keys fall out as
+  their values, including the `'m'` missing bucket the typed encoder already
+  emits. Works for the dense field in ANY group-key position and across
+  provenance (jn:store / shredder). Density is never guessed: if NO group field
+  is provably dense (path summary off, nested source, ambiguous path, or every
+  candidate genuinely sparse) the kernel keeps the loud bail / projection
+  fallback. It also REFUSES to re-anchor when the FIRST group field is absent on
+  EVERY record — brackit's interpreter collapses such a grouping to a single
+  all-null tuple (an empty FIRST grouping key swallows the whole tuple), which a
+  dense-anchored scan cannot reproduce, so that shape fails closed.
 - **Aggregate edge semantics.** `avg`/`min`/`max` over zero contributing rows
   return the empty sequence (was a fabricated 0); `count(... return $u.f)`
   counts non-empty derefs of ANY value type (was: numeric values only, and
@@ -138,10 +158,17 @@ else falls back to the generic (always correct) pipeline.
 
 ### Remaining limitations
 
-- **Multi-key group-by with a sparse FIRST key (scan path).** The anchor walk
-  cannot reconstruct the secondary key values of unvisited records — it fails
-  LOUDLY (`QueryException` naming the field). A covering projection index
-  serves the same query correctly (presence bitmaps see every record).
+- **Multi-key group-by where NO group field is provably dense (scan path).**
+  Re-anchoring (see fixed gaps) handles a sparse anchor whenever ANOTHER group
+  field is provably dense. When density cannot be proven for ANY group field —
+  every candidate genuinely sparse, the source is nested (record total not
+  cheaply known), the path summary is off, or the path is ambiguous — the anchor
+  walk still cannot reconstruct the secondary key values of unvisited records,
+  so it fails LOUDLY (`QueryException` naming the anchor field). A covering
+  projection index serves the same query correctly (presence bitmaps see every
+  record). Likewise an entirely-absent FIRST group field fails closed: the
+  interpreter collapses that grouping to one all-null tuple, which the scan
+  cannot reproduce.
 - **Nested sources with sparse group fields (scan path).** The record total
   is only cheaply known for top-level array sources; for nested sources a
   sparse single group key still yields silently-partial groups (pre-existing,
@@ -167,13 +194,18 @@ else falls back to the generic (always correct) pipeline.
   Rebuild persisted projections with `-Dsirix.projection.forceRebuild=true`
   to migrate to the v2 leaf format.
 
-The `TypedGroupByDifferentialTest` suite (80 cases) pins vectorized ≡
+The `TypedGroupByDifferentialTest` suite (89 cases) pins vectorized ≡
 interpreted for the supported shapes, including typed (numeric/boolean/double)
 and multi-key group keys, the negative-hash nameKey regressions, adversarial
 sparse shapes (missing-on-30%, missing-on-all, present-but-null, mixed-kind
 columns, sparse group keys/aggregates/predicates, OR/NOT-over-sparse), the
-double/decimal predicate family across scan and projection paths, and exact
-decimal/genuine-double aggregate parity (jn:store vs shredder provenance).
+double/decimal predicate family across scan and projection paths, exact
+decimal/genuine-double aggregate parity (jn:store vs shredder provenance), and
+the multi-key dense-anchor selection (sparse anchor + dense second key in both
+orders, dense anchor as the 2nd/3rd key, numeric dense anchor, mixed
+provenance, plus the fail-closed cases: both-sparse-no-projection loud bail with
+the same query correct via a covering projection, and absent-first-key loud
+bail).
 
 ## Cleanup actions queued
 


### PR DESCRIPTION
Closes the last documented vectorized-executor gap: multi-key group-by over a **sparse anchor** on the scan path previously failed loudly (the projection path already answered it exactly). The scan now anchors on a *provably-dense* group field instead of always `groupFields[0]`, so every record is visited and the remaining sparse keys fall out as values — including the `'m'` missing bucket #1035's kernels already encode.

## Density evidence (sound, conservative, never guesses)

**Path-summary OBJECT_KEY reference counts** (`PathNode.getReferences()`, maintained structurally by `PathSummaryWriter.incrementReferenceCount`). For a top-level array of objects a key occurs at most once per record, so for an *unambiguously-resolved, query-scoped* path node the count equals the number of records carrying the field; `resolveTargetPathNodeKey` already fails closed on ambiguous paths. Equality with the array's `childCount` (the record-total oracle from #1035) proves presence on every record. A sparse field's count is strictly less — never falsely dense.

## Succeeds vs. still fails closed

- **Succeeds (byte-identical to interpreter):** unpredicated multi-key group-by with any provably-dense group field, at any key position, across jn:store and shredder provenance. Group keys use original field order, so output is independent of which field is the anchor.
- **Still fails closed (loud bail / projection fallback):** no provably-dense field (path summary off, nested source, ambiguous path, all candidates sparse), and — an interpreter quirk found and verified here — an entirely-absent **first** group field (brackit collapses `group by $absent, $x` to one all-null tuple, which a dense-anchored scan can't reproduce, so it's vetoed).

## Coverage

`TypedGroupByDifferentialTest`: **80 → 89 cases** (137 assertions + 5 fail-closed proofs), incl. sparse-first/dense-second both orders, dense anchor as 3rd key, mixed provenance, absent-second-key success, and fail-closed proofs (both-sparse bail returning correct results via a covering projection; absent-first bail). `:sirix-query:test` 887/0, `:sirix-core:test` 9220/0. KNOWN_LIMITATIONS updated.