### PR TITLE
docs: refresh for the beta series (HN-readiness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to SirixDB are documented in this file.
 
+## [1.0.0-beta4] — 2026-06-19
+
+### Changed
+
+- Bumped brackit to `1.0-alpha7`, fixing the sequence functions (`fn:subsequence`/`reverse`/`remove`/`insert-before`) over JSON arrays and objects.
+
+## [1.0.0-beta3] — 2026-06-19
+
+### Added
+
+- **Valid-time interval index** — a persistent HOT-backed Relational-Interval-Tree that accelerates `jn:valid-at` / `jn:open-bitemporal` with an `O(h)` point stab, plus a CAS-index narrowing path and a linear-scan fallback. Bumped brackit to `1.0-alpha6`.
+
+## [1.0.0-beta2] — 2026-06-13
+
+### Changed
+
+- Version bump and packaging fixes.
+
+## [1.0.0-beta1] — 2026-06-12
+
+### Added
+
+- **V0 on-disk format** with write-through (preallocated, buffered-beacon) commits.
+- **Typed, fail-closed vectorized analytics** — a columnar group-by/aggregate path that lands within a small factor of DuckDB at 100M records.
+
+### Fixed
+
+- Durability and operational hardening across core, query, and the REST API; the REST read/query hot path no longer serializes concurrent requests (unordered `executeBlocking`).
+
+## [1.0.0-alpha11 – alpha22] — 2026-06-04 … 2026-06-10
+
+A rapid correctness, durability, and performance hardening series on the way to beta. Highlights:
+
+### Fixed
+
+- **Serializer correctness** — invalid JSON on single-named-scalar projections; unescaped object keys; number round-trip (exponent-without-dot, overflow, subnormal). (alpha12–alpha14, alpha21)
+- **Query semantics** — int/double comparison (`XPTY0004`) over mixed-numeric fields via brackit; a predicate-over-unwrapped-array optimizer that destructively returned empty; `jn:open`/`xml:open` before the first revision now returns an empty sequence. (alpha14, alpha16, alpha19)
+- **Latency** — node-history/query latency (event-loop blocking + an uncached history path); array-unbox `O(n²)`. (alpha20)
+- **Durability / IO** — streaming-shredder back-pressure deadlock; flaky `UberPageCorruptionTest` (page data-length bounded to the file size); Docker fat-jar glob for versioned release builds. (alpha15, alpha21, alpha11)
+
+See the [GitHub releases](https://github.com/sirixdb/sirix/releases) for full per-version notes.
+
 ## [1.0.0-alpha10]
 
 The first 1.0 alpha series — the API is stabilizing toward a production 1.0 release.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Both questions have correct, different answers. Without bitemporal support, the 
 - **Append-only storage**: Data is never overwritten. New revisions write to new locations.
 - **Structural sharing**: Unchanged pages and nodes are referenced between revisions via copy-on-write.
 - **Snapshot isolation**: Readers see a consistent view; one writer per resource.
-- **Embeddable**: Single JAR, no external dependencies. Or run as REST server.
+- **Embeddable**: a single self-contained JAR (third-party dependencies shaded in) — embed it in-process, or run it as a REST server.
 
 ## Performance
 
@@ -82,7 +82,7 @@ A few measured receipts (we benchmark against ourselves and **publish the losses
 
 - **Concurrent reads under a committing writer** — on a 12,800-revision database, 16 reader threads + 1 writer over REST went from 361 to **11,198 reads/s** with reader **p99 334 ms → 4.8 ms** and **zero errors**, after fixing a page-lifecycle bug and an O(history) open cost ([`BENCHMARKS.md`](docs/BENCHMARKS.md)). The aged database now outruns the pre-fix fresh one.
 - **Semantic diffs** — node-level insert/update/delete between two revisions (with stable keys) in **~0.3 ms**, not a text diff.
-- **Analytics** — a vectorized, fail-closed execution path lands the full group-by/aggregate suite within **1.1–4.5× of DuckDB 1.5.2 at 100M records** (sum 16 ms, two-key group-by 240 ms), and the GraalVM native binary runs **7–17× faster than the JVM** on warm analytical queries ([`COMPARISON_DUCKDB.md`](docs/COMPARISON_DUCKDB.md), [`NATIVE_IMAGE.md`](docs/NATIVE_IMAGE.md)). The standalone query engine, [brackit](https://github.com/sirixdb/brackit), beats `jq` by up to **6.8×** on analytical JSON.
+- **Analytics** — a vectorized, fail-closed execution path lands the full group-by/aggregate suite within **1.1–4.5× of DuckDB 1.5.2 at 100M records** (sum 16 ms, two-key group-by 240 ms), and the GraalVM native binary runs **7–17× faster than the JVM** on warm analytical queries ([`COMPARISON_DUCKDB.md`](docs/COMPARISON_DUCKDB.md), [`NATIVE_IMAGE.md`](docs/NATIVE_IMAGE.md)). The standalone query engine, [brackit](https://github.com/sirixdb/brackit), runs analytical JSON queries several times faster than `jq` in its own benchmark suite.
 - **Honest loss vs PostgreSQL** ([`COMPARISON_POSTGRES.md`](docs/COMPARISON_POSTGRES.md)) — PG 17 with a history table wins raw small-document ingest (4,015 vs ~430 commits/s) and total storage. SirixDB wins per-statement embedded reads, 0.3 ms semantic diffs, and sub-document time travel — things PG doesn't have. Durability settings were verified equivalent before measuring.
 
 Every fast path is **fail-closed**: a kernel only runs when the optimizer can prove the query's shape matches what it emits, and a differential suite requires byte-identical output against the general path. Wrong-but-fast is a bug class, not a setting.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-SirixDB is currently in the **1.0.0-alpha** series. The engine and query layer are
+SirixDB is currently in the **1.0.0-beta** series. The engine and query layer are
 feature-rich and well-tested; the focus now is stabilizing the public API and
 fixing the rough edges real users hit, on the way to a stable **1.0.0** release.
 


### PR DESCRIPTION
Pre-Show-HN doc cleanup (the public-facing inconsistencies an HN reader would pick at):

- **ROADMAP.md** — was "currently in the **1.0.0-alpha** series"; we ship **beta4**. → "1.0.0-beta".
- **CHANGELOG.md** — was frozen at `[1.0.0-alpha10]` (14 releases stale, reads as abandoned). Added entries for `beta1`–`beta4` and a consolidated `alpha11`–`alpha22` hardening summary, with a pointer to GitHub Releases for full per-version notes.
- **README.md** — corrected "Single JAR, **no external dependencies**" (it's a shaded fat jar that bundles brackit/Jackson/SLF4J/Caffeine/RoaringBitmap), and softened the unsourced "beats jq by up to **6.8×**" to a sourced, directional claim.

Doc-only; no code changes.