### PR TITLE
ci: raise Test sirix-core timeout 20→35 min

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -41,7 +41,10 @@ jobs:
     name: Test sirix-core
     needs: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # sirix-core is the heaviest test module; the test step was brushing the 20-min cap and getting
+    # cancelled (not failing) on busy runners. 35 min gives the suite comfortable headroom after the
+    # ~5 min of runner setup, without masking a genuine hang.
+    timeout-minutes: 35
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `Test sirix-core` job (the heaviest test module) was brushing its 20-minute `timeout-minutes` cap and getting **cancelled** — not failing — on busy runners. It happened on the beta4 release run (#1046): the job's ~25 min wall-clock = ~5 min runner setup + the test step hitting the 20-min cap; it passed cleanly on re-run.

Raises the cap to 35 minutes so the suite has comfortable headroom after setup, without masking a genuine hang. No other job changed (Build 15, other test jobs 20, native-image 25 are unaffected).