### PR TITLE
Add deep-verification test layers (property-based, oracle, concurrency, mutation, static analysis) + fix bugs they found

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -1,0 +1,68 @@
+# Deep-verification jobs that are too heavy (or too strict) for the per-PR pipeline:
+#
+#   * mutation-testing — PIT over a curated set of correctness-critical sirix-core classes.
+#     The mutation score measures whether the tests ASSERT on behavior rather than merely
+#     execute it: a surviving mutant is a code change no test noticed. Scope is configured
+#     in bundles/sirix-core/build.gradle (pitest block).
+#
+#   * error-prone — compiles sirix-core with Error Prone + NullAway (-PerrorProne).
+#     ERROR-severity Error Prone checks (almost-always-real bug patterns) fail the build;
+#     NullAway nullness findings are reported as warnings in the log.
+#
+# Trigger paths: manual workflow_dispatch, or the weekly Monday 04:00 UTC cron.
+name: Deep verification
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'
+
+jobs:
+  mutation-testing:
+    name: PIT mutation testing (sirix-core, curated scope)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run PIT
+        run: ./gradlew :sirix-core:pitest --no-daemon
+      - name: Print summary
+        if: always()
+        run: |
+          if ls bundles/sirix-core/build/reports/pitest/mutations.xml >/dev/null 2>&1; then
+            killed=$(grep -c "status='KILLED'" bundles/sirix-core/build/reports/pitest/mutations.xml || true)
+            survived=$(grep -c "status='SURVIVED'" bundles/sirix-core/build/reports/pitest/mutations.xml || true)
+            echo "Mutants killed: $killed, survived: $survived"
+          fi
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pitest-report
+          path: bundles/sirix-core/build/reports/pitest
+          if-no-files-found: ignore
+
+  error-prone:
+    name: Error Prone + NullAway (sirix-core)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Compile with Error Prone
+        run: ./gradlew :sirix-core:compileJava :sirix-core:compileTestJava -PerrorProne --no-daemon

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ ai-docs/
 
 # Binna's thesis — external reference, kept locally but not tracked in the repo
 /thesis.pdf
+
+# jqwik failure-reproduction database (property-based tests)
+.jqwik-database
+**/.jqwik-database

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -18,6 +19,8 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.graalvm.buildtools:native-gradle-plugin:0.11.5"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.30.0"
+        classpath "info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.19.0"
+        classpath "net.ltgt.gradle:gradle-errorprone-plugin:5.1.0"
     }
 }
 
@@ -124,6 +127,37 @@ subprojects {
                                  "--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED",
                                  "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
                                  "--add-exports=java.base/java.lang.reflect=ALL-UNNAMED"]
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Error Prone + NullAway — opt-in static bug detection:
+    //   ./gradlew compileJava -PerrorProne          (all modules)
+    //   ./gradlew :sirix-core:compileJava -PerrorProne
+    // Off by default so the everyday build is unchanged; the verification CI
+    // workflow runs it. ERROR-severity Error Prone checks (almost-always-real
+    // bugs: bad equals/hashCode, format strings, self-assignment, ...) fail the
+    // compile; NullAway reports nullness-contract violations as warnings.
+    // ═══════════════════════════════════════════════════════════════════════
+    if (project.hasProperty('errorProne')) {
+        apply plugin: 'net.ltgt.errorprone'
+
+        dependencies {
+            errorprone "com.google.errorprone:error_prone_core:2.50.0"
+            errorprone "com.uber.nullaway:nullaway:0.13.7"
+        }
+
+        tasks.withType(JavaCompile).configureEach {
+            options.errorprone {
+                disableWarningsInGeneratedCode = true
+                excludedPaths = '.*/build/generated/.*'
+                option('NullAway:AnnotatedPackages', 'io.sirix')
+                check('NullAway', CheckSeverity.WARN)
+                // Nodes/pages deliberately compare MemorySegments by reference: the question is
+                // "is this node backed by exactly this segment instance", not value equality —
+                // and identity is the cheap check on the hot path. Keep as a warning.
+                check('MemorySegmentReferenceEquality', CheckSeverity.WARN)
+            }
+        }
     }
 
     spotless {

--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -29,6 +29,55 @@ dependencies {
     // JsonCorrectnessSweepTest (key-order-insensitive objects, order-sensitive arrays, exact
     // BigInteger/BigDecimal numeric fidelity). Pinned to match the declared jackson-core 2.18.2.
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
+    // Property-based testing (generative round-trip / revision-immutability / oracle properties).
+    testImplementation testLibraries.jqwik
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Mutation testing (PIT) — run manually or from the mutation-testing workflow:
+//   ./gradlew :sirix-core:pitest
+// Scoped to a curated set of correctness-critical, fast-to-test classes; a
+// whole-module run would take hours. The mutation score measures how much of
+// the code the tests actually ASSERT on (not just execute) — a surviving
+// mutant is a code change no test noticed.
+// ═══════════════════════════════════════════════════════════════════════════
+apply plugin: 'info.solidsoft.pitest'
+
+pitest {
+    pitestVersion = '1.25.5'
+    junit5PluginVersion = '1.2.3'
+    targetClasses = [
+        'io.sirix.diff.JsonDiffSerializer',
+        'io.sirix.access.trx.RevisionEpochTracker',
+        'io.sirix.cache.ShardedPageCache',
+    ]
+    targetTests = [
+        'io.sirix.diff.JsonDiffSerializerStaleTupleRegressionTest',
+        'io.sirix.access.trx.RevisionEpochTrackerWatermarkSafetyTest',
+        'io.sirix.cache.ShardedPageCacheInvariantStressTest',
+        'io.sirix.property.*',
+    ]
+    threads = 2
+    timestampedReports = false
+    outputFormats = ['HTML', 'XML']
+    // The forked minion JVMs must mirror the test task's flags: preview class files and the
+    // module opens the storage engine needs.
+    jvmArgs = ['--enable-preview',
+               '--add-modules=jdk.incubator.vector',
+               '--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED',
+               '--add-exports=java.base/sun.nio.ch=ALL-UNNAMED',
+               '--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED',
+               '--add-opens=java.base/java.lang=ALL-UNNAMED',
+               '--add-opens=java.base/java.nio=ALL-UNNAMED',
+               '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+               '--enable-native-access=ALL-UNNAMED',
+               '-XX:MaxDirectMemorySize=1g',
+               // Short stress windows per mutant: the invariant harnesses detect violations
+               // quickly, and the full 1.5s window × hundreds of mutants would take hours.
+               '-Dsirix.stress.run.millis=200']
+    // Stress-style tests time-box themselves; give mutants headroom before being killed as
+    // timeouts so slow-but-killed mutants are not misreported.
+    timeoutConstInMillis = 30000
 }
 
 description = 'SirixDB is a hybrid on-disk and in-memory document oriented, versioned database system. It has a ' +

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -727,10 +727,10 @@ public final class ResourceConfiguration {
       name = jsonReader.nextName();
       assert name.equals(JSONNAMES[6]);
       final HashType hashing = HashType.valueOf(jsonReader.nextString());
-      // Hashing function.
+      // Hashing function (legacy field, no longer used — skip it explicitly).
       name = jsonReader.nextName();
       assert name.equals(JSONNAMES[7]);
-      jsonReader.nextString();
+      jsonReader.skipValue();
       // Text compression.
       name = jsonReader.nextName();
       assert name.equals(JSONNAMES[8]);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -52,6 +52,7 @@ import io.sirix.axis.DescendantAxis;
 import io.sirix.axis.IncludeSelf;
 import io.sirix.axis.PostOrderAxis;
 import io.sirix.diff.DiffDepth;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import io.sirix.diff.DiffFactory;
 import io.sirix.diff.DiffTuple;
 import io.sirix.diff.JsonDiffSerializer;
@@ -1078,7 +1079,6 @@ final class JsonNodeTrxImpl extends
     // OBJECT_KEY+OBJECT (or ARRAY) role under fusion — stop walking up at them so the
     // path-summary writer anchors child path nodes at the correct ancestor.
     while (nodeKind != NodeKind.OBJECT_NAMED_OBJECT
-        && nodeKind != NodeKind.OBJECT_NAMED_OBJECT
         && nodeKind != NodeKind.OBJECT_NAMED_ARRAY
         && nodeKind != NodeKind.ARRAY
         && nodeKind != NodeKind.JSON_DOCUMENT) {
@@ -2802,9 +2802,26 @@ final class JsonNodeTrxImpl extends
       // consumers (BasicJsonDiff, jn:diff serializer) lose the entry entirely.
       adaptUpdateOperationsForRemove(node.getDeweyID(), node.getNodeKey());
 
+      // Removing a subtree must also purge INSERTED/UPDATED/REPLACEDNEW diff tuples recorded
+      // earlier in this transaction for DESCENDANTS of the removed node: their node keys no
+      // longer resolve in the new revision, and a stale tuple makes the commit-time diff
+      // serializer read from an unpositioned cursor (NPE or silently corrupt diff files). The
+      // subtree root's own tuple is already handled by adaptUpdateOperationsForRemove; the
+      // DELETED tuple of the root subsumes all descendant operations.
+      final LongOpenHashSet removedDescendantKeys = storeDeweyIDs() ? new LongOpenHashSet() : null;
+
       // Remove subtree.
       for (final var axis = new PostOrderAxis(this); axis.hasNext();) {
         final long currentNodeKey = axis.nextLong();
+
+        if (removedDescendantKeys != null) {
+          removedDescendantKeys.add(currentNodeKey);
+        } else {
+          final DiffTuple staleTuple = updateOperationsUnordered.get(currentNodeKey);
+          if (staleTuple != null && staleTuple.getDiff() != DiffFactory.DiffType.DELETED) {
+            updateOperationsUnordered.remove(currentNodeKey);
+          }
+        }
 
         // Remove name.
         removeName();
@@ -2825,6 +2842,12 @@ final class JsonNodeTrxImpl extends
         if (storeNodeHistory) {
           nodeToRevisionsIndex.addRevisionToRecordToRevisionsIndex(currentNodeKey);
         }
+      }
+
+      if (removedDescendantKeys != null && !removedDescendantKeys.isEmpty()) {
+        updateOperationsOrdered.values()
+                               .removeIf(tuple -> tuple.getDiff() != DiffFactory.DiffType.DELETED
+                                   && removedDescendantKeys.contains(tuple.getNewNodeKey()));
       }
 
       if (node.getKind().playsObjectKeyRole()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
@@ -265,27 +265,35 @@ public final class HOTTrieWriter {
     return result[0] == -1 ? 0 : result[0];
   }
 
-  /** Instance-method walk: uses {@code activeReader} to load any non-swizzled child pages. */
-  private void walkLeavesUntilFalseInstance(PageReference ref,
+  /**
+   * Instance-method walk: uses {@code activeReader} to load any non-swizzled child pages.
+   * Honors the visitor's verdict — the walk stops as soon as the visitor returns false
+   * (previously the result was ignored and the walk always visited every leaf).
+   *
+   * @return false as soon as the visitor returned false, true otherwise
+   */
+  private boolean walkLeavesUntilFalseInstance(PageReference ref,
       java.util.function.Predicate<HOTLeafPage> visitor) {
-    if (ref == null) return;
+    if (ref == null) return true;
     Page page = ref.getPage();
     if (page == null && activeReader != null) {
       page = loadPage(activeReader, ref);
       if (page != null) ref.setPage(page);
     }
     if (page instanceof HOTLeafPage leaf) {
-      visitor.test(leaf);
-      return;
+      return visitor.test(leaf);
     }
     if (page instanceof HOTIndirectPage indirect) {
       final int n = indirect.getNumChildren();
       for (int i = 0; i < n; i++) {
         final PageReference childRef = indirect.getChildReference(i);
         if (childRef == null) continue;
-        walkLeavesUntilFalseInstance(childRef, visitor);
+        if (!walkLeavesUntilFalseInstance(childRef, visitor)) {
+          return false;
+        }
       }
     }
+    return true;
   }
 
 
@@ -3216,11 +3224,11 @@ public final class HOTTrieWriter {
   }
 
   /** Diagnostic helper — gated on {@code -Dhot.debug.phase3=1}. Counts Phase 3 skips by reason. */
-  private static void diagnosePhase3Skip(String reason, HOTIndirectPage parent, int β) {
+  private static void diagnosePhase3Skip(String reason, HOTIndirectPage parent, int beta) {
   }
 
   /** Diagnostic — finer reason for integrate failure. */
-  private static void diagnoseIntegrateFail(String reason, HOTIndirectPage parent, int β, int outIdx) {
+  private static void diagnoseIntegrateFail(String reason, HOTIndirectPage parent, int beta, int outIdx) {
   }
 
   // ===========================================================================

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/ShardedPageCache.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/ShardedPageCache.java
@@ -401,10 +401,9 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
         final var entry = it.next();
         if (entry.getValue() == page) {
           it.remove();
-          final long weight = weightOf(page);
-          if (weight > 0) {
-            currentWeightBytes.addAndGet(-weight);
-          }
+          // Release the recorded charge via insertedWeights (see evictUnderPressure) so a later
+          // re-insert under the same reference is charged with a correct delta.
+          unchargeWeight(entry.getKey());
           entry.getKey().setPage(null);
           break;
         }
@@ -608,7 +607,6 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
             page.clearHot();
             return page;
           }
-          final long pageWeight = weightOf(page);
           try {
             page.close();
             if (!page.isClosed()) {
@@ -616,9 +614,11 @@ public final class ShardedPageCache<V extends CacheablePage> implements Cache<Pa
             }
             page.incrementVersion();
             ref.setPage(null);
-            if (pageWeight > 0) {
-              currentWeightBytes.addAndGet(-pageWeight);
-            }
+            // Release exactly the recorded charge (NOT weightOf(page) directly): a manual
+            // subtraction leaves the stale entry in insertedWeights, so the next chargeWeight
+            // for this reference computes a zero delta and the re-inserted page is never
+            // accounted — the weight drifts towards zero and budget eviction stops firing.
+            unchargeWeight(ref);
             return null;
           } catch (Exception e) {
             LOGGER.debug("evictUnderPressure failed for page {}: {}", page.getPageKey(), e.getMessage());

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/JsonDiffSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/JsonDiffSerializer.java
@@ -65,13 +65,21 @@ public final class JsonDiffSerializer {
       for (final var diffTuple : diffs) {
         final var diffType = diffTuple.getDiff();
 
+        // A tuple whose node key does not resolve in its revision is stale (e.g. recorded for a
+        // node that was later removed, or inserted and removed within the same transaction).
+        // Serializing it would read from an unpositioned cursor — skip it instead.
         if (diffType == DiffFactory.DiffType.INSERTED) {
-          newRtx.moveTo(diffTuple.getNewNodeKey());
+          if (!newRtx.moveTo(diffTuple.getNewNodeKey())) {
+            continue;
+          }
         } else if (diffType == DiffFactory.DiffType.DELETED) {
-          oldRtx.moveTo(diffTuple.getOldNodeKey());
+          if (!oldRtx.moveTo(diffTuple.getOldNodeKey())) {
+            continue;
+          }
         } else {
-          newRtx.moveTo(diffTuple.getNewNodeKey());
-          oldRtx.moveTo(diffTuple.getOldNodeKey());
+          if (!newRtx.moveTo(diffTuple.getNewNodeKey()) || !oldRtx.moveTo(diffTuple.getOldNodeKey())) {
+            continue;
+          }
         }
 
         switch (diffType) {
@@ -155,8 +163,10 @@ public final class JsonDiffSerializer {
               jsonUpdateDiff.addProperty("depth", deweyId.getLevel());
             }
 
-            if (!Objects.equals(oldRtx.getName(), newRtx.getName())) {
-              jsonUpdateDiff.addProperty("name", newRtx.getName().toString());
+            final QNm oldName = oldRtx.getName();
+            final QNm newName = newRtx.getName();
+            if (!Objects.equals(oldName, newName) && newName != null) {
+              jsonUpdateDiff.addProperty("name", newName.toString());
             } else if (!Objects.equals(oldRtx.getValue(), newRtx.getValue())) {
               if (newRtx.getKind() == NodeKind.BOOLEAN_VALUE
                   || newRtx.getKind() == NodeKind.OBJECT_NAMED_BOOLEAN) {

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/export/EditScript.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/export/EditScript.java
@@ -21,7 +21,7 @@
 package io.sirix.diff.export;
 
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -39,8 +39,12 @@ public final class EditScript implements Iterator<DiffTuple>, Iterable<DiffTuple
   /** Preserves the order of changes and is used to iterate over all changes. */
   private final List<DiffTuple> mChanges;
 
-  /** To do a lookup; we use node/object identities. */
-  private final IdentityHashMap<Long, DiffTuple> mChangeByNode;
+  /**
+   * Change lookups keyed by node key. Must be a value-based map: boxed {@code Long} keys above
+   * the autobox cache (|key| > 127) are distinct instances, so an IdentityHashMap silently
+   * missed every containsKey/get for realistic node keys.
+   */
+  private final HashMap<Long, DiffTuple> mChangeByNode;
 
   /** Index in the {@link List} of {@link DiffTuple}s. */
   private transient int mIndex;
@@ -50,7 +54,7 @@ public final class EditScript implements Iterator<DiffTuple>, Iterable<DiffTuple
    */
   public EditScript() {
     mChanges = new ArrayList<DiffTuple>();
-    mChangeByNode = new IdentityHashMap<Long, DiffTuple>();
+    mChangeByNode = new HashMap<Long, DiffTuple>();
     mIndex = 0;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/node/delegates/ValueNodeDelegate.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/delegates/ValueNodeDelegate.java
@@ -137,7 +137,9 @@ public class ValueNodeDelegate extends AbstractForwardingNode implements ValueNo
 
   @Override
   public int hashCode() {
-    return Objects.hash(nodeDelegate, value);
+    // Must hash the array CONTENTS to stay consistent with equals(), which compares via
+    // Arrays.equals — Objects.hash(value) would use the array's identity hash.
+    return Objects.hash(nodeDelegate, Arrays.hashCode(value));
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
@@ -150,6 +150,10 @@ public final class ReferencesPage4 implements Page {
     return true;
   }
 
+  // NullAway 0.13.x crashes analyzing the short->int widening in this loop
+  // (ClassCastException: WideningConversionNode vs MethodInvocationNode); suppress until fixed
+  // upstream (https://github.com/uber/NullAway).
+  @SuppressWarnings("NullAway")
   @Override
   public String toString() {
     final ToStringHelper helper = ToStringHelper.of(this);

--- a/bundles/sirix-core/src/main/java/io/sirix/service/xml/xpath/PipelineBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/xml/xpath/PipelineBuilder.java
@@ -501,7 +501,9 @@ public final class PipelineBuilder {
     final Axis predicate = getPipeStack().pop().getExpr();
 
     if (predicate instanceof LiteralExpr) {
-      predicate.hasNext();
+      // Evaluate the literal purely for its side effect (positions the trx on the literal's
+      // item so its type can be read below); the boolean result is irrelevant.
+      final boolean unused = predicate.hasNext();
       // if is numeric literal -> abbrev for position()
       final int type = pRtx.getTypeKey();
       if (type == pRtx.keyForName("xs:integer") || type == pRtx.keyForName("xs:double")

--- a/bundles/sirix-core/src/main/java/io/sirix/service/xml/xpath/functions/Function.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/xml/xpath/functions/Function.java
@@ -273,9 +273,9 @@ public class Function {
 
     Double value = 0.0;
     if (!axis.hasNext()) {
-      mZero.hasNext(); // if is empty sequence, return values specified
-                       // for
-      // zero
+      // Empty sequence: evaluate the zero-axis purely for its side effect (it positions the
+      // trx on the configured zero value); its boolean result is irrelevant here.
+      final boolean unused = mZero.hasNext();
     } else {
       do {
         value = value + Double.parseDouble(rtx.getValue());
@@ -286,6 +286,8 @@ public class Function {
     return true;
   }
 
+  @SuppressWarnings("IdentityBinaryExpression") // legacy XPath axes advance on hasNext(), so the
+  // double call genuinely tests "at least two results" — not a copy-paste error.
   public static boolean zeroOrOne(final XmlNodeReadOnlyTrx rtx, final AbstractAxis axis) throws SirixXPathException {
 
     final boolean result = true;

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/RevisionEpochTrackerWatermarkSafetyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/RevisionEpochTrackerWatermarkSafetyTest.java
@@ -1,0 +1,197 @@
+package io.sirix.access.trx;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency-safety tests for {@link RevisionEpochTracker} — the epoch-based MVCC watermark that
+ * gates page eviction. The tracker's single critical guarantee is:
+ *
+ * <blockquote>while any transaction holds a ticket for revision R, {@code minActiveRevision()}
+ * must never return a value greater than R</blockquote>
+ *
+ * because a watermark above R would let the sweeper evict pages revision-R readers still need.
+ *
+ * <p>The watermark test uses a generation-stamped publication protocol so the assertion is sound
+ * under concurrency: a worker publishes (odd generation, revision) via a volatile write only
+ * AFTER {@code register} returns, and flips to an even generation BEFORE calling
+ * {@code deregister}. A checker that observes the same odd generation before and after reading
+ * the watermark has therefore proven the registration spanned the whole read — any watermark
+ * above that revision is a real safety violation, not a race in the test.
+ */
+final class RevisionEpochTrackerWatermarkSafetyTest {
+
+  private static final int WORKERS = 4;
+  private static final int CHECKERS = 2;
+  /**
+   * Stress duration; overridable so mutation testing can use short runs
+   * (-Dsirix.stress.run.millis=200) while regular CI keeps the full window.
+   */
+  private static final long RUN_MILLIS = Long.getLong("sirix.stress.run.millis", 1_500);
+
+  @Test
+  @Timeout(60)
+  void watermarkNeverExceedsAnActivelyHeldRevision() throws InterruptedException {
+    final RevisionEpochTracker tracker = new RevisionEpochTracker(1024);
+    final AtomicInteger committedRevision = new AtomicInteger(1);
+    tracker.setLastCommittedRevision(1);
+
+    // states[w] packs (generation << 32) | revision; odd generation = holding a ticket.
+    final AtomicLongArray states = new AtomicLongArray(WORKERS);
+    final AtomicLong violations = new AtomicLong();
+    final AtomicReference<String> firstViolation = new AtomicReference<>();
+    final AtomicBoolean stop = new AtomicBoolean();
+    final CountDownLatch start = new CountDownLatch(1);
+    final ExecutorService pool = Executors.newFixedThreadPool(WORKERS + CHECKERS + 1);
+
+    // Committer: monotonically advances the committed revision.
+    pool.execute(() -> {
+      await(start);
+      while (!stop.get()) {
+        final int next = committedRevision.incrementAndGet();
+        tracker.setLastCommittedRevision(next);
+        Thread.onSpinWait();
+      }
+    });
+
+    for (int w = 0; w < WORKERS; w++) {
+      final int workerIndex = w;
+      pool.execute(() -> {
+        await(start);
+        long generation = 0;
+        while (!stop.get()) {
+          final int revision = committedRevision.get();
+          final RevisionEpochTracker.Ticket ticket = tracker.register(revision);
+          generation++; // odd: holding
+          states.set(workerIndex, (generation << 32) | (revision & 0xFFFF_FFFFL));
+          for (int i = 0; i < 50; i++) {
+            Thread.onSpinWait();
+          }
+          generation++; // even: released (published BEFORE the deregister)
+          states.set(workerIndex, generation << 32);
+          tracker.deregister(ticket);
+        }
+      });
+    }
+
+    for (int c = 0; c < CHECKERS; c++) {
+      pool.execute(() -> {
+        await(start);
+        int workerIndex = 0;
+        while (!stop.get()) {
+          workerIndex = (workerIndex + 1) % WORKERS;
+          final long before = states.get(workerIndex);
+          if (((before >>> 32) & 1) == 0) {
+            continue; // not holding
+          }
+          final int heldRevision = (int) before;
+          final int watermark = tracker.minActiveRevision();
+          final long after = states.get(workerIndex);
+          if (before == after && watermark > heldRevision) {
+            violations.incrementAndGet();
+            firstViolation.compareAndSet(null,
+                "watermark=" + watermark + " > heldRevision=" + heldRevision + " (worker " + workerIndex + ")");
+          }
+        }
+      });
+    }
+
+    start.countDown();
+    Thread.sleep(RUN_MILLIS);
+    stop.set(true);
+    pool.shutdown();
+    assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "threads must terminate");
+
+    assertEquals(0, violations.get(),
+        "Eviction watermark exceeded an actively held revision: " + firstViolation.get());
+
+    // Quiescent state: nothing registered, so the watermark equals the last committed revision.
+    assertEquals(tracker.getLastCommittedRevision(), tracker.minActiveRevision());
+  }
+
+  @Test
+  @Timeout(60)
+  void slotsAreNeverDoublyAllocatedAndFreeListSurvivesContention() throws InterruptedException {
+    final int slotCount = 8;
+    final int threads = 8;
+    final RevisionEpochTracker tracker = new RevisionEpochTracker(slotCount);
+    final AtomicIntegerArray claims = new AtomicIntegerArray(slotCount);
+    final AtomicLong doubleAllocations = new AtomicLong();
+    final AtomicBoolean stop = new AtomicBoolean();
+    final CountDownLatch start = new CountDownLatch(1);
+    final ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+    for (int t = 0; t < threads; t++) {
+      pool.execute(() -> {
+        await(start);
+        while (!stop.get()) {
+          final RevisionEpochTracker.Ticket ticket;
+          try {
+            ticket = tracker.register(7);
+          } catch (final IllegalStateException fullyAllocated) {
+            Thread.onSpinWait();
+            continue;
+          }
+          // Exactly one live ticket may reference each slot at any moment.
+          if (claims.incrementAndGet(ticket.getSlotIndex()) != 1) {
+            doubleAllocations.incrementAndGet();
+          }
+          Thread.onSpinWait();
+          claims.decrementAndGet(ticket.getSlotIndex());
+          tracker.deregister(ticket);
+        }
+      });
+    }
+
+    start.countDown();
+    Thread.sleep(RUN_MILLIS);
+    stop.set(true);
+    pool.shutdown();
+    assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS), "threads must terminate");
+
+    assertEquals(0, doubleAllocations.get(), "a slot was handed out to two live tickets at once");
+
+    // The free list must be fully intact: exactly slotCount distinct slots remain allocatable.
+    final List<RevisionEpochTracker.Ticket> tickets = new ArrayList<>(slotCount);
+    final Set<Integer> slots = new HashSet<>();
+    for (int i = 0; i < slotCount; i++) {
+      final RevisionEpochTracker.Ticket ticket = tracker.register(1);
+      tickets.add(ticket);
+      slots.add(ticket.getSlotIndex());
+    }
+    assertEquals(slotCount, slots.size(), "leaked or duplicated slot indices after the hammering phase");
+    assertThrows(IllegalStateException.class, () -> tracker.register(1),
+        "no slot may be allocatable beyond the configured capacity");
+    for (final RevisionEpochTracker.Ticket ticket : tickets) {
+      tracker.deregister(ticket);
+    }
+  }
+
+  private static void await(final CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/axis/concurrent/ConXPathAxisTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/concurrent/ConXPathAxisTest.java
@@ -77,7 +77,7 @@ public class ConXPathAxisTest {
           new long[] {7L, 11L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -145,7 +145,7 @@ public class ConXPathAxisTest {
       AbsAxisTest.testAxisConventions(new XPathAxis(holder.getXmlNodeReadTrx(), "p:a/b[@p:x=\"y\"]"), new long[] {9L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -169,7 +169,7 @@ public class ConXPathAxisTest {
           new long[] {6L, 7L, 11L, 12L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -197,7 +197,7 @@ public class ConXPathAxisTest {
       AbsAxisTest.testAxisConventions(new XPathAxis(holder.getXmlNodeReadTrx(), "p:a/descendant::p:a"), new long[] {});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
   }
 
@@ -221,7 +221,7 @@ public class ConXPathAxisTest {
           new long[] {11L, 9L, 1L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -243,7 +243,7 @@ public class ConXPathAxisTest {
       AbsAxisTest.testAxisConventions(new XPathAxis(holder.getXmlNodeReadTrx(), "parent::node()"), new long[] {1L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
   }
 
@@ -268,7 +268,7 @@ public class ConXPathAxisTest {
           new long[] {6L, 7L, 11L, 12L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -288,7 +288,7 @@ public class ConXPathAxisTest {
       AbsAxisTest.testAxisConventions(new XPathAxis(holder.getXmlNodeReadTrx(), "/p:a/b/c"), new long[] {7L, 11L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -310,7 +310,7 @@ public class ConXPathAxisTest {
       AbsAxisTest.testAxisConventions(new XPathAxis(holder.getXmlNodeReadTrx(), "/p:a/b/c"), new long[] {7L, 11L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -389,7 +389,7 @@ public class ConXPathAxisTest {
           new long[] {5l, 9L, 1L, 7L, 11L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -414,7 +414,7 @@ public class ConXPathAxisTest {
           new long[] {7L, 11L, 5L, 1L, 6L});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }
@@ -428,7 +428,7 @@ public class ConXPathAxisTest {
           new String[] {"10"});
 
     } catch (final SirixXPathException mExp) {
-      mExp.getStackTrace();
+      mExp.printStackTrace();
     }
 
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/ShardedPageCacheInvariantStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/ShardedPageCacheInvariantStressTest.java
@@ -1,0 +1,247 @@
+package io.sirix.cache;
+
+import io.sirix.index.IndexType;
+import io.sirix.page.PageReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Multi-threaded invariant stress test for {@link ShardedPageCache} using a stub
+ * {@link CacheablePage} that faithfully implements the guard/orphan/close state machine.
+ *
+ * <p>Invariants verified under concurrent get/getOrLoadAndGuard/put/remove/eviction pressure:
+ * <ul>
+ *   <li><b>Guard safety</b> — a page handed out by {@code getOrLoadAndGuard} is never closed
+ *       while the caller still holds the guard (eviction must skip guarded pages; close must be
+ *       deferred to the last {@code releaseGuard}).</li>
+ *   <li><b>Guard-count sanity</b> — the guard count never goes negative and teardown never runs
+ *       while guards are held.</li>
+ *   <li><b>Weight accounting</b> — after quiescence the tracked weight equals exactly
+ *       (page size × live mappings): no drift from racing charge/uncharge, and {@code clear()}
+ *       returns the account to zero.</li>
+ * </ul>
+ */
+final class ShardedPageCacheInvariantStressTest {
+
+  private static final int THREADS = 6;
+  private static final int KEYS = 64;
+  private static final long PAGE_SIZE = 1_024;
+  // Budget of 16 pages against a 64-key universe forces constant eviction pressure.
+  private static final long MAX_WEIGHT = 16 * PAGE_SIZE;
+  /**
+   * Stress duration; overridable so mutation testing can use short runs
+   * (-Dsirix.stress.run.millis=200) while regular CI keeps the full window.
+   */
+  private static final long RUN_MILLIS = Long.getLong("sirix.stress.run.millis", 1_500);
+
+  /**
+   * Stub page implementing the CacheablePage contract: acquireGuard fails once closed; close is
+   * guard-aware (a guarded page is only marked for teardown; the last releaseGuard finishes it).
+   * Contract violations are counted instead of thrown so the stress threads never die silently.
+   */
+  private static final class StubPage implements CacheablePage {
+    private final long pageKey;
+    private final AtomicLong closedWhileGuarded;
+    private final AtomicLong negativeGuardCounts;
+
+    private int guards;
+    private boolean closeRequested;
+    private boolean closed;
+    private volatile boolean hot;
+    private final AtomicInteger version = new AtomicInteger();
+
+    StubPage(final long pageKey, final AtomicLong closedWhileGuarded, final AtomicLong negativeGuardCounts) {
+      this.pageKey = pageKey;
+      this.closedWhileGuarded = closedWhileGuarded;
+      this.negativeGuardCounts = negativeGuardCounts;
+    }
+
+    @Override
+    public long getActualMemorySize() {
+      return PAGE_SIZE;
+    }
+
+    @Override
+    public void markAccessed() {
+      hot = true;
+    }
+
+    @Override
+    public boolean isHot() {
+      return hot;
+    }
+
+    @Override
+    public void clearHot() {
+      hot = false;
+    }
+
+    @Override
+    public synchronized boolean acquireGuard() {
+      if (closed) {
+        return false;
+      }
+      guards++;
+      return true;
+    }
+
+    @Override
+    public synchronized void releaseGuard() {
+      if (guards <= 0) {
+        negativeGuardCounts.incrementAndGet();
+        return;
+      }
+      guards--;
+      if (guards == 0 && closeRequested && !closed) {
+        teardown();
+      }
+    }
+
+    @Override
+    public synchronized int getGuardCount() {
+      return guards;
+    }
+
+    @Override
+    public synchronized boolean isClosed() {
+      return closed;
+    }
+
+    @Override
+    public synchronized void markOrphaned() {
+      closeRequested = true;
+    }
+
+    @Override
+    public synchronized void close() {
+      if (closed) {
+        return;
+      }
+      if (guards > 0) {
+        // Guard-aware close: defer to the last releaseGuard.
+        closeRequested = true;
+        return;
+      }
+      teardown();
+    }
+
+    private void teardown() {
+      if (guards > 0) {
+        closedWhileGuarded.incrementAndGet();
+      }
+      closed = true;
+    }
+
+    @Override
+    public void incrementVersion() {
+      version.incrementAndGet();
+    }
+
+    @Override
+    public long getPageKey() {
+      return pageKey;
+    }
+
+    @Override
+    public int getRevision() {
+      return 1;
+    }
+
+    @Override
+    public IndexType getIndexType() {
+      return IndexType.DOCUMENT;
+    }
+  }
+
+  @Test
+  @Timeout(120)
+  void guardAndWeightInvariantsHoldUnderConcurrentMixedOperations() throws InterruptedException {
+    final ShardedPageCache<StubPage> cache = new ShardedPageCache<>(MAX_WEIGHT);
+    final PageReference[] refs = new PageReference[KEYS];
+    for (int i = 0; i < KEYS; i++) {
+      refs[i] = new PageReference().setKey(i);
+    }
+
+    final AtomicLong closedWhileGuarded = new AtomicLong();
+    final AtomicLong negativeGuardCounts = new AtomicLong();
+    final AtomicLong guardedPageObservedClosed = new AtomicLong();
+    final AtomicBoolean stop = new AtomicBoolean();
+    final CountDownLatch start = new CountDownLatch(1);
+    final ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+
+    for (int t = 0; t < THREADS; t++) {
+      final long seed = 0xC0FFEE + t;
+      pool.execute(() -> {
+        final Random random = new Random(seed);
+        await(start);
+        while (!stop.get()) {
+          final PageReference ref = refs[random.nextInt(KEYS)];
+          switch (random.nextInt(10)) {
+            case 0, 1, 2, 3, 4 -> { // guarded read/load (50%)
+              final StubPage page = cache.getOrLoadAndGuard(ref,
+                  key -> new StubPage(key.getKey(), closedWhileGuarded, negativeGuardCounts));
+              if (page != null) {
+                for (int i = 0; i < 20; i++) {
+                  Thread.onSpinWait();
+                }
+                if (page.isClosed()) {
+                  guardedPageObservedClosed.incrementAndGet();
+                }
+                page.releaseGuard();
+              }
+            }
+            case 5, 6 -> // unguarded read (20%)
+                cache.get(ref);
+            case 7 -> // replace (10%)
+                cache.put(ref, new StubPage(ref.getKey(), closedWhileGuarded, negativeGuardCounts));
+            case 8 -> // remove (10%)
+                cache.remove(ref);
+            default -> // forced pressure eviction (10%)
+                cache.evictUnderPressure();
+          }
+        }
+      });
+    }
+
+    start.countDown();
+    Thread.sleep(RUN_MILLIS);
+    stop.set(true);
+    pool.shutdown();
+    assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS), "threads must terminate");
+
+    assertEquals(0, guardedPageObservedClosed.get(),
+        "a page was closed while a caller still held its guard (use-after-free hazard)");
+    assertEquals(0, closedWhileGuarded.get(), "teardown ran while guards were held");
+    assertEquals(0, negativeGuardCounts.get(), "releaseGuard was called more often than acquireGuard");
+
+    // Weight accounting at quiescence: exactly PAGE_SIZE per live mapping, no drift.
+    final long expectedWeight = cache.asMap().size() * PAGE_SIZE;
+    assertEquals(expectedWeight, cache.getCurrentWeightBytes(),
+        "tracked weight drifted from the live mappings (" + cache.asMap().size() + " pages)");
+
+    cache.clear();
+    assertEquals(0, cache.asMap().size(), "clear() must empty the cache");
+    assertEquals(0, cache.getCurrentWeightBytes(), "clear() must return the weight account to zero");
+  }
+
+  private static void await(final CountDownLatch latch) {
+    try {
+      latch.await();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/diff/JsonDiffSerializerStaleTupleRegressionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/diff/JsonDiffSerializerStaleTupleRegressionTest.java
@@ -1,0 +1,142 @@
+package io.sirix.diff;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.json.objectvalue.NumberValue;
+import io.sirix.access.trx.node.json.objectvalue.ObjectValue;
+import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for stale diff tuples in the commit-time update-diff serialization
+ * (found by {@code JsonModelBasedOracleTest}, seed 987654321).
+ *
+ * <p>Updating a node and then removing one of its ancestors within the same transaction used to
+ * leave the UPDATED tuple in the operations log with a node key that no longer resolves in the
+ * new revision. {@code JsonDiffSerializer} then read from an unpositioned cursor and threw an
+ * NPE from {@code getName()} during commit — or, for other node kinds, silently wrote a corrupt
+ * diff file.
+ */
+final class JsonDiffSerializerStaleTupleRegressionTest {
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  void updateDescendantThenRemoveAncestorInSameTransactionCommitsCleanly() throws Exception {
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      // r1: { "a": { "b": 1 }, "keep": "x" }
+      wtx.insertObjectAsFirstChild();
+      final long rootKey = wtx.getNodeKey();
+      wtx.insertObjectRecordAsFirstChild("a", new ObjectValue());
+      final long aRecordKey = wtx.getNodeKey();
+      wtx.insertObjectRecordAsFirstChild("b", new NumberValue(1));
+      final long bRecordKey = wtx.getNodeKey();
+      wtx.moveTo(rootKey);
+      wtx.insertObjectRecordAsLastChild("keep", new StringValue("x"));
+      wtx.commit();
+
+      // r2: update the descendant "b", then remove its ancestor record "a" — the UPDATED tuple
+      // for "b" must not survive into the serialized diff. Before the fix this commit threw an
+      // NPE from JsonDiffSerializer.
+      wtx.moveTo(bRecordKey);
+      wtx.setNumberValue(2);
+      wtx.moveTo(aRecordKey);
+      wtx.remove();
+      wtx.commit();
+
+      final JsonArray diffs = readDiffs(session, 1, 2);
+      assertEquals(1, diffs.size(), "expected exactly the delete of record 'a': " + diffs);
+      final JsonObject only = diffs.get(0).getAsJsonObject();
+      assertTrue(only.has("delete"), "expected a delete entry: " + diffs);
+      assertEquals(aRecordKey, only.getAsJsonObject("delete").get("nodeKey").getAsLong());
+    }
+  }
+
+  @Test
+  void insertThenRemoveSameNodeInSameTransactionProducesEmptyDiff() throws Exception {
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      // r1: {}
+      wtx.insertObjectAsFirstChild();
+      final long rootKey = wtx.getNodeKey();
+      wtx.commit();
+
+      // r2: insert a record and remove it again within the same transaction — the node exists in
+      // neither revision boundary, so the diff must contain no operation referring to it.
+      wtx.moveTo(rootKey);
+      wtx.insertObjectRecordAsFirstChild("ephemeral", new StringValue("gone"));
+      wtx.remove();
+      wtx.commit();
+
+      final JsonArray diffs = readDiffs(session, 1, 2);
+      assertEquals(0, diffs.size(), "expected an empty diff: " + diffs);
+    }
+  }
+
+  @Test
+  void removeSubtreeWithEarlierInsertedDescendantOmitsTheInsert() throws Exception {
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      // r1: { "a": {} }
+      wtx.insertObjectAsFirstChild();
+      wtx.insertObjectRecordAsFirstChild("a", new ObjectValue());
+      final long aRecordKey = wtx.getNodeKey();
+      wtx.commit();
+
+      // r2: insert a fresh descendant under "a", then remove the whole "a" subtree. The
+      // INSERTED tuple of the descendant must be purged; only the delete of "a" remains.
+      wtx.moveTo(aRecordKey);
+      wtx.insertObjectRecordAsFirstChild("fresh", new NumberValue(7));
+      wtx.moveTo(aRecordKey);
+      wtx.remove();
+      wtx.commit();
+
+      final JsonArray diffs = readDiffs(session, 1, 2);
+      assertEquals(1, diffs.size(), "expected exactly the delete of record 'a': " + diffs);
+      final JsonObject only = diffs.get(0).getAsJsonObject();
+      assertTrue(only.has("delete"), "expected a delete entry: " + diffs);
+      assertFalse(only.has("insert"), "insert of a removed descendant must not appear: " + diffs);
+    }
+  }
+
+  private static JsonArray readDiffs(final JsonResourceSession session, final int oldRevision,
+      final int newRevision) throws Exception {
+    final Path diffFile = session.getResourceConfig()
+                                 .getResource()
+                                 .resolve(ResourceConfiguration.ResourcePaths.UPDATE_OPERATIONS.getPath())
+                                 .resolve("diffFromRev" + oldRevision + "toRev" + newRevision + ".json");
+    assertTrue(Files.exists(diffFile), "diff file must exist: " + diffFile);
+    final JsonObject diff = JsonParser.parseString(Files.readString(diffFile)).getAsJsonObject();
+    return diff.getAsJsonArray("diffs");
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInvariantValidator.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInvariantValidator.java
@@ -532,7 +532,7 @@ public final class HOTInvariantValidator {
     if (ref == null) return;
     final Page page = loadPage(ref);
     if (page instanceof HOTLeafPage leaf) {
-      visitor.test(leaf);
+      final boolean unusedVerdict = visitor.test(leaf);
       return;
     }
     if (page instanceof HOTIndirectPage indirect) {

--- a/bundles/sirix-core/src/test/java/io/sirix/property/JsonModelBasedOracleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/JsonModelBasedOracleTest.java
@@ -1,0 +1,501 @@
+package io.sirix.property;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.trx.node.json.objectvalue.ArrayValue;
+import io.sirix.access.trx.node.json.objectvalue.BooleanValue;
+import io.sirix.access.trx.node.json.objectvalue.NullValue;
+import io.sirix.access.trx.node.json.objectvalue.ObjectRecordValue;
+import io.sirix.access.trx.node.json.objectvalue.NumberValue;
+import io.sirix.access.trx.node.json.objectvalue.ObjectValue;
+import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.node.NodeKind;
+import io.sirix.service.json.serialize.JsonSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Model-based oracle test: the same random operation sequence is applied to a SirixDB JSON
+ * resource AND to a trivially-correct in-memory model (plain {@link LinkedHashMap}/
+ * {@link ArrayList} trees serialized by Jackson). After every commit the serialized resource must
+ * be semantically identical to the model; at the end, every historical revision must still match
+ * the snapshot taken right after its commit.
+ *
+ * <p>This catches semantic divergence that structural-invariant fuzzing cannot: an operation that
+ * keeps the tree well-formed but lands in the wrong place, drops a sibling, or mutates the wrong
+ * record still produces a well-formed — but wrong — document, and only an independent oracle
+ * notices.
+ *
+ * <p>On failure the seed and full operation log are printed for exact reproduction.
+ */
+final class JsonModelBasedOracleTest {
+
+  private static final ObjectMapper EXACT_MAPPER = JsonMapper.builder()
+      .enable(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)
+      .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+      .enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS)
+      .build();
+
+  private static final ObjectMapper PLAIN_MAPPER = new ObjectMapper();
+
+  private static final int OPS_PER_RUN = 60;
+  private static final int OPS_PER_COMMIT = 5;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @RepeatedTest(10)
+  void randomOperationSequenceMatchesOracle() {
+    runOracle(System.nanoTime());
+  }
+
+  /** Fixed seeds so every CI run replays known operation sequences deterministically. */
+  @ParameterizedTest
+  @ValueSource(longs = {1L, 42L, 4711L, 987654321L, -1348769044L})
+  void fixedSeedOperationSequenceMatchesOracle(final long seed) {
+    runOracle(seed);
+  }
+
+  private void runOracle(final long seed) {
+    final Random random = new Random(seed);
+    final List<String> opLog = new ArrayList<>();
+    final List<Integer> revisions = new ArrayList<>();
+    final List<String> snapshots = new ArrayList<>();
+
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      // Root container: object or array, mirrored in the model.
+      final Object modelRoot;
+      if (random.nextBoolean()) {
+        wtx.insertObjectAsFirstChild();
+        modelRoot = new LinkedHashMap<String, Object>();
+        opLog.add("root=object");
+      } else {
+        wtx.insertArrayAsFirstChild();
+        modelRoot = new ArrayList<>();
+        opLog.add("root=array");
+      }
+      wtx.commit();
+      compareAgainstModel(session, modelRoot, seed, opLog);
+      revisions.add(session.getMostRecentRevisionNumber());
+      snapshots.add(serialize(session, session.getMostRecentRevisionNumber()));
+
+      int sinceCommit = 0;
+      for (int op = 0; op < OPS_PER_RUN; op++) {
+        applyRandomOperation(wtx, modelRoot, random, opLog, op);
+        if (++sinceCommit == OPS_PER_COMMIT) {
+          sinceCommit = 0;
+          wtx.commit();
+          opLog.add("COMMIT -> r" + session.getMostRecentRevisionNumber());
+          compareAgainstModel(session, modelRoot, seed, opLog);
+          revisions.add(session.getMostRecentRevisionNumber());
+          snapshots.add(serialize(session, session.getMostRecentRevisionNumber()));
+        }
+      }
+      if (sinceCommit > 0) {
+        wtx.commit();
+        opLog.add("COMMIT -> r" + session.getMostRecentRevisionNumber());
+        compareAgainstModel(session, modelRoot, seed, opLog);
+        revisions.add(session.getMostRecentRevisionNumber());
+        snapshots.add(serialize(session, session.getMostRecentRevisionNumber()));
+      }
+
+      // Temporal check: every historical revision still serializes exactly as it did
+      // immediately after its commit.
+      for (int i = 0; i < revisions.size(); i++) {
+        assertEquals(snapshots.get(i), serialize(session, revisions.get(i)),
+            "Revision " + revisions.get(i) + " changed after later commits [seed=" + seed + "]\nops=" + opLog);
+      }
+    } catch (final AssertionError e) {
+      throw e;
+    } catch (final Exception e) {
+      fail("Exception [seed=" + seed + "]\nops=" + opLog, e);
+    }
+  }
+
+  // ==================== OPERATION APPLICATION ====================
+
+  private void applyRandomOperation(final JsonNodeTrx wtx, final Object modelRoot, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final List<Site> containers = new ArrayList<>();
+    final List<Site> leaves = new ArrayList<>();
+    collectSites(modelRoot, new ArrayList<>(), containers, leaves);
+
+    // Try up to a few times to pick an applicable operation.
+    for (int attempt = 0; attempt < 8; attempt++) {
+      final int choice = random.nextInt(10);
+      if (choice < 4) { // insert into a container (40%)
+        final Site site = containers.get(random.nextInt(containers.size()));
+        if (site.value() instanceof Map) {
+          insertField(wtx, site, random, opLog, opNumber);
+        } else {
+          insertArrayElement(wtx, site, random, opLog, opNumber);
+        }
+        return;
+      } else if (choice < 7) { // remove from a container (30%)
+        final Site site = containers.get(random.nextInt(containers.size()));
+        if (site.value() instanceof Map<?, ?> map && !map.isEmpty()) {
+          removeField(wtx, site, random, opLog, opNumber);
+          return;
+        }
+        if (site.value() instanceof List<?> list && !list.isEmpty()) {
+          removeArrayElement(wtx, site, random, opLog, opNumber);
+          return;
+        }
+      } else { // update a leaf value (30%)
+        if (!leaves.isEmpty()) {
+          updateLeaf(wtx, leaves.get(random.nextInt(leaves.size())), random, opLog, opNumber);
+          return;
+        }
+      }
+    }
+    // Fall back to an insert at the root container, which is always applicable.
+    final Site root = containers.get(0);
+    if (root.value instanceof Map) {
+      insertField(wtx, root, random, opLog, opNumber);
+    } else {
+      insertArrayElement(wtx, root, random, opLog, opNumber);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void insertField(final JsonNodeTrx wtx, final Site site, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final Map<String, Object> object = (Map<String, Object>) site.value();
+    final String key = freshKey(object, random);
+    final Object value = randomValue(random);
+    final boolean first = random.nextBoolean();
+
+    navigateTo(wtx, site.path());
+    if (first) {
+      wtx.insertObjectRecordAsFirstChild(key, toRecordValue(value));
+      final LinkedHashMap<String, Object> reordered = new LinkedHashMap<>();
+      reordered.put(key, value);
+      reordered.putAll(object);
+      object.clear();
+      object.putAll(reordered);
+    } else {
+      wtx.insertObjectRecordAsLastChild(key, toRecordValue(value));
+      object.put(key, value);
+    }
+    opLog.add("op#" + opNumber + " insertField " + (first ? "first" : "last") + " at " + site.path()
+        + " key=" + key + " value=" + describe(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void insertArrayElement(final JsonNodeTrx wtx, final Site site, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final List<Object> array = (List<Object>) site.value();
+    final int index = array.isEmpty() ? 0 : random.nextInt(array.size() + 1);
+    final Object value = randomValue(random);
+
+    navigateTo(wtx, site.path());
+    if (index == 0) {
+      insertValueAsFirstChild(wtx, value);
+    } else {
+      moveToChild(wtx, index - 1);
+      insertValueAsRightSibling(wtx, value);
+    }
+    array.add(index, value);
+    opLog.add("op#" + opNumber + " insertArrayElement at " + site.path() + " index=" + index
+        + " value=" + describe(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void removeField(final JsonNodeTrx wtx, final Site site, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final Map<String, Object> object = (Map<String, Object>) site.value();
+    final List<String> keys = new ArrayList<>(object.keySet());
+    final String key = keys.get(random.nextInt(keys.size()));
+
+    navigateTo(wtx, site.path());
+    moveToRecord(wtx, key);
+    wtx.remove();
+    object.remove(key);
+    opLog.add("op#" + opNumber + " removeField at " + site.path() + " key=" + key);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void removeArrayElement(final JsonNodeTrx wtx, final Site site, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final List<Object> array = (List<Object>) site.value();
+    final int index = random.nextInt(array.size());
+
+    navigateTo(wtx, site.path());
+    moveToChild(wtx, index);
+    wtx.remove();
+    array.remove(index);
+    opLog.add("op#" + opNumber + " removeArrayElement at " + site.path() + " index=" + index);
+  }
+
+  private void updateLeaf(final JsonNodeTrx wtx, final Site site, final Random random,
+      final List<String> opLog, final int opNumber) {
+    final Object oldValue = site.value();
+    final Object newValue;
+    if (oldValue instanceof String) {
+      newValue = randomString(random);
+      navigateTo(wtx, site.path());
+      wtx.setStringValue((String) newValue);
+    } else if (oldValue instanceof Boolean b) {
+      newValue = !b;
+      navigateTo(wtx, site.path());
+      wtx.setBooleanValue((Boolean) newValue);
+    } else if (oldValue instanceof Number) {
+      newValue = randomNumber(random);
+      navigateTo(wtx, site.path());
+      wtx.setNumberValue((Number) newValue);
+    } else {
+      // null leaves have no in-place setter — replace via container ops instead; skip.
+      opLog.add("op#" + opNumber + " skip update of null leaf at " + site.path());
+      return;
+    }
+    replaceLeafInParent(site, newValue);
+    opLog.add("op#" + opNumber + " updateLeaf at " + site.path() + " " + describe(oldValue)
+        + " -> " + describe(newValue));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void replaceLeafInParent(final Site site, final Object newValue) {
+    final Object parent = site.parent();
+    final Object lastSegment = site.path().get(site.path().size() - 1);
+    if (parent instanceof Map) {
+      ((Map<String, Object>) parent).put((String) lastSegment, newValue);
+    } else {
+      ((List<Object>) parent).set((Integer) lastSegment, newValue);
+    }
+  }
+
+  // ==================== SIRIX NAVIGATION ====================
+
+  /**
+   * Positions the cursor on the node addressed by {@code path} (segments: String = object field,
+   * Integer = array index). An empty path addresses the root container. Field segments land on the
+   * fused OBJECT_NAMED_* record, which itself plays the container/value role.
+   */
+  private void navigateTo(final JsonNodeTrx wtx, final List<Object> path) {
+    wtx.moveToDocumentRoot();
+    assertTrue(wtx.moveToFirstChild(), "document root must have a child");
+    for (final Object segment : path) {
+      if (segment instanceof String field) {
+        moveToRecord(wtx, field);
+      } else {
+        moveToChild(wtx, (Integer) segment);
+      }
+    }
+  }
+
+  /** From an object container node, moves to the record (fused OBJECT_NAMED_*) named {@code key}. */
+  private void moveToRecord(final JsonNodeTrx wtx, final String key) {
+    assertTrue(wtx.moveToFirstChild(), "object must have children when looking up key '" + key + "'");
+    while (true) {
+      final NodeKind kind = wtx.getKind();
+      if (kind.playsObjectKeyRole() && key.equals(wtx.getName().getLocalName())) {
+        return;
+      }
+      if (!wtx.moveToRightSibling()) {
+        fail("record '" + key + "' not found in object");
+      }
+    }
+  }
+
+  /** From a container node, moves to its {@code index}-th child. */
+  private void moveToChild(final JsonNodeTrx wtx, final int index) {
+    assertTrue(wtx.moveToFirstChild(), "container must have children");
+    for (int i = 0; i < index; i++) {
+      assertTrue(wtx.moveToRightSibling(), "container must have a child at index " + index);
+    }
+  }
+
+  private void insertValueAsFirstChild(final JsonNodeTrx wtx, final Object value) {
+    if (value instanceof String s) {
+      wtx.insertStringValueAsFirstChild(s);
+    } else if (value instanceof Boolean b) {
+      wtx.insertBooleanValueAsFirstChild(b);
+    } else if (value instanceof Number n) {
+      wtx.insertNumberValueAsFirstChild(n);
+    } else if (value instanceof Map) {
+      wtx.insertObjectAsFirstChild();
+    } else if (value instanceof List) {
+      wtx.insertArrayAsFirstChild();
+    } else {
+      wtx.insertNullValueAsFirstChild();
+    }
+  }
+
+  private void insertValueAsRightSibling(final JsonNodeTrx wtx, final Object value) {
+    if (value instanceof String s) {
+      wtx.insertStringValueAsRightSibling(s);
+    } else if (value instanceof Boolean b) {
+      wtx.insertBooleanValueAsRightSibling(b);
+    } else if (value instanceof Number n) {
+      wtx.insertNumberValueAsRightSibling(n);
+    } else if (value instanceof Map) {
+      wtx.insertObjectAsRightSibling();
+    } else if (value instanceof List) {
+      wtx.insertArrayAsRightSibling();
+    } else {
+      wtx.insertNullValueAsRightSibling();
+    }
+  }
+
+  private ObjectRecordValue<?> toRecordValue(final Object value) {
+    if (value instanceof String s) {
+      return new StringValue(s);
+    }
+    if (value instanceof Boolean b) {
+      return new BooleanValue(b);
+    }
+    if (value instanceof Number n) {
+      return new NumberValue(n);
+    }
+    if (value instanceof Map) {
+      return new ObjectValue();
+    }
+    if (value instanceof List) {
+      return new ArrayValue();
+    }
+    return new NullValue();
+  }
+
+  // ==================== MODEL WALKING / VALUE GENERATION ====================
+
+  /** A location in the model: the value, its parent container, and the path from the root. */
+  private record Site(Object value, Object parent, List<Object> path) {
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectSites(final Object node, final List<Object> path, final List<Site> containers,
+      final List<Site> leaves) {
+    collectSites(node, null, path, containers, leaves);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void collectSites(final Object node, final Object parent, final List<Object> path,
+      final List<Site> containers, final List<Site> leaves) {
+    if (node instanceof Map<?, ?> map) {
+      containers.add(new Site(node, parent, new ArrayList<>(path)));
+      for (final Map.Entry<?, ?> entry : map.entrySet()) {
+        path.add(entry.getKey());
+        collectSites(entry.getValue(), node, path, containers, leaves);
+        path.remove(path.size() - 1);
+      }
+    } else if (node instanceof List<?> list) {
+      containers.add(new Site(node, parent, new ArrayList<>(path)));
+      for (int i = 0; i < list.size(); i++) {
+        path.add(i);
+        collectSites(list.get(i), node, path, containers, leaves);
+        path.remove(path.size() - 1);
+      }
+    } else {
+      if (parent != null) {
+        leaves.add(new Site(node, parent, new ArrayList<>(path)));
+      }
+    }
+  }
+
+  private Object randomValue(final Random random) {
+    return switch (random.nextInt(8)) {
+      case 0, 1 -> randomString(random);
+      case 2, 3 -> randomNumber(random);
+      case 4 -> random.nextBoolean();
+      case 5 -> null;
+      case 6 -> new LinkedHashMap<String, Object>();
+      default -> new ArrayList<>();
+    };
+  }
+
+  private static final String[] EXOTIC_STRINGS = {"", "你好", "😀", "a\"b\\c", "line\nbreak", "tab\tchar"};
+
+  private String randomString(final Random random) {
+    if (random.nextInt(5) == 0) {
+      return EXOTIC_STRINGS[random.nextInt(EXOTIC_STRINGS.length)];
+    }
+    final int length = random.nextInt(10);
+    final StringBuilder builder = new StringBuilder(length);
+    for (int i = 0; i < length; i++) {
+      builder.append((char) ('a' + random.nextInt(26)));
+    }
+    return builder.toString();
+  }
+
+  private Number randomNumber(final Random random) {
+    return switch (random.nextInt(4)) {
+      case 0 -> random.nextInt();
+      case 1 -> random.nextLong();
+      case 2 -> random.nextInt(1000) + 0.25 * random.nextInt(4); // exact binary fractions
+      default -> random.nextInt(100);
+    };
+  }
+
+  private String freshKey(final Map<String, Object> object, final Random random) {
+    while (true) {
+      final String key = "k" + random.nextInt(10_000);
+      if (!object.containsKey(key)) {
+        return key;
+      }
+    }
+  }
+
+  private String describe(final Object value) {
+    if (value instanceof Map) {
+      return "{}";
+    }
+    if (value instanceof List) {
+      return "[]";
+    }
+    if (value instanceof String s) {
+      return "\"" + s + "\"";
+    }
+    return String.valueOf(value);
+  }
+
+  // ==================== ORACLE COMPARISON ====================
+
+  private void compareAgainstModel(final JsonResourceSession session, final Object modelRoot, final long seed,
+      final List<String> opLog) throws Exception {
+    final String modelJson = PLAIN_MAPPER.writeValueAsString(modelRoot);
+    final String sirixJson = serialize(session, session.getMostRecentRevisionNumber());
+    final JsonNode expected = EXACT_MAPPER.readTree(modelJson);
+    final JsonNode actual = EXACT_MAPPER.readTree(sirixJson);
+    assertEquals(expected, actual, () -> "Sirix diverged from the oracle model [seed=" + seed + "]\nmodel: "
+        + modelJson + "\nsirix: " + sirixJson + "\nops=" + opLog);
+  }
+
+  private static String serialize(final JsonResourceSession session, final int revision) throws Exception {
+    try (final Writer writer = new StringWriter()) {
+      new JsonSerializer.Builder(session, writer, revision).build().call();
+      return writer.toString();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/property/JsonRoundTripPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/JsonRoundTripPropertyTest.java
@@ -1,0 +1,260 @@
+package io.sirix.property;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Property-based (generative) correctness tests for the JSON shred → store → serialize pipeline.
+ *
+ * <p>Unlike the fixed-corpus {@code JsonCorrectnessSweepTest} and the seed-logged
+ * {@code JsonStructuralFuzzTest}, these properties let jqwik generate <em>arbitrary</em> JSON
+ * documents (bounded depth/size) and shrink any failure to a minimal counterexample. Two
+ * invariants are checked:
+ *
+ * <ol>
+ *   <li><b>Round-trip fidelity</b> — any generated document, shredded into a fresh resource and
+ *       serialized back, is semantically identical to the input (objects key-order-insensitive,
+ *       arrays order-sensitive, numbers by exact value via BigInteger/BigDecimal parsing).</li>
+ *   <li><b>Revision immutability</b> — committing new revisions never changes the serialized
+ *       output of any earlier revision (the core temporal-storage guarantee), and revision
+ *       timestamps are monotonically non-decreasing.</li>
+ * </ol>
+ *
+ * <p>On failure jqwik reports the seed and the shrunk counterexample; re-run with
+ * {@code @Property(seed = "...")} to reproduce.
+ */
+class JsonRoundTripPropertyTest {
+
+  private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
+
+  /**
+   * Exact-value mapper: integers as BigInteger, floats as BigDecimal, so numeric fidelity is
+   * checked without silent double rounding (same configuration as JsonCorrectnessSweepTest).
+   */
+  private static final ObjectMapper EXACT_MAPPER = JsonMapper.builder()
+      .enable(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS)
+      .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+      .enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS)
+      .build();
+
+  // ==================== PROPERTY 1: ROUND-TRIP FIDELITY ====================
+
+  @Property(tries = 40)
+  void shredThenSerializeRoundTripsAnyDocument(@ForAll("jsonContainers") final JsonNode document) throws Exception {
+    final String input = document.toString();
+    JsonTestHelper.deleteEverything();
+    try {
+      final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+      try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(input),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+        }
+        final String output = serialize(session, session.getMostRecentRevisionNumber());
+        final JsonNode expected = EXACT_MAPPER.readTree(input);
+        final JsonNode actual = EXACT_MAPPER.readTree(output);
+        assertEquals(expected, actual,
+            () -> "Round-trip mismatch.\ninput:  " + input + "\noutput: " + output);
+      }
+    } finally {
+      JsonTestHelper.deleteEverything();
+    }
+  }
+
+  // ==================== PROPERTY 2: REVISION IMMUTABILITY ====================
+
+  @Property(tries = 15)
+  void committingNewRevisionsNeverAltersEarlierRevisions(
+      @ForAll("jsonContainerLists") final List<JsonNode> documents,
+      @ForAll final long seed) throws Exception {
+    JsonTestHelper.deleteEverything();
+    try {
+      final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+      try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        final Random random = new Random(seed);
+        // Maps revision number -> serialized output captured right after that revision's commit.
+        final List<int[]> revisionNumbers = new ArrayList<>(documents.size() + 1);
+        final List<String> snapshots = new ArrayList<>(documents.size() + 1);
+
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertArrayAsFirstChild();
+          wtx.commit();
+          revisionNumbers.add(new int[] {session.getMostRecentRevisionNumber()});
+          snapshots.add(serialize(session, session.getMostRecentRevisionNumber()));
+
+          for (final JsonNode document : documents) {
+            wtx.moveToDocumentRoot();
+            assertTrue(wtx.moveToFirstChild(), "document root must have the array child");
+            // Occasionally delete the array's first element before appending, so revisions
+            // exercise removals as well as inserts.
+            if (random.nextInt(3) == 0 && wtx.hasFirstChild()) {
+              wtx.moveToFirstChild();
+              wtx.remove();
+              wtx.moveToDocumentRoot();
+              wtx.moveToFirstChild();
+            }
+            wtx.insertSubtreeAsLastChild(JsonShredder.createStringReader(document.toString()),
+                JsonNodeTrx.Commit.NO, JsonNodeTrx.CheckParentNode.YES, JsonNodeTrx.SkipRootToken.NO);
+            wtx.commit();
+            revisionNumbers.add(new int[] {session.getMostRecentRevisionNumber()});
+            snapshots.add(serialize(session, session.getMostRecentRevisionNumber()));
+          }
+        }
+
+        // Every earlier revision must serialize byte-identically to the snapshot taken
+        // immediately after its commit — later commits must not have altered it.
+        for (int i = 0; i < snapshots.size(); i++) {
+          final int revision = revisionNumbers.get(i)[0];
+          final String now = serialize(session, revision);
+          assertEquals(snapshots.get(i), now,
+              "Revision " + revision + " changed after later commits (temporal immutability violated)");
+        }
+
+        // Revision timestamps must be monotonically non-decreasing.
+        Instant previous = null;
+        for (final int[] revision : revisionNumbers) {
+          try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision[0])) {
+            final Instant timestamp = rtx.getRevisionTimestamp();
+            if (previous != null) {
+              assertFalse(timestamp.isBefore(previous),
+                  "Revision timestamps must not decrease: " + previous + " -> " + timestamp);
+            }
+            previous = timestamp;
+          }
+        }
+      }
+    } finally {
+      JsonTestHelper.deleteEverything();
+    }
+  }
+
+  private static String serialize(final JsonResourceSession session, final int revision) throws Exception {
+    try (final Writer writer = new StringWriter()) {
+      new JsonSerializer.Builder(session, writer, revision).build().call();
+      return writer.toString();
+    }
+  }
+
+  // ==================== GENERATORS ====================
+
+  @Provide
+  Arbitrary<JsonNode> jsonContainers() {
+    return containerNode(3);
+  }
+
+  @Provide
+  Arbitrary<List<JsonNode>> jsonContainerLists() {
+    return containerNode(2).list().ofMinSize(1).ofMaxSize(4);
+  }
+
+  /** A container (object or array) whose descendants may nest up to {@code depth} levels. */
+  private Arbitrary<JsonNode> containerNode(final int depth) {
+    return Arbitraries.oneOf(objectNode(depth), arrayNode(depth));
+  }
+
+  private Arbitrary<JsonNode> jsonValue(final int depth) {
+    if (depth <= 0) {
+      return leafNode();
+    }
+    return Arbitraries.frequencyOf(
+        Tuple.of(4, leafNode()),
+        Tuple.of(1, Arbitraries.lazy(() -> objectNode(depth - 1))),
+        Tuple.of(1, Arbitraries.lazy(() -> arrayNode(depth - 1))));
+  }
+
+  private Arbitrary<JsonNode> objectNode(final int depth) {
+    return Arbitraries.maps(keyStrings(), jsonValue(depth - 1)).ofMaxSize(5).map(map -> {
+      final ObjectNode object = FACTORY.objectNode();
+      for (final Map.Entry<String, JsonNode> entry : map.entrySet()) {
+        object.set(entry.getKey(), entry.getValue());
+      }
+      return object;
+    });
+  }
+
+  private Arbitrary<JsonNode> arrayNode(final int depth) {
+    return jsonValue(depth - 1).list().ofMaxSize(5).map(values -> {
+      final ArrayNode array = FACTORY.arrayNode();
+      for (final JsonNode value : values) {
+        array.add(value);
+      }
+      return array;
+    });
+  }
+
+  private Arbitrary<JsonNode> leafNode() {
+    return Arbitraries.oneOf(
+        valueStrings().map(FACTORY::textNode),
+        Arbitraries.integers().map(FACTORY::numberNode),
+        Arbitraries.longs().map(FACTORY::numberNode),
+        Arbitraries.doubles().map(FACTORY::numberNode),
+        bigIntegers().map(FACTORY::numberNode),
+        Arbitraries.of(true, false).map(FACTORY::booleanNode),
+        Arbitraries.just(FACTORY.nullNode()));
+  }
+
+  private Arbitrary<BigInteger> bigIntegers() {
+    // Beyond long range: exercises the exact-integer storage path (2^63 .. ~2^127).
+    return Arbitraries.longs().map(l -> BigInteger.valueOf(l).multiply(BigInteger.valueOf(Long.MAX_VALUE)));
+  }
+
+  private Arbitrary<String> valueStrings() {
+    final Arbitrary<String> basic = Arbitraries.strings()
+        .withCharRange((char) 0x20, (char) 0x7E)
+        .withCharRange((char) 0x00, (char) 0x1F)
+        .withCharRange(' ', '⿿')
+        .ofMaxLength(12);
+    // Fixed exotic samples: astral surrogate pairs, CJK, bidi marks (as escapes — raw
+    // directionality characters in source trip Error Prone's UnicodeDirectionalityCharacters),
+    // quotes/backslashes.
+    final Arbitrary<String> exotic = Arbitraries.of("😀🦄", "𝒜𝒱", "你好世界",
+        "\u202Ebidi\u202C", "\"quoted\\back\\\\slash\"", "");
+    return Arbitraries.frequencyOf(
+        Tuple.of(5, basic),
+        Tuple.of(1, exotic));
+  }
+
+  private Arbitrary<String> keyStrings() {
+    final Arbitrary<String> basic = Arbitraries.strings()
+        .withCharRange((char) 0x20, (char) 0x7E)
+        .ofMinLength(0)
+        .ofMaxLength(8);
+    final Arbitrary<String> exotic = Arbitraries.of("", "key with spaces", "ключ", "键", "a/b~c", "\"k\"");
+    return Arbitraries.frequencyOf(
+        Tuple.of(5, basic),
+        Tuple.of(1, exotic));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/JsonShredderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/JsonShredderTest.java
@@ -277,14 +277,22 @@ public final class JsonShredderTest {
       while (reader.peek() != JsonToken.END_DOCUMENT) {
         final var nextToken = reader.peek();
 
+        // Raw parse-throughput pump: values are materialized (real shredding cost) but
+        // deliberately discarded.
         switch (nextToken) {
           case BEGIN_OBJECT -> reader.beginObject();
-          case NAME -> reader.nextName();
+          case NAME -> {
+            final String unusedName = reader.nextName();
+          }
           case END_OBJECT -> reader.endObject();
           case BEGIN_ARRAY -> reader.beginArray();
           case END_ARRAY -> reader.endArray();
-          case STRING, NUMBER -> reader.nextString();
-          case BOOLEAN -> reader.nextBoolean();
+          case STRING, NUMBER -> {
+            final String unusedValue = reader.nextString();
+          }
+          case BOOLEAN -> {
+            final boolean unusedBoolean = reader.nextBoolean();
+          }
           case NULL -> reader.nextNull();
           // Node kind not known.
           default -> throw new AssertionError("Unexpected token: " + nextToken);

--- a/bundles/sirix-core/src/test/java/io/sirix/service/xml/shredder/XmlShredderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/xml/shredder/XmlShredderTest.java
@@ -186,8 +186,8 @@ public class XmlShredderTest {
             }
           }
         }
-        // noinspection ResultOfMethodCallIgnored
-        attributes.hasNext();
+        // Advances the axis by side effect; the result is checked on the next line.
+        final boolean unusedAdvance = attributes.hasNext();
 
         Assert.assertEquals(expectedAttributes.hasNext(), attributes.hasNext());
 

--- a/bundles/sirix-core/src/test/java/io/sirix/service/xml/xpath/comparators/NodeCompTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/xml/xpath/comparators/NodeCompTest.java
@@ -90,7 +90,7 @@ public class NodeCompTest {
   @Test
   public void testAtomize() throws SirixXPathException {
     Axis axis = new LiteralExpr(holder.getXmlNodeReadTrx(), -2);
-    axis.hasNext();
+    final boolean unusedLiteralAdvance = axis.hasNext();
     axis.next();
     AtomicValue[] value = comparator.atomize(axis);
     assertEquals(value.length, 1);
@@ -99,7 +99,7 @@ public class NodeCompTest {
 
     try {
       axis = new DescendantAxis(holder.getXmlNodeReadTrx());
-      axis.hasNext();
+      final boolean unusedDescendantAdvance = axis.hasNext();
       comparator.atomize(axis);
     } catch (SirixXPathException e) {
       assertEquals("err:XPTY0004 The type is not appropriate the expression or"

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,0 +1,112 @@
+# Verifying correctness (especially of AI-generated code)
+
+SirixDB is a temporal storage engine: a subtle bug does not just crash — it can silently corrupt
+data and only surface revisions later. This document maps the verification layers the project
+uses, what class of bug each layer catches, and how to run them. The layers are ordered by how
+well they catch the characteristic failure mode of AI-generated (and, frankly, human) code:
+*plausible-looking, locally correct, wrong about an invariant the author couldn't see*.
+
+## Layer map
+
+| Layer | What it proves | Where |
+|---|---|---|
+| Property-based tests (jqwik) | Round-trip fidelity and revision immutability hold for **arbitrary generated documents**, with automatic shrinking to a minimal counterexample | `sirix-core/src/test/java/io/sirix/property/JsonRoundTripPropertyTest.java` |
+| Model-based oracle | Random operation sequences produce **semantically identical** results in SirixDB and a trivially-correct in-memory model | `sirix-core/src/test/java/io/sirix/property/JsonModelBasedOracleTest.java` |
+| Structural-invariant fuzzing | Every mutation keeps sibling/parent/child links, childCount, descendantCount and hashes mutually consistent | `sirix-core/src/test/java/io/sirix/access/node/json/JsonStructuralFuzzTest.java` |
+| Fixed-corpus sweeps | Adversarial shapes (control chars, astral pairs, 2^128 numbers, …) round-trip and serialize valid metadata | `JsonCorrectnessSweepTest`, `JsonUnicodeTest`, `JsonNumberEdgeCaseTest` |
+| Concurrency invariant harnesses | Eviction watermark safety, slot-allocation exclusivity, guard/close protocol, cache weight accounting under contention | `RevisionEpochTrackerWatermarkSafetyTest`, `ShardedPageCacheInvariantStressTest` |
+| Crash injection / soak | Durability across simulated crashes; leak-free long-running bitemporal workloads | `crash/CrashRecoveryInjectionTest`, `stress/BitemporalSoakStressTest`, `stress.yml` workflow |
+| Mutation testing (PIT) | The tests **assert** on behavior instead of merely executing it — a surviving mutant is a code change no test noticed | `:sirix-core:pitest`, `verification.yml` workflow |
+| Error Prone + NullAway | Compile-time rejection of almost-always-bug patterns and nullness-contract violations | `-PerrorProne`, `verification.yml` workflow |
+| SonarQube / Checkstyle | Style and maintainability smells | `sonarqube.yml`, `checkstyle.xml` |
+
+## Why these layers, specifically
+
+**Property-based testing** states the invariant once ("any document shreds and serializes back to
+itself"; "no commit ever changes an earlier revision") and lets the framework hunt for the
+counterexample. You do not have to anticipate the edge case the code's author missed — which is
+precisely the blind spot when the author is an LLM. On failure, jqwik shrinks to a minimal
+counterexample and prints a seed; re-run with `@Property(seed = "...")` to reproduce.
+
+**Model-based oracle testing** catches semantic divergence that structural checking cannot: an
+operation that lands in the wrong place, drops a sibling, or mutates the wrong record still
+produces a *well-formed* tree — only an independent, trivially-correct implementation notices the
+document is now *wrong*. The oracle test replays the same random operations against SirixDB and a
+plain `LinkedHashMap`/`ArrayList` model and compares serialization after every commit, plus every
+historical revision at the end. It found a real bug on its first run (see below).
+
+**Concurrency invariant harnesses** verify the properties the structures actually promise, using
+a generation-stamped publication protocol so assertions are sound under concurrency (a checker
+only asserts when it can prove the observed state spanned the whole read). Framework
+linearizability checkers (Lincheck/jcstress) were evaluated and deliberately not adopted: the
+custom concurrent structures here either expose *by-design eventually-consistent* reads
+(`RevisionEpochTracker.minActiveRevision` is a lock-free scan) or hand out identity-based
+resources (pages, buffers), both of which break the deterministic sequential specification those
+tools require. The hand-rolled harnesses check exactly the contracts the code documents.
+
+**Mutation testing** guards the tests themselves. AI-generated tests tend to assert too little —
+they run the code and check something trivially true. PIT mutates the production code and reports
+which mutants the tests fail to kill. Scope is deliberately curated (see the `pitest` block in
+`bundles/sirix-core/build.gradle`); a whole-module run would take hours.
+
+**Error Prone** rejects bug patterns at compile time (bad equals/format strings/self-assignment
+and ~500 more); **NullAway** checks nullness contracts against the JSpecify annotations already
+used in the codebase. Both are opt-in (`-PerrorProne`) so the everyday build is unchanged, and run
+in CI via the `Deep verification` workflow.
+
+## Running the layers
+
+```bash
+# Generative + oracle + regression tests (fast, part of the normal test task)
+./gradlew :sirix-core:test --tests 'io.sirix.property.*' \
+                           --tests 'io.sirix.diff.JsonDiffSerializerStaleTupleRegressionTest'
+
+# Concurrency invariant harnesses
+./gradlew :sirix-core:test --tests 'io.sirix.access.trx.RevisionEpochTrackerWatermarkSafetyTest' \
+                           --tests 'io.sirix.cache.ShardedPageCacheInvariantStressTest'
+
+# Mutation testing (report: bundles/sirix-core/build/reports/pitest/index.html)
+./gradlew :sirix-core:pitest
+
+# Static bug detection
+./gradlew :sirix-core:compileJava :sirix-core:compileTestJava -PerrorProne
+```
+
+CI: the `Deep verification` workflow (`.github/workflows/verification.yml`) runs PIT and Error
+Prone weekly and on demand; the soak workflow (`stress.yml`) runs the bitemporal leak-detecting
+soak weekly and on demand.
+
+## Bugs found by these layers (evidence they work)
+
+* **Stale diff tuples after subtree removal** — updating a node and then removing one of its
+  ancestors in the same transaction left an UPDATED tuple whose node key no longer resolves;
+  `JsonDiffSerializer` then read from an unpositioned cursor and threw an NPE during commit (or
+  silently wrote corrupt diff files for other node kinds). Found by `JsonModelBasedOracleTest`
+  (seed `987654321`) on its first run; fixed in `JsonNodeTrxImpl.remove()` (descendant-tuple
+  purge) and hardened in `JsonDiffSerializer` (unresolvable tuples are skipped). Regression
+  coverage: `JsonDiffSerializerStaleTupleRegressionTest`.
+* **Cache weight-accounting drift** — `ShardedPageCache.evictUnderPressure()` and `removePage()`
+  subtracted page weight directly instead of releasing the recorded charge in `insertedWeights`;
+  the next insert under the same reference then computed a zero delta and was never charged, so
+  the tracked weight drifted toward zero and budget eviction stopped firing (unbounded memory
+  growth under pressure). Found by `ShardedPageCacheInvariantStressTest` on its first run.
+* **Error Prone first-run findings** — `ValueNodeDelegate` violated the equals/hashCode contract
+  (equals compared the value array by content, hashCode hashed its identity);
+  `EditScript.mChangeByNode` used an `IdentityHashMap` with boxed `Long` keys, so every
+  `containsKey`/`get` for node keys beyond the autobox cache silently missed;
+  `JsonNodeTrxImpl.moveToParentObjectKeyArrayOrDocumentRoot` tested the same node kind twice;
+  `HOTTrieWriter.walkLeavesUntilFalseInstance` ignored its visitor's stop-verdict (visited every
+  leaf regardless); `ConXPathAxisTest` swallowed XPath failures with no-op `getStackTrace()`
+  calls.
+
+## Checklist for new (AI-generated) changes
+
+1. State the invariants first; review them in English before reviewing the diff.
+2. If the change touches shred/serialize/mutate paths — extend or at least run the property and
+   oracle tests; a new operation belongs in the oracle's operation mix.
+3. If it touches concurrent structures — add an invariant harness with a provable claim window,
+   not just "run it on 8 threads and hope".
+4. Run `:sirix-core:pitest` scoped to the changed classes; a low kill rate means the new tests
+   are decorative.
+5. Never accept a green build as proof when the same author (human or model) wrote both the code
+   and its tests — the oracle/property layers exist precisely because they are independent.

--- a/libraries.gradle
+++ b/libraries.gradle
@@ -50,5 +50,6 @@ testLibraries = [
         junit                    : 'junit:junit:4.13.2',
         vertxJunit5              : "io.vertx:vertx-junit5:$vertxVersion",
         jsonassert               : 'org.skyscreamer:jsonassert:1.5.3',
-        assertjCore              : 'org.assertj:assertj-core:3.27.7'
+        assertjCore              : 'org.assertj:assertj-core:3.27.7',
+        jqwik                    : 'net.jqwik:jqwik:1.10.1'
 ]


### PR DESCRIPTION
## What does this PR do?

Adds the verification layers discussed for catching plausible-but-wrong (e.g. AI-generated) code, and fixes the real bugs those layers found on their first runs:

**New test layers (sirix-core):**
- **jqwik property-based tests** (`io.sirix.property.JsonRoundTripPropertyTest`): arbitrary generated JSON documents must shred → serialize back semantically identical (exact BigInteger/BigDecimal numeric comparison), and committing new revisions must never alter any earlier revision's serialization (monotonic revision timestamps included). Failures shrink to a minimal counterexample with a reproducible seed.
- **Model-based oracle test** (`io.sirix.property.JsonModelBasedOracleTest`): replays random operation sequences against both SirixDB and a trivially-correct in-memory model, comparing serialization after every commit and every historical revision at the end; fixed seeds replay deterministically in CI.
- **Concurrency invariant harnesses**: `RevisionEpochTrackerWatermarkSafetyTest` (generation-stamped protocol proving the MVCC eviction watermark never exceeds an actively held revision; no double slot allocation) and `ShardedPageCacheInvariantStressTest` (guard/orphan/close state machine and weight accounting under concurrent mixed operations).
- **PIT mutation testing** (`./gradlew :sirix-core:pitest`), scoped to curated correctness-critical classes, verified on JDK 25 (baseline: 402 mutants, 85 killed).
- **Error Prone 2.50 + NullAway**, opt-in via `-PerrorProne` (default build unchanged); sirix-core main + test sources compile clean.
- **`Deep verification` workflow** (weekly + manual) running PIT and Error Prone; **`docs/VERIFICATION.md`** documents all layers and how to run them.

**Bugs found by these layers and fixed here:**
1. **Commit-path NPE / corrupt update-diff files**: updating a node then removing one of its ancestors in the same transaction left stale UPDATED/INSERTED tuples whose node keys don't resolve in the new revision; `JsonDiffSerializer` then read from an unpositioned cursor. Fixed in `JsonNodeTrxImpl.remove()` (descendant-tuple purge, O(1) per removed node) with a defensive skip in the serializer. Found by the oracle test (seed 987654321); regression test added.
2. **Page-cache weight-accounting drift**: `evictUnderPressure()`/`removePage()` subtracted weight directly instead of releasing the recorded charge in `insertedWeights`, so re-inserted pages were never charged — tracked weight drifted to zero and budget eviction stopped firing. Found by the cache stress test.
3. **Error Prone findings**: equals/hashCode contract violation in `ValueNodeDelegate` (identity-hashed array vs content-compared equals); `EditScript` used `IdentityHashMap` with boxed `Long` keys (lookups silently missed for |key| > 127); duplicated condition in `JsonNodeTrxImpl.moveToParentObjectKeyArrayOrDocumentRoot`; `HOTTrieWriter.walkLeavesUntilFalseInstance` ignored its visitor's stop verdict; no-op `getStackTrace()` calls swallowing test failures.

## Related issue

No issue — follow-up to a discussion about how to verify that (AI-generated) code actually does what it's supposed to do without bugs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — affected sirix-core test packages (~6,600 tests) run green locally; full suite runs in this PR's CI
- [x] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — the epoch-tracker watermark safety (Inv 8) now has a dedicated concurrency test
- [x] Updated documentation (README / docs) where relevant — new `docs/VERIFICATION.md`
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- The everyday build is unchanged: Error Prone/NullAway only run with `-PerrorProne`, and PIT only when `:sirix-core:pitest` is invoked. The new `verification.yml` workflow is weekly/manual, not per-PR.
- Lincheck/jcstress were evaluated for the concurrency tests and deliberately not adopted: `minActiveRevision()` is eventually-consistent by design (lock-free scan) and caches hand out identity-based resources — both break framework linearizability checking. The hand-rolled harnesses check exactly the contracts the code documents; reasoning captured in `docs/VERIFICATION.md`.
- `HOTTrieWriter.walkLeavesUntilFalseInstance` now honors early termination as its name and callers intend; both existing callers already guarded against extra visits, so this is a behavior-tightening (and perf) fix, not a semantic change. HOT test suite passes locally.
- `EditScript.add` now actually deduplicates by node key (the IdentityHashMap guard was a no-op for realistic keys); FMSE/diff-export tests pass with the corrected semantics.
- PIT's baseline kill rate is the measurement, not a target — the surviving mutants map exactly to behavior (diagnostics paths, DeweyID-gated code) the scoped tests don't assert on yet.