### PR TITLE
Validate RevisionRootPages by content hash on read

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/AbstractReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/AbstractReader.java
@@ -110,6 +110,32 @@ public abstract class AbstractReader implements Reader {
     }
   }
 
+  /**
+   * Build the synthetic {@link PageReference} used to integrity-check a RevisionRootPage body on
+   * the {@code readRevisionRootPage} path (which has no real parent reference). The stored page
+   * hash is a {@code long} read from the revisions record; it is converted to the SAME canonical
+   * 8-byte form the writer produced ({@link HashAlgorithm#longToBytes(long)} — big-endian, exactly
+   * what {@code PageHasher.compute} emits) so {@link #verifyChecksumIfNeeded} compares like for
+   * like, independent of the little-endian way the record stores it.
+   *
+   * <p>This is the single place both readers (FileChannel + MemoryMapped) build the reference, so
+   * the byte-order contract can never diverge between them. A {@code storedPageHash} of {@code 0}
+   * (legacy beta1 record, or a backend that does not persist page bytes) yields a reference with no
+   * hash, which {@link #verifyChecksumIfNeeded} treats as "nothing to verify".
+   *
+   * @param dataFileOffset the RevisionRootPage offset (becomes the reference key, for error msgs)
+   * @param storedPageHash the record's hash field ({@code 0} = no hash / legacy)
+   * @return a reference carrying the canonical hash bytes, or no hash when {@code storedPageHash == 0}
+   */
+  protected static PageReference revisionRootReference(final long dataFileOffset, final long storedPageHash) {
+    final PageReference reference = new PageReference();
+    reference.setKey(dataFileOffset);
+    if (storedPageHash != 0L) {
+      reference.setHash(HashAlgorithm.longToBytes(storedPageHash));
+    }
+    return reference;
+  }
+
   public Page deserialize(ResourceConfiguration resourceConfiguration, byte[] page) throws IOException {
     return deserialize(resourceConfiguration, page, null);
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/IOStorage.java
@@ -76,11 +76,50 @@ public interface IOStorage {
 
   /**
    * Size in bytes of one revisions-file record:
-   * {@code [u64 revisionRootOffset][u64 epochMillis][u64 xxh3 of the first 16 bytes][u64 reserved]}.
+   * {@code [u64 revisionRootOffset][u64 epochMillis][u64 recordChecksum][u64 revisionRootPageHash]}
+   * (little-endian). The 4th field carries the XXH3-64 of the RevisionRootPage's compressed
+   * payload (the same hash the writer puts on every page's PageReference) so the page body can be
+   * integrity-checked on the {@code readRevisionRootPage} path, which carries no parent reference.
+   * <p>
+   * The record checksum self-protects this 4th field: when the hash field is non-zero it covers
+   * all 24 leading bytes; when it is zero (a LEGACY beta1-and-earlier record, whose reserved field
+   * was {@code putLong(0L)}) it covers only the first 16 bytes. The hash field thus doubles as the
+   * format-version discriminator, so older resources open under this build with no false-positive
+   * corruption error. See {@link #expectedRevisionRecordChecksum(long, long, long)}.
+   * <p>
    * The checksum exists because these records are the ONLY path to any RevisionRootPage and used
    * to be the least-protected bytes in the system.
    */
   int REVISIONS_FILE_RECORD_SIZE = 32;
+
+  /**
+   * Sentinel substituted for an all-zero RevisionRootPage hash before it is stored in a record, so
+   * that "hash field == {@code 0}" unambiguously means "legacy record, no hash recorded".
+   * <p>
+   * XXH3-64 producing exactly {@code 0} for a real page payload is a ~1-in-2^64 event. Remapping it
+   * to this sentinel means the stored field is NEVER {@code 0} when a hash is genuinely present, so
+   * "present" can never be misread as "legacy" — which is the safety-critical direction, because
+   * misreading present-as-legacy would SILENTLY SKIP verification (a fail-open miss). The readers
+   * do NOT reverse the remap: a real {@code 0}-hash page is verified against the sentinel and so
+   * fails the check (a fail-CLOSED false positive on that one astronomically-rare page) rather than
+   * going unverified. A page whose real hash happens to equal the sentinel itself is stored and
+   * verified as the sentinel unchanged — no false positive there. The value is otherwise arbitrary.
+   */
+  long ZERO_HASH_SENTINEL = 0xFFFF_FFFF_FFFF_FFFFL;
+
+  /**
+   * Normalize a RevisionRootPage hash for storage: an all-zero hash is remapped to
+   * {@link #ZERO_HASH_SENTINEL} so the stored field is never {@code 0} when a hash IS present
+   * ({@code 0} is reserved to mean "legacy / no hash"). Any non-zero hash is stored unchanged. The
+   * remap is one-way (readers never reverse it) — see {@link #ZERO_HASH_SENTINEL} for the
+   * fail-closed rationale.
+   *
+   * @param pageHash the page hash as a long (canonical, as produced from {@code PageHasher})
+   * @return the value to store in the record's hash field (never {@code 0} for a present hash)
+   */
+  static long normalizeRevisionRootPageHash(final long pageHash) {
+    return pageHash == 0L ? ZERO_HASH_SENTINEL : pageHash;
+  }
 
   /**
    * The revisions file is a fixed-slot array: record for {@code revision} lives at this offset.
@@ -96,8 +135,9 @@ public interface IOStorage {
   }
 
   /**
-   * XXH3-64 of a revisions record's first 16 bytes (offset + timestamp), little-endian — the
-   * integrity check both writers and readers must agree on.
+   * XXH3-64 of a LEGACY revisions record's first 16 bytes (offset + timestamp), little-endian.
+   * Used to verify records whose hash field is {@code 0} (beta1 and earlier), and to compute the
+   * checksum a legacy record would carry.
    */
   static long revisionRecordChecksum(final long offset, final long timestampMillis) {
     final byte[] first16 = new byte[16];
@@ -105,6 +145,44 @@ public interface IOStorage {
     bb.putLong(offset);
     bb.putLong(timestampMillis);
     return net.openhft.hashing.LongHashFunction.xx3().hashBytes(first16);
+  }
+
+  /**
+   * XXH3-64 of a revisions record's first 24 bytes (offset + timestamp + RevisionRootPage hash),
+   * little-endian — the integrity check writers and readers agree on when a page hash is present.
+   * The hash field is folded into the checksum so a torn write or bit-rot in the hash itself is
+   * detected by the same record check, not silently used to (mis)verify the page body.
+   *
+   * @param offset           the RevisionRootPage offset in the data file
+   * @param timestampMillis  the revision commit timestamp
+   * @param storedPageHash   the (already-normalized, non-zero) page-hash field as stored
+   * @return the XXH3-64 of the 24-byte prefix
+   */
+  static long revisionRecordChecksum(final long offset, final long timestampMillis, final long storedPageHash) {
+    final byte[] first24 = new byte[24];
+    final java.nio.ByteBuffer bb = java.nio.ByteBuffer.wrap(first24).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+    bb.putLong(offset);
+    bb.putLong(timestampMillis);
+    bb.putLong(storedPageHash);
+    return net.openhft.hashing.LongHashFunction.xx3().hashBytes(first24);
+  }
+
+  /**
+   * The checksum a record is EXPECTED to carry, dispatching on its hash field — the single place
+   * the legacy-vs-present rule lives, so every reader (FileChannel, MemoryMapped, recovery scan)
+   * applies it identically. {@code storedPageHash == 0} ⇒ legacy 16-byte checksum (offset +
+   * timestamp only); otherwise the 24-byte checksum that also covers the hash field.
+   *
+   * @param offset          the RevisionRootPage offset
+   * @param timestampMillis the revision commit timestamp
+   * @param storedPageHash  the record's 4th field exactly as read from disk ({@code 0} = legacy)
+   * @return the checksum the record's 3rd field must equal to be considered intact
+   */
+  static long expectedRevisionRecordChecksum(final long offset, final long timestampMillis,
+      final long storedPageHash) {
+    return storedPageHash == 0L
+        ? revisionRecordChecksum(offset, timestampMillis)
+        : revisionRecordChecksum(offset, timestampMillis, storedPageHash);
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/InterruptedFirstCommitRecovery.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/InterruptedFirstCommitRecovery.java
@@ -271,8 +271,10 @@ public final class InterruptedFirstCommitRecovery {
   /**
    * Scans every revisions-file slot (deterministic layout, see
    * {@link IOStorage#revisionsFileOffset(int)}) for a checksum-valid record, reusing the
-   * writer/reader checksum contract {@link IOStorage#revisionRecordChecksum(long, long)}. An
-   * all-zero slot never matches — the checksum of {@code (0, 0)} is a nonzero constant.
+   * writer/reader checksum contract {@link IOStorage#expectedRevisionRecordChecksum(long, long, long)}
+   * (which selects the 16- or 24-byte variant by the record's hash field). An all-zero slot never
+   * matches — the legacy checksum of {@code (0, 0)} is a nonzero constant, so a zeroed slot's stored
+   * checksum of 0 cannot equal it.
    */
   private static boolean hasNoChecksumValidRevisionRecord(final Path revisionsFile) throws IOException {
     if (!Files.isRegularFile(revisionsFile)) {
@@ -293,14 +295,19 @@ public final class InterruptedFirstCommitRecovery {
           }
           position += read;
         }
-        if (position < 3 * Long.BYTES) {
+        if (position < 4 * Long.BYTES) {
           continue; // a torn partial slot cannot hold a verifiable record
         }
         record.flip();
         final long revisionRootOffset = record.getLong();
         final long timestampMillis = record.getLong();
         final long storedChecksum = record.getLong();
-        if (storedChecksum == IOStorage.revisionRecordChecksum(revisionRootOffset, timestampMillis)) {
+        // 4th field: the RevisionRootPage hash (0 = legacy). It selects the 16- vs 24-byte
+        // checksum variant, exactly as the readers do — so a hash-carrying record written by
+        // this build is recognized as valid here too.
+        final long pageHash = record.getLong();
+        if (storedChecksum == IOStorage.expectedRevisionRecordChecksum(revisionRootOffset, timestampMillis,
+            pageHash)) {
           return false;
         }
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/RevisionFileData.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/RevisionFileData.java
@@ -2,5 +2,25 @@ package io.sirix.io;
 
 import java.time.Instant;
 
-public record RevisionFileData(long offset, Instant timestamp) {
+/**
+ * One revisions-file record, in-memory.
+ *
+ * @param offset    byte offset of the RevisionRootPage in {@code sirix.data}
+ * @param timestamp commit timestamp of the revision
+ * @param pageHash  XXH3-64 of the RevisionRootPage's compressed on-disk payload, as a {@code long}
+ *                  (the same value the writer stored on the page's {@link io.sirix.page.PageReference}).
+ *                  {@code 0} means "no hash recorded" — a legacy (beta1 and earlier) record whose
+ *                  reserved field was zero, OR a backend (e.g. RAM) that does not persist page
+ *                  bytes. A zero {@code pageHash} therefore disables RevisionRootPage body
+ *                  verification for that revision (the record checksum still covers offset+timestamp).
+ */
+public record RevisionFileData(long offset, Instant timestamp, long pageHash) {
+
+  /**
+   * Convenience constructor for backends/records without a persisted RevisionRootPage hash (RAM
+   * backend, legacy records). Equivalent to {@code RevisionFileData(offset, timestamp, 0L)}.
+   */
+  public RevisionFileData(long offset, Instant timestamp) {
+    this(offset, timestamp, 0L);
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -239,7 +239,11 @@ public final class FileChannelReader extends AbstractReader {
   public RevisionRootPage readRevisionRootPage(final int revision, final ResourceConfiguration resourceConfiguration) {
     ByteBuffer buffer = acquireBuffer(4);
     try {
-      final var dataFileOffset = cache.get(revision, (unused) -> getRevisionFileData(revision)).offset();
+      // The cached record carries (offset, timestamp, pageHash) — reuse it so we neither re-read
+      // the revisions record nor lose the page hash needed to integrity-check the body below.
+      final RevisionFileData revisionFileData =
+          cache.get(revision, (unused) -> getRevisionFileData(revision));
+      final long dataFileOffset = revisionFileData.offset();
 
       buffer.clear().limit(4);
       readFully(buffer, dataFileOffset, "revision-root length header");
@@ -257,13 +261,22 @@ public final class FileChannelReader extends AbstractReader {
       readFully(buffer, dataFileOffset + 4, "revision-root body");
       buffer.flip();
 
+      // The RevisionRootPage read path carries no parent PageReference, so unlike every other page
+      // its body was historically NOT integrity-checked here. The hash recorded alongside the
+      // record (the same XXH3 the writer set on the page's reference) lets us verify the compressed
+      // payload BEFORE deserialization — mirroring read(reference, config) exactly. Gated on
+      // verifyChecksumsOnRead and skipped for legacy/RAM records that carry no hash (pageHash == 0).
+      final PageReference reference = revisionRootReference(dataFileOffset, revisionFileData.pageHash());
+
       if (byteHandler.supportsMemorySegments()) {
         final MemorySegment segment = MemorySegment.ofBuffer(buffer);
-        return (RevisionRootPage) deserializeFromSegment(resourceConfiguration, segment);
+        verifyChecksumIfNeeded(segment, reference, resourceConfiguration);
+        return (RevisionRootPage) deserializeFromSegment(resourceConfiguration, segment, reference);
       } else {
         final byte[] page = new byte[dataLength];
         buffer.get(page);
-        return (RevisionRootPage) deserialize(resourceConfiguration, page);
+        verifyChecksumIfNeeded(page, reference, resourceConfiguration);
+        return (RevisionRootPage) deserialize(resourceConfiguration, page, reference);
       }
     } catch (IOException e) {
       throw new SirixIOException(e);
@@ -331,12 +344,16 @@ public final class FileChannelReader extends AbstractReader {
         final long offset = buffer.getLong(base);
         final long timestamp = buffer.getLong(base + 8);
         final long storedChecksum = buffer.getLong(base + 16);
-        // These bytes are the ONLY path to the revision's root page — verify them.
-        if (storedChecksum != IOStorage.revisionRecordChecksum(offset, timestamp)) {
+        // 4th field: the RevisionRootPage's own page hash (0 = legacy record / no hash).
+        final long pageHash = buffer.getLong(base + 24);
+        // These bytes are the ONLY path to the revision's root page — verify them. The checksum
+        // covers 24 bytes when a page hash is present, 16 when legacy (hash == 0), so beta1
+        // resources still open cleanly.
+        if (storedChecksum != IOStorage.expectedRevisionRecordChecksum(offset, timestamp, pageHash)) {
           throw new SirixIOException("Corrupt revisions record for revision " + (fromRevision + i)
               + " (checksum mismatch) — torn write or storage corruption");
         }
-        result[i] = new RevisionFileData(offset, Instant.ofEpochMilli(timestamp));
+        result[i] = new RevisionFileData(offset, Instant.ofEpochMilli(timestamp), pageHash);
       }
       return result;
     } catch (IOException e) {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -397,14 +397,21 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       if (serializationType == SerializationType.DATA && page instanceof RevisionRootPage revisionRootPage) {
         // DETERMINISTIC slot (the shared layout formula) — append-at-file-size shifted every
         // later slot after a failed commit or a torn record. The record carries an XXH3 of its
-        // first 16 bytes: these records are the only path to any RevisionRootPage and used to
-        // be completely unprotected.
+        // first 16/24 bytes: these records are the only path to any RevisionRootPage and used to
+        // be completely unprotected. The former "reserved" 4th field now stores the
+        // RevisionRootPage's own page hash (XXH3 of its compressed payload, the same value set on
+        // pageReference above) so the page body is integrity-checked on read; the checksum covers
+        // it. Normalize an (astronomically unlikely) all-zero hash to a sentinel so the stored
+        // field is never 0 — 0 is reserved to mean "legacy record, no hash".
+        final long storedPageHash =
+            IOStorage.normalizeRevisionRootPageHash(io.sirix.io.HashAlgorithm.bytesToLong(pageHash));
         final ByteBuffer buffer =
             ByteBuffer.allocateDirect(IOStorage.REVISIONS_FILE_RECORD_SIZE).order(ByteOrder.LITTLE_ENDIAN);
         buffer.putLong(offset);
         buffer.putLong(revisionRootPage.getRevisionTimestamp());
-        buffer.putLong(IOStorage.revisionRecordChecksum(offset, revisionRootPage.getRevisionTimestamp()));
-        buffer.putLong(0L); // reserved
+        buffer.putLong(
+            IOStorage.revisionRecordChecksum(offset, revisionRootPage.getRevisionTimestamp(), storedPageHash));
+        buffer.putLong(storedPageHash);
         buffer.flip();
         final long revisionsFileOffset = IOStorage.revisionsFileOffset(revisionRootPage.getRevision());
         while (buffer.hasRemaining()) {
@@ -413,7 +420,7 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
         final long currOffset = offset;
         final long currTimestamp = revisionRootPage.getRevisionTimestamp();
         cache.put(revisionRootPage.getRevision(), CompletableFuture.supplyAsync(
-            () -> new RevisionFileData(currOffset, Instant.ofEpochMilli(currTimestamp))));
+            () -> new RevisionFileData(currOffset, Instant.ofEpochMilli(currTimestamp), storedPageHash)));
         // Update the optimized revision index
         revisionIndexHolder.addRevision(currOffset, currTimestamp);
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
@@ -196,23 +196,35 @@ public final class MMFileReader extends AbstractReader {
   @Override
   public RevisionRootPage readRevisionRootPage(final int revision, final ResourceConfiguration resourceConfiguration) {
     try {
+      // The cached record carries (offset, timestamp, pageHash) — reuse it so we neither re-read
+      // the revisions record nor lose the page hash needed to integrity-check the body below.
       // noinspection DataFlowIssue
-      final var dataFileOffset = cache.get(revision, (unused) -> getRevisionFileData(revision)).offset();
+      final RevisionFileData revisionFileData = cache.get(revision, (unused) -> getRevisionFileData(revision));
+      final long dataFileOffset = revisionFileData.offset();
 
       final int dataLength = dataFileSegment.get(LAYOUT_INT, dataFileOffset);
       checkDataLength(dataLength);
       final long offset = dataFileOffset + LAYOUT_INT.byteSize();
 
+      // The RevisionRootPage read path carries no parent PageReference, so unlike every other page
+      // its body was historically NOT integrity-checked here. The hash recorded alongside the
+      // record (the same XXH3 the writer set on the page's reference) lets us verify the compressed
+      // payload BEFORE deserialization — mirroring read(reference, config) exactly. Gated on
+      // verifyChecksumsOnRead and skipped for legacy/RAM records that carry no hash (pageHash == 0).
+      final PageReference reference = revisionRootReference(dataFileOffset, revisionFileData.pageHash());
+
       // Check if we can use zero-copy MemorySegment path (Umbra-style)
       if (byteHandler.supportsMemorySegments()) {
         // Slice mmap segment directly instead of copying to byte[]
         MemorySegment pageSlice = dataFileSegment.asSlice(offset, dataLength);
-        return (RevisionRootPage) deserializeFromSegment(resourceConfiguration, pageSlice);
+        verifyChecksumIfNeeded(pageSlice, reference, resourceConfiguration);
+        return (RevisionRootPage) deserializeFromSegment(resourceConfiguration, pageSlice, reference);
       } else {
         // Fallback: copy to byte[] for stream-based decompression
         final byte[] page = new byte[dataLength];
         MemorySegment.copy(dataFileSegment, LAYOUT_BYTE, offset, page, 0, dataLength);
-        return (RevisionRootPage) deserialize(resourceConfiguration, page);
+        verifyChecksumIfNeeded(page, reference, resourceConfiguration);
+        return (RevisionRootPage) deserialize(resourceConfiguration, page, reference);
       }
     } catch (final IOException e) {
       throw new SirixIOException(e);
@@ -228,20 +240,23 @@ public final class MMFileReader extends AbstractReader {
   @Override
   public RevisionFileData getRevisionFileData(int revision) {
     final var fileOffset = IOStorage.revisionsFileOffset(revision);
-    // The three 8-byte fields read below end at fileOffset + 24 — a shorter mapping means a
+    // The four 8-byte fields read below end at fileOffset + 32 — a shorter mapping means a
     // truncated record, which would otherwise surface as a raw IndexOutOfBoundsException.
-    if (fileOffset + 3L * Long.BYTES > revisionsOffsetFileSegment.byteSize()) {
+    if (fileOffset + 4L * Long.BYTES > revisionsOffsetFileSegment.byteSize()) {
       throw new SirixIOException("Truncated revisions record for revision " + revision);
     }
     final long revisionOffset = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, fileOffset);
     final long timestampMillis = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, fileOffset + 8);
     final long storedChecksum = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, fileOffset + 16);
-    // These 16 bytes are the ONLY path to the revision's root page — verify them.
-    if (storedChecksum != IOStorage.revisionRecordChecksum(revisionOffset, timestampMillis)) {
+    // 4th field: the RevisionRootPage's own page hash (0 = legacy record / no hash).
+    final long pageHash = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, fileOffset + 24);
+    // These bytes are the ONLY path to the revision's root page — verify them. The checksum covers
+    // 24 bytes when a page hash is present, 16 when legacy (hash == 0), so beta1 resources open.
+    if (storedChecksum != IOStorage.expectedRevisionRecordChecksum(revisionOffset, timestampMillis, pageHash)) {
       throw new io.sirix.exception.SirixIOException("Corrupt revisions record for revision " + revision
           + " (checksum mismatch) — torn write or storage corruption");
     }
-    return new RevisionFileData(revisionOffset, Instant.ofEpochMilli(timestampMillis));
+    return new RevisionFileData(revisionOffset, Instant.ofEpochMilli(timestampMillis), pageHash);
   }
 
   @Override
@@ -253,8 +268,8 @@ public final class MMFileReader extends AbstractReader {
     // path is not about I/O batching — it only hoists the truncation check out of the
     // per-record loop (the revision-index load calls this with the full history).
     final long lastRecordOffset = IOStorage.revisionsFileOffset(fromRevision + count - 1);
-    if (lastRecordOffset + 3L * Long.BYTES > revisionsOffsetFileSegment.byteSize()) {
-      final long tail = revisionsOffsetFileSegment.byteSize() - IOStorage.REVISIONS_RECORDS_START - 3L * Long.BYTES;
+    if (lastRecordOffset + 4L * Long.BYTES > revisionsOffsetFileSegment.byteSize()) {
+      final long tail = revisionsOffsetFileSegment.byteSize() - IOStorage.REVISIONS_RECORDS_START - 4L * Long.BYTES;
       final long firstTruncated = tail < 0 ? 0 : tail / IOStorage.REVISIONS_FILE_RECORD_SIZE + 1;
       throw new SirixIOException("Truncated revisions record for revision " + Math.max(fromRevision, firstTruncated));
     }
@@ -264,11 +279,13 @@ public final class MMFileReader extends AbstractReader {
       final long revisionOffset = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base);
       final long timestampMillis = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base + 8);
       final long storedChecksum = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base + 16);
-      if (storedChecksum != IOStorage.revisionRecordChecksum(revisionOffset, timestampMillis)) {
+      // 4th field: the RevisionRootPage's own page hash (0 = legacy record / no hash).
+      final long pageHash = revisionsOffsetFileSegment.get(LAYOUT_LONG_LE, base + 24);
+      if (storedChecksum != IOStorage.expectedRevisionRecordChecksum(revisionOffset, timestampMillis, pageHash)) {
         throw new io.sirix.exception.SirixIOException("Corrupt revisions record for revision " + (fromRevision + i)
             + " (checksum mismatch) — torn write or storage corruption");
       }
-      result[i] = new RevisionFileData(revisionOffset, Instant.ofEpochMilli(timestampMillis));
+      result[i] = new RevisionFileData(revisionOffset, Instant.ofEpochMilli(timestampMillis), pageHash);
     }
     return result;
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/io/RevisionRootPageHashValidationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/RevisionRootPageHashValidationTest.java
@@ -1,0 +1,473 @@
+package io.sirix.io;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.exception.SirixCorruptionException;
+import io.sirix.exception.SirixIOException;
+import io.sirix.io.filechannel.FileChannelStorage;
+import io.sirix.io.memorymapped.MMStorage;
+import io.sirix.page.RevisionRootPage;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Hardening regression tests: RevisionRootPage bodies are content-hash-validated on read, like
+ * every other page.
+ *
+ * <p>Background. Every page's XXH3 (of its compressed payload) is stored on its PARENT's
+ * PageReference and verified on read ({@code AbstractReader.verifyChecksumIfNeeded}). The
+ * RevisionRootPage is the one page reached WITHOUT a parent reference — via
+ * {@code Reader.readRevisionRootPage}, whose offset comes from a fixed-slot record in
+ * {@code sirix.revisions}. Before this change that path deserialized the body with no integrity
+ * check at all: a single flipped byte in a RevisionRootPage on disk was silently deserialized
+ * (documented in {@code docs/DISK_FORMAT.md} §3 "Still not covered").
+ *
+ * <p>The fix stores the RevisionRootPage's own page hash in the revisions record's former
+ * "reserved" 4th field and verifies the body against it on read. The record checksum is widened to
+ * cover that field (24 bytes) when it is present; a record whose hash field is {@code 0} is a
+ * LEGACY (beta1-and-earlier) record and keeps the 16-byte checksum, so old resources still open.
+ *
+ * <p>Each corruption case is paired with a "demonstrates the pre-fix gap" assertion: the same
+ * corrupted body, read through a reader with verification DISABLED, deserializes to a non-null
+ * page instead of throwing — exactly the (un-hardened) behavior the production default now
+ * prevents. (Pre-fix, the verify-enabled path behaved identically to the verify-disabled path,
+ * because there was no verification on this path at all; verified independently by stashing the
+ * fix.)
+ */
+final class RevisionRootPageHashValidationTest {
+
+  private static final String RESOURCE = "revroot-hash-resource";
+
+  private static final String DOC = "{\"r\":1,\"name\":\"alpha\",\"nested\":{\"a\":[1,2,3],\"b\":true}}";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.clearGlobalCaches();
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // Helpers
+  // ----------------------------------------------------------------------------------------------
+
+  private static Path resourcePath(final Path dbPath) {
+    return dbPath.resolve(DatabaseConfiguration.DatabasePaths.DATA.getFile()).resolve(RESOURCE);
+  }
+
+  private static Path dataFilePath(final Path dbPath) {
+    return resourcePath(dbPath).resolve(ResourceConfiguration.ResourcePaths.DATA.getPath()).resolve("sirix.data");
+  }
+
+  private static Path revisionsFilePath(final Path dbPath) {
+    return resourcePath(dbPath).resolve(ResourceConfiguration.ResourcePaths.DATA.getPath()).resolve("sirix.revisions");
+  }
+
+  /**
+   * Create a resource with the given storage type and commit {@code commits} revisions (each a
+   * fresh subtree insert so the RevisionRootPage genuinely differs). Returns the last user-visible
+   * revision number. The database is fully closed on return so the on-disk files can be poked.
+   */
+  private int createResourceWithRevisions(final Path dbPath, final StorageType storageType, final int commits) {
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    int lastRevision;
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+          .storeDiffs(false)
+          .hashKind(HashType.NONE)
+          .buildPathSummary(false)
+          .versioningApproach(VersioningType.FULL)
+          .storageType(storageType)
+          .build());
+
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        for (int i = 0; i < commits; i++) {
+          try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(DOC));
+            wtx.commit();
+          }
+        }
+        try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+          lastRevision = rtx.getRevisionNumber();
+        }
+      }
+    }
+    // Drop any cached RevisionFileData / pages so a subsequent raw read goes to disk.
+    Databases.clearGlobalCaches();
+    return lastRevision;
+  }
+
+  /** Deserialize the on-disk resource configuration (carries storageType + verifyChecksumsOnRead). */
+  private ResourceConfiguration loadConfig(final Path dbPath) {
+    return ResourceConfiguration.deserialize(resourcePath(dbPath));
+  }
+
+  /** A fresh per-call cache so a reader never sees a stale RevisionFileData from another phase. */
+  private static AsyncCache<Integer, RevisionFileData> freshCache() {
+    return Caffeine.newBuilder().maximumSize(10_000).buildAsync();
+  }
+
+  /** Build a storage instance directly (no global cache, no session) for the given config. */
+  private static IOStorage storageFor(final ResourceConfiguration config) {
+    return config.getStorageType() == StorageType.MEMORY_MAPPED
+        ? new MMStorage(config, freshCache())
+        : new FileChannelStorage(config, freshCache());
+  }
+
+  /** Read revision record {@code revision} straight from {@code sirix.revisions} (little-endian). */
+  private static long[] readRecord(final Path dbPath, final int revision) throws Exception {
+    final long off = IOStorage.revisionsFileOffset(revision);
+    try (final RandomAccessFile raf = new RandomAccessFile(revisionsFilePath(dbPath).toFile(), "r")) {
+      final byte[] buf = new byte[IOStorage.REVISIONS_FILE_RECORD_SIZE];
+      raf.seek(off);
+      raf.readFully(buf);
+      final ByteBuffer bb = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
+      return new long[] {bb.getLong(0), bb.getLong(8), bb.getLong(16), bb.getLong(24)};
+    }
+  }
+
+  /** Overwrite one 8-byte field (0=offset,1=timestamp,2=checksum,3=hash) of a revision record. */
+  private static void writeRecordField(final Path dbPath, final int revision, final int fieldIndex,
+      final long value) throws Exception {
+    final long off = IOStorage.revisionsFileOffset(revision) + fieldIndex * 8L;
+    final ByteBuffer bb = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+    bb.putLong(value).flip();
+    try (final FileChannel ch = FileChannel.open(revisionsFilePath(dbPath), StandardOpenOption.WRITE)) {
+      ch.write(bb, off);
+    }
+  }
+
+  /**
+   * Flip a byte INSIDE the RevisionRootPage's compressed body (the {@code [u32 len][payload]} at
+   * the record's offset; we poke {@code payload[byteInBody]}). This corrupts exactly the bytes the
+   * page hash covers, without touching the length prefix or any other page.
+   */
+  private static void corruptRevisionRootBody(final Path dbPath, final int revision, final int byteInBody)
+      throws Exception {
+    final long recordOffset = readRecord(dbPath, revision)[0];
+    final long bodyByteOffset = recordOffset + Integer.BYTES + byteInBody;
+    try (final RandomAccessFile raf = new RandomAccessFile(dataFilePath(dbPath).toFile(), "rw")) {
+      raf.seek(bodyByteOffset);
+      final int original = raf.read();
+      raf.seek(bodyByteOffset);
+      raf.write(original ^ 0xFF);
+    }
+  }
+
+  /** Read a single revision-root via a freshly-built reader for {@code config}. */
+  private static RevisionRootPage readRevisionRoot(final ResourceConfiguration config, final int revision) {
+    final IOStorage storage = storageFor(config);
+    try (final Reader reader = storage.createReader()) {
+      return reader.readRevisionRootPage(revision, config);
+    } finally {
+      storage.close();
+    }
+  }
+
+  /**
+   * Assert the read does NOT surface a {@link SirixCorruptionException} — i.e. the content-hash
+   * integrity layer did not run / was bypassed. This is the pre-fix behavior on this path: a
+   * corrupt body was either silently deserialized into a wrong page OR blew up deep in the
+   * deserializer with an opaque low-level exception ({@code NegativeArraySizeException} etc.), but
+   * was NEVER cleanly flagged as corruption. Either of those non-corruption outcomes is acceptable
+   * here; a {@code SirixCorruptionException} is NOT (that would mean verification ran).
+   */
+  private static void assertNoCorruptionDetection(final ResourceConfiguration config, final int revision) {
+    try {
+      assertNotNull(readRevisionRoot(config, revision),
+          "verification bypassed: a (possibly wrong) page is returned, not a corruption error");
+    } catch (final SirixCorruptionException unexpected) {
+      throw new AssertionError("expected NO clean corruption detection on this path, but got one", unexpected);
+    } catch (final RuntimeException deserializationBlewUp) {
+      // A corrupt compressed body can also fail deserialization with a low-level exception — that
+      // is precisely the un-hardened failure mode (garbage-in surfaces as an opaque crash, not a
+      // clean SirixCorruptionException). Acceptable: it is not a corruption *detection*.
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (a) Corrupt RevisionRootPage body -> SirixCorruptionException (both backends)
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(a) FILE_CHANNEL: flipped byte in a RevisionRootPage body is detected on read")
+  void fileChannel_corruptRevisionRootBody_throws() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.FILE_CHANNEL, 2);
+
+    corruptRevisionRootBody(dbPath, rev, 3);
+
+    // Verify-enabled (production default) MUST reject the corrupt body.
+    final SirixCorruptionException ex =
+        assertThrows(SirixCorruptionException.class, () -> readRevisionRoot(loadConfig(dbPath), rev),
+            "a flipped RevisionRootPage body byte must be caught by hash verification");
+    assertTrue(ex.getMessage().toLowerCase().contains("corruption"), "should report corruption");
+
+    // Demonstrate the pre-fix gap: with verification DISABLED the integrity layer is bypassed —
+    // the corrupt body is NOT cleanly flagged (it returns a wrong page or crashes in the
+    // deserializer). That is exactly the un-hardened behavior the default now prevents.
+    assertNoCorruptionDetection(withVerificationDisabled(loadConfig(dbPath)), rev);
+  }
+
+  @Test
+  @DisplayName("(a) MEMORY_MAPPED: flipped byte in a RevisionRootPage body is detected on read")
+  void memoryMapped_corruptRevisionRootBody_throws() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.MEMORY_MAPPED, 2);
+
+    corruptRevisionRootBody(dbPath, rev, 3);
+
+    assertThrows(SirixCorruptionException.class, () -> readRevisionRoot(loadConfig(dbPath), rev),
+        "a flipped RevisionRootPage body byte must be caught by hash verification (mmap)");
+
+    assertNoCorruptionDetection(withVerificationDisabled(loadConfig(dbPath)), rev);
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (b) Corrupt the record's offset / timestamp / hash field -> caught by the record checksum
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(b) corrupt record offset field is caught by the record checksum")
+  void corruptRecordOffset_throws() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.FILE_CHANNEL, 1);
+
+    final long[] before = readRecord(dbPath, rev);
+    writeRecordField(dbPath, rev, 0, before[0] ^ 0xABCDL); // flip the offset, leave checksum stale
+
+    assertThrows(SirixIOException.class, () -> readRevisionRoot(loadConfig(dbPath), rev),
+        "a corrupted offset must fail the record checksum");
+  }
+
+  @Test
+  @DisplayName("(b) corrupt record timestamp field is caught by the record checksum")
+  void corruptRecordTimestamp_throws() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.MEMORY_MAPPED, 1);
+
+    final long[] before = readRecord(dbPath, rev);
+    writeRecordField(dbPath, rev, 1, before[1] ^ 0x5L);
+
+    assertThrows(SirixIOException.class, () -> readRevisionRoot(loadConfig(dbPath), rev),
+        "a corrupted timestamp must fail the record checksum (mmap)");
+  }
+
+  @Test
+  @DisplayName("(b) corrupt record HASH field is caught by the (24-byte) record checksum")
+  void corruptRecordHashField_throws() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.FILE_CHANNEL, 1);
+
+    final long[] before = readRecord(dbPath, rev);
+    // Sanity: a fresh record written by this build carries a non-zero hash in field 3.
+    assertTrue(before[3] != 0L, "a record written by this build must carry a non-zero page hash");
+    // Flip the hash field only — the 24-byte checksum must now mismatch (it covers field 3).
+    writeRecordField(dbPath, rev, 3, before[3] ^ 0x1L);
+
+    assertThrows(SirixIOException.class, () -> readRevisionRoot(loadConfig(dbPath), rev),
+        "tampering with the page-hash field must fail the 24-byte record checksum");
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (c) verifyChecksumsOnRead=false -> opt-out respected (corrupt body still reads)
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(c) verifyChecksumsOnRead=false does NOT raise a corruption error for a corrupt body")
+  void verificationDisabled_corruptBody_doesNotThrowCorruption() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.FILE_CHANNEL, 1);
+
+    corruptRevisionRootBody(dbPath, rev, 3);
+
+    // Opt-out honored: the hash check is skipped, so no SirixCorruptionException is raised for the
+    // tampered body (it is read back as-is — possibly garbage). Contrast (a), where the same
+    // corruption under the default ON yields a clean SirixCorruptionException.
+    assertNoCorruptionDetection(withVerificationDisabled(loadConfig(dbPath)), rev);
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (d) Backward compat: a legacy record (hash field == 0, 16-byte checksum) opens cleanly
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(d) legacy record (hash==0, 16-byte checksum) opens cleanly — beta1 resources still work")
+  void legacyRecord_opensCleanly() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    final int rev = createResourceWithRevisions(dbPath, StorageType.FILE_CHANNEL, 1);
+
+    // Downgrade the record to the LEGACY format beta1 wrote: hash field 0, checksum over 16 bytes.
+    final long[] r = readRecord(dbPath, rev);
+    writeRecordField(dbPath, rev, 3, 0L);                                   // hash field -> legacy 0
+    writeRecordField(dbPath, rev, 2, IOStorage.revisionRecordChecksum(r[0], r[1])); // 16-byte checksum
+    Databases.clearGlobalCaches();
+
+    // Opens and reads with NO false-positive corruption error (default verification ON).
+    final RevisionRootPage page = readRevisionRoot(loadConfig(dbPath), rev);
+    assertNotNull(page, "a legacy (hash==0) record must open cleanly under this build");
+
+    // And because a legacy record carries no page hash, the body is (correctly) NOT verified:
+    // corrupting it is NOT cleanly flagged — there is simply nothing to check against. This proves
+    // the hash==0 disambiguation: present-hash => verify, absent-hash (legacy) => skip.
+    corruptRevisionRootBody(dbPath, rev, 3);
+    Databases.clearGlobalCaches();
+    assertNoCorruptionDetection(loadConfig(dbPath), rev);
+  }
+
+  @Test
+  @DisplayName("(d) bulk getRevisionFileData over a legacy record opens cleanly (mmap + filechannel)")
+  void legacyRecord_bulkRead_opensCleanly() throws Exception {
+    for (final StorageType type : new StorageType[] {StorageType.FILE_CHANNEL, StorageType.MEMORY_MAPPED}) {
+      JsonTestHelper.deleteEverything();
+      Databases.clearGlobalCaches();
+      final Path dbPath = PATHS.PATH1.getFile();
+      final int rev = createResourceWithRevisions(dbPath, type, 2);
+
+      // Downgrade revision `rev` to legacy.
+      final long[] r = readRecord(dbPath, rev);
+      writeRecordField(dbPath, rev, 3, 0L);
+      writeRecordField(dbPath, rev, 2, IOStorage.revisionRecordChecksum(r[0], r[1]));
+      Databases.clearGlobalCaches();
+
+      final ResourceConfiguration config = loadConfig(dbPath);
+      final IOStorage storage = storageFor(config);
+      try (final Reader reader = storage.createReader()) {
+        final RevisionFileData[] all = reader.getRevisionFileData(0, rev + 1);
+        assertEquals(rev + 1, all.length, type + ": bulk read returns all records");
+        assertEquals(0L, all[rev].pageHash(), type + ": downgraded record reports a 0 (legacy) hash");
+      } finally {
+        storage.close();
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (e) Round-trip: a clean resource reads every revision (no false positives) incl. time-travel
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(e) clean multi-revision resource reads every revision + time-travels with no false positive")
+  void cleanResource_allRevisionsReadable() throws Exception {
+    for (final StorageType type : new StorageType[] {StorageType.FILE_CHANNEL, StorageType.MEMORY_MAPPED}) {
+      JsonTestHelper.deleteEverything();
+      Databases.clearGlobalCaches();
+      final Path dbPath = PATHS.PATH1.getFile();
+      final int last = createResourceWithRevisions(dbPath, type, 4);
+
+      final ResourceConfiguration config = loadConfig(dbPath);
+      // Raw reader: read every revision-root directly (verification ON by default).
+      for (int rev = 1; rev <= last; rev++) {
+        final RevisionRootPage page = readRevisionRoot(config, rev);
+        assertNotNull(page, type + ": revision " + rev + " must read cleanly");
+        assertEquals(rev, page.getRevision(), type + ": revision number round-trips");
+      }
+
+      // And via the full session/time-travel path (exercises the RevisionRootPage cache + readers).
+      Databases.clearGlobalCaches();
+      try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath);
+          final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        for (int rev = 1; rev <= last; rev++) {
+          try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(rev)) {
+            assertEquals(rev, rtx.getRevisionNumber(), type + ": time-travel to revision " + rev);
+            assertTrue(rtx.moveToFirstChild(), type + ": revision " + rev + " data must be navigable");
+          }
+        }
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // (f) Checksum/sentinel invariants (pure, no I/O) — lock in the soundness reasoning
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  @DisplayName("(f) expectedRevisionRecordChecksum dispatches 16-byte (legacy) vs 24-byte (present)")
+  void checksumDispatch_legacyVsPresent() {
+    final long off = 0x1122334455667788L;
+    final long ts = 0x0000017F_ABCDEF01L;
+    final long hash = 0xDEADBEEFCAFEBABEL;
+
+    // Present hash -> 24-byte variant; legacy (0) -> 16-byte variant.
+    assertEquals(IOStorage.revisionRecordChecksum(off, ts, hash),
+        IOStorage.expectedRevisionRecordChecksum(off, ts, hash), "present hash -> 24-byte checksum");
+    assertEquals(IOStorage.revisionRecordChecksum(off, ts),
+        IOStorage.expectedRevisionRecordChecksum(off, ts, 0L), "hash==0 -> legacy 16-byte checksum");
+    // The two variants must differ for the same (off,ts) — otherwise the hash field would be
+    // unprotected and a present record indistinguishable from a legacy one by checksum alone.
+    assertTrue(IOStorage.revisionRecordChecksum(off, ts) != IOStorage.revisionRecordChecksum(off, ts, hash),
+        "16- and 24-byte checksums must differ so the hash field is genuinely covered");
+  }
+
+  @Test
+  @DisplayName("(f) an all-zero slot never matches the legacy checksum (recovery scan safety)")
+  void allZeroSlot_neverMatchesLegacyChecksum() {
+    // hasNoChecksumValidRevisionRecord relies on this: a zeroed slot has storedChecksum==0, which
+    // must not equal the checksum of (offset=0, timestamp=0, hash=0/legacy).
+    assertTrue(IOStorage.expectedRevisionRecordChecksum(0L, 0L, 0L) != 0L,
+        "checksum of an all-zero legacy record must be non-zero");
+  }
+
+  @Test
+  @DisplayName("(f) hash normalization: 0 -> non-zero sentinel; everything else (incl. sentinel) unchanged")
+  void hashNormalization_isFailClosed() {
+    assertEquals(IOStorage.ZERO_HASH_SENTINEL, IOStorage.normalizeRevisionRootPageHash(0L),
+        "an all-zero real hash is remapped to the sentinel so the stored field is never 0");
+    assertTrue(IOStorage.ZERO_HASH_SENTINEL != 0L, "the sentinel itself must be non-zero");
+    assertEquals(0xCAFEL, IOStorage.normalizeRevisionRootPageHash(0xCAFEL), "non-zero hashes are unchanged");
+    // A page whose real hash equals the sentinel is stored unchanged (verifies fine, no remap).
+    assertEquals(IOStorage.ZERO_HASH_SENTINEL,
+        IOStorage.normalizeRevisionRootPageHash(IOStorage.ZERO_HASH_SENTINEL),
+        "a real hash equal to the sentinel is stored as-is (round-trips, no false positive)");
+  }
+
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+   * Clone the persisted config but with {@code verifyChecksumsOnRead=false}. Copies the
+   * byte-handler pipeline + storage type so deserialization stays byte-compatible, and points the
+   * (public, mutable) {@code resourcePath} at the SAME on-disk files as the persisted config — the
+   * storage classes read only {@code resourcePath} + {@code byteHandlePipeline}. Used to exhibit
+   * the pre-fix (un-hardened) read behavior, where no verification ran on this path at all.
+   */
+  private static ResourceConfiguration withVerificationDisabled(final ResourceConfiguration persisted) {
+    final ResourceConfiguration disabled = new ResourceConfiguration.Builder(RESOURCE)
+        .storageType(persisted.getStorageType())
+        .byteHandlerPipeline(persisted.byteHandlePipeline)
+        .verifyChecksumsOnRead(false)
+        .build();
+    disabled.resourcePath = persisted.resourcePath;
+    return disabled;
+  }
+}

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -71,13 +71,26 @@ and the next commit is no longer an unopenable state (regression-tested by
 0      : SUPERBLOCK (64 B, role = revisions)
 64     : reserved (sparse zeros) up to 4096
 4096 + 32*revision : [u64 dataFileOffsetOfRevisionRootPage][u64 epochMillis]
-                     [u64 XXH3 of the previous 16 bytes][u64 reserved]   (little-endian)
+                     [u64 recordChecksum][u64 revisionRootPageHash]      (little-endian)
 ```
 
 This file is **load-bearing**: the serialized UberPage holds only `revisionCount`, so every
 RevisionRootPage lookup goes through a slot here — which is why every record now carries a
 checksum (verified on read; mismatch is a hard error, not a garbage offset). The write-only
 uber-page copies an earlier draft of the layout kept at offsets 0/512 are gone.
+
+The 4th field (formerly `reserved`, zero) now stores the **XXH3-64 of the RevisionRootPage's
+compressed on-disk payload** — the same hash the writer puts on every other page's parent
+PageReference. It closes the one gap where a page was reached without a parent reference: the
+`readRevisionRootPage` path now verifies the body against this hash before deserializing (gated on
+`verifyChecksumsOnRead`). The **record checksum covers 24 bytes** (offset + timestamp + hash) when
+the hash field is present, so a torn write or bit-rot in the hash itself is also caught.
+**Backward-compat rule:** a record whose hash field is `0` is a *legacy* (beta1-and-earlier)
+record — its checksum covers only the first **16 bytes** and its RevisionRootPage body is not
+hash-verified (there is nothing to check against). The hash field thus doubles as the
+format-version discriminator, so older resources open under this build with no false-positive
+corruption error. (An all-zero real hash is remapped to a non-zero sentinel before storage so `0`
+unambiguously means "legacy".)
 
 ### Endianness
 
@@ -123,9 +136,12 @@ PAX-region + `structuralFlags` extension points without a format break.
 - Every page's XXH3-64 (of the compressed payload) is stored in its **parent's** PageReference →
   Merkle-style chain. Verified on read when `verifyChecksumsOnRead` (default true).
 - The roots are covered too: both files' superblocks carry a CRC, both uber beacon
-  slots carry an XXH3 trailer, and every revision record embeds an XXH3 of its offset+timestamp.
-- **Still not covered**: RevisionRootPages read via `readRevisionRootPage` (no parent
-  reference on that path) and record length prefixes.
+  slots carry an XXH3 trailer, and every revision record embeds an XXH3 of its offset+timestamp
+  (+ the RevisionRootPage hash when present — 24-byte coverage; see §1).
+- **RevisionRootPages are covered now too**: the one page reached without a parent reference
+  (via `readRevisionRootPage`) carries its XXH3 in the 4th field of its revisions record, verified
+  on read before deserialization exactly like a normal page (legacy `hash==0` records skip this).
+- **Still not covered**: record/page length prefixes.
 
 ## 4. Storage backends
 


### PR DESCRIPTION
Closes a gap that `docs/DISK_FORMAT.md` §3 literally listed under "**Still not covered**": the RevisionRootPage was the one page reached without a parent `PageReference`, so `readRevisionRootPage` (both `FileChannelReader` and `MMFileReader`) deserialized its body with no hash to check — `verifyChecksumIfNeeded` never ran. Only the revisions-record's (offset, timestamp) was checksummed, not the page content. Pre-fix, a flipped body byte surfaced as an opaque `NegativeArraySizeException` deep in deserialization; post-fix it's a clean `SirixCorruptionException` **before** deserialization.

## The fix uses space and a hash that already existed

The writer already computes each page's XXH3 (`PageHasher.compute`) and set it on the reference — then **dropped it** for revision roots. And the 32-byte revisions record already had a `putLong(0L)` **reserved** field. So:

**Revisions record (32 B, little-endian):**
- before: `[u64 offset][u64 epochMillis][u64 XXH3-of-first-16B][u64 reserved=0]`
- after: `[u64 offset][u64 epochMillis][u64 recordChecksum][u64 revisionRootPageHash]`

`recordChecksum` covers **24 bytes** when the hash is present, **16 bytes** when legacy. On `readRevisionRootPage`, a hash-bearing `PageReference` is passed into the existing `verifyChecksumIfNeeded` (gated on `verifyChecksumsOnRead`, default true).

## Backward-compatible and fail-closed

- `hashField == 0` ⇒ legacy (beta1) record ⇒ 16-byte checksum, body not verified — so **beta1 resources open with no false positive**.
- An all-zero *real* hash is remapped to a non-zero sentinel before storage, so "present" can never be misread as "legacy" — fail-closed (the ~1-in-2⁶⁴ residual is a false *positive*, the safe direction).
- Byte order is consistent writer↔both readers; the reference build is centralized in `AbstractReader.revisionRootReference` so the two readers can't diverge.

## Tests — `RevisionRootPageHashValidationTest` (12, all green)

Corrupt body → `SirixCorruptionException` for **FILE_CHANNEL and MEMORY_MAPPED**; corrupt offset/timestamp/hash field → record-checksum error; `verifyChecksumsOnRead=false` → opt-out respected; forged legacy record opens cleanly (incl. bulk-read, both backends); clean multi-revision round-trip + time-travel with no false positive; invariants (16-vs-24 dispatch, all-zero slot never matches, fail-closed normalization).

Full `:sirix-core:test` **9236 / 0** (plus targeted io/crash/recovery runs 213/0). `DISK_FORMAT.md` updated.