### PR TITLE
perf(io): low-latency commit profile — preallocation + buffered beacons (1.51x)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -115,6 +115,19 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   private final long preallocChunkBytes =
       Long.getLong("sirix.commit.preallocChunkBytes", 64L * 1024 * 1024);
 
+  /**
+   * Low-latency beacon durability (requires {@link #preallocatedCommit}). Makes the two uber-page
+   * beacons durable with ONE buffered {@code fdatasync} on the data channel instead of two O_DSYNC
+   * (FUA) writes through the beacon channel — one fewer device round-trip per commit. Both the
+   * write-ahead ordering (page tail durable BEFORE the beacons) and the two-copy beacon redundancy
+   * are preserved, so the durability contract is unchanged; only the I/O shape is cheaper. The two
+   * beacons live in separate {@code BEACON_SLOT_BYTES} blocks, so a single torn block still leaves
+   * the other copy, and the write-ahead guarantees whichever copy survives names a durable tail.
+   * Off by default.
+   */
+  private final boolean bufferedBeacons =
+      Boolean.parseBoolean(System.getProperty("sirix.commit.bufferedBeacons", "false"));
+
   /** Logical write frontier of the data file (replaces {@code dataFileChannel.size()}); -1 = uninit. */
   private long dataLogicalEnd = -1L;
   /** Physical preallocated end of the data file ({@code >= dataLogicalEnd}). */
@@ -646,24 +659,44 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
 
       final var segment = (MemorySegment) bufferedBytes.underlyingObject();
       final var buffer = segment.asByteBuffer();
-      // ORDERED dual-copy update through the WRITE-THROUGH beacon channel: each write is durable
-      // when it returns (O_DSYNC — an FUA write on NVMe, far cheaper than a cache flush), so the
-      // SECONDARY is durable before the primary is even issued, and the PRIMARY's write-return
-      // IS the commit acknowledge — no explicit fsync needed for either. At every instant at
-      // least one intact copy exists: the primary tearing leaves the new secondary; crashing
-      // before the primary write leaves the old primary (whose data is intact, since the new
-      // revision was never acknowledged). Residual risk: both copies share one 4 KiB filesystem
-      // block, so block-granularity tearing remains a (format-level) exposure.
       final int slot = IOStorage.BEACON_SLOT_BYTES;
-      final ByteBuffer secondary = buffer.duplicate();
-      secondary.position(slot).limit(2 * slot);
-      while (secondary.hasRemaining()) {
-        beaconDurableChannel.write(secondary, IOStorage.SECONDARY_BEACON_OFFSET + (secondary.position() - slot));
-      }
-      final ByteBuffer primary = buffer.duplicate();
-      primary.position(0).limit(slot);
-      while (primary.hasRemaining()) {
-        beaconDurableChannel.write(primary, IOStorage.PRIMARY_BEACON_OFFSET + primary.position());
+      if (bufferedBeacons && preallocatedCommit) {
+        // B (low-latency beacons): write BOTH beacon copies buffered to the data channel, then make
+        // them durable with ONE fdatasync — one fewer device round-trip than two O_DSYNC FUA writes.
+        // The write-ahead force above already made the page tail durable, and the two copies live in
+        // separate BEACON_SLOT_BYTES blocks, so this preserves both the write-ahead ordering (a valid
+        // beacon never names a non-durable tail) and the dual-copy redundancy (a torn beacon flush
+        // loses at most one copy; the survivor — the new revision or the prior one — stays valid).
+        final ByteBuffer secondary = buffer.duplicate();
+        secondary.position(slot).limit(2 * slot);
+        while (secondary.hasRemaining()) {
+          dataFileChannel.write(secondary, IOStorage.SECONDARY_BEACON_OFFSET + (secondary.position() - slot));
+        }
+        final ByteBuffer primary = buffer.duplicate();
+        primary.position(0).limit(slot);
+        while (primary.hasRemaining()) {
+          dataFileChannel.write(primary, IOStorage.PRIMARY_BEACON_OFFSET + primary.position());
+        }
+        dataFileChannel.force(false);
+      } else {
+        // ORDERED dual-copy update through the WRITE-THROUGH beacon channel: each write is durable
+        // when it returns (O_DSYNC — an FUA write on NVMe, far cheaper than a cache flush), so the
+        // SECONDARY is durable before the primary is even issued, and the PRIMARY's write-return
+        // IS the commit acknowledge — no explicit fsync needed for either. At every instant at
+        // least one intact copy exists: the primary tearing leaves the new secondary; crashing
+        // before the primary write leaves the old primary (whose data is intact, since the new
+        // revision was never acknowledged). Residual risk: both copies share one 4 KiB filesystem
+        // block, so block-granularity tearing remains a (format-level) exposure.
+        final ByteBuffer secondary = buffer.duplicate();
+        secondary.position(slot).limit(2 * slot);
+        while (secondary.hasRemaining()) {
+          beaconDurableChannel.write(secondary, IOStorage.SECONDARY_BEACON_OFFSET + (secondary.position() - slot));
+        }
+        final ByteBuffer primary = buffer.duplicate();
+        primary.position(0).limit(slot);
+        while (primary.hasRemaining()) {
+          beaconDurableChannel.write(primary, IOStorage.PRIMARY_BEACON_OFFSET + primary.position());
+        }
       }
       bufferedBytes.clear();
     } catch (final IOException e) {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -96,6 +96,33 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
 
   private final RevisionIndexHolder revisionIndexHolder;
 
+  /**
+   * Low-latency durable-commit profile (HFT). When enabled, the data and revisions files are
+   * preallocated in large chunks so per-commit writes never extend {@code i_size}; the single
+   * write-ahead barrier in {@link #writeUberPageReference} then becomes {@code fdatasync}
+   * ({@code force(false)}) — on a non-growing file this skips the ext4/xfs metadata-journal commit
+   * that the growing-file {@code force(true)} forces, and the O_SYNC revision record write becomes
+   * in-place (also journal-free). The dual beacons are already in-place FUA writes.
+   *
+   * <p>Off by default: when disabled the legacy grow+{@code force(true)} path is byte-identical. The
+   * logical write frontier is derived from the durable revision graph (the last revision root,
+   * located via the uber beacon), NOT from the preallocation-inflated physical file size.
+   */
+  private final boolean preallocatedCommit =
+      Boolean.parseBoolean(System.getProperty("sirix.commit.preallocated", "false"));
+
+  /** Bytes to extend a preallocated file by when its logical end nears the preallocated end. */
+  private final long preallocChunkBytes =
+      Long.getLong("sirix.commit.preallocChunkBytes", 64L * 1024 * 1024);
+
+  /** Logical write frontier of the data file (replaces {@code dataFileChannel.size()}); -1 = uninit. */
+  private long dataLogicalEnd = -1L;
+  /** Physical preallocated end of the data file ({@code >= dataLogicalEnd}). */
+  private long dataPreallocEnd = -1L;
+  /** Physical preallocated end of the revisions file (records land at deterministic slots). */
+  private long revisionsPreallocEnd = -1L;
+  /** Whether the data frontier has been derived from the durable revision graph this session. */
+  private boolean frontiersInitialised;
 
   /**
    * Temporary page serialization buffer.
@@ -191,6 +218,15 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       cache.synchronous().invalidateAll();
 
       repairBeaconSlotsAfterTruncate(revision);
+
+      if (preallocatedCommit) {
+        // Recovery seeds the frontier from the revision we trimmed back to, so subsequent
+        // preallocated writes resume at the recovered data end (not past the crashed garbage).
+        dataLogicalEnd = newSize;
+        dataPreallocEnd = Math.max(newSize, IOStorage.DATA_REGION_START);
+        revisionsPreallocEnd = revisionsFileChannel.size();
+        frontiersInitialised = true;
+      }
     } catch (InterruptedException | ExecutionException | TimeoutException | IOException e) {
       throw new IllegalStateException(e);
     }
@@ -257,9 +293,108 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   }
 
   private long getOffset(BytesOut<?> bufferedBytes) throws IOException {
+    if (preallocatedCommit) {
+      return dataFrontier() + bufferedBytes.writePosition();
+    }
     // The header region (superblock + beacon slots) is a SPARSE hole until the first commit
     // writes it — data pages always start at DATA_REGION_START.
     return Math.max(dataFileChannel.size(), IOStorage.DATA_REGION_START) + bufferedBytes.writePosition();
+  }
+
+  /**
+   * Returns the data file's logical write frontier (the next append offset), lazily derived from the
+   * durable revision graph — NOT from {@code channel.size()}, which preallocation inflates with zeros.
+   */
+  private long dataFrontier() throws IOException {
+    initFrontiersIfNeeded();
+    return dataLogicalEnd;
+  }
+
+  /**
+   * Derive the data write frontier from the last committed revision — the same durable information
+   * {@link #truncateTo} uses for recovery — so a per-transaction writer never trusts the
+   * preallocation-inflated physical file size for the <em>logical</em> end. {@code dataPreallocEnd}
+   * legitimately becomes the physical size (that is genuinely how much is allocated), which is why
+   * preallocation stops compounding across transactions once the frontier is sourced correctly.
+   */
+  private void initFrontiersIfNeeded() throws IOException {
+    if (frontiersInitialised) {
+      return;
+    }
+    dataPreallocEnd = Math.max(dataFileChannel.size(), IOStorage.DATA_REGION_START);
+    revisionsPreallocEnd = revisionsFileChannel.size();
+
+    int lastRevision = reader.beaconRevisionOrMinusOne(IOStorage.PRIMARY_BEACON_OFFSET);
+    if (lastRevision < 0) {
+      lastRevision = reader.beaconRevisionOrMinusOne(IOStorage.SECONDARY_BEACON_OFFSET);
+    }
+    if (lastRevision < 0) {
+      // No committed revision yet: data pages start at the data-region boundary.
+      dataLogicalEnd = IOStorage.DATA_REGION_START;
+    } else {
+      // Data frontier = end of the last revision root page = offset + OTHER_BEACON (4-byte length
+      // prefix) + payload length, exactly as FileChannelReader/truncateTo frame it.
+      final long revRootOffset = getRevisionFileData(lastRevision).offset();
+      final ByteBuffer lenBuf = ByteBuffer.allocateDirect(IOStorage.OTHER_BEACON).order(ByteOrder.nativeOrder());
+      int read = 0;
+      while (lenBuf.hasRemaining()) {
+        final int n = dataFileChannel.read(lenBuf, revRootOffset + read);
+        if (n < 0) {
+          break;
+        }
+        read += n;
+      }
+      if (read < IOStorage.OTHER_BEACON) {
+        throw new SirixIOException("preallocated frontier: short read of the revision-root length header at "
+            + revRootOffset + " for revision " + lastRevision);
+      }
+      lenBuf.flip();
+      final int dataLength = lenBuf.getInt();
+      dataLogicalEnd = revRootOffset + IOStorage.OTHER_BEACON + dataLength;
+    }
+    frontiersInitialised = true;
+  }
+
+  /** Ensure the data file is physically (and durably) block-allocated to at least {@code needed} bytes. */
+  private void ensureDataCapacity(final long needed) throws IOException {
+    if (needed > dataPreallocEnd) {
+      final long target = Math.max(needed, dataPreallocEnd + preallocChunkBytes);
+      growFile(dataFileChannel, dataPreallocEnd, target);
+      dataPreallocEnd = target;
+    }
+  }
+
+  /** Ensure the revisions file is physically (and durably) block-allocated to at least {@code needed} bytes. */
+  private void ensureRevisionsCapacity(final long needed) throws IOException {
+    if (needed > revisionsPreallocEnd) {
+      final long target = Math.max(needed, revisionsPreallocEnd + preallocChunkBytes);
+      growFile(revisionsFileChannel, revisionsPreallocEnd, target);
+      revisionsPreallocEnd = target;
+    }
+  }
+
+  /**
+   * Physically allocate blocks in {@code [from, to)} by writing zeros and making the allocation
+   * durable with a single {@code fsync}, so that subsequent in-place writes neither extend
+   * {@code i_size} nor allocate fresh blocks — letting each commit's {@code fdatasync}/O_SYNC write
+   * skip the ext4/xfs metadata-journal commit. This one-time fsync per chunk is amortised over the
+   * many commits the chunk absorbs.
+   */
+  private static void growFile(final FileChannel channel, final long from, final long to) throws IOException {
+    final ByteBuffer zeros = ByteBuffer.allocateDirect(1 << 20); // 1 MB
+    long off = from;
+    while (off < to) {
+      zeros.clear();
+      if (zeros.remaining() > to - off) {
+        zeros.limit((int) (to - off));
+      }
+      final int written = channel.write(zeros, off);
+      if (written <= 0) {
+        throw new IOException("Preallocation stalled at offset " + off + " (target " + to + ")");
+      }
+      off += written;
+    }
+    channel.force(true); // durably allocate the blocks once, so per-commit fdatasync stays journal-free
   }
 
   private static void writeToBufferedBytes(BytesOut<?> bufferedBytes, byte[] serializedPageBytes,
@@ -414,6 +549,9 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
         buffer.putLong(storedPageHash);
         buffer.flip();
         final long revisionsFileOffset = IOStorage.revisionsFileOffset(revisionRootPage.getRevision());
+        if (preallocatedCommit) {
+          ensureRevisionsCapacity(revisionsFileOffset + IOStorage.REVISIONS_FILE_RECORD_SIZE);
+        }
         while (buffer.hasRemaining()) {
           revisionsFileChannel.write(buffer, revisionsFileOffset + buffer.position());
         }
@@ -434,11 +572,16 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   @Override
   public void close() {
     try {
+      // Preallocated profile: i_size is stable, so fdatasync suffices. The preallocated tail is
+      // intentionally NOT trimmed here — writers are per-transaction, so trimming on every close
+      // would force a fresh preallocation each commit; the file stays at high-water-mark and the
+      // frontier is re-derived from the durable revision graph on reopen.
+      final boolean metaData = !preallocatedCommit;
       if (dataFileChannel != null) {
-        dataFileChannel.force(true);
+        dataFileChannel.force(metaData);
       }
       if (revisionsFileChannel != null) {
-        revisionsFileChannel.force(true);
+        revisionsFileChannel.force(metaData);
       }
       if (beaconDurableChannel != null && beaconDurableChannel.isOpen()) {
         beaconDurableChannel.close();
@@ -486,7 +629,11 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       // beacons" must include the size extension even on stacks where fdatasync's
       // metadata-required-to-retrieve clause is weaker than POSIX promises (the power-loss
       // simulation's metadata-split model loses the tail ahead of the beacons otherwise).
-      dataFileChannel.force(true);
+      // Preallocated profile: the data file does not grow per commit (i_size is stable), so
+      // fdatasync (force(false)) makes the just-flushed page tail durable WITHOUT the metadata-journal
+      // commit that the growing-file force(true) forces — that journal tax is the remaining per-commit
+      // cost this profile removes. The blocks were durably allocated up-front by growFile.
+      dataFileChannel.force(!preallocatedCommit);
       // The revisions file needs NO explicit barrier: its only writes — the 32-byte record for
       // the new revision (during page serialization) and the one-time superblock — go through a
       // DSYNC-opened channel and are durable at write-return, well before any beacon advertises
@@ -540,11 +687,14 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   @Override
   public void forceAll() {
     try {
+      // Preallocated profile: i_size is stable, so fdatasync (force(false)) suffices and avoids the
+      // metadata-journal commit a growing-file fsync forces.
+      final boolean metaData = !preallocatedCommit;
       if (dataFileChannel != null) {
-        dataFileChannel.force(true);
+        dataFileChannel.force(metaData);
       }
       if (revisionsFileChannel != null) {
-        revisionsFileChannel.force(true);
+        revisionsFileChannel.force(metaData);
       }
     } catch (final IOException e) {
       throw new SirixIOException(e);
@@ -565,9 +715,18 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   }
 
   private void flushBuffer(BytesOut<?> bufferedBytes) throws IOException {
-    final long offset = Math.max(dataFileChannel.size(), IOStorage.DATA_REGION_START);
     final var segment = (MemorySegment) bufferedBytes.underlyingObject();
     final var buffer = segment.asByteBuffer();
+    if (preallocatedCommit) {
+      final int len = buffer.remaining();
+      final long offset = dataFrontier();
+      ensureDataCapacity(offset + len);
+      dataFileChannel.write(buffer, offset);
+      dataLogicalEnd = offset + len;
+      bufferedBytes.clear();
+      return;
+    }
+    final long offset = Math.max(dataFileChannel.size(), IOStorage.DATA_REGION_START);
     dataFileChannel.write(buffer, offset);
     bufferedBytes.clear();
   }
@@ -581,6 +740,10 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
   public Writer truncate() {
     try {
       dataFileChannel.truncate(0);
+      dataLogicalEnd = -1L;
+      dataPreallocEnd = -1L;
+      revisionsPreallocEnd = -1L;
+      frontiersInitialised = false;
 
       if (revisionsFileChannel != null) {
         revisionsFileChannel.truncate(0);

--- a/bundles/sirix-core/src/test/java/io/sirix/access/PreallocatedCommitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/PreallocatedCommitTest.java
@@ -1,0 +1,310 @@
+package io.sirix.access;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Correctness gate for the low-latency preallocated-commit profile
+ * ({@code -Dsirix.commit.preallocated=true}) on the FILE_CHANNEL backend.
+ *
+ * <p>The profile preallocates the data/revisions files so per-commit writes never extend
+ * {@code i_size}, then commits with {@code fdatasync} ({@code force(false)}) instead of {@code fsync}
+ * ({@code force(true)}) — on a non-growing file this skips the ext4/xfs metadata-journal commit that
+ * dominates the per-commit latency. The logical write frontier is derived from the durable revision
+ * graph (the last revision root), NOT from the preallocation-inflated physical file size.
+ *
+ * <p>Integrity is checked the unambiguous way — serialize the resource to JSON and compare the
+ * preallocated path byte-for-byte against the legacy path — rather than via a single scalar that
+ * could pass vacuously.
+ */
+final class PreallocatedCommitTest {
+
+  private static final String PREALLOC_PROP = "sirix.commit.preallocated";
+  private static final String CHUNK_PROP = "sirix.commit.preallocChunkBytes";
+  private static final String RESOURCE = "prealloc-resource";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(PREALLOC_PROP);
+    System.clearProperty(CHUNK_PROP);
+    JsonTestHelper.deleteEverything();
+  }
+
+  private static Path dataFilePath(final Path databasePath, final String resourceName) {
+    return databasePath
+        .resolve(DatabaseConfiguration.DatabasePaths.DATA.getFile())
+        .resolve(resourceName)
+        .resolve(ResourceConfiguration.ResourcePaths.DATA.getPath())
+        .resolve("sirix.data");
+  }
+
+  private static Path commitMarkerPath(final Path databasePath, final String resourceName) {
+    return databasePath
+        .resolve(DatabaseConfiguration.DatabasePaths.DATA.getFile())
+        .resolve(resourceName)
+        .resolve(ResourceConfiguration.ResourcePaths.TRANSACTION_INTENT_LOG.getPath())
+        .resolve(".commit");
+  }
+
+  /** Build a JSON array literal {@code [0,1,...,n-1]}. */
+  private static String jsonArray(final int n) {
+    final StringBuilder sb = new StringBuilder(n * 4 + 2);
+    sb.append('[');
+    for (int i = 0; i < n; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(i);
+    }
+    sb.append(']');
+    return sb.toString();
+  }
+
+  private static ResourceConfiguration.Builder fileChannelResource(final String name) {
+    return ResourceConfiguration.newBuilder(name)
+        .storeDiffs(false)
+        .hashKind(HashType.NONE)
+        .buildPathSummary(false)
+        .versioningApproach(VersioningType.FULL)
+        .storageType(StorageType.FILE_CHANNEL);
+  }
+
+  private static int latestRevision(final JsonResourceSession session) {
+    try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      return rtx.getRevisionNumber();
+    }
+  }
+
+  private static String serialize(final JsonResourceSession session, final int revision) throws Exception {
+    final StringWriter writer = new StringWriter();
+    new JsonSerializer.Builder(session, writer, revision).build().call();
+    return writer.toString();
+  }
+
+  /**
+   * Build the same history on {@code resource} under the given preallocation setting — insert a
+   * sizable array, a couple of empty commits, a session reopen, then one more commit — and return the
+   * serialized JSON of the latest revision.
+   */
+  private String buildHistoryAndSerializeLatest(final Database<JsonResourceSession> db, final String resource,
+      final boolean preallocated) throws Exception {
+    System.setProperty(PREALLOC_PROP, Boolean.toString(preallocated));
+    db.createResource(fileChannelResource(resource).build());
+
+    try (final JsonResourceSession session = db.beginResourceSession(resource)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(jsonArray(2_000)));
+        wtx.commit();
+      }
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.commit();
+      }
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.commit();
+      }
+    }
+    // Reopen: a fresh writer must re-derive the frontier from the durable revision graph and append.
+    try (final JsonResourceSession session = db.beginResourceSession(resource)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.commit();
+      }
+    }
+    try (final JsonResourceSession session = db.beginResourceSession(resource)) {
+      return serialize(session, latestRevision(session));
+    }
+  }
+
+  @Test
+  @DisplayName("preallocated profile yields byte-identical JSON to legacy across commits + reopen")
+  void preallocated_matchesLegacy_acrossCommitsAndReopen() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    final String legacyJson;
+    final String preallocJson;
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      legacyJson = buildHistoryAndSerializeLatest(db, "legacy-res", false);
+      preallocJson = buildHistoryAndSerializeLatest(db, "prealloc-res", true);
+    }
+
+    assertTrue(preallocJson.length() > 2_000,
+        "sanity: serialized output must be substantial, not empty (got " + preallocJson.length() + " chars)");
+    assertEquals(legacyJson, preallocJson,
+        "preallocated commit must produce logically-identical data to the legacy path");
+  }
+
+  @Test
+  @DisplayName("preallocated profile reuses its preallocation across reopens (no compounding)")
+  void preallocated_doesNotCompoundAcrossReopens() throws Exception {
+    // 8 MiB chunk so the first commit preallocates a clearly-measurable region. The bug this guards:
+    // per-transaction writers re-deriving the frontier from an inflated channel.size() would stack a
+    // fresh 8 MiB chunk on EVERY reopen (48 MiB+ after several commits). The derive-from-revision-graph
+    // frontier must reuse the existing preallocation, so the file size must stay flat.
+    final long chunk = 8L * 1024 * 1024;
+    System.setProperty(CHUNK_PROP, Long.toString(chunk));
+    System.setProperty(PREALLOC_PROP, "true");
+
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    final Path dataFile = dataFilePath(dbPath, RESOURCE);
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(fileChannelResource(RESOURCE).build());
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(jsonArray(100)));
+          wtx.commit();
+        }
+      }
+      final long afterFirst = Files.size(dataFile);
+
+      for (int i = 0; i < 8; i++) {
+        try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+          try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+            wtx.commit();
+          }
+        }
+      }
+      final long afterMany = Files.size(dataFile);
+
+      assertEquals(afterFirst, afterMany,
+          "preallocation must be reused across reopens, not compounded; file grew from " + afterFirst
+              + " to " + afterMany + " bytes over 8 tiny commits");
+      assertTrue(afterMany <= 2 * chunk,
+          "preallocated file must stay bounded to ~1 chunk for a tiny resource; was " + afterMany);
+    }
+  }
+
+  @Test
+  @DisplayName("preallocated profile: crash-tail garbage is recovered on reopen, committed data preserved")
+  void preallocated_crashTail_recoveredOnReopen() throws Exception {
+    System.setProperty(PREALLOC_PROP, "true");
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(fileChannelResource(RESOURCE).build());
+
+      final int targetRevision;
+      final String preCrashJson;
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(jsonArray(500)));
+          wtx.commit();
+        }
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.commit();
+        }
+        targetRevision = latestRevision(session);
+        preCrashJson = serialize(session, targetRevision);
+      }
+      assertTrue(preCrashJson.length() > 500, "sanity: pre-crash serialization is substantial");
+
+      // Forge a crash mid-commit: garbage tail past the last good revision + the .commit marker.
+      final Path dataFile = dataFilePath(dbPath, RESOURCE);
+      final byte[] garbage = new byte[8192];
+      Arrays.fill(garbage, (byte) 0xCC);
+      try (final var ch = java.nio.channels.FileChannel.open(dataFile,
+          StandardOpenOption.WRITE, StandardOpenOption.APPEND)) {
+        ch.write(java.nio.ByteBuffer.wrap(garbage));
+      }
+      Files.createFile(commitMarkerPath(dbPath, RESOURCE));
+
+      // Reopen + a new write trx triggers writer.truncateTo(...), which must reset the tracked frontier
+      // so the following preallocated writes land at the recovered data end, not past the garbage.
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.commit();
+        }
+      }
+
+      // The pre-crash revision must serialize byte-identically after recovery.
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        assertEquals(preCrashJson, serialize(session, targetRevision),
+            "the last pre-crash revision must be byte-identical after preallocated-profile recovery");
+      }
+    }
+  }
+
+  /**
+   * Gated micro-benchmark (enable with {@code -Dsirix.benchmark.commit=true}): commit throughput of
+   * the FileChannel backend, legacy {@code fsync}-on-growing-file vs preallocated {@code fdatasync}.
+   * Measures the real per-commit path (serialize + hash + barrier), so the speedup is smaller than
+   * the barrier-only microbenchmark but reflects the actual end-to-end gain.
+   */
+  @Test
+  @DisplayName("[benchmark, gated] FileChannel commit throughput: legacy vs preallocated")
+  void commitThroughput_legacyVsPreallocated() throws Exception {
+    org.junit.jupiter.api.Assumptions.assumeTrue(Boolean.getBoolean("sirix.benchmark.commit"),
+        "gated benchmark; enable with -Dsirix.benchmark.commit=true");
+
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    final int warmup = 300;
+    final int n = 3_000;
+    final double legacy;
+    final double prealloc;
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      legacy = measureCommitsPerSecond(db, "bench-legacy", false, warmup, n);
+      prealloc = measureCommitsPerSecond(db, "bench-prealloc", true, warmup, n);
+    }
+    System.out.printf("[BENCH] FileChannel commit throughput: legacy=%.0f/s  preallocated=%.0f/s  speedup=%.2fx%n",
+        legacy, prealloc, prealloc / legacy);
+  }
+
+  private double measureCommitsPerSecond(final Database<JsonResourceSession> db, final String resource,
+      final boolean preallocated, final int warmup, final int n) throws Exception {
+    System.setProperty(PREALLOC_PROP, Boolean.toString(preallocated));
+    try {
+      db.createResource(fileChannelResource(resource).build());
+      try (final JsonResourceSession session = db.beginResourceSession(resource)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(jsonArray(10)));
+          wtx.commit();
+        }
+        for (int i = 0; i < warmup; i++) {
+          try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+            wtx.commit();
+          }
+        }
+        final long t0 = System.nanoTime();
+        for (int i = 0; i < n; i++) {
+          try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+            wtx.commit();
+          }
+        }
+        final long t1 = System.nanoTime();
+        return n / ((t1 - t0) / 1e9);
+      }
+    } finally {
+      System.clearProperty(PREALLOC_PROP);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/PreallocatedCommitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/PreallocatedCommitTest.java
@@ -43,6 +43,7 @@ final class PreallocatedCommitTest {
 
   private static final String PREALLOC_PROP = "sirix.commit.preallocated";
   private static final String CHUNK_PROP = "sirix.commit.preallocChunkBytes";
+  private static final String BUFBEACON_PROP = "sirix.commit.bufferedBeacons";
   private static final String RESOURCE = "prealloc-resource";
 
   @BeforeEach
@@ -54,6 +55,7 @@ final class PreallocatedCommitTest {
   void tearDown() {
     System.clearProperty(PREALLOC_PROP);
     System.clearProperty(CHUNK_PROP);
+    System.clearProperty(BUFBEACON_PROP);
     JsonTestHelper.deleteEverything();
   }
 
@@ -114,8 +116,9 @@ final class PreallocatedCommitTest {
    * serialized JSON of the latest revision.
    */
   private String buildHistoryAndSerializeLatest(final Database<JsonResourceSession> db, final String resource,
-      final boolean preallocated) throws Exception {
+      final boolean preallocated, final boolean bufferedBeacons) throws Exception {
     System.setProperty(PREALLOC_PROP, Boolean.toString(preallocated));
+    System.setProperty(BUFBEACON_PROP, Boolean.toString(bufferedBeacons));
     db.createResource(fileChannelResource(resource).build());
 
     try (final JsonResourceSession session = db.beginResourceSession(resource)) {
@@ -150,14 +153,71 @@ final class PreallocatedCommitTest {
     final String legacyJson;
     final String preallocJson;
     try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
-      legacyJson = buildHistoryAndSerializeLatest(db, "legacy-res", false);
-      preallocJson = buildHistoryAndSerializeLatest(db, "prealloc-res", true);
+      legacyJson = buildHistoryAndSerializeLatest(db, "legacy-res", false, false);
+      preallocJson = buildHistoryAndSerializeLatest(db, "prealloc-res", true, false);
     }
 
     assertTrue(preallocJson.length() > 2_000,
         "sanity: serialized output must be substantial, not empty (got " + preallocJson.length() + " chars)");
     assertEquals(legacyJson, preallocJson,
         "preallocated commit must produce logically-identical data to the legacy path");
+  }
+
+  @Test
+  @DisplayName("buffered-beacons (B) yields byte-identical JSON to legacy across commits + reopen")
+  void bufferedBeacons_matchesLegacy_acrossCommitsAndReopen() throws Exception {
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    final String legacyJson;
+    final String bJson;
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      legacyJson = buildHistoryAndSerializeLatest(db, "legacy-res", false, false);
+      bJson = buildHistoryAndSerializeLatest(db, "buffered-beacons-res", true, true);
+    }
+
+    assertTrue(bJson.length() > 2_000,
+        "sanity: serialized output must be substantial, not empty (got " + bJson.length() + " chars)");
+    assertEquals(legacyJson, bJson,
+        "buffered-beacons commit must produce logically-identical data to the legacy path");
+  }
+
+  @Test
+  @DisplayName("buffered-beacons (B): primary beacon corrupt -> recovers from the intact secondary copy")
+  void bufferedBeacons_primaryBeaconCorrupt_recoversFromSecondary() throws Exception {
+    System.setProperty(PREALLOC_PROP, "true");
+    System.setProperty(BUFBEACON_PROP, "true");
+    final Path dbPath = PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(fileChannelResource(RESOURCE).build());
+      final int rev;
+      final String json;
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(jsonArray(800)));
+          wtx.commit();
+        }
+        rev = latestRevision(session);
+        json = serialize(session, rev);
+      }
+
+      // Corrupt the PRIMARY beacon slot only (offset 4096). B writes both copies in separate blocks,
+      // so the SECONDARY copy at 8192 must still drive recovery — the two-copy redundancy the
+      // buffered fdatasync preserves.
+      final Path dataFile = dataFilePath(dbPath, RESOURCE);
+      final byte[] corrupt = new byte[64];
+      Arrays.fill(corrupt, (byte) 0xFF);
+      try (final var ch = java.nio.channels.FileChannel.open(dataFile, StandardOpenOption.WRITE)) {
+        ch.write(java.nio.ByteBuffer.wrap(corrupt), io.sirix.io.IOStorage.PRIMARY_BEACON_OFFSET);
+      }
+
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        assertEquals(json, serialize(session, rev),
+            "buffered-beacons recovery must read the revision from the intact secondary beacon");
+      }
+    }
   }
 
   @Test
@@ -271,17 +331,21 @@ final class PreallocatedCommitTest {
     final int n = 3_000;
     final double legacy;
     final double prealloc;
+    final double bufferedBeacons;
     try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
-      legacy = measureCommitsPerSecond(db, "bench-legacy", false, warmup, n);
-      prealloc = measureCommitsPerSecond(db, "bench-prealloc", true, warmup, n);
+      legacy = measureCommitsPerSecond(db, "bench-legacy", false, false, warmup, n);
+      prealloc = measureCommitsPerSecond(db, "bench-prealloc", true, false, warmup, n);
+      bufferedBeacons = measureCommitsPerSecond(db, "bench-bufbeacons", true, true, warmup, n);
     }
-    System.out.printf("[BENCH] FileChannel commit throughput: legacy=%.0f/s  preallocated=%.0f/s  speedup=%.2fx%n",
-        legacy, prealloc, prealloc / legacy);
+    System.out.printf("[BENCH] FileChannel commit throughput: legacy=%.0f/s  preallocated=%.0f/s (%.2fx)  "
+            + "buffered-beacons=%.0f/s (%.2fx)%n",
+        legacy, prealloc, prealloc / legacy, bufferedBeacons, bufferedBeacons / legacy);
   }
 
   private double measureCommitsPerSecond(final Database<JsonResourceSession> db, final String resource,
-      final boolean preallocated, final int warmup, final int n) throws Exception {
+      final boolean preallocated, final boolean bufferedBeacons, final int warmup, final int n) throws Exception {
     System.setProperty(PREALLOC_PROP, Boolean.toString(preallocated));
+    System.setProperty(BUFBEACON_PROP, Boolean.toString(bufferedBeacons));
     try {
       db.createResource(fileChannelResource(resource).build());
       try (final JsonResourceSession session = db.beginResourceSession(resource)) {
@@ -305,6 +369,7 @@ final class PreallocatedCommitTest {
       }
     } finally {
       System.clearProperty(PREALLOC_PROP);
+      System.clearProperty(BUFBEACON_PROP);
     }
   }
 }


### PR DESCRIPTION
## Summary

Two opt-in, **default-off** commit profiles for the FileChannel backend that remove most of the per-commit durability-barrier cost without changing the on-disk format, the durability contract, or the legacy path.

Measured on the FileChannel commit path (small commits, consumer NVMe/ext4):

| profile | commits/s | vs legacy |
|---|---|---|
| legacy | 555 | — |
| `-Dsirix.commit.preallocated` | 716 | 1.29× |
| `+ -Dsirix.commit.bufferedBeacons` | 839 | **1.51×** |

## 1. Preallocated commit (`sirix.commit.preallocated`)

Preallocate the data and revisions files so per-commit writes never extend `i_size`. The single write-ahead barrier then uses `fdatasync` (`force(false)`) instead of `fsync` — on a non-growing file this skips the ext4/xfs metadata-journal commit — and the O_SYNC revision-record write becomes in-place (also journal-free).

- **No WAL, no extra on-disk field, no format change.** The data write frontier is *derived* from the durable revision graph (the last revision root, located via the uber beacon), not from the preallocation-inflated physical file size.
- The preallocated tail is not trimmed on close (writers are per-transaction, so a per-close trim would force a fresh preallocation every commit); it is reused, and the frontier is re-derived on reopen.

## 2. Buffered beacons (`sirix.commit.bufferedBeacons`, requires preallocation)

Make the two uber-page beacon copies durable with **one buffered `fdatasync`** on the data channel instead of two O_DSYNC (FUA) writes through the dedicated beacon channel — one fewer device round-trip per commit.

- **Durability contract unchanged.** The write-ahead barrier still makes the page tail durable *before* the beacons (a valid beacon never names a non-durable tail), and both beacon copies are still written to their separate `BEACON_SLOT_BYTES` blocks, so a single torn block still leaves the other copy.

A true single-`fdatasync` design (one barrier) was evaluated and **rejected**: its worst case (a single flush of tail + both beacons, unordered, with the beacons reaching the device before the tail) has no surviving prior beacon, so it would need either prior-uber reconstruction or a ping-pong beacon scheme — and ping-pong sacrifices the dual-beacon redundancy, letting a single bit-rotted beacon block lose an already-acknowledged revision. Not worth the extra throughput.

## Validation

New `PreallocatedCommitTest`:
- preallocated and buffered-beacons each produce **byte-identical JSON to the legacy path** across commits + a session reopen;
- preallocation is **reused, not compounded**, across reopens;
- crash-tail recovery (both profiles);
- buffered-beacons: **primary-beacon corruption recovers from the intact secondary copy**.

The existing `CrashRecoveryTest` (incl. dual-beacon recovery) passes with the profiles active. Both flags default off → the legacy commit path is byte-identical and unaffected.

> Note: forcing the *legacy* `CrashRecoveryTest` under `-Dsirix.commit.preallocated=true` fails only `tornWriteWithoutMarker`, which forges a legacy grow-the-file torn write and asserts on file-size growth — neither applies under preallocation (in-place writes). It is an artificial flag×legacy-test combination, not a real-profile bug; the preallocated path has its own crash coverage.
