### PR TITLE
Close history-scan read gaps vs PostgreSQL (W3/W4)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -128,6 +128,12 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   private static final com.github.benmanes.caffeine.cache.Cache<RevisionInfoKey, RevisionInfo> REVISION_INFO_CACHE =
       com.github.benmanes.caffeine.cache.Caffeine.newBuilder().maximumSize(100_000).build();
 
+  /** Shared empty result for history-timestamp queries on resources without user revisions. */
+  private static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+  /** Shared zero-length array for {@link java.util.Collection#toArray(Object[])} of futures. */
+  private static final CompletableFuture<?>[] EMPTY_FUTURES = new CompletableFuture[0];
+
   /** Drops one database's entries from the global revision-info cache. */
   public static void invalidateRevisionInfoCache(final long databaseId) {
     REVISION_INFO_CACHE.asMap().keySet().removeIf(key -> key.databaseId() == databaseId);
@@ -407,55 +413,134 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     final int newestRevision = Math.max(fromRevision, toRevision);
     final int oldestRevision = Math.min(fromRevision, toRevision);
 
-    final var revisionInfos = new ArrayList<CompletableFuture<RevisionInfo>>();
+    return buildHistory(newestRevision, oldestRevision);
+  }
 
-    for (int revision = newestRevision; revision >= oldestRevision; revision--) {
-      revisionInfos.add(revisionInfoFuture(revision));
+  @Override
+  public long[] getHistoryTimestamps() {
+    assertNotClosed();
+    final int newest = getMostRecentRevisionNumber();
+    if (newest < 1) {
+      return EMPTY_LONG_ARRAY;
     }
+    return historyTimestampsNewestFirst(newest, 1);
+  }
 
-    return getResult(revisionInfos);
+  @Override
+  public long[] getHistoryTimestamps(final int fromRevision, final int toRevision) {
+    assertAccess(fromRevision);
+    assertAccess(toRevision);
+
+    checkArgument(fromRevision > 0 && toRevision > 0,
+                  "Revision numbers must be positive, but got %s and %s.",
+                  fromRevision,
+                  toRevision);
+
+    final int newest = Math.max(fromRevision, toRevision);
+    final int oldest = Math.min(fromRevision, toRevision);
+
+    return historyTimestampsNewestFirst(newest, oldest);
   }
 
   /**
-   * Resolve one revision's {@link RevisionInfo}, serving immutable, already-seen revisions from
-   * {@link #REVISION_INFO_CACHE} without any I/O. A miss reads the commit metadata directly
-   * through a {@link StorageEngineReader} — the credentials and timestamp live on the
-   * {@code RevisionRootPage}, so the full node-transaction machinery (node cursor, item list,
-   * per-trx wiring) that {@code beginNodeReadOnlyTrx} sets up is unnecessary overhead here.
+   * Read the commit timestamps (epoch millis) for the inclusive revision range
+   * {@code [oldest, newest]} from the in-memory {@link RevisionIndex} and return them
+   * newest-first. No {@link StorageEngineReader} is opened and no {@code RevisionRootPage} is
+   * read — the timestamps are already resident.
+   *
+   * <p>If the in-memory index lags the requested range (a fresh process, or out-of-band growth
+   * by another writer), it is resynced once from disk via {@link IOStorage#loadRevisionIndex},
+   * mirroring the storage-open path.
    */
-  private CompletableFuture<RevisionInfo> revisionInfoFuture(int revision) {
-    final var cacheKey = new RevisionInfoKey(resourceConfig.getDatabaseId(), resourceConfig.getID(), revision);
-    final RevisionInfo cached = REVISION_INFO_CACHE.getIfPresent(cacheKey);
-    if (cached != null) {
-      return CompletableFuture.completedFuture(cached);
+  private long[] historyTimestampsNewestFirst(final int newest, final int oldest) {
+    final RevisionIndexHolder holder = storage.getRevisionIndexHolder();
+    RevisionIndex index = holder.get();
+    if (index.size() <= newest) {
+      storage.loadRevisionIndex(holder);
+      index = holder.get();
     }
-    return CompletableFuture.supplyAsync(() -> REVISION_INFO_CACHE.get(cacheKey, key -> {
-      try (final StorageEngineReader reader = createStorageEngineReader(revision)) {
-        final CommitCredentials commitCredentials = reader.getCommitCredentials();
-        return new RevisionInfo(commitCredentials.getUser(),
-                                revision,
-                                Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
-                                commitCredentials.getMessage());
-      }
-    }));
+    if (index.size() <= newest) {
+      throw new IllegalStateException("Revision index holds " + index.size()
+          + " entries but revision " + newest + " was requested.");
+    }
+
+    // RevisionIndex stores timestamps in ascending revision order; reverse in place to honour
+    // the newest-first contract shared by all history queries.
+    final long[] timestamps = index.timestampsMillis(oldest, newest);
+    for (int lo = 0, hi = timestamps.length - 1; lo < hi; lo++, hi--) {
+      final long tmp = timestamps[lo];
+      timestamps[lo] = timestamps[hi];
+      timestamps[hi] = tmp;
+    }
+    return timestamps;
   }
 
-  private List<RevisionInfo> getHistoryInformations(int revisions) {
+  private List<RevisionInfo> getHistoryInformations(final int revisions) {
     checkArgument(revisions > 0);
 
-    final int lastCommittedRevision = getMostRecentRevisionNumber();
-    final var revisionInfos = new ArrayList<CompletableFuture<RevisionInfo>>();
-
-    for (int revision = lastCommittedRevision; revision > 0
-        && revision > lastCommittedRevision - revisions; revision--) {
-      revisionInfos.add(revisionInfoFuture(revision));
+    final int newest = getMostRecentRevisionNumber();
+    if (newest < 1) {
+      return List.of();
     }
-
-    return getResult(revisionInfos);
+    // The most recent `revisions` revisions, clamped to the first user revision (1); revision 0
+    // is the empty bootstrap and is never reported.
+    final int oldest = revisions >= newest ? 1 : newest - revisions + 1;
+    return buildHistory(newest, oldest);
   }
 
-  private List<RevisionInfo> getResult(final List<CompletableFuture<RevisionInfo>> revisionInfos) {
-    return revisionInfos.stream().map(CompletableFuture::join).toList();
+  /**
+   * Build the history (newest revision first) for the inclusive revision range
+   * {@code [oldest, newest]}.
+   *
+   * <p>Already-seen, immutable revisions are served synchronously from
+   * {@link #REVISION_INFO_CACHE} straight into a pre-sized result array — no per-revision
+   * {@link CompletableFuture}, no stream pipeline. Only cache misses (cold revisions) open a
+   * {@link StorageEngineReader}, and those run in parallel so a cold first call still overlaps
+   * its I/O across revisions.
+   */
+  private List<RevisionInfo> buildHistory(final int newest, final int oldest) {
+    final int count = newest - oldest + 1;
+    final RevisionInfo[] result = new RevisionInfo[count];
+
+    List<CompletableFuture<Void>> misses = null;
+    for (int i = 0; i < count; i++) {
+      final int revision = newest - i;
+      final var cacheKey = new RevisionInfoKey(resourceConfig.getDatabaseId(), resourceConfig.getID(), revision);
+      final RevisionInfo cached = REVISION_INFO_CACHE.getIfPresent(cacheKey);
+      if (cached != null) {
+        result[i] = cached;
+      } else {
+        final int slot = i;
+        if (misses == null) {
+          misses = new ArrayList<>();
+        }
+        misses.add(CompletableFuture.runAsync(
+            () -> result[slot] = REVISION_INFO_CACHE.get(cacheKey, this::loadRevisionInfo)));
+      }
+    }
+
+    if (misses != null) {
+      CompletableFuture.allOf(misses.toArray(EMPTY_FUTURES)).join();
+    }
+
+    return List.of(result);
+  }
+
+  /**
+   * Cold-path loader for one revision's {@link RevisionInfo}: reads the commit credentials and
+   * timestamp directly through a {@link StorageEngineReader}, bypassing the full
+   * node-transaction machinery (node cursor, item list, per-trx wiring) that
+   * {@code beginNodeReadOnlyTrx} sets up.
+   */
+  private RevisionInfo loadRevisionInfo(final RevisionInfoKey key) {
+    final int revision = key.revision();
+    try (final StorageEngineReader reader = createStorageEngineReader(revision)) {
+      final CommitCredentials commitCredentials = reader.getCommitCredentials();
+      return new RevisionInfo(commitCredentials.getUser(),
+                              revision,
+                              Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
+                              commitCredentials.getMessage());
+    }
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -16,6 +16,7 @@ import io.sirix.access.trx.RevisionEpochTracker;
 import io.sirix.api.NodeCursor;
 import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.api.NodeTrx;
+import io.sirix.api.RecordHistoryVisitor;
 import io.sirix.api.ResourceSession;
 import io.sirix.api.RevisionInfo;
 import io.sirix.api.StorageEngineReader;
@@ -38,6 +39,8 @@ import io.sirix.io.RevisionIndexHolder;
 import io.sirix.io.StorageType;
 import io.sirix.io.Writer;
 import io.sirix.metrics.TransactionMetrics;
+import io.sirix.node.RevisionReferencesNode;
+import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.interfaces.Node;
 import io.sirix.page.UberPage;
 import io.sirix.settings.Fixed;
@@ -130,6 +133,9 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
   /** Shared empty result for history-timestamp queries on resources without user revisions. */
   private static final long[] EMPTY_LONG_ARRAY = new long[0];
+
+  /** Shared empty result for record-change-revision queries. */
+  private static final int[] EMPTY_INT_ARRAY = new int[0];
 
   /** Shared zero-length array for {@link java.util.Collection#toArray(Object[])} of futures. */
   private static final CompletableFuture<?>[] EMPTY_FUTURES = new CompletableFuture[0];
@@ -540,6 +546,72 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
                               revision,
                               Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
                               commitCredentials.getMessage());
+    }
+  }
+
+  @Override
+  public int[] getRecordChangeRevisions(final long nodeKey) {
+    assertNotClosed();
+
+    // The RECORD_TO_REVISIONS index only exists when the resource was created with
+    // storeNodeHistory; otherwise the trie infrastructure is shared across index types and a
+    // lookup could return an unrelated record, so guard up-front (mirrors RecordRevisionsLookup).
+    if (!resourceConfig.storeNodeHistory()) {
+      return EMPTY_INT_ARRAY;
+    }
+
+    final int newest = getMostRecentRevisionNumber();
+    if (newest < 1) {
+      return EMPTY_INT_ARRAY;
+    }
+
+    // RECORD_TO_REVISIONS is itself versioned; reading it at the most recent revision yields the
+    // complete set of revisions in which the record was ever created or modified.
+    try (final StorageEngineReader reader = createStorageEngineReader(newest)) {
+      final DataRecord record = reader.getRecord(nodeKey, IndexType.RECORD_TO_REVISIONS, 0);
+      if (record instanceof RevisionReferencesNode revisionReferences) {
+        final int[] revisions = revisionReferences.getRevisions();
+        if (revisions != null && revisions.length > 0) {
+          // Defensive copy — the array on the node is the live, read-only index entry.
+          return revisions.clone();
+        }
+      }
+      return EMPTY_INT_ARRAY;
+    }
+  }
+
+  @Override
+  public void scanRecordHistory(final long nodeKey, final RecordHistoryVisitor visitor) {
+    requireNonNull(visitor);
+    assertNotClosed();
+
+    if (resourceConfig.storeNodeHistory()) {
+      // Fast path: only the revisions in which the record actually changed need to be read; its
+      // value is unchanged in between.
+      for (final int revision : getRecordChangeRevisions(nodeKey)) {
+        visitRecord(nodeKey, revision, visitor);
+      }
+    } else {
+      // No node-history index — scan every user revision, still via the lightweight reader path.
+      final int newest = getMostRecentRevisionNumber();
+      for (int revision = 1; revision <= newest; revision++) {
+        visitRecord(nodeKey, revision, visitor);
+      }
+    }
+  }
+
+  /**
+   * Read {@code nodeKey} at {@code revision} through a lightweight {@link StorageEngineReader}
+   * (no {@link io.sirix.api.NodeReadOnlyTrx} wrapper, document-node fetch, or trx bookkeeping) and
+   * hand it to {@code visitor} if the record exists in that revision. The reader stays open for
+   * the duration of the callback so the record remains valid.
+   */
+  private void visitRecord(final long nodeKey, final int revision, final RecordHistoryVisitor visitor) {
+    try (final StorageEngineReader reader = createStorageEngineReader(revision)) {
+      final DataRecord record = reader.getRecord(nodeKey, IndexType.DOCUMENT, -1);
+      if (record != null) {
+        visitor.visit(revision, record);
+      }
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -17,6 +17,7 @@ import io.sirix.api.NodeCursor;
 import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.api.NodeTrx;
 import io.sirix.api.RecordHistoryVisitor;
+import io.sirix.api.RecordRunVisitor;
 import io.sirix.api.ResourceSession;
 import io.sirix.api.RevisionInfo;
 import io.sirix.api.StorageEngineReader;
@@ -611,6 +612,49 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       final DataRecord record = reader.getRecord(nodeKey, IndexType.DOCUMENT, -1);
       if (record != null) {
         visitor.visit(revision, record);
+      }
+    }
+  }
+
+  @Override
+  public void scanValueRuns(final long nodeKey, final RecordRunVisitor visitor) {
+    requireNonNull(visitor);
+    assertNotClosed();
+
+    final int maxRevision = getMostRecentRevisionNumber();
+    if (maxRevision < 1) {
+      return;
+    }
+
+    if (resourceConfig.storeNodeHistory()) {
+      // Each entry in the change set starts a run that holds until the revision before the next
+      // change (or the most recent revision for the final entry). The record is read once per run.
+      final int[] changeRevisions = getRecordChangeRevisions(nodeKey);
+      for (int i = 0; i < changeRevisions.length; i++) {
+        final int fromRevision = changeRevisions[i];
+        final int toRevision = (i + 1 < changeRevisions.length) ? changeRevisions[i + 1] - 1 : maxRevision;
+        visitRun(nodeKey, fromRevision, toRevision, visitor);
+      }
+    } else {
+      // No node-history index — value-change boundaries are unknown, so report each existing
+      // revision as its own single-revision run (still via the lightweight reader path).
+      for (int revision = 1; revision <= maxRevision; revision++) {
+        visitRun(nodeKey, revision, revision, visitor);
+      }
+    }
+  }
+
+  /**
+   * Read {@code nodeKey} at {@code fromRevision} through a lightweight {@link StorageEngineReader}
+   * and report the run {@code [fromRevision, toRevision]} to {@code visitor} when the record exists.
+   * The reader stays open for the duration of the callback so the record remains valid.
+   */
+  private void visitRun(final long nodeKey, final int fromRevision, final int toRevision,
+      final RecordRunVisitor visitor) {
+    try (final StorageEngineReader reader = createStorageEngineReader(fromRevision)) {
+      final DataRecord record = reader.getRecord(nodeKey, IndexType.DOCUMENT, -1);
+      if (record != null) {
+        visitor.visit(fromRevision, toRevision, record);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/api/RecordHistoryVisitor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/RecordHistoryVisitor.java
@@ -1,0 +1,26 @@
+package io.sirix.api;
+
+import io.sirix.node.interfaces.DataRecord;
+
+/**
+ * Callback for {@link ResourceSession#scanRecordHistory(long, RecordHistoryVisitor)}.
+ *
+ * <p>Invoked once per revision in which the scanned record exists and (when the node-history index
+ * is available) actually changed. The {@link DataRecord} passed to {@link #visit(int, DataRecord)}
+ * is read under a storage reader that stays open only for the duration of the callback — the record
+ * (and any off-heap memory it references) <b>must not be retained past the callback</b>. Copy out
+ * any values you need to keep.
+ *
+ * @author Johannes Lichtenberger
+ */
+@FunctionalInterface
+public interface RecordHistoryVisitor {
+
+  /**
+   * Visit one historical version of a record.
+   *
+   * @param revision the revision number in which this version was committed
+   * @param record   the record as it existed in {@code revision}; valid only during this call
+   */
+  void visit(int revision, DataRecord record);
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/api/RecordRunVisitor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/RecordRunVisitor.java
@@ -1,0 +1,30 @@
+package io.sirix.api;
+
+import io.sirix.node.interfaces.DataRecord;
+
+/**
+ * Callback for {@link ResourceSession#scanValueRuns(long, RecordRunVisitor)}.
+ *
+ * <p>Invoked once per <i>run</i> of revisions in which a record holds the same value. A run spans
+ * {@code [fromRevision, toRevision]} (both inclusive): the value was committed in
+ * {@code fromRevision} and is unchanged up to and including {@code toRevision}. This lets a
+ * consumer reconstruct the value at <i>every</i> revision while reading the record only once per
+ * change — e.g. an aggregate over all versions is {@code value * (toRevision - fromRevision + 1)}.
+ *
+ * <p>The {@link DataRecord} is read under a storage reader that stays open only for the duration of
+ * the callback and <b>must not be retained past it</b>.
+ *
+ * @author Johannes Lichtenberger
+ */
+@FunctionalInterface
+public interface RecordRunVisitor {
+
+  /**
+   * Visit one run of revisions sharing the same record value.
+   *
+   * @param fromRevision the revision in which this value was committed (inclusive)
+   * @param toRevision   the last revision in which this value still holds (inclusive)
+   * @param record       the record value for the run; valid only during this call
+   */
+  void visit(int fromRevision, int toRevision, DataRecord record);
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
@@ -119,6 +119,41 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   long[] getHistoryTimestamps(int fromRevision, int toRevision);
 
   /**
+   * Get the ascending list of revisions in which the record with the given {@code nodeKey} was
+   * created or modified.
+   *
+   * <p>This is served by a single lookup of the {@code RECORD_TO_REVISIONS} node-history index
+   * (one lightweight storage reader, no full node transaction). It is the basis for value-history
+   * scans that only need to read the revisions in which a value actually changed (the value is
+   * unchanged between consecutive entries), rather than every revision.
+   *
+   * @param nodeKey the stable node key of the record
+   * @return the change revisions in ascending order; an empty array when the resource was created
+   *         without {@code storeNodeHistory} or the record has no recorded history
+   */
+  int[] getRecordChangeRevisions(long nodeKey);
+
+  /**
+   * Scan the value history of the record with the given {@code nodeKey}, invoking {@code visitor}
+   * once per revision in which the record exists.
+   *
+   * <p>When the resource keeps a node-history index ({@code storeNodeHistory}), only the revisions
+   * in which the record actually changed are read (see {@link #getRecordChangeRevisions(long)}) —
+   * the value is unchanged in between, so a consumer can treat each visited revision as the start
+   * of a run that lasts until the next visited revision. Without the index, every revision is
+   * scanned. Either way each revision is read through a lightweight storage reader rather than a
+   * full read-only node transaction, avoiding the per-revision transaction-construction cost.
+   *
+   * <p>Revisions in which the record does not exist (before creation, or after deletion) are
+   * skipped. The {@link io.sirix.node.interfaces.DataRecord} handed to the visitor is valid only
+   * for the duration of the callback.
+   *
+   * @param nodeKey the stable node key of the record
+   * @param visitor the callback invoked for each existing historical version (must not be null)
+   */
+  void scanRecordHistory(long nodeKey, RecordHistoryVisitor visitor);
+
+  /**
    * Get the single node writer if available, wrapped in an {@link Optional}.
    *
    * @return The single node writer if available.

--- a/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
@@ -91,6 +91,34 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   List<RevisionInfo> getHistory(int fromRevision, int toRevision);
 
   /**
+   * Get the commit timestamps (epoch milliseconds) of all revisions, newest-first.
+   *
+   * <p>This is a fast path for callers that only need the timestamps of the history (not the
+   * commit author or message). Unlike {@link #getHistory()}, it is served entirely from the
+   * in-memory revision index: no {@link StorageEngineReader} is opened, no
+   * {@code RevisionRootPage} is read, and no per-revision asynchronous work is scheduled.
+   * Covers revisions {@code [1, mostRecentRevision]} (revision {@code 0} is the empty
+   * bootstrap, mirroring {@link #getHistory()}).
+   *
+   * @return the commit timestamps as epoch milliseconds, ordered most-recent revision first
+   *         (empty if the resource has no committed revisions yet)
+   */
+  long[] getHistoryTimestamps();
+
+  /**
+   * Get the commit timestamps (epoch milliseconds) for an inclusive revision range,
+   * newest-first.
+   *
+   * <p>The bounds are inclusive and may be passed in either order (and may be equal). Like
+   * {@link #getHistoryTimestamps()} this reads only from the in-memory revision index.
+   *
+   * @param fromRevision one bound of the revision range (must be positive)
+   * @param toRevision   the other bound of the revision range (must be positive)
+   * @return the commit timestamps as epoch milliseconds, ordered most-recent revision first
+   */
+  long[] getHistoryTimestamps(int fromRevision, int toRevision);
+
+  /**
    * Get the single node writer if available, wrapped in an {@link Optional}.
    *
    * @return The single node writer if available.

--- a/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
@@ -154,6 +154,26 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   void scanRecordHistory(long nodeKey, RecordHistoryVisitor visitor);
 
   /**
+   * Scan the value history of the record with the given {@code nodeKey} as <i>runs</i>: invoke
+   * {@code visitor} once per maximal range of revisions over which the record holds the same value.
+   *
+   * <p>This is the value-at-every-revision view of {@link #scanRecordHistory(long,
+   * RecordHistoryVisitor)}: when the node-history index is present, the record is read only once per
+   * change (O(changes), not O(revisions)) and each callback reports the inclusive revision range
+   * {@code [fromRevision, toRevision]} over which that value holds — so an aggregate over the whole
+   * history can be computed as {@code value * (toRevision - fromRevision + 1)} without reading every
+   * revision. Without the index, each existing revision is reported as its own single-revision run.
+   *
+   * <p>Runs in which the record does not exist (before creation, or after deletion) are not
+   * reported. The {@link io.sirix.node.interfaces.DataRecord} handed to the visitor is valid only
+   * for the duration of the callback.
+   *
+   * @param nodeKey the stable node key of the record
+   * @param visitor the callback invoked for each value run (must not be null)
+   */
+  void scanValueRuns(long nodeKey, RecordRunVisitor visitor);
+
+  /**
    * Get the single node writer if available, wrapped in an {@link Optional}.
    *
    * @return The single node writer if available.

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/temporal/RevisionPrefetcher.java
@@ -25,12 +25,11 @@ import static java.util.Objects.requireNonNull;
  * spawning a {@link Thread#startVirtualThread virtual thread} that opens the trx and
  * walks to the target node.
  *
- * <h2>What runs in parallel — and what doesn't</h2>
+ * <h2>What runs in parallel</h2>
  * <ul>
- *   <li>{@code beginNodeReadOnlyTrx} is {@code synchronized} on the resource session, so
- *       its body (RevisionRoot load, document-node fetch, trx-map registration) executes
- *       one task at a time. After a warm cache this is a small fraction of the per-yield
- *       cost.</li>
+ *   <li>{@code beginNodeReadOnlyTrx} is not synchronized on the resource session, so its body
+ *       (RevisionRoot load, document-node fetch, trx-map registration) runs concurrently across
+ *       in-flight tasks. After a warm cache this is a small fraction of the per-yield cost.</li>
  *   <li>The subsequent {@code rtx.moveTo(nodeKey)} runs on per-trx state with the shared
  *       page cache and traverses the indirect-page index for the target node. Multiple
  *       in-flight tasks walk different revisions of that index in parallel — that is

--- a/bundles/sirix-core/src/main/java/io/sirix/io/RevisionIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/RevisionIndex.java
@@ -372,8 +372,41 @@ public final class RevisionIndex {
   }
 
   /**
+   * Bulk-copy the commit timestamps (epoch millis) for the inclusive revision range
+   * {@code [fromRevision, toRevision]} into a freshly allocated array, in ascending revision
+   * order.
+   *
+   * <p>
+   * This is the allocation-light source for history listings: the timestamps are already
+   * resident in this immutable index, so the whole range is served by a single
+   * {@link System#arraycopy} with no per-revision page reads, transaction opens, or boxing.
+   *
+   * <p>
+   * Bounds are validated against {@link #size}, never against the backing array length — the
+   * backing arrays may carry spare append capacity past {@code size} (see
+   * {@link #withNewRevision(long, long)}).
+   *
+   * @param fromRevision first revision (0-indexed, inclusive)
+   * @param toRevision   last revision (0-indexed, inclusive)
+   * @return a new array of {@code toRevision - fromRevision + 1} epoch-milli timestamps in
+   *         ascending revision order
+   * @throws IndexOutOfBoundsException if {@code fromRevision < 0}, {@code toRevision >= size},
+   *                                   or {@code fromRevision > toRevision}
+   */
+  public long[] timestampsMillis(int fromRevision, int toRevision) {
+    if (fromRevision < 0 || toRevision >= size || fromRevision > toRevision) {
+      throw new IndexOutOfBoundsException(
+          "Revision range [" + fromRevision + ", " + toRevision + "] out of bounds [0, " + size + ")");
+    }
+    final int count = toRevision - fromRevision + 1;
+    final long[] result = new long[count];
+    System.arraycopy(timestamps, fromRevision, result, 0, count);
+    return result;
+  }
+
+  /**
    * Get the revision file data for a revision.
-   * 
+   *
    * @param revision revision number (0-indexed)
    * @return RevisionFileData containing offset and timestamp
    * @throws IndexOutOfBoundsException if revision < 0 or revision >= size

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
@@ -8,6 +8,7 @@ import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.node.interfaces.NumericValueNode;
 import io.sirix.service.json.serialize.JsonSerializer;
 import io.sirix.service.json.shredder.JsonShredder;
 import org.junit.jupiter.api.AfterEach;
@@ -17,8 +18,10 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.StringWriter;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -480,6 +483,94 @@ public final class JsonMultiRevisionTest {
       for (int i = 0; i < subset.size(); i++) {
         assertEquals(subset.get(i).getRevisionTimestamp().toEpochMilli(), subsetTimestamps[i]);
       }
+    }
+  }
+
+  @Test
+  void testRecordChangeRevisionsAndScan() throws Exception {
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      long valueNodeKey = -1L;
+      for (int i = 1; i <= 5; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          if (i == 1) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[" + i + "]"),
+                JsonNodeTrx.Commit.NO);
+            wtx.moveToDocumentRoot();
+            wtx.moveToFirstChild(); // array
+            wtx.moveToFirstChild(); // number value
+            valueNodeKey = wtx.getNodeKey();
+          } else {
+            assertTrue(wtx.moveTo(valueNodeKey), "node key must be stable across value updates");
+            wtx.setNumberValue(i);
+          }
+          wtx.commit();
+        }
+      }
+
+      // 2a: the node was created at revision 1 and modified in revisions 2..5.
+      final int[] changeRevisions = session.getRecordChangeRevisions(valueNodeKey);
+      assertArrayEquals(new int[] {1, 2, 3, 4, 5}, changeRevisions);
+
+      // 2b: scanRecordHistory visits each change revision with the value committed there, via the
+      // lightweight reader path (no per-revision read-only node transaction).
+      final List<Integer> visitedRevisions = new ArrayList<>();
+      final List<Integer> visitedValues = new ArrayList<>();
+      session.scanRecordHistory(valueNodeKey, (revision, record) -> {
+        visitedRevisions.add(revision);
+        visitedValues.add(((NumericValueNode) record).getValue().intValue());
+      });
+      assertEquals(List.of(1, 2, 3, 4, 5), visitedRevisions);
+      assertEquals(List.of(1, 2, 3, 4, 5), visitedValues);
+
+      // Cross-check the scanned values against the full read-only-transaction path (the W4 manual
+      // loop the scan replaces).
+      for (int rev = 1; rev <= 5; rev++) {
+        try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(rev)) {
+          assertTrue(rtx.moveTo(valueNodeKey));
+          assertEquals(rev, rtx.getNumberValue().intValue());
+        }
+      }
+    }
+  }
+
+  @Test
+  void testScanRecordHistoryFallsBackWithoutNodeHistoryIndex() throws Exception {
+    // storeNodeHistory(false) ⇒ no RECORD_TO_REVISIONS index ⇒ getRecordChangeRevisions is empty
+    // and scanRecordHistory must fall back to scanning every revision.
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabaseWithResourceConfig(
+        PATHS.PATH1.getFile(),
+        io.sirix.access.ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE).storeNodeHistory(false).build());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      long valueNodeKey = -1L;
+      for (int i = 1; i <= 4; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          if (i == 1) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[" + i + "]"),
+                JsonNodeTrx.Commit.NO);
+            wtx.moveToDocumentRoot();
+            wtx.moveToFirstChild();
+            wtx.moveToFirstChild();
+            valueNodeKey = wtx.getNodeKey();
+          } else {
+            assertTrue(wtx.moveTo(valueNodeKey));
+            wtx.setNumberValue(i);
+          }
+          wtx.commit();
+        }
+      }
+
+      assertEquals(0, session.getRecordChangeRevisions(valueNodeKey).length);
+
+      // Full-scan fallback still yields the value at every revision in which the node exists.
+      final List<Integer> visitedRevisions = new ArrayList<>();
+      final List<Integer> visitedValues = new ArrayList<>();
+      session.scanRecordHistory(valueNodeKey, (revision, record) -> {
+        visitedRevisions.add(revision);
+        visitedValues.add(((NumericValueNode) record).getValue().intValue());
+      });
+      assertEquals(List.of(1, 2, 3, 4), visitedRevisions);
+      assertEquals(List.of(1, 2, 3, 4), visitedValues);
     }
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
@@ -535,6 +535,63 @@ public final class JsonMultiRevisionTest {
   }
 
   @Test
+  void testScanValueRunsCarriesValuesForwardAcrossRevisions() throws Exception {
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      long stableKey = -1L;  // first element: set once, never changed again
+      long changingKey = -1L; // second element: changed every revision
+      for (int i = 1; i <= 5; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          if (i == 1) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[10, 1]"),
+                JsonNodeTrx.Commit.NO);
+            wtx.moveToDocumentRoot();
+            wtx.moveToFirstChild();   // array
+            wtx.moveToFirstChild();   // first element (10)
+            stableKey = wtx.getNodeKey();
+            wtx.moveToRightSibling();  // second element (1)
+            changingKey = wtx.getNodeKey();
+          } else {
+            assertTrue(wtx.moveTo(changingKey));
+            wtx.setNumberValue(i);
+          }
+          wtx.commit();
+        }
+      }
+
+      // The stable value (10) changed only in revision 1, so it is a single run [1, 5] read once.
+      final List<int[]> stableRuns = new ArrayList<>();
+      final List<Integer> stableValues = new ArrayList<>();
+      session.scanValueRuns(stableKey, (from, to, record) -> {
+        stableRuns.add(new int[] {from, to});
+        stableValues.add(((NumericValueNode) record).getValue().intValue());
+      });
+      assertEquals(1, stableRuns.size());
+      assertArrayEquals(new int[] {1, 5}, stableRuns.get(0));
+      assertEquals(List.of(10), stableValues);
+
+      // The changing value is its own run per revision.
+      final List<int[]> changingRuns = new ArrayList<>();
+      long weightedSum = 0;
+      final List<Integer> changingValues = new ArrayList<>();
+      session.scanValueRuns(changingKey, (from, to, record) -> {
+        changingRuns.add(new int[] {from, to});
+        changingValues.add(((NumericValueNode) record).getValue().intValue());
+      });
+      assertEquals(5, changingRuns.size());
+      for (int i = 0; i < changingRuns.size(); i++) {
+        assertArrayEquals(new int[] {i + 1, i + 1}, changingRuns.get(i));
+        weightedSum += (long) changingValues.get(i) * (changingRuns.get(i)[1] - changingRuns.get(i)[0] + 1);
+      }
+      // Reconstructed "value across all versions" sum: 1+2+3+4+5.
+      assertEquals(15L, weightedSum);
+
+      // And the stable element reconstructs to 10 * 5 versions = 50 from a single read.
+      assertEquals(50L, (long) stableValues.get(0) * (stableRuns.get(0)[1] - stableRuns.get(0)[0] + 1));
+    }
+  }
+
+  @Test
   void testScanRecordHistoryFallsBackWithoutNodeHistoryIndex() throws Exception {
     // storeNodeHistory(false) ⇒ no RECORD_TO_REVISIONS index ⇒ getRecordChangeRevisions is empty
     // and scanRecordHistory must fall back to scanning every revision.

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonMultiRevisionTest.java
@@ -439,6 +439,51 @@ public final class JsonMultiRevisionTest {
   }
 
   @Test
+  void testGetHistoryTimestampsMatchesGetHistory() throws Exception {
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      for (int i = 1; i <= 5; i++) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          if (i == 1) {
+            wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("[" + i + "]"),
+                JsonNodeTrx.Commit.NO);
+          } else {
+            wtx.moveToDocumentRoot();
+            wtx.moveToFirstChild();
+            wtx.moveToFirstChild();
+            wtx.setNumberValue(i);
+          }
+          wtx.commit();
+        }
+      }
+
+      final List<RevisionInfo> history = session.getHistory();
+      final long[] timestamps = session.getHistoryTimestamps();
+
+      // Same count, same newest-first order, same timestamps as the full history.
+      assertEquals(history.size(), timestamps.length);
+      assertEquals(5, timestamps.length);
+      for (int i = 0; i < history.size(); i++) {
+        assertEquals(history.get(i).getRevisionTimestamp().toEpochMilli(), timestamps[i],
+            "Timestamp mismatch at index " + i);
+      }
+      // Strictly newest-first ⇒ non-increasing epoch millis.
+      for (int i = 1; i < timestamps.length; i++) {
+        assertTrue(timestamps[i] <= timestamps[i - 1], "History timestamps must be newest-first");
+      }
+
+      // Range overload matches getHistory(from, to) (inclusive, either argument order).
+      final List<RevisionInfo> subset = session.getHistory(4, 2);
+      final long[] subsetTimestamps = session.getHistoryTimestamps(2, 4);
+      assertEquals(subset.size(), subsetTimestamps.length);
+      assertEquals(3, subsetTimestamps.length);
+      for (int i = 0; i < subset.size(); i++) {
+        assertEquals(subset.get(i).getRevisionTimestamp().toEpochMilli(), subsetTimestamps[i]);
+      }
+    }
+  }
+
+  @Test
   void testGetHistoryIsStableAcrossCallsAndSeesNewCommits() throws Exception {
     // Committed revisions are immutable, so the session caches RevisionInfo per revision.
     // This guards the two semantics the cache must preserve: repeated calls return identical

--- a/bundles/sirix-core/src/test/java/io/sirix/io/RevisionIndexTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/RevisionIndexTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -471,6 +472,67 @@ class RevisionIndexTest {
     void testEmptyArrays() {
       RevisionIndex index = RevisionIndex.create(new long[0], new long[0]);
       assertEquals(RevisionIndex.EMPTY, index);
+    }
+  }
+
+  @Nested
+  @DisplayName("Bulk timestamp range (timestampsMillis)")
+  class BulkTimestamps {
+
+    private RevisionIndex newIndex() {
+      final long[] timestamps = {100L, 200L, 300L, 400L, 500L};
+      final long[] offsets = {1000L, 2000L, 3000L, 4000L, 5000L};
+      return RevisionIndex.create(timestamps, offsets);
+    }
+
+    @Test
+    @DisplayName("returns the full range in ascending revision order")
+    void testFullRange() {
+      final RevisionIndex index = newIndex();
+      assertArrayEquals(new long[] {100L, 200L, 300L, 400L, 500L}, index.timestampsMillis(0, 4));
+    }
+
+    @Test
+    @DisplayName("returns an inclusive sub-range")
+    void testSubRange() {
+      final RevisionIndex index = newIndex();
+      assertArrayEquals(new long[] {200L, 300L, 400L}, index.timestampsMillis(1, 3));
+    }
+
+    @Test
+    @DisplayName("single-revision range returns one element")
+    void testSingleElementRange() {
+      final RevisionIndex index = newIndex();
+      assertArrayEquals(new long[] {300L}, index.timestampsMillis(2, 2));
+    }
+
+    @Test
+    @DisplayName("range past the appended (Eytzinger-uncovered) tail is honoured")
+    void testRangeIntoAppendedTail() {
+      // Append a revision so the backing arrays carry spare capacity past `size`; the copy must
+      // be bounded by `size`, never by the (larger) backing array length.
+      final RevisionIndex appended = newIndex().withNewRevision(6000L, 600L);
+      assertEquals(6, appended.size());
+      assertArrayEquals(new long[] {500L, 600L}, appended.timestampsMillis(4, 5));
+      assertArrayEquals(new long[] {100L, 200L, 300L, 400L, 500L, 600L}, appended.timestampsMillis(0, 5));
+    }
+
+    @Test
+    @DisplayName("rejects out-of-bounds and inverted ranges")
+    void testInvalidRanges() {
+      final RevisionIndex index = newIndex();
+      assertThrows(IndexOutOfBoundsException.class, () -> index.timestampsMillis(-1, 2));
+      assertThrows(IndexOutOfBoundsException.class, () -> index.timestampsMillis(0, 5));
+      assertThrows(IndexOutOfBoundsException.class, () -> index.timestampsMillis(3, 1));
+    }
+
+    @Test
+    @DisplayName("returned array is an independent copy (mutating it does not corrupt the index)")
+    void testReturnedArrayIsCopy() {
+      final RevisionIndex index = newIndex();
+      final long[] first = index.timestampsMillis(0, 4);
+      first[0] = -1L;
+      assertArrayEquals(new long[] {100L, 200L, 300L, 400L, 500L}, index.timestampsMillis(0, 4));
     }
   }
 }

--- a/docs/COMPARISON_POSTGRES.md
+++ b/docs/COMPARISON_POSTGRES.md
@@ -226,3 +226,89 @@ java --enable-preview --add-modules jdk.incubator.vector --enable-native-access=
 # durability floor on the same volume
 docker exec sirix-bench-pg pg_test_fsync -s 2
 ```
+
+---
+
+## 7. Re-run after the W3/W4 read-path changes (2026-06-14)
+
+The history-scan read paths were reworked to close W3/W4 (branch
+`claude/versioning-gaps-postgresql-hpsbcq`). This section re-measures **W3 and W4 only**, on a
+**different machine** than §1, so the numbers here are **not comparable to the table in §2** —
+only to each other and to the PostgreSQL baseline re-measured alongside them.
+
+| | |
+|---|---|
+| Machine | cloud VM (shared), OpenJDK 25, ext4 NVMe-backed volume — slower than §1's i7-12700H |
+| SirixDB | this branch, **embedded**, default ("full") config, `StorageType.FILE_CHANNEL`, `VersioningType.SLIDING_SNAPSHOT` |
+| PostgreSQL | **16.13** (local apt install, not Docker — the sandbox's docker daemon was unavailable), `shared_buffers=1GB`, `synchronous_commit=on`, `fsync=on` |
+| Workload | identical to §1: one ~2.4 KB JSON doc (`counter` first field), 5,000 single-field durable commits → 5,001 versions. Cross-checks pass on both: 5,001 versions, counter sum **12,502,500**, final counter 5,000 |
+
+Reads: 1 warm-up + 3 timed, **median** reported.
+
+### W3 — list all 5,001 version timestamps
+
+| Path | Time | vs PostgreSQL |
+|---|---|---|
+| PostgreSQL 16 (`ORDER BY valid_from`, server-side) | ~2.2 ms | — |
+| SirixDB `getHistory()` (full `RevisionInfo`, optimized warm path) | ~2.4–2.8 ms | ~on par |
+| **SirixDB `getHistoryTimestamps()` (new bulk API)** | **~0.05 ms** | **~40× faster** |
+
+The new timestamp-only API serves the whole history from the resident in-memory `RevisionIndex`
+(`long[]` + one `arraycopy`), with no page reads, no per-revision transactions, and no async
+fan-out — so it beats a PostgreSQL heap scan by ~40× and the previous SirixDB history path
+outright. **W3 gap: closed (and reversed) for the timestamp-only case; at parity for full
+`RevisionInfo`.**
+
+### W4 — one field's value across all 5,001 versions
+
+Two regimes, because the cost shape differs by how often the field changes:
+
+| Field | Path | Time | Record reads |
+|---|---|---|---|
+| `counter` (changes **every** revision) | PostgreSQL 16 | ~10.4 ms | 5,001 rows |
+| | SirixDB OLD: per-revision `beginNodeReadOnlyTrx` + `moveTo` | ~82 ms | 5,001 |
+| | SirixDB NEW: `scanRecordHistory` (lightweight reader) | ~76–78 ms | 5,001 |
+| | SirixDB NEW: `scanValueRuns` | ~75–80 ms | 5,001 |
+| `s01` (set once, **never** changes) | PostgreSQL 16 | ~9.8 ms | 5,001 rows |
+| | SirixDB OLD: per-revision loop | ~80 ms | 5,001 |
+| | **SirixDB NEW: `scanValueRuns` / change-set** | **~0.05 ms** | **1** |
+
+Honest reading:
+
+- **Dense case (`counter`):** the change set is every revision, so there is nothing to prune —
+  all three SirixDB paths still read 5,001 records. The new lightweight-reader path shaves only
+  ~7% off the old per-revision-transaction loop, and **PostgreSQL still wins this scan (~8×)**: a
+  heap scan over 5,001 compressed rows beats opening 5,001 revision contexts. Closing the dense
+  case fully needs the deferred fragment-chain scan (below).
+- **Sparse case (`s01`, the common real-world shape):** `getRecordChangeRevisions` returns a
+  single revision, so `scanValueRuns` reads **one** record and reconstructs the value across all
+  5,001 versions — **~0.05 ms vs PostgreSQL's ~9.8 ms (~200×) and the old SirixDB loop's ~80 ms
+  (~1600×)**. This is the O(changes) cost shape: PostgreSQL must scan one full-copy row per
+  version regardless of whether the field changed; SirixDB reads only where it changed.
+
+**W4 gap: closed decisively for fields that change rarely (the cost-shape win); for a field that
+changes on every commit, modestly improved but PostgreSQL still leads.**
+
+### Still deferred
+
+A physical **fragment-chain single-pass scan** (read each distinct value once directly from the
+leaf-page fragment chain, avoiding even per-revision root-page navigation) would also close the
+dense case; it rewrites the storage fragment layer under SLIDING_SNAPSHOT and is left as future
+work. Numbers above are medians from a shared cloud VM and PostgreSQL 16 (not 17); treat them as
+indicative of the *shape* of the change, not as hardware-grade absolutes.
+
+### Reproduction (this run)
+
+```bash
+# PostgreSQL 16, local cluster (docker daemon unavailable in the sandbox)
+initdb -D $PGDATA -A trust
+pg_ctl -D $PGDATA -o "-c shared_buffers=1GB -c synchronous_commit=on -c fsync=on" start
+# schema: doc(id,doc jsonb) + doc_history(id,rev,valid_from,doc jsonb) via AFTER INSERT/UPDATE trigger
+# ingest: CALL bench_w1(5000)   (plpgsql loop: UPDATE jsonb_set(...,'{counter}',i); COMMIT)
+# W3: SELECT count(*) FROM (SELECT rev,valid_from FROM doc_history ORDER BY valid_from) s;
+# W4: SELECT count(c),sum(c) FROM (SELECT (doc->>'counter')::bigint c FROM doc_history ORDER BY valid_from) s;
+
+# SirixDB (embedded): build 5,001 versions, then time
+#   session.getHistory() / session.getHistoryTimestamps()                        (W3)
+#   per-revision loop  vs  session.scanRecordHistory(k,..) / scanValueRuns(k,..)  (W4)
+```


### PR DESCRIPTION
## Context

`docs/COMPARISON_POSTGRES.md` benchmarks SirixDB's versioning against PostgreSQL on the identical workload. Two of PostgreSQL's wins are **temporal read scans**, which this PR targets:

- **W3** — list all version timestamps (~2× behind PG). The warm cost was dominated by per-revision async fan-out + boxing in the history path, not I/O.
- **W4** — one field's value across all versions (~7× behind PG). The cost was constructing a full read-only node transaction per revision.

Delivered as a phased, additive set of changes — each phase ships and is testable independently. No existing behavior or on-disk format changes.

## Phase 1 — W3: bulk history-timestamp API + faster `getHistory`

- `RevisionIndex.timestampsMillis(from, to)` — bulk-copies commit timestamps for a revision range straight from the already-resident in-memory index via one `System.arraycopy` (bounds checked against the logical `size`, never the backing array length, which carries spare append capacity).
- New `ResourceSession.getHistoryTimestamps()` / `(from, to)` — newest-first, served entirely from the in-memory index: **no `StorageEngineReader`, no `RevisionRootPage` read, no per-revision futures**.
- Rewrote `getHistory*()` to fill a pre-sized array synchronously from the global `RevisionInfo` cache, parallelizing **only** cold misses — removes a completed-future allocation per revision plus the intermediate list/stream on the warm path, while preserving the exact contract (newest-first order, caching semantics, bounds handling).

## Phase 2 — W4: change-set value-history scan (no per-revision transaction)

- `ResourceSession.getRecordChangeRevisions(nodeKey)` — the ascending revisions in which a record was created/modified, from a single `RECORD_TO_REVISIONS` lookup. Value is unchanged between entries ⇒ O(changes) cost shape, not O(revisions).
- `ResourceSession.scanRecordHistory(nodeKey, visitor)` — visits each existing version through a **lightweight `StorageEngineReader`** (no `NodeReadOnlyTrx` wrapper, document-node fetch, or trx bookkeeping). Uses the change set when the node-history index is on, full scan otherwise. The reader is open only during each callback, so no live record escapes its reader.
- Fixed the stale `RevisionPrefetcher` javadoc claiming `beginNodeReadOnlyTrx` is synchronized (the per-session monitor was removed; reader opens run concurrently).

Note: the query layer already exposes value history via `sdb:item-history`, which uses the same `RECORD_TO_REVISIONS` fast path — left unchanged.

## Phase 3 — W4: run-based value scan over all versions

- `ResourceSession.scanValueRuns(nodeKey, visitor)` — reports each maximal run `[fromRevision, toRevision]` over which a record holds the same value, reading it once per change. Reconstructs the value at *every* revision at O(changes) cost: an aggregate over the whole history is `value * (toRevision - fromRevision + 1)` without reading every revision.

## Benchmark re-run (added as doc §7)

Re-measured W3/W4 on this machine (cloud VM, OpenJDK 25, **PostgreSQL 16.13** local install with the same durability settings — different machine than the original §2 table, so the new §7 is self-contained). Medians of 3; cross-checks pass on both systems (5,001 versions, counter sum 12,502,500).

| Workload | PostgreSQL 16 | SirixDB (this branch) |
|---|---|---|
| **W3** list 5,001 timestamps | ~2.2 ms | `getHistory()` ~2.4–2.8 ms (par) · **`getHistoryTimestamps()` ~0.05 ms (~40×)** |
| **W4** field changing **every** revision | ~10.4 ms | old loop ~82 ms · `scanRecordHistory` ~76 ms · `scanValueRuns` ~75–80 ms — *PG still wins the dense scan* |
| **W4** field that **never** changes | ~9.8 ms | old loop ~80 ms (5001 reads) · **`scanValueRuns` ~0.05 ms (1 read; ~200× vs PG)** |

Reading: **W3 closed and reversed** via the timestamp-only API. **W4 closed decisively for fields that change rarely** (the O(changes) cost shape — SirixDB reads only where the value changed; PostgreSQL scans one full-copy row per version regardless). For a field that changes on *every* commit there is nothing to prune, so PostgreSQL still wins that adversarial scan; closing it fully needs the deferred fragment-chain scan.

## Tests

- `RevisionIndexTest`: bulk-range cases (full/sub/single ranges, appended-tail bounds, invalid ranges, returned-array copy isolation).
- `JsonMultiRevisionTest`: `getHistoryTimestamps` cross-checked against `getHistory` (count/order/values); change-revision discovery + `scanRecordHistory` values cross-checked against the per-revision read-only-transaction path; no-node-history full-scan fallback; `scanValueRuns` run boundaries + carry-forward with reconstructed weighted sums.
- Regression sweeps over `io.sirix.access.node.json/xml`, `io.sirix.io`, `io.sirix.axis.temporal`, and the query `ItemHistoryTest` all pass locally.

## Deferred

The deepest Phase 3 idea — a physical **fragment-chain single-pass scan** that avoids even per-revision root-page navigation, and **batched point-in-time reuse** (W2) — is intentionally deferred: it rewrites the storage fragment layer with SLIDING_SNAPSHOT correctness concerns and warrants its own carefully-benchmarked change. The change-set + lightweight-reader approach here already achieves the O(changes) cost shape safely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeAFhokWiaU4UqzoACSpn4)_