### PR TITLE
docs: scope index revision-isolation claim accurately by backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Two interchangeable storage backends sit behind every index type, selected per r
 | **HOT** (default) | [Height-Optimized Trie](docs/ARCHITECTURE.md#hot-height-optimized-trie-index) over off-heap leaf pages | cache-friendly, SIMD partial-key search, fewer levels |
 | **RBTree** | red-black-tree records in the standard page trie | traditional, stable |
 
-Like the rest of the engine, indexes are **fully versioned**: opening an index at revision *N* returns the index state as of *N* — never a later commit's. This revision isolation is verified for both backends across point and range reads, session close/reopen, and a concurrent pinned-reader-vs-writer (see `HOTMultiVersionInvariantsTest`).
+Like the rest of the engine, indexes are **fully versioned**: opening an index at revision *N* returns the index state as of *N* — never a later commit's. RBTree indexes inherit this from the standard page-versioning trie (the same copy-on-write pages as the document tree); for the HOT backend it is verified directly across point and range reads, session close/reopen, and a concurrent pinned-reader-vs-writer (see `HOTMultiVersionInvariantsTest`).
 
 ## Correctness & Formal Verification
 


### PR DESCRIPTION
## What does this PR do?

Follow-up doc accuracy fix after #1054. While double-checking the docs against the code, the README's index revision-isolation note said the property was "verified for both backends (see `HOTMultiVersionInvariantsTest`)". That test forces the HOT backend (`-Dsirix.index.useHOT=true`), so it verifies HOT only — not RBTree.

Reworded to be precise: RBTree indexes inherit revision isolation from the standard page-versioning trie (the same copy-on-write pages as the document tree, `IndexPage → IndirectPages → KeyValueLeafPage`); the HOT backend is the one verified directly by the cited test.

Documentation only — no code change.

## Related issue

Follow-up to #1054 (task #57).

## Type of change

- [x] Documentation only

## Checklist

- [x] Verified each remaining README/ARCHITECTURE claim against the code (CAS equality+range via `SearchMode`, NAME indexes object keys via `QNm`, `beginNodeReadOnlyTrx(int)` signature, `useHOTIndexes()`/`useRBTreeIndexes()`, the ARCHITECTURE anchor link, and the `HOTLeafPageCache` storage-key mechanism)
- [x] Documentation updated

## Notes for reviewers

Single-sentence reword in the README Indexes section. The ARCHITECTURE "Multi-revision read isolation" subsection was already HOT-scoped and accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjpXtTdngQ1zQ5KpHGS85U)_