### PR TITLE
Fix flaky BitemporalSoakStressTest (RevisionFileData cache never saturates)

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -62,8 +62,16 @@ jobs:
           SIRIX_STRESS_DURATION_SECONDS: ${{ github.event.inputs.duration_seconds || '3600' }}
           SIRIX_STRESS_READER_THREADS: ${{ github.event.inputs.reader_threads || '4' }}
         run: |
+          # Cap the global RevisionFileData cache so it SATURATES within the soak instead of
+          # filling linearly toward its 1M-entry default for the whole hour. That cache is
+          # correctly bounded (maximumSize), but at the default cap a 1h soak (~800k revisions)
+          # never reaches it, so its legitimate fill dominates post-plateau heap growth and the
+          # leak detector flags a non-leak (the test's own javadoc prescribes exactly this knob).
+          # 10k entries saturate within ~100 cycles, leaving the rest of the soak to measure
+          # genuine per-cycle leaks. Forwarded to the test JVM by the build's sirix.* passthrough.
           ./gradlew :sirix-core:test \
             --tests io.sirix.stress.BitemporalSoakStressTest \
+            -Dsirix.revision.file.data.cache.size=10000 \
             --no-daemon
 
       - name: Upload test reports

--- a/bundles/sirix-core/src/test/java/io/sirix/stress/BitemporalSoakStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/stress/BitemporalSoakStressTest.java
@@ -185,10 +185,21 @@ final class BitemporalSoakStressTest {
         throw e;
       }
 
-      System.gc();
-      Thread.sleep(50); // yield so concurrent finalizers / Cleaner threads run
-      final MemoryUsage heap = memBean.getHeapMemoryUsage();
-      heapSamples.add(heap.getUsed());
+      // Sample the SETTLED live set, not a single post-gc() reading. One System.gc() is a
+      // hint that leaves transient garbage and post-GC allocation in getUsed(), producing
+      // ±10 MB cycle-to-cycle noise that defeats the {@link #PLATEAU_RANGE_TOLERANCE} window
+      // (so a genuinely flat heap never "plateaus" and the leak check silently skips). The
+      // MINIMUM used-heap across a few forced GCs approximates the true live-set floor: a real
+      // per-cycle leak grows that floor monotonically and still trips the post-plateau check,
+      // so taking the min cannot hide a leak — it only removes transient-garbage jitter.
+      long settledUsed = Long.MAX_VALUE;
+      for (int gcRound = 0; gcRound < 3; gcRound++) {
+        System.gc();
+        Thread.sleep(40); // yield so concurrent finalizers / Cleaner threads run
+        settledUsed = Math.min(settledUsed, memBean.getHeapMemoryUsage().getUsed());
+      }
+      final long heapUsed = settledUsed;
+      heapSamples.add(heapUsed);
 
       // Capture a class-histogram baseline at cycle 50 (post-warmup, ~5K commits).
       // The end-of-soak diff against this baseline names the leaking class.
@@ -208,7 +219,7 @@ final class BitemporalSoakStressTest {
                           cycle,
                           Duration.between(tStart, Instant.now()),
                           totalCommits.get(),
-                          heap.getUsed() / (1024L * 1024L));
+                          heapUsed / (1024L * 1024L));
       }
     }
 


### PR DESCRIPTION
The scheduled 1h soak (`stress.yml`) failed today with "heap leak suspected: 2.15x > 1.20x" — but **it is not a production leak**.

## Diagnosis

The class-histogram slope analysis in the failed run pinned the growth to `io.sirix.io.RevisionFileData` + `RevisionFileDataCacheKey` at a constant per-cycle slope — i.e. the **global RevisionFileData cache**. That cache is correctly bounded (`Caffeine.maximumSize`, 1M-entry default). But `stress.yml` ran the soak at the 1M default, and a 1-hour soak creates ~800k revisions — so the cache **fills linearly the entire hour and never saturates**, and its legitimate fill dominates post-plateau heap growth. The detector then flags a non-leak. (06-07's soak passed by timing luck; the ratio is inherently borderline at the 1M cap.)

**Proven not a leak:** re-ran with the cache bounded small → heap stays **flat at ~107-110 MB** the whole run.

## Fixes

1. **`stress.yml`**: `-Dsirix.revision.file.data.cache.size=10000` so the cache saturates in ~100 cycles, leaving the rest of the soak to measure genuine per-cycle leaks. The test's own javadoc prescribes exactly this knob; the workflow just never set it.
2. **Settled heap sampling**: the per-cycle sample was a single `System.gc()`+`getUsed()` reading — noisy enough (transient garbage, ~10 MB) that a *flat* heap never hit the 3% plateau window, so the leak check silently **skipped**. Now it samples the **min used-heap over 3 forced GCs** (the live-set floor). A real per-cycle leak grows that floor monotonically and still trips the check — taking the min cannot hide a leak, only removes jitter.

## Validation

420s soak with both changes: **plateau detected at cycle 48, post-plateau ratio 1.03x → PASS** (a real assertion, not a skip). Heap stable 107→110 MB across 1100 cycles.

Touches only the (env-gated, no-op-by-default) soak test and its CI workflow — the normal `./gradlew test` path is unaffected.