### PR TITLE
Bump version to 1.0.0-beta2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-beta1
+version=1.0.0-beta2
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
Cuts **1.0.0-beta2** — seven PRs merged since the `sirix-1.0.0-beta1` tag:

- #1031 reader use-after-free + O(revisions) storage-open cost (aged-DB 361 → 11,198 reads/s)
- #1032 HOT projection storage corruption + structural swizzle fix
- #1033 crash-window / recovery self-heal / auto-commit race / REST Error-mapping robustness wave
- #1034 CodeFactor checkstyle config
- #1035 vectorized sparse-field presence bitmaps + exact FpCmp/DecCmp predicates + mixed-type group keys
- #1036 dense-anchor multi-key group-by
- #1037 first working GraalVM native-image write path

brackit pinned to the released `1.0-alpha5`. Fat jar built + smoke-tested (boot → create → shred → query). Merging this, then tagging `sirix-1.0.0-beta2`, triggers the Maven Central + Docker + GitHub Release publish.