### PR TITLE
docs: correct stale HOT index claims (revision isolation + default backend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,9 +650,20 @@ Database (directory)
 
 ### Indexes
 
-- **Path index**: Index specific JSON paths for faster navigation
-- **CAS index** (Content-and-Structure): Index values with type awareness
-- **Name index**: Index object keys
+Three secondary index types, all updated **synchronously** inside the writing transaction — queries never see a stale index:
+
+- **Path index** — index specific JSON paths for faster navigation.
+- **CAS index** (Content-And-Structure) — index values with type awareness; supports equality and range predicates, optionally `unique` for constraint enforcement.
+- **Name index** — index object-key / element names.
+
+Two interchangeable storage backends sit behind every index type:
+
+| Backend | Structure | Notes |
+|---------|-----------|-------|
+| **RBTree** (default) | red-black-tree records in the standard page trie | battle-tested |
+| **HOT** (opt-in, `-Dsirix.index.useHOT=true`) | [Height-Optimized Trie](docs/ARCHITECTURE.md#hot-height-optimized-trie-index) over off-heap leaf pages | cache-friendly, SIMD partial-key search, fewer levels |
+
+Like the rest of the engine, indexes are **fully versioned**: opening an index at revision *N* returns the index state as of *N* — never a later commit's. This revision isolation is verified for both backends across point and range reads, session close/reopen, and a concurrent pinned-reader-vs-writer (see `HOTMultiVersionInvariantsTest`).
 
 ## Correctness & Formal Verification
 

--- a/README.md
+++ b/README.md
@@ -656,12 +656,12 @@ Three secondary index types, all updated **synchronously** inside the writing tr
 - **CAS index** (Content-And-Structure) — index values with type awareness; supports equality and range predicates, optionally `unique` for constraint enforcement.
 - **Name index** — index object-key / element names.
 
-Two interchangeable storage backends sit behind every index type:
+Two interchangeable storage backends sit behind every index type, selected per resource via `ResourceConfiguration` (`useHOTIndexes()` / `useRBTreeIndexes()`):
 
 | Backend | Structure | Notes |
 |---------|-----------|-------|
-| **RBTree** (default) | red-black-tree records in the standard page trie | battle-tested |
-| **HOT** (opt-in, `-Dsirix.index.useHOT=true`) | [Height-Optimized Trie](docs/ARCHITECTURE.md#hot-height-optimized-trie-index) over off-heap leaf pages | cache-friendly, SIMD partial-key search, fewer levels |
+| **HOT** (default) | [Height-Optimized Trie](docs/ARCHITECTURE.md#hot-height-optimized-trie-index) over off-heap leaf pages | cache-friendly, SIMD partial-key search, fewer levels |
+| **RBTree** | red-black-tree records in the standard page trie | traditional, stable |
 
 Like the rest of the engine, indexes are **fully versioned**: opening an index at revision *N* returns the index state as of *N* — never a later commit's. This revision isolation is verified for both backends across point and range reads, session close/reopen, and a concurrent pinned-reader-vs-writer (see `HOTMultiVersionInvariantsTest`).
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -1274,8 +1274,8 @@ public final class ResourceConfiguration {
      * <p>
      * This controls which data structure is used for storing index data:
      * <ul>
-     * <li>{@link IndexBackendType#RBTREE} - Red-Black Tree (default, stable)</li>
-     * <li>{@link IndexBackendType#HOT} - Height-Optimized Trie (high performance)</li>
+     * <li>{@link IndexBackendType#HOT} - Height-Optimized Trie (default, high performance)</li>
+     * <li>{@link IndexBackendType#RBTREE} - Red-Black Tree (traditional, stable)</li>
      * </ul>
      *
      * @param indexBackendType the index backend type to use

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -978,6 +978,36 @@ The HOT index is a cache-friendly alternative to B-trees:
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
+#### Multi-revision read isolation
+
+HOT index reads are **revision-isolated**: a read-only transaction pinned to
+revision *N* (`session.beginNodeReadOnlyTrx(N)`) observes the index state as of
+revision *N* — never a later commit's state. A writer committing revision *N+1*
+cannot bleed into a concurrently pinned reader of revision *N*.
+
+This holds because every committed HOT leaf fragment lands at a **unique
+physical storage key** under Sirix's copy-on-write model. The reconstructed
+leaf for revision *N* and for revision *N+1* are therefore cached under
+distinct keys in the storage-key-keyed `HOTLeafPageCache` and cannot collide —
+the storage key already encodes the version. The fragment chain
+(`PageReference.getPageFragments()`) walked during reconstruction is the chain
+recorded at write time for that revision's root reference, so combining it
+yields exactly the cumulative-up-to-*N* view.
+
+The property is enforced by test (NAME and CAS indexes, point and range reads,
+in-memory, across session close/reopen, and under a concurrent
+pinned-reader-vs-writer):
+
+- `HOTMultiVersionInvariantsTest` — per-revision independent readability and
+  monotone-cumulative value distributions.
+- `HOTVersionedLeafStressTest.MultiRevisionIsolation` — a reader pinned to rev 1
+  sees a stable key count while a writer commits rev 2; oracle-verified range
+  queries across 5 revisions.
+- `HOTVersioningIntegrationTest`, `HOTIndirectPageVersioningTest`,
+  `HOTIndexManyRevisionsTest`, `HOTMultiRevisionFragmentChainTest` — historical
+  revisions reconstruct correctly under FULL / INCREMENTAL / DIFFERENTIAL /
+  SLIDING_SNAPSHOT versioning, including chain rotation.
+
 ### Index Configuration
 
 ```java

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -317,15 +317,7 @@ resource at the desired revision number or timestamp via
    resource written by an incompatible Sirix version raises
    `IllegalStateException: <n> not known.`
 
-4. **HOT index does not isolate historical revisions on reads.** A read-only
-   transaction at revision N opening a HOT index sub-tree may observe the
-   latest committed state of the index rather than the state at revision N.
-   Tracked as task #57 in project memory; not blocking the typical bench /
-   analytical use case where the index reflects the most recent commit. The
-   previously-documented "NAME-with-HOT variable-length key serialization"
-   gap is now resolved (test re-enabled in `IndexIntegrationTest`).
-
-5. **Auto-commit features are in flight on multiple branches**
+4. **Auto-commit features are in flight on multiple branches**
    (`feature/warm-auto-commit-v1`, `feature/async-auto-commit`,
    `feature/eager-serialize-gc-fix`). The `AfterCommitState.KEEP_OPEN_ASYNC`
    path on `main` now passes a basic round-trip test (3000 inserts crossing
@@ -336,12 +328,12 @@ resource at the desired revision number or timestamp via
    consolidation (merging the three feature branches' design improvements
    into one) remains a multi-session effort.
 
-6. **Chicago-scale ingestion tests are `@Disabled`.** The reference 3.6 GB
+5. **Chicago-scale ingestion tests are `@Disabled`.** The reference 3.6 GB
    Chicago dataset is not in CI; large-scale ingestion regressions are caught
    manually by removing the `@Disabled` annotation and running locally on a
    machine with ≥ 16 GB RAM.
 
-7. **Crash-recovery test coverage.** `CrashRecoveryTest` exercises seven
+6. **Crash-recovery test coverage.** `CrashRecoveryTest` exercises seven
    scenarios: stale-marker no-op, marker-driven partial-write truncation
    (single + multi-revision), missing marker normal case, **torn-write
    without `.commit` marker (orphan tail bytes don't lose committed data)**,


### PR DESCRIPTION
## What does this PR do?

Documentation-only fixes for two stale claims about the HOT index. No engine code changed — the implementation was already correct; the docs lagged behind it.

1. **HOT revision isolation is not a limitation.** `operations.md` listed "HOT index does not isolate historical revisions on reads" as a known limitation. That is no longer true: reading an index at revision *N* returns the state as of *N*, verified by the HOT versioning suites (NAME + CAS, point and range reads, in-memory, across session close/reopen, and under a concurrent pinned-reader-vs-writer). The note was removed and a "Multi-revision read isolation" subsection added to `ARCHITECTURE.md` explaining the mechanism (each committed leaf fragment lands at a unique physical storage key, so the storage-key-keyed `HOTLeafPageCache` is inherently revision-discriminating).

2. **HOT is the default index backend, not RBTree.** The `ResourceConfiguration` builder default is `IndexBackendType.HOT`; `RBTREE` only appears as the backward-compat fallback when deserializing a config that predates the field. Fixed the stale `indexBackendType()` Javadoc and the README Indexes section (HOT default / RBTree alternative, selected per resource via `useHOTIndexes()` / `useRBTreeIndexes()`).

The README Indexes section was also expanded from three bare bullets into the index types + backend table.

## Related issue

Closes the internally-tracked "task #57". No public issue.

## Type of change

- [x] Documentation only

## Checklist

- [x] Verified the claims against the test suite (`HOTMultiVersionInvariantsTest`, `HOTVersionedLeafStressTest$MultiRevisionIsolation`, `HOTVersioningIntegrationTest`, `HOTIndirectPageVersioningTest`, `HOTIndexManyRevisionsTest`, `HOTMultiRevisionFragmentChainTest` — all green)
- [x] Updated documentation (README / docs)
- [x] No unrelated formatting churn

## Notes for reviewers

The only non-`.md` change is a one-line Javadoc correction in `ResourceConfiguration.java` (HOT listed as default). Everything else is Markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjpXtTdngQ1zQ5KpHGS85U)_