### PR TITLE
Batch of audit-found correctness fixes (RB-tree cache, transaction, diff, serialization, concurrency, cache/IO, index, REST)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -567,7 +567,21 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
 
       nodeFactory = reInstantiateNodeFactory(storageEngineWriter);
 
+      // Re-bind nodeHashing to the NEW page transaction: AbstractNodeHashing holds a final
+      // reference to its StorageEngineWriter, and the old one was just closed by the abort. Without
+      // this, the first post-rollback mutation on a hash-enabled resource would call
+      // prepareRecordForModification on the closed writer and throw.
+      final boolean isBulkInsert = nodeHashing.isBulkInsert();
+      nodeHashing = reInstantiateNodeHashing(storageEngineWriter);
+      nodeHashing.setBulkInsert(isBulkInsert);
+
       reInstantiateIndexes();
+
+      // Discard update-operation tuples recorded before the rollback: their node keys belong to the
+      // aborted revision and must not leak into the next commit's diff (a later commit would
+      // otherwise serialize phantom operations that were never committed).
+      updateOperationsUnordered.clear();
+      updateOperationsOrdered.clear();
 
       // Re-read the current node from the new page transaction (FlyweightNode binding is stale).
       nodeReadOnlyTrx.moveTo(rollbackNodeKey);
@@ -620,6 +634,10 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
 
       // New index instances.
       reInstantiateIndexes();
+
+      // Discard update-operation tuples recorded against the reverted-from revision.
+      updateOperationsUnordered.clear();
+      updateOperationsOrdered.clear();
 
       // Reset modification counter.
       modificationCount = 0L;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -3977,7 +3977,8 @@ final class JsonNodeTrxImpl extends
     };
     switch (insert) {
       case AS_FIRST_CHILD -> insertObjectRecordWithPrimitiveAsFirstChild(keyName, value);
-      case AS_LEFT_SIBLING, AS_RIGHT_SIBLING -> insertObjectRecordWithPrimitiveAsRightSibling(keyName, value);
+      case AS_LEFT_SIBLING -> insertObjectRecordWithPrimitiveAsLeftSibling(keyName, value);
+      case AS_RIGHT_SIBLING -> insertObjectRecordWithPrimitiveAsRightSibling(keyName, value);
       default -> throw new IllegalStateException("unsupported copy insert position: " + insert);
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
@@ -993,12 +993,17 @@ final class XmlNodeTrxImpl extends
       final long leftSibKey = currentNode.getLeftSiblingKey();
       final long rightSibKey = currentNode.getNodeKey();
 
-      // Update value in case of adjacent text nodes.
+      // Update value in case of adjacent text nodes. `value` is appended unconditionally so that
+      // for a non-TEXT anchor (element/comment/PI) `builder` equals `value` and control falls
+      // through to inserting a new text node — mirroring insertTextAsRightSibling. Only when the
+      // anchor itself is a TEXT node do we merge (new text is prepended to the anchor's text, as
+      // this is a left-sibling insert). Previously `getValue()` was appended unconditionally, so a
+      // non-TEXT anchor took the setValue branch and threw (element) or dropped the insert (comment/PI).
       final StringBuilder builder = new StringBuilder(value.length() + 16);
+      builder.append(value);
       if (currentNodeKind == NodeKind.TEXT) {
-        builder.append(value);
+        builder.append(getValue());
       }
-      builder.append(getValue());
 
       if (!value.contentEquals(builder)) {
         setValue(builder.toString());

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/KeyedTrieWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/KeyedTrieWriter.java
@@ -21,6 +21,7 @@
 
 package io.sirix.access.trx.page;
 
+import java.util.ArrayList;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.cache.PageContainer;
@@ -133,8 +134,13 @@ final class KeyedTrieWriter {
       newReference.setKey(reference.getKey());
       newReference.setLogKey(reference.getLogKey());
       newReference.setActiveTilGeneration(reference.getActiveTilGeneration());
+      newReference.setDatabaseId(reference.getDatabaseId());
+      newReference.setResourceId(reference.getResourceId());
       newReference.setPage(reference.getPage());
-      newReference.setPageFragments(reference.getPageFragments());
+      newReference.setHash(reference.getHash());
+      // Copy the fragment list, never alias it: the new reference lives in a new revision and its
+      // fragment list must be able to diverge from the source's.
+      newReference.setPageFragments(new ArrayList<>(reference.getPageFragments()));
 
       // Create new page reference, add it to the transaction-log and reassign it in the root pages
       // of the trie.

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -1462,6 +1462,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
                    KeyValueLeafPage cachedPage = resourceBufferManager.getRecordPageFragmentCache()
                        .getOrLoadAndGuard(pageReference, _ -> (KeyValueLeafPage) loadedPage);
 
+                   // If another thread won the race, its instance is now cached and the page we
+                   // loaded from disk was never adopted — close it to free its off-heap segments
+                   // (production builds have no Cleaner fallback, so this would leak the slot).
+                   if (cachedPage != loadedPage) {
+                     ((KeyValueLeafPage) loadedPage).close();
+                   }
+
                    return (KeyValuePage<DataRecord>) cachedPage;
                  });
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentAxis.java
@@ -25,6 +25,7 @@ import io.sirix.api.Axis;
 import io.sirix.api.NodeCursor;
 import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.axis.AbstractAxis;
+import io.sirix.exception.SirixThreadedException;
 import io.sirix.utils.LogWrapper;
 import io.sirix.settings.Fixed;
 import org.slf4j.LoggerFactory;
@@ -155,7 +156,11 @@ public final class ConcurrentAxis<R extends NodeCursor & NodeReadOnlyTrx> extend
       result = results.take();
       LOGGER.debug("ConcurrentAxis got result: {}", result);
     } catch (final InterruptedException e) {
-      LOGGER.warn("Interrupted while waiting for results", e);
+      // Restore the interrupt flag and propagate: silently returning NULL_NODE_KEY here reported a
+      // clean, shorter result sequence (an incorrect query answer indistinguishable from success)
+      // and swallowed the cancellation signal.
+      Thread.currentThread().interrupt();
+      throw new SirixThreadedException(e);
     }
 
     // NULL_NODE_KEY marks end of the sequence computed by the producer.

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentExceptAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentExceptAxis.java
@@ -142,4 +142,17 @@ public final class ConcurrentExceptAxis<R extends NodeCursor & NodeReadOnlyTrx> 
 
     return done();
   }
+  /**
+   * Close both concurrent operands on termination. Each {@link ConcurrentAxis} runs a producer
+   * thread that blocks in {@code results.put(...)} on a bounded queue; when this set-operation axis
+   * finishes early (e.g. one operand exhausts while the other is mid-stream), the undrained
+   * producer would otherwise block forever, leaking a non-daemon thread and an open read
+   * transaction per query. close() shutdownNow()s the executor, interrupting the blocked put.
+   */
+  @Override
+  protected long done() {
+    op1.close();
+    op2.close();
+    return super.done();
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentIntersectAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentIntersectAxis.java
@@ -131,4 +131,17 @@ public final class ConcurrentIntersectAxis<R extends NodeCursor & NodeReadOnlyTr
     }
     return done();
   }
+  /**
+   * Close both concurrent operands on termination. Each {@link ConcurrentAxis} runs a producer
+   * thread that blocks in {@code results.put(...)} on a bounded queue; when this set-operation axis
+   * finishes early (e.g. one operand exhausts while the other is mid-stream), the undrained
+   * producer would otherwise block forever, leaking a non-daemon thread and an open read
+   * transaction per query. close() shutdownNow()s the executor, interrupting the blocked put.
+   */
+  @Override
+  protected long done() {
+    op1.close();
+    op2.close();
+    return super.done();
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentUnionAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/ConcurrentUnionAxis.java
@@ -137,4 +137,17 @@ public final class ConcurrentUnionAxis<R extends NodeCursor & NodeReadOnlyTrx> e
 
     return done();
   }
+  /**
+   * Close both concurrent operands on termination. Each {@link ConcurrentAxis} runs a producer
+   * thread that blocks in {@code results.put(...)} on a bounded queue; when this set-operation axis
+   * finishes early (e.g. one operand exhausts while the other is mid-stream), the undrained
+   * producer would otherwise block forever, leaking a non-daemon thread and an open read
+   * transaction per query. close() shutdownNow()s the executor, interrupting the blocked put.
+   */
+  @Override
+  protected long done() {
+    op1.close();
+    op2.close();
+    return super.done();
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -11,6 +11,8 @@ import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -285,6 +287,14 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   public void init(final long maxBufferSize) {
     if (initialized.compareAndSet(false, true)) {
       initInternal(maxBufferSize);
+    } else {
+      // Another thread already claimed initialization but may not have published `classes` yet
+      // (initInternal maps several large regions before assigning it). Wait for the volatile
+      // `classes` write so a caller never returns from init() — and then dereferences classes —
+      // while it is still null (the concurrent allocateSlot NPE window).
+      while (classes == null) {
+        Thread.onSpinWait();
+      }
     }
   }
 
@@ -704,11 +714,22 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    * not release the slot. Close exactly once to return it to the free stack.
    */
   public static final class FrameSlot implements AutoCloseable {
+    private static final VarHandle CLOSED;
+
+    static {
+      try {
+        CLOSED = MethodHandles.lookup().findVarHandle(FrameSlot.class, "closed", boolean.class);
+      } catch (final ReflectiveOperationException e) {
+        throw new ExceptionInInitializerError(e);
+      }
+    }
+
     private final FrameSlotAllocator owner;
     private final int classIdx;
     private final int slotIdx;
     private final long versionAtAlloc;
     private final MemorySegment segment;
+    @SuppressWarnings("unused") // accessed via the CLOSED VarHandle
     private volatile boolean closed;
 
     FrameSlot(final FrameSlotAllocator owner, final int classIdx, final int slotIdx,
@@ -739,10 +760,12 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
 
     @Override
     public void close() {
-      if (closed) {
+      // Atomic close guard: a non-atomic check-then-set let two threads closing the same handle
+      // both reach releaseSlot, pushing the slot index onto the free stack twice (two allocations
+      // then own one slot) and double-decrementing the budget. CAS ensures exactly one closer.
+      if (!CLOSED.compareAndSet(this, false, true)) {
         return;
       }
-      closed = true;
       owner.releaseSlot(classIdx, slotIdx);
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/WindowsMemorySegmentAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/WindowsMemorySegmentAllocator.java
@@ -136,6 +136,22 @@ public final class WindowsMemorySegmentAllocator implements MemorySegmentAllocat
    * @return The allocated MemorySegment.
    */
   public MemorySegment allocate(long size) {
+    // Reuse a released segment before VirtualAlloc'ing a new one: release() pools segments by size
+    // class, but this method never polled that pool, so every allocation was a fresh VirtualAlloc
+    // and every release parked a segment forever — native memory grew unbounded with read traffic.
+    // Only reuse a pooled segment that is at least `size` bytes (the pool may hold a smaller raw
+    // segment filed under the same rounded class); slice it to the requested size for the caller.
+    final int index = SegmentAllocators.getIndexForSize(size);
+    if (index >= 0 && index < segmentPools.length) {
+      final MemorySegment pooled = segmentPools[index].poll();
+      if (pooled != null) {
+        if (pooled.byteSize() >= size) {
+          return pooled.byteSize() == size ? pooled : pooled.asSlice(0, size);
+        }
+        // Too small to satisfy this request — hand it back and fall through to a fresh allocation.
+        segmentPools[index].offer(pooled);
+      }
+    }
     try {
       MemorySegment address =
           (MemorySegment) virtualAllocHandle.invoke(MemorySegment.NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/AbstractDiff.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/AbstractDiff.java
@@ -327,7 +327,10 @@ abstract class AbstractDiff<R extends NodeReadOnlyTrx & NodeCursor, W extends No
       while (moveCursor(newRtx, Revision.NEW, Move.DOCUMENT_ORDER)) {
         final DiffDepth depth = new DiffDepth(this.depth.getNewDepth(), this.depth.getOldDepth());
         fireDiff(DiffType.INSERTED, newRtx.getNodeKey(), oldRtx.getNodeKey(), depth);
-        emitNonStructuralDiff(newRtx, oldRtx, depth, DiffType.DELETED);
+        // INSERTED, not DELETED: this walks the NEW subtree, so its attribute/namespace diffs are
+        // insertions. emitNonStructuralDiff's DELETED branch iterates the old cursor and would emit
+        // spurious deletes while missing the real attribute inserts (mirror of fireDeletes).
+        emitNonStructuralDiff(newRtx, oldRtx, depth, DiffType.INSERTED);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/algorithm/fmse/FMSE.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/algorithm/fmse/FMSE.java
@@ -139,6 +139,9 @@ public final class FMSE implements ImportDiff, AutoCloseable {
   /** Path summary reader for the new revision. */
   private PathSummaryReader newPathSummary;
 
+  /** Set once {@link #diff} completes without throwing; gates the commit in {@link #close}. */
+  private boolean diffSucceeded;
+
   /** The node comparison factory to check leaf/inner nodes for a matching candidate. */
   private final NodeComparisonFactory nodeComparisonFactory;
 
@@ -201,6 +204,7 @@ public final class FMSE implements ImportDiff, AutoCloseable {
     totalMatching = new Matching(fastMatching);
     firstFMESStep(this.wtx, this.rtx);
     secondFMESStep(this.wtx, this.rtx);
+    diffSucceeded = true;
   }
 
   /**
@@ -694,6 +698,11 @@ public final class FMSE implements ImportDiff, AutoCloseable {
                     }
                     oldAxis.asXmlNodeReadTrx().moveTo(oldNodeKey);
                   }
+                  // Restore the old write cursor to the element after the inner loop, regardless of
+                  // whether a match broke out early: on a match the loop skipped the restore above,
+                  // leaving wtx parked on the matched attribute, so the next i-iteration's
+                  // wtx.moveToAttribute(0) ran from an attribute (no-op) and compared a stale name.
+                  wtx.moveTo(oldNodeKey);
                   newAxis.asXmlNodeReadTrx().moveTo(newNodeKey);
                 }
               }
@@ -709,6 +718,8 @@ public final class FMSE implements ImportDiff, AutoCloseable {
                     }
                     oldAxis.asXmlNodeReadTrx().moveTo(oldNodeKey);
                   }
+                  // Restore wtx to the element after the inner loop (see the attribute loop above).
+                  wtx.moveTo(oldNodeKey);
                   newAxis.asXmlNodeReadTrx().moveTo(newNodeKey);
                 }
               }
@@ -951,8 +962,25 @@ public final class FMSE implements ImportDiff, AutoCloseable {
 
   @Override
   public void close() {
-    wtx.commit();
-    oldPathSummary.close();
-    newPathSummary.close();
+    try {
+      // Commit only a fully-applied edit script. If diff() threw partway through, the mutations so
+      // far must be rolled back — try-with-resources otherwise commits a half-applied, corrupt
+      // revision (neither the old nor the new document). Guard wtx too: close() before a successful
+      // diff() (wtx == null) must not NPE.
+      if (wtx != null) {
+        if (diffSucceeded) {
+          wtx.commit();
+        } else {
+          wtx.rollback();
+        }
+      }
+    } finally {
+      if (oldPathSummary != null) {
+        oldPathSummary.close();
+      }
+      if (newPathSummary != null) {
+        newPathSummary.close();
+      }
+    }
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/algorithm/fmse/json/JsonFMSE.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/algorithm/fmse/json/JsonFMSE.java
@@ -72,6 +72,9 @@ public final class JsonFMSE implements JsonImportDiff, AutoCloseable {
   /** Write transaction on old revision. */
   private JsonNodeTrx wtx;
 
+  /** Set once {@link #diff} completes without throwing; gates the commit in {@link #close}. */
+  private boolean diffSucceeded;
+
   /** Read-only transaction on new revision. */
   private JsonNodeReadOnlyTrx rtx;
 
@@ -121,6 +124,7 @@ public final class JsonFMSE implements JsonImportDiff, AutoCloseable {
     totalMatching = new JsonMatching(fastMatching);
     firstFMESStep(this.wtx, this.rtx);
     secondFMESStep(this.wtx, this.rtx);
+    diffSucceeded = true;
   }
 
   // ==================== Initialization ====================
@@ -695,8 +699,14 @@ public final class JsonFMSE implements JsonImportDiff, AutoCloseable {
 
   @Override
   public void close() {
+    // Commit only a fully-applied edit script; a diff() that threw partway must roll back rather
+    // than durably persist a half-applied revision (try-with-resources always calls close()).
     if (wtx != null) {
-      wtx.commit();
+      if (diffSucceeded) {
+        wtx.commit();
+      } else {
+        wtx.rollback();
+      }
     }
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/diff/export/EditScript.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/diff/export/EditScript.java
@@ -124,7 +124,8 @@ public final class EditScript implements Iterator<DiffTuple>, Iterable<DiffTuple
     }
 
     mChanges.add(change);
-    return mChangeByNode.put(nodeKey, change);
+    mChangeByNode.put(nodeKey, change);
+    return change;
   }
 
   @Override
@@ -134,10 +135,10 @@ public final class EditScript implements Iterator<DiffTuple>, Iterable<DiffTuple
 
   @Override
   public boolean hasNext() {
-    if (mIndex < mChanges.size() - 1) {
-      return true;
-    }
-    return false;
+    // NOT size() - 1: next() consumes index mIndex, so the last element (index size()-1) is still
+    // pending when mIndex == size()-1. The off-by-one dropped the final edit for consumers driving
+    // the script via while (hasNext()) next().
+    return mIndex < mChanges.size();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
@@ -146,7 +146,12 @@ public final class RBTreeReader<K extends Comparable<? super K>, V extends Refer
         assert node.getNodeKey() != 0;
         final var cacheKey = new RBIndexKey(storageEngineReader.getDatabaseId(), storageEngineReader.getResourceId(),
             node.getNodeKey(), revisionNumber, indexType, indexNumber);
-        this.cache.put(cacheKey, getCurrentNodeAsRBNodeKey());
+        // Cache the node the key was built from — NOT getCurrentNodeAsRBNodeKey(): the iterator's
+        // computeNext() runs stackOperation(node), which leaves the read cursor parked on node's
+        // left child (when present). Caching the cursor node stored the left child under the
+        // parent's key, so later cache hits during index searches compared the wrong key and
+        // descended the wrong subtree (missing existing entries).
+        this.cache.put(cacheKey, node);
       }
       setCurrentNode(currentNode);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeWriter.java
@@ -261,13 +261,17 @@ public final class RBTreeWriter<K extends Comparable<? super K>, V extends Refer
     if (searchedValue.isPresent()) {
       final V value = searchedValue.get();
 
-      removed = value.removeNodeKey(nodeKey);
-
-      if (removed) {
+      // Check membership WITHOUT mutating the value: get() returns the live record from the shared
+      // page cache / TIL, so removing the node key here (before copy-on-write) would strip it from
+      // the committed revision's record — a concurrent read-only trx scanning the index would miss
+      // it (snapshot-isolation leak), and a rollback would leave the in-memory record corrupted.
+      // Mutate only the copy-on-write instance returned by prepareRecordForModification. Mirrors
+      // the clone discipline already applied to the insert paths (see NameIndexListener).
+      if (value.contains(nodeKey)) {
         @SuppressWarnings("DataFlowIssue")
         final RBNodeValue<V> node = storageEngineWriter.prepareRecordForModification(
             rbTreeReader.getCurrentNodeAsRBNodeKey().getValueNodeKey(), rbTreeReader.indexType, rbTreeReader.index);
-        node.getValue().removeNodeKey(nodeKey);
+        removed = node.getValue().removeNodeKey(nodeKey);
       }
     }
     return removed;

--- a/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/ByteHandlerPipeline.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/ByteHandlerPipeline.java
@@ -180,7 +180,18 @@ public final class ByteHandlerPipeline implements ByteHandler {
 
     for (int i = 0; i < byteHandlers.size(); i++) {
       ByteHandler handler = byteHandlers.get(i);
-      DecompressionResult result = handler.decompressScoped(current);
+      final DecompressionResult result;
+      try {
+        result = handler.decompressScoped(current);
+      } catch (final RuntimeException e) {
+        // A later handler threw (e.g. corrupt payload). Release the intermediate buffer produced by
+        // the previous handler before rethrowing — otherwise its allocator-owned segment leaks, and
+        // repeated corrupt reads drain the frame-slot budget into an OutOfMemoryError.
+        if (releaser != null) {
+          releaser.run();
+        }
+        throw e;
+      }
 
       // Release previous buffer (if any), keep the latest
       if (releaser != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMStorage.java
@@ -241,9 +241,14 @@ public final class MMStorage implements IOStorage {
 
   @Override
   public Reader createReader() {
+    // Guard the release with the acquired flag: release() must run ONLY after a successful acquire.
+    // Previously the finally released unconditionally, so a failed tryAcquire / timeout, or a throw
+    // from validateSuperblocksOnce before the acquire, each added a permit to the Semaphore(1),
+    // permanently defeating the intended mutual exclusion.
+    boolean sempahoreAcquired = false;
     try {
       validateSuperblocksOnce();
-      final var sempahoreAcquired = semaphore.tryAcquire(5, TimeUnit.SECONDS);
+      sempahoreAcquired = semaphore.tryAcquire(5, TimeUnit.SECONDS);
 
       if (!sempahoreAcquired) {
         throw new IllegalStateException("Couldn't acquire semaphore.");
@@ -298,7 +303,9 @@ public final class MMStorage implements IOStorage {
     } catch (final IOException | InterruptedException e) {
       throw new SirixIOException(e);
     } finally {
-      semaphore.release();
+      if (sempahoreAcquired) {
+        semaphore.release();
+      }
     }
   }
 
@@ -336,9 +343,12 @@ public final class MMStorage implements IOStorage {
 
   @Override
   public synchronized Writer createWriter() {
+    // Guard the release with the acquired flag (see createReader) — a failed acquire must not add a
+    // permit to the Semaphore(1).
+    boolean sempahoreAcquired = false;
     try {
       validateSuperblocksOnce();
-      final var sempahoreAcquired = semaphore.tryAcquire(5, TimeUnit.SECONDS);
+      sempahoreAcquired = semaphore.tryAcquire(5, TimeUnit.SECONDS);
 
       if (!sempahoreAcquired) {
         throw new IllegalStateException("Couldn't acquire semaphore.");
@@ -368,7 +378,9 @@ public final class MMStorage implements IOStorage {
     } catch (final IOException | InterruptedException e) {
       throw new SirixIOException(e);
     } finally {
-      semaphore.release();
+      if (sempahoreAcquired) {
+        semaphore.release();
+      }
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/BitmapReferencesPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/BitmapReferencesPage.java
@@ -30,7 +30,6 @@ import io.sirix.page.SerializationType;
 import io.sirix.page.interfaces.Page;
 import io.sirix.settings.Constants;
 
-import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/BitmapReferencesPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/BitmapReferencesPage.java
@@ -131,16 +131,9 @@ public final class BitmapReferencesPage implements Page {
     references = new GapList<>(length);
 
     for (int offset = 0; offset < length; offset++) {
-      final PageReference pageReference = new PageReference();
-      final var pageReferenceToClone = pageToClone.getReferences().get(offset);
-      pageReference.setKey(pageReferenceToClone.getKey());
-      pageReference.setPage(pageReferenceToClone.getPage());
-      pageReference.setLogKey(pageReferenceToClone.getLogKey());
-      pageReference.setActiveTilGeneration(pageReferenceToClone.getActiveTilGeneration());
-      pageReference.setDatabaseId(pageReferenceToClone.getDatabaseId());
-      pageReference.setResourceId(pageReferenceToClone.getResourceId());
-      pageReference.setPageFragments(new ArrayList<>(pageReferenceToClone.getPageFragments()));
-      references.add(offset, pageReference);
+      // Route through the PageReference copy constructor (copies hashInBytes + fragments, nulls a
+      // resolvable swizzle) — a manual copy dropped the hash, disabling checksum verification.
+      references.add(offset, new PageReference(pageToClone.getReferences().get(offset)));
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/FullReferencesPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/FullReferencesPage.java
@@ -79,20 +79,11 @@ public final class FullReferencesPage implements Page {
     references = new PageReference[Constants.INP_REFERENCE_COUNT];
 
     for (int index = 0, size = pageToClone.references.length; index < size; index++) {
-      final var pageReference = new PageReference();
       final var pageReferenceToClone = pageToClone.getReferences().get(index);
-
-      if (pageReferenceToClone != null) {
-        pageReference.setPage(pageReferenceToClone.getPage());
-        pageReference.setKey(pageReferenceToClone.getKey());
-        pageReference.setLogKey(pageReferenceToClone.getLogKey());
-        pageReference.setActiveTilGeneration(pageReferenceToClone.getActiveTilGeneration());
-        pageReference.setDatabaseId(pageReferenceToClone.getDatabaseId());
-        pageReference.setResourceId(pageReferenceToClone.getResourceId());
-        pageReference.setPageFragments(new ArrayList<>(pageReferenceToClone.getPageFragments()));
-      }
-
-      references[index] = pageReference;
+      // Route through the PageReference copy constructor (copies hashInBytes + fragments, nulls a
+      // resolvable swizzle) — a manual copy dropped the hash, disabling checksum verification.
+      references[index] =
+          pageReferenceToClone != null ? new PageReference(pageReferenceToClone) : new PageReference();
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/FullReferencesPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/FullReferencesPage.java
@@ -29,7 +29,6 @@ import io.sirix.page.interfaces.Page;
 import io.sirix.settings.Constants;
 import io.sirix.node.BytesIn;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/delegates/ReferencesPage4.java
@@ -81,19 +81,12 @@ public final class ReferencesPage4 implements Page {
 
     for (int offset = 0, size = otherOffsets.size(); offset < size; offset++) {
       offsets.add(otherOffsets.getShort(offset));
-      final var pageReference = new PageReference();
-      final var pageReferenceToClone = pageToClone.getReferences().get(offset);
-      pageReference.setKey(pageReferenceToClone.getKey());
-      pageReference.setLogKey(pageReferenceToClone.getLogKey());
-      pageReference.setActiveTilGeneration(pageReferenceToClone.getActiveTilGeneration());
-      pageReference.setDatabaseId(pageReferenceToClone.getDatabaseId());
-      pageReference.setResourceId(pageReferenceToClone.getResourceId());
-      pageReference.setPage(pageReferenceToClone.getPage());
-      // Copy the list, never alias it: the clone lives in a new revision and its fragment list
-      // must be able to diverge from the committed page's (FullReferencesPage and
-      // BitmapReferencesPage already copy).
-      pageReference.setPageFragments(new ArrayList<>(pageReferenceToClone.getPageFragments()));
-      references.add(pageReference);
+      // Route through the PageReference copy constructor: it copies the page hash (a manual
+      // field-by-field copy dropped hashInBytes, silently disabling checksum verification for
+      // unchanged children in every CoW'd revision), copies the fragment list freshly, and nulls
+      // the swizzled pointer when the reference is resolvable via logKey/disk key (an eagerly
+      // copied pointer can go stale and be read after free through recycled frames).
+      references.add(new PageReference(pageToClone.getReferences().get(offset)));
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -194,9 +194,21 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
                 "XQuery-result serialization with maxLevel/maxChildren/maxNodes limits is not supported: "
                     + "JsonLimitedSerializer lacks the named-member result wrap (see emitRevisionStartNode).");
           }
+          // Expand the "serialize all revisions" convention (revisions[0] < 0) into an explicit
+          // 1..mostRecentRevision list, mirroring AbstractSerializer.call(). JsonLimitedSerializer
+          // opens the revision numbers verbatim (no < 0 handling), so without this it would attempt
+          // beginNodeReadOnlyTrx(-1) and fail.
+          int[] effectiveRevisions = revisions;
+          if (revisions.length == 1 && revisions[0] < 0) {
+            final int mostRecent = resourceSession.getMostRecentRevisionNumber();
+            effectiveRevisions = new int[mostRecent];
+            for (int r = 0; r < mostRecent; r++) {
+              effectiveRevisions[r] = r + 1;
+            }
+          }
           // Use JsonLimitedSerializer for proper limit handling
           JsonLimitedSerializer.Builder limitedBuilder =
-              new JsonLimitedSerializer.Builder(resourceSession, out, revisions).startNodeKey(startNodeKey)
+              new JsonLimitedSerializer.Builder(resourceSession, out, effectiveRevisions).startNodeKey(startNodeKey)
                                                                                 .maxLevel(hasLevelLimit
                                                                                     ? (int) maxLevelLimit
                                                                                     : 0)
@@ -495,7 +507,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
           throw new IllegalStateException("Node kind not known!");
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -704,7 +716,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
         }
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -733,7 +745,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
         appendArrayStart(true);
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -752,7 +764,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
         appendArrayEnd(true).appendObjectEnd(true);
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -803,7 +815,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
         }
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -858,7 +870,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
           appendSeparator();
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/service/xml/serialize/XmlSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/xml/serialize/XmlSerializer.java
@@ -245,7 +245,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
           throw new IllegalStateException("Node kind not known!");
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -261,7 +261,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
         out.write(CharsForSerializing.NEWLINE.getBytes());
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -301,7 +301,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
         }
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -327,7 +327,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
 
       out.flush();
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -379,7 +379,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
         }
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 
@@ -405,7 +405,7 @@ public final class XmlSerializer extends AbstractSerializer<XmlNodeReadOnlyTrx, 
         out.write(CharsForSerializing.NEWLINE.getBytes());
       }
     } catch (final IOException e) {
-      LOGWRAPPER.error(e.getMessage(), e);
+      throw new java.io.UncheckedIOException(e);
     }
   }
 

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/SirixVerticle.kt
@@ -248,6 +248,14 @@ class SirixVerticle : CoroutineVerticle() {
             "cors.allowedOriginPattern",
             "*"
         )
+        val allowCredentials = config.getBoolean("cors.allowCredentials", false)
+        // Reject the credentialed-wildcard combination at startup. A reflected/wildcard origin with
+        // Access-Control-Allow-Credentials: true lets any site issue credentialed cross-origin
+        // reads against the API (and bypasses the browser's "no * with credentials" guard). Require
+        // an explicit origin list when credentials are enabled.
+        require(!(allowCredentials && ("*" == allowedOriginPattern || ".*" == allowedOriginPattern))) {
+            "cors.allowCredentials=true requires an explicit cors.allowedOriginPattern (not '*'/'.*')."
+        }
         if ("*" == allowedOriginPattern) {
             allowedOriginPattern = ".*"
         }
@@ -257,9 +265,7 @@ class SirixVerticle : CoroutineVerticle() {
                 .addOriginWithRegex(allowedOriginPattern)
                 .allowedHeaders(allowedHeaders)
                 .allowedMethods(allowedMethods)
-                .allowCredentials(
-                    config.getBoolean("cors.allowCredentials", false)
-                )
+                .allowCredentials(allowCredentials)
         )
 
         // Security headers

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/DiffHandler.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/DiffHandler.kt
@@ -195,6 +195,11 @@ class DiffHandler(private val location: Path, private val authz: AuthorizationPr
                                 includeData
                             )
                         }
+                    } else {
+                        // Diff is only implemented for JSON resources. Without this the XML branch
+                        // left diffString null and the response path dereferenced diff!!, producing
+                        // an opaque 500. Fail with a clear 400 instead.
+                        throw IllegalArgumentException("Diffing is only supported for JSON resources.")
                     }
                 }
             }


### PR DESCRIPTION
## What does this PR do?

Fixes a batch of correctness bugs found by the systematic code audit (issues #1058–#1080). Grouped by subsystem; each commit/issue has a concrete failure scenario in its issue. All touched test suites pass locally (diff, index/RB-tree, JSON/XML serialization, concurrent axes, JSON/XML node trx, io, page, cache).

**RB-tree index cache** (#1063): warm-up loop cached the cursor node (left child, left parked by the iterator's `stackOperation`) under the parent's key → wrong index lookups. Cache the iterator's node directly.

**Transaction layer**
- #1058 `XmlNodeTrxImpl.insertTextAsLeftSibling`: non-TEXT anchor now inserts a text node instead of throwing (element) / silently dropping (comment/PI).
- #1059 `copySubtreeAsLeftSibling` of a fused primitive record now inserts on the left.
- #1060 `rollback()` re-instantiates `nodeHashing` against the new page trx and clears the update-operation maps (revertTo too).

**Diff / serialization**
- #1066 `AbstractDiff.fireInserts` emits attribute/namespace diffs of an inserted subtree as INSERTED, not DELETED.
- #1067 `FMSE`/`JsonFMSE.close()` commit only a fully-applied edit script, else roll back; path summaries closed in finally.
- #1068 JSON/XML serializers rethrow per-node `IOException` instead of logging and continuing (silently produced invalid output).
- #1069 `JsonSerializer.call()` expands the `revisions[0] < 0` "all revisions" convention before delegating to `JsonLimitedSerializer`.
- #1074 `EditScript.hasNext()` off-by-one + `add()` return value; `FMSE.emitInsert` cursor restore.

**Concurrency / axes**
- #1064 concurrent set-op axes close both operands on termination (no leaked producer threads / read-trx).
- #1074 `ConcurrentAxis` restores the interrupt and propagates instead of silently truncating.

**Cache / IO**
- #1071 `WindowsMemorySegmentAllocator.allocate` polls the pool before `VirtualAlloc` (Windows-only unbounded leak).
- #1072 `MMStorage` guards the semaphore release with the acquired flag.
- #1073 `FrameSlotAllocator` atomic `FrameSlot.close()` CAS; `init()` waits for `classes` publication.
- #1078 `readPage` closes a freshly loaded page that loses the cache race.
- #1079 delegate clone constructors route through the `PageReference` copy constructor (re-enables checksum verification by copying the hash; nulls a resolvable swizzle).
- #1074 `ByteHandlerPipeline` releases the intermediate buffer if a later handler throws.

**Index / REST**
- #1065 `RBTreeWriter.remove` checks membership without mutating the live shared record (snapshot-isolation).
- #1075 `DiffHandler` returns 400 for a diff on an XML resource (was NPE→500); `SirixVerticle` rejects credentialed-wildcard CORS at startup.

## Deferred (intentionally not in this PR)

These are architecturally significant or security-sensitive and warrant dedicated, separately-reviewed changes rather than being bundled here:
- **#1070** REST query-path authorization bypass (security) — needs the full auth-wrapper redesign; a partial fix would be a false sense of security.
- **#1077** async-commit TIL Layer-3 offset pruning; **#1061** failed-commit state machine; **#1062** count-based auto-commit reentrancy — deep commit/durability changes.
- **#1080** index-catalog write ordering vs the uber-page beacon (minor, durability-path).
- **#1073 Defect A** FrameSlotAllocator address-keyed ABA release (currently suppressed by page-level synchronized close) — needs the identity-based release redesign.
- **#1065 Defect B** RB-tree structural delete of empty nodes (rebalance in a COW tree).
- **#1076** large-value / overflow storage — separate feature (scoped in the issue).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — all touched suites green in isolation; full suite runs in CI
- [x] Added or updated tests covering the change — existing suites; the RB-tree/index integration suites guard the cache fix
- [x] No unrelated formatting churn

## Notes for reviewers

Large but mechanical; each hunk carries a comment explaining the failure it fixes. The `PageReference`-copy-constructor routing (#1079) changes swizzle-pointer behavior on CoW clones to the already-documented "null when resolvable" rule — please sanity-check against the HOT split paths. The serializer `IOException` rethrow (#1068) changes previously-swallowed failures into surfaced ones; in-memory sinks (the common case) never threw, so behavior is unchanged there.