### PR TITLE
Reject VIEW tokens on all REST query-store write paths (#1070)

### DIFF
--- a/bundles/sirix-kotlin-cli/src/main/kotlin/io/sirix/cli/commands/Query.kt
+++ b/bundles/sirix-kotlin-cli/src/main/kotlin/io/sirix/cli/commands/Query.kt
@@ -14,6 +14,7 @@ import io.sirix.query.XmlDBSerializer
 import io.sirix.query.json.*
 import io.sirix.query.node.BasicXmlDBStore
 import io.sirix.query.node.XmlDBCollection
+import io.sirix.query.node.XmlDBCollectionImpl
 import io.sirix.query.node.XmlDBNode
 import io.brackit.query.Query
 import io.brackit.query.util.serialize.Serializer
@@ -49,7 +50,7 @@ class Query(options: io.sirix.cli.CliOptions, private val queryOptions: QueryOpt
             val manager = database.beginResourceSession(queryOptions.resource)
             manager.use {
                 val dbCollection =
-                    XmlDBCollection(options.location, database)
+                    XmlDBCollectionImpl(options.location, database)
 
                 dbCollection.use {
                     val revisionNumber = RevisionsHelper.getRevisionNumber(
@@ -104,7 +105,7 @@ class Query(options: io.sirix.cli.CliOptions, private val queryOptions: QueryOpt
         database.use {
             val manager = database.beginResourceSession(queryOptions.resource)
             manager.use {
-                val dbCollection = JsonDBCollection(options.location, database)
+                val dbCollection = JsonDBCollectionImpl(options.location, database)
                 dbCollection.use {
                     val revisionNumber = RevisionsHelper.getRevisionNumber(
                         queryOptions.revision,

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -372,7 +372,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
         // No existing database found, open a new one
         final var database = Databases.openJsonDatabase(dbPath);
         databases.add(database);
-        final JsonDBCollection collection = new JsonDBCollection(name, database, this);
+        final JsonDBCollection collection = new JsonDBCollectionImpl(name, database, this);
         collections.put(database, collection);
         return collection;
       } catch (final SirixRuntimeException e) {
@@ -393,7 +393,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       final var database = Databases.openJsonDatabase(dbConf.getDatabaseFile());
       databases.add(database);
 
-      final JsonDBCollection collection = new JsonDBCollection(name, database, this);
+      final JsonDBCollection collection = new JsonDBCollectionImpl(name, database, this);
       collections.put(database, collection);
       return collection;
     } catch (final SirixRuntimeException e) {
@@ -488,7 +488,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
       final var resourceOptions = createResource(options, database, resourceName);
 
-      final JsonDBCollection collection = new JsonDBCollection(collName, database, this);
+      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
 
       if (reader == null) {
@@ -559,7 +559,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       // join that left a half-created database on any partition failure.
       ParallelJsonShredder.shred(database, resourceNames, partitions,
           name -> buildResourceConfiguration(resourceOptions, name), numberOfNodesBeforeAutoCommit, 0);
-      final JsonDBCollection collection = new JsonDBCollection(collName, database, this);
+      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       return collection;
     } catch (final SirixRuntimeException e) {
@@ -616,7 +616,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
           i++;
         }
       }
-      return new JsonDBCollection(collName, database, this);
+      return new JsonDBCollectionImpl(collName, database, this);
     } catch (final SirixRuntimeException e) {
       throw new DocumentException(e.getCause());
     }
@@ -627,7 +627,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
     createResource(options, database, resourceName);
     try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
         final JsonNodeTrx wtx = resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit)) {
-      final JsonDBCollection collection = new JsonDBCollection(collName, database, this);
+      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       wtx.insertSubtreeAsFirstChild(reader);
     }
@@ -672,7 +672,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
                                        .storeNodeHistory(storeNodeHistory)
                                        .build(),
           numberOfNodesBeforeAutoCommit, 0);
-      final JsonDBCollection collection = new JsonDBCollection(collName, database, this);
+      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       return collection;
     } catch (final SirixRuntimeException e) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollection.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollection.java
@@ -1,403 +1,75 @@
 package io.sirix.query.json;
 
 import com.google.gson.stream.JsonReader;
-import io.brackit.query.atomic.QNm;
-import io.brackit.query.jdm.DocumentException;
-import io.brackit.query.jdm.Sequence;
-import io.brackit.query.jdm.Stream;
 import io.brackit.query.jdm.json.Object;
 import io.brackit.query.jdm.json.TemporalJsonCollection;
-import io.brackit.query.jsonitem.AbstractJsonItemCollection;
-import io.brackit.query.jsonitem.object.ArrayObject;
-import io.brackit.query.node.stream.ArrayStream;
-import io.sirix.access.Databases;
-import io.sirix.access.ResourceConfiguration;
 import io.sirix.api.Database;
-import io.sirix.api.json.JsonNodeReadOnlyTrx;
-import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
-import io.sirix.exception.SirixException;
-import io.sirix.exception.SirixIOException;
-import io.sirix.service.json.shredder.JsonShredder;
-import io.sirix.utils.LogWrapper;
-import org.slf4j.LoggerFactory;
 
-import java.nio.file.Path;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static java.util.Objects.requireNonNull;
-
-public final class JsonDBCollection extends AbstractJsonItemCollection<JsonDBItem>
-    implements TemporalJsonCollection<JsonDBItem>, AutoCloseable {
-
-  /**
-   * Logger.
-   */
-  private static final LogWrapper LOG_WRAPPER = new LogWrapper(LoggerFactory.getLogger(JsonDBCollection.class));
-
-  /**
-   * ID sequence.
-   */
-  private static final AtomicInteger ID_SEQUENCE = new AtomicInteger();
-
-  /**
-   * Sirix database.
-   */
-  private final Database<JsonResourceSession> database;
-
-  /**
-   * Unique ID.
-   */
-  private final int id;
-
-  private JsonDBStore jsonDbStore;
-
-  /**
-   * Constructor.
-   *
-   * @param name collection name
-   * @param database Sirix {@link Database} reference
-   */
-  public JsonDBCollection(final String name, final Database<JsonResourceSession> database) {
-    super(requireNonNull(name));
-    this.database = requireNonNull(database);
-    id = ID_SEQUENCE.incrementAndGet();
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param name collection name
-   * @param database Sirix {@link Database} reference
-   */
-  public JsonDBCollection(final String name, final Database<JsonResourceSession> database,
-      final JsonDBStore jsonDBStore) {
-    super(requireNonNull(name));
-    this.database = requireNonNull(database);
-    id = ID_SEQUENCE.incrementAndGet();
-    this.jsonDbStore = requireNonNull(jsonDBStore);
-  }
-
-  public JsonDBCollection setJsonDBStore(final JsonDBStore jsonDBStore) {
-    this.jsonDbStore = jsonDBStore;
-    return this;
-  }
-
-  /**
-   * Get the JsonDBStore for this collection.
-   *
-   * @return the JsonDBStore, or null if not set
-   */
-  public JsonDBStore getJsonDBStore() {
-    return jsonDbStore;
-  }
-
-  @Override
-  public boolean equals(final java.lang.Object other) {
-    if (this == other) {
-      return true;
-    }
-
-    if (!(other instanceof JsonDBCollection coll)) {
-      return false;
-    }
-
-    return database.equals(coll.database);
-  }
-
-  @Override
-  public int hashCode() {
-    return database.hashCode();
-  }
-
-  /**
-   * Get the unique ID.
-   *
-   * @return unique ID
-   */
-  public int getID() {
-    return id;
-  }
+/**
+ * A JSON database collection backed by a Sirix {@link Database}.
+ *
+ * <p>This is an interface (implemented by {@link JsonDBCollectionImpl}) so that cross-cutting
+ * concerns can be layered on by composition/delegation rather than by subclassing the concrete
+ * implementation. In particular the REST layer wraps a collection in an authorization-checking
+ * decorator that delegates every read to the real collection and re-checks the caller's role on
+ * the mutating methods.
+ *
+ * <p>The brackit {@link TemporalJsonCollection} supertype already declares the standard collection
+ * operations ({@code getDocument*}, {@code getDocuments}, {@code getDocumentCount}, {@code add},
+ * {@code delete}, {@code remove}, {@code getName}); this interface only adds the Sirix-specific
+ * accessors and the resource-named {@code add} overloads.
+ */
+public interface JsonDBCollection extends TemporalJsonCollection<JsonDBItem>, AutoCloseable {
 
   /**
    * Get the underlying Sirix {@link Database}.
    *
-   * @return Sirix {@link Database}
+   * @return the Sirix {@link Database}
    */
-  public Database<JsonResourceSession> getDatabase() {
-    return database;
-  }
+  Database<JsonResourceSession> getDatabase();
+
+  /**
+   * Get the unique ID.
+   *
+   * @return the unique ID
+   */
+  int getID();
+
+  /**
+   * Get the {@link JsonDBStore} this collection belongs to.
+   *
+   * @return the {@link JsonDBStore}, or {@code null} if not set
+   */
+  JsonDBStore getJsonDBStore();
+
+  /**
+   * Set the {@link JsonDBStore} this collection belongs to.
+   *
+   * @param jsonDBStore the store
+   * @return this collection
+   */
+  JsonDBCollection setJsonDBStore(JsonDBStore jsonDBStore);
+
+  /**
+   * Add a resource to the collection from a JSON reader with the given options.
+   *
+   * @param resourceName the resource name
+   * @param reader the JSON reader
+   * @param options the resource options
+   * @return the stored document
+   */
+  JsonDBItem add(String resourceName, JsonReader reader, Object options);
+
+  /**
+   * Add a resource to the collection from a JSON reader.
+   *
+   * @param resourceName the resource name
+   * @param reader the JSON reader
+   * @return the stored document
+   */
+  JsonDBItem add(String resourceName, JsonReader reader);
 
   @Override
-  public JsonDBItem getDocument(Instant pointInTime) {
-    return getDocumentInternal(name, pointInTime);
-  }
-
-  @Override
-  public JsonDBItem getDocument(String name, Instant pointInTime) {
-    return getDocumentInternal(name, pointInTime);
-  }
-
-  private JsonDBItem getDocumentInternal(final String resName, final Instant pointInTime) {
-    final JsonResourceSession resource = database.beginResourceSession(resName);
-    try {
-      JsonNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx(pointInTime);
-
-      if (trx.getRevisionTimestamp().isAfter(pointInTime)) {
-        final int revision = trx.getRevisionNumber();
-
-        if (revision > 1) {
-          trx.close();
-
-          trx = resource.beginNodeReadOnlyTrx(revision - 1);
-        } else {
-          // Even the earliest revision was committed after the requested point
-          // in time, i.e. the resource did not exist yet. Return the empty
-          // sequence instead of anachronistically yielding the first revision.
-          trx.close();
-          resource.close();
-          return null;
-        }
-      }
-
-      return getItem(trx);
-    } catch (final Exception e) {
-      resource.close();
-      throw e;
-    }
-  }
-
-  private JsonDBItem getDocumentInternal(final String resName, final int revision) {
-    final JsonResourceSession resource = database.beginResourceSession(resName);
-    try {
-      final int version = revision == -1
-          ? resource.getMostRecentRevisionNumber()
-          : revision;
-
-      final JsonNodeReadOnlyTrx rtx = resource.beginNodeReadOnlyTrx(version);
-
-      return getItem(rtx);
-    } catch (final Exception e) {
-      resource.close();
-      throw e;
-    }
-  }
-
-  @Override
-  public void delete() {
-    try {
-      final Path databaseFile = database.getDatabaseConfig().getDatabaseFile();
-      database.close();
-      jsonDbStore.removeDatabase(database);
-      Databases.removeDatabase(databaseFile);
-    } catch (final SirixIOException e) {
-      throw new DocumentException(e.getCause());
-    }
-  }
-
-  @Override
-  public void remove(final long documentID) {
-    if (documentID >= 0) {
-      final String resource = database.getResourceName((int) documentID);
-      if (resource != null) {
-        database.removeResource(resource);
-      }
-    }
-  }
-
-  @Override
-  public JsonDBItem getDocument(final int revision) {
-    final List<Path> resources = database.listResources();
-    if (resources.size() > 1) {
-      throw new DocumentException("More than one document stored in database/collection!");
-    }
-    final JsonResourceSession resourceSession = database.beginResourceSession(resources.get(0).getFileName().toString());
-    try {
-      final int version = revision == -1
-          ? resourceSession.getMostRecentRevisionNumber()
-          : revision;
-      final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx(version);
-
-      return getItem(rtx);
-    } catch (final SirixException e) {
-      resourceSession.close();
-      throw new DocumentException(e.getCause());
-    } catch (final Exception e) {
-      resourceSession.close();
-      throw e;
-    }
-  }
-
-  private JsonDBItem getItem(final JsonNodeReadOnlyTrx rtx) {
-    final JsonNodeReadOnlyTrx proxy = new ThreadSafeJsonReadOnlyTrx(rtx);
-    if (proxy.hasFirstChild()) {
-      proxy.moveToFirstChild();
-      if (proxy.isObject())
-        return new JsonDBObject(proxy, this);
-      else if (proxy.isArray())
-        return new JsonDBArray(proxy, this);
-    }
-
-    return null;
-  }
-
-  public JsonDBItem add(final String resourceName, final JsonReader reader, final Object options) {
-    try {
-      String resName = resourceName;
-      for (final Path resource : database.listResources()) {
-        final String existingResourceName = resource.getFileName().toString();
-        if (existingResourceName.equals(resourceName)) {
-          resName = existingResourceName + "1";
-          break;
-        }
-      }
-
-      final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
-
-      database.createResource(ResourceConfiguration.newBuilder(resName)
-                                                   .useTextCompression(resourceOptions.useTextCompression())
-                                                   .storageType(resourceOptions.storageType())
-                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
-                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                                                   .buildPathSummary(resourceOptions.buildPathSummary())
-                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
-                                                   .hashKind(resourceOptions.hashType())
-                                                   .build());
-      final JsonResourceSession resourceSession = database.beginResourceSession(resName);
-      try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-        wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
-        wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
-      } catch (final Exception e) {
-        resourceSession.close();
-        throw e;
-      }
-      try {
-        final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx();
-        rtx.moveToDocumentRoot();
-        return getItem(rtx);
-      } catch (final Exception e) {
-        resourceSession.close();
-        throw e;
-      }
-    } catch (final SirixException e) {
-      LOG_WRAPPER.error(e.getMessage(), e);
-      return null;
-    }
-  }
-
-  public JsonDBItem add(final String resourceName, final JsonReader reader) {
-    return add(resourceName, reader, new ArrayObject(new QNm[0], new Sequence[0]));
-  }
-
-  @Override
-  public void close() {
-    jsonDbStore.removeDatabase(database);
-    database.close();
-  }
-
-  @Override
-  public long getDocumentCount() {
-    return database.listResources().size();
-  }
-
-  @Override
-  public JsonDBItem getDocument() {
-    return getDocument(-1);
-  }
-
-  @Override
-  public JsonDBItem getDocument(final String name, final int revision) {
-    return getDocumentInternal(name, revision);
-  }
-
-  @Override
-  public JsonDBItem getDocument(final String name) {
-    return getDocument(name, -1);
-  }
-
-  @Override
-  public Stream<JsonDBItem> getDocuments() {
-    final List<Path> resources = database.listResources();
-    final List<JsonDBItem> documents = new ArrayList<>(resources.size());
-
-    resources.forEach(resourcePath -> {
-      final String resourceName = resourcePath.getFileName().toString();
-      final JsonResourceSession resource = database.beginResourceSession(resourceName);
-      try {
-        final JsonNodeReadOnlyTrx rtx = resource.beginNodeReadOnlyTrx();
-        final JsonNodeReadOnlyTrx proxy = new ThreadSafeJsonReadOnlyTrx(rtx);
-
-        if (proxy.moveToFirstChild()) {
-          if (proxy.isObject())
-            documents.add(new JsonDBObject(proxy, this));
-          else if (proxy.isArray())
-            documents.add(new JsonDBArray(proxy, this));
-        }
-      } catch (final SirixException e) {
-        resource.close();
-        throw new DocumentException(e.getCause());
-      } catch (final Exception e) {
-        resource.close();
-        throw e;
-      }
-    });
-
-    return new ArrayStream<>(documents.toArray(new JsonDBItem[0]));
-  }
-
-  @Override
-  public JsonDBItem add(final String json) {
-    requireNonNull(json);
-
-    return add(JsonShredder.createStringReader(json), new ArrayObject(new QNm[0], new Sequence[0]));
-  }
-
-  @SuppressWarnings("SameParameterValue")
-  private JsonDBItem add(final JsonReader reader, final Object options) {
-    try {
-
-      final String resourceName = "resource" + (database.listResources().size() + 1);
-      final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
-
-      database.createResource(ResourceConfiguration.newBuilder(resourceName)
-                                                   .useTextCompression(resourceOptions.useTextCompression())
-                                                   .storageType(resourceOptions.storageType())
-                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
-                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                                                   .buildPathSummary(resourceOptions.buildPathSummary())
-                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
-                                                   .hashKind(resourceOptions.hashType())
-                                                   .build());
-      final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
-      try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-        wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
-        wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
-      } catch (final Exception e) {
-        resourceSession.close();
-        throw e;
-      }
-
-      try {
-        final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx();
-        return getItem(rtx);
-      } catch (final Exception e) {
-        resourceSession.close();
-        throw e;
-      }
-    } catch (final SirixException e) {
-      LOG_WRAPPER.error(e.getMessage(), e);
-      return null;
-    }
-  }
-
-  @Override
-  public JsonDBItem add(final Path file) {
-    requireNonNull(file);
-
-    return add(JsonShredder.createFileReader(file), new ArrayObject(new QNm[0], new Sequence[0]));
-  }
-
+  void close();
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
@@ -1,0 +1,411 @@
+package io.sirix.query.json;
+
+import com.google.gson.stream.JsonReader;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.DocumentException;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Stream;
+import io.brackit.query.jdm.json.Object;
+import io.brackit.query.jsonitem.AbstractJsonItemCollection;
+import io.brackit.query.jsonitem.object.ArrayObject;
+import io.brackit.query.node.stream.ArrayStream;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.exception.SirixException;
+import io.sirix.exception.SirixIOException;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.utils.LogWrapper;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Standard {@link JsonDBCollection} implementation backed by a Sirix {@link Database}.
+ *
+ * <p>{@link JsonDBCollection} is an interface so cross-cutting concerns (e.g. the REST layer's
+ * per-request authorization, see {@code AuthCheckingJsonDBCollection}) can be layered on by
+ * composition/delegation rather than by subclassing this class. equals/hashCode key on the
+ * database only, so a delegating wrapper over the same database compares equal to the original.
+ */
+public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonDBItem>
+    implements JsonDBCollection {
+
+  /**
+   * Logger.
+   */
+  private static final LogWrapper LOG_WRAPPER = new LogWrapper(LoggerFactory.getLogger(JsonDBCollectionImpl.class));
+
+  /**
+   * ID sequence.
+   */
+  private static final AtomicInteger ID_SEQUENCE = new AtomicInteger();
+
+  /**
+   * Sirix database.
+   */
+  private final Database<JsonResourceSession> database;
+
+  /**
+   * Unique ID.
+   */
+  private final int id;
+
+  private JsonDBStore jsonDbStore;
+
+  /**
+   * Constructor.
+   *
+   * @param name collection name
+   * @param database Sirix {@link Database} reference
+   */
+  public JsonDBCollectionImpl(final String name, final Database<JsonResourceSession> database) {
+    super(requireNonNull(name));
+    this.database = requireNonNull(database);
+    id = ID_SEQUENCE.incrementAndGet();
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param name collection name
+   * @param database Sirix {@link Database} reference
+   */
+  public JsonDBCollectionImpl(final String name, final Database<JsonResourceSession> database,
+      final JsonDBStore jsonDBStore) {
+    super(requireNonNull(name));
+    this.database = requireNonNull(database);
+    id = ID_SEQUENCE.incrementAndGet();
+    this.jsonDbStore = requireNonNull(jsonDBStore);
+  }
+
+  @Override
+  public JsonDBCollection setJsonDBStore(final JsonDBStore jsonDBStore) {
+    this.jsonDbStore = jsonDBStore;
+    return this;
+  }
+
+  /**
+   * Get the JsonDBStore for this collection.
+   *
+   * @return the JsonDBStore, or null if not set
+   */
+  public JsonDBStore getJsonDBStore() {
+    return jsonDbStore;
+  }
+
+  @Override
+  public boolean equals(final java.lang.Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (!(other instanceof JsonDBCollection coll)) {
+      return false;
+    }
+
+    return database.equals(coll.getDatabase());
+  }
+
+  @Override
+  public int hashCode() {
+    return database.hashCode();
+  }
+
+  /**
+   * Get the unique ID.
+   *
+   * @return unique ID
+   */
+  public int getID() {
+    return id;
+  }
+
+  /**
+   * Get the underlying Sirix {@link Database}.
+   *
+   * @return Sirix {@link Database}
+   */
+  public Database<JsonResourceSession> getDatabase() {
+    return database;
+  }
+
+  @Override
+  public JsonDBItem getDocument(Instant pointInTime) {
+    return getDocumentInternal(name, pointInTime);
+  }
+
+  @Override
+  public JsonDBItem getDocument(String name, Instant pointInTime) {
+    return getDocumentInternal(name, pointInTime);
+  }
+
+  private JsonDBItem getDocumentInternal(final String resName, final Instant pointInTime) {
+    final JsonResourceSession resource = database.beginResourceSession(resName);
+    try {
+      JsonNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx(pointInTime);
+
+      if (trx.getRevisionTimestamp().isAfter(pointInTime)) {
+        final int revision = trx.getRevisionNumber();
+
+        if (revision > 1) {
+          trx.close();
+
+          trx = resource.beginNodeReadOnlyTrx(revision - 1);
+        } else {
+          // Even the earliest revision was committed after the requested point
+          // in time, i.e. the resource did not exist yet. Return the empty
+          // sequence instead of anachronistically yielding the first revision.
+          trx.close();
+          resource.close();
+          return null;
+        }
+      }
+
+      return getItem(trx);
+    } catch (final Exception e) {
+      resource.close();
+      throw e;
+    }
+  }
+
+  private JsonDBItem getDocumentInternal(final String resName, final int revision) {
+    final JsonResourceSession resource = database.beginResourceSession(resName);
+    try {
+      final int version = revision == -1
+          ? resource.getMostRecentRevisionNumber()
+          : revision;
+
+      final JsonNodeReadOnlyTrx rtx = resource.beginNodeReadOnlyTrx(version);
+
+      return getItem(rtx);
+    } catch (final Exception e) {
+      resource.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public void delete() {
+    try {
+      final Path databaseFile = database.getDatabaseConfig().getDatabaseFile();
+      database.close();
+      jsonDbStore.removeDatabase(database);
+      Databases.removeDatabase(databaseFile);
+    } catch (final SirixIOException e) {
+      throw new DocumentException(e.getCause());
+    }
+  }
+
+  @Override
+  public void remove(final long documentID) {
+    if (documentID >= 0) {
+      final String resource = database.getResourceName((int) documentID);
+      if (resource != null) {
+        database.removeResource(resource);
+      }
+    }
+  }
+
+  @Override
+  public JsonDBItem getDocument(final int revision) {
+    final List<Path> resources = database.listResources();
+    if (resources.size() > 1) {
+      throw new DocumentException("More than one document stored in database/collection!");
+    }
+    final JsonResourceSession resourceSession = database.beginResourceSession(resources.get(0).getFileName().toString());
+    try {
+      final int version = revision == -1
+          ? resourceSession.getMostRecentRevisionNumber()
+          : revision;
+      final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx(version);
+
+      return getItem(rtx);
+    } catch (final SirixException e) {
+      resourceSession.close();
+      throw new DocumentException(e.getCause());
+    } catch (final Exception e) {
+      resourceSession.close();
+      throw e;
+    }
+  }
+
+  private JsonDBItem getItem(final JsonNodeReadOnlyTrx rtx) {
+    final JsonNodeReadOnlyTrx proxy = new ThreadSafeJsonReadOnlyTrx(rtx);
+    if (proxy.hasFirstChild()) {
+      proxy.moveToFirstChild();
+      if (proxy.isObject())
+        return new JsonDBObject(proxy, this);
+      else if (proxy.isArray())
+        return new JsonDBArray(proxy, this);
+    }
+
+    return null;
+  }
+
+  public JsonDBItem add(final String resourceName, final JsonReader reader, final Object options) {
+    try {
+      String resName = resourceName;
+      for (final Path resource : database.listResources()) {
+        final String existingResourceName = resource.getFileName().toString();
+        if (existingResourceName.equals(resourceName)) {
+          resName = existingResourceName + "1";
+          break;
+        }
+      }
+
+      final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
+
+      database.createResource(ResourceConfiguration.newBuilder(resName)
+                                                   .useTextCompression(resourceOptions.useTextCompression())
+                                                   .storageType(resourceOptions.storageType())
+                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
+                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
+                                                   .buildPathSummary(resourceOptions.buildPathSummary())
+                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
+                                                   .hashKind(resourceOptions.hashType())
+                                                   .build());
+      final JsonResourceSession resourceSession = database.beginResourceSession(resName);
+      try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+        wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
+      } catch (final Exception e) {
+        resourceSession.close();
+        throw e;
+      }
+      try {
+        final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx();
+        rtx.moveToDocumentRoot();
+        return getItem(rtx);
+      } catch (final Exception e) {
+        resourceSession.close();
+        throw e;
+      }
+    } catch (final SirixException e) {
+      LOG_WRAPPER.error(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  public JsonDBItem add(final String resourceName, final JsonReader reader) {
+    return add(resourceName, reader, new ArrayObject(new QNm[0], new Sequence[0]));
+  }
+
+  @Override
+  public void close() {
+    jsonDbStore.removeDatabase(database);
+    database.close();
+  }
+
+  @Override
+  public long getDocumentCount() {
+    return database.listResources().size();
+  }
+
+  @Override
+  public JsonDBItem getDocument() {
+    return getDocument(-1);
+  }
+
+  @Override
+  public JsonDBItem getDocument(final String name, final int revision) {
+    return getDocumentInternal(name, revision);
+  }
+
+  @Override
+  public JsonDBItem getDocument(final String name) {
+    return getDocument(name, -1);
+  }
+
+  @Override
+  public Stream<JsonDBItem> getDocuments() {
+    final List<Path> resources = database.listResources();
+    final List<JsonDBItem> documents = new ArrayList<>(resources.size());
+
+    resources.forEach(resourcePath -> {
+      final String resourceName = resourcePath.getFileName().toString();
+      final JsonResourceSession resource = database.beginResourceSession(resourceName);
+      try {
+        final JsonNodeReadOnlyTrx rtx = resource.beginNodeReadOnlyTrx();
+        final JsonNodeReadOnlyTrx proxy = new ThreadSafeJsonReadOnlyTrx(rtx);
+
+        if (proxy.moveToFirstChild()) {
+          if (proxy.isObject())
+            documents.add(new JsonDBObject(proxy, this));
+          else if (proxy.isArray())
+            documents.add(new JsonDBArray(proxy, this));
+        }
+      } catch (final SirixException e) {
+        resource.close();
+        throw new DocumentException(e.getCause());
+      } catch (final Exception e) {
+        resource.close();
+        throw e;
+      }
+    });
+
+    return new ArrayStream<>(documents.toArray(new JsonDBItem[0]));
+  }
+
+  @Override
+  public JsonDBItem add(final String json) {
+    requireNonNull(json);
+
+    return add(JsonShredder.createStringReader(json), new ArrayObject(new QNm[0], new Sequence[0]));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private JsonDBItem add(final JsonReader reader, final Object options) {
+    try {
+
+      final String resourceName = "resource" + (database.listResources().size() + 1);
+      final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
+
+      database.createResource(ResourceConfiguration.newBuilder(resourceName)
+                                                   .useTextCompression(resourceOptions.useTextCompression())
+                                                   .storageType(resourceOptions.storageType())
+                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
+                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
+                                                   .buildPathSummary(resourceOptions.buildPathSummary())
+                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
+                                                   .hashKind(resourceOptions.hashType())
+                                                   .build());
+      final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
+      try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+        wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
+      } catch (final Exception e) {
+        resourceSession.close();
+        throw e;
+      }
+
+      try {
+        final JsonNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx();
+        return getItem(rtx);
+      } catch (final Exception e) {
+        resourceSession.close();
+        throw e;
+      }
+    } catch (final SirixException e) {
+      LOG_WRAPPER.error(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  @Override
+  public JsonDBItem add(final Path file) {
+    requireNonNull(file);
+
+    return add(JsonShredder.createFileReader(file), new ArrayObject(new QNm[0], new Sequence[0]));
+  }
+
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/node/BasicXmlDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/node/BasicXmlDBStore.java
@@ -352,7 +352,7 @@ public final class BasicXmlDBStore implements XmlDBStore {
         // No existing database found, open a new one
         final var database = Databases.openXmlDatabase(dbPath);
         databases.add(database);
-        final XmlDBCollection collection = new XmlDBCollection(name, database);
+        final XmlDBCollection collection = new XmlDBCollectionImpl(name, database);
         collections.put(database, collection);
         return collection;
       } catch (final SirixRuntimeException e) {
@@ -373,7 +373,7 @@ public final class BasicXmlDBStore implements XmlDBStore {
       final var database = Databases.openXmlDatabase(dbConf.getDatabaseFile());
       databases.add(database);
 
-      final XmlDBCollection collection = new XmlDBCollection(name, database);
+      final XmlDBCollection collection = new XmlDBCollectionImpl(name, database);
       collections.put(database, collection);
       return collection;
     } catch (final SirixRuntimeException e) {
@@ -426,7 +426,7 @@ public final class BasicXmlDBStore implements XmlDBStore {
                                                    .versioningApproach(versioningType)
                                                    .storeNodeHistory(storeNodeHistory)
                                                    .build());
-      final XmlDBCollection collection = new XmlDBCollection(collName, database);
+      final XmlDBCollection collection = new XmlDBCollectionImpl(collName, database);
       collections.put(database, collection);
 
       try (final XmlResourceSession resourceSession = database.beginResourceSession(resName);
@@ -469,7 +469,7 @@ public final class BasicXmlDBStore implements XmlDBStore {
                                                            .build());
               try (final XmlResourceSession resourceSession = database.beginResourceSession(resourceName);
                   final XmlNodeTrx wtx = resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit)) {
-                final XmlDBCollection collection = new XmlDBCollection(collName, database);
+                final XmlDBCollection collection = new XmlDBCollectionImpl(collName, database);
                 collections.put(database, collection);
                 nextParser.parse(
                     new SubtreeBuilder(collection, wtx, InsertPosition.AS_FIRST_CHILD, Collections.emptyList()));
@@ -480,7 +480,7 @@ public final class BasicXmlDBStore implements XmlDBStore {
             i++;
           }
         }
-        return new XmlDBCollection(collName, database);
+        return new XmlDBCollectionImpl(collName, database);
       } catch (final SirixRuntimeException e) {
         throw new DocumentException(e.getCause());
       }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollection.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollection.java
@@ -1,374 +1,92 @@
 package io.sirix.query.node;
 
-import io.brackit.query.jdm.DocumentException;
 import io.brackit.query.jdm.Stream;
 import io.brackit.query.jdm.node.AbstractTemporalNode;
 import io.brackit.query.jdm.node.TemporalNodeCollection;
-import io.brackit.query.node.AbstractNodeCollection;
-import io.brackit.query.node.parser.CollectionParser;
-import io.brackit.query.node.parser.NodeSubtreeHandler;
 import io.brackit.query.node.parser.NodeSubtreeParser;
-import io.brackit.query.node.stream.ArrayStream;
-import org.jspecify.annotations.Nullable;
-import io.sirix.access.Databases;
-import io.sirix.access.ResourceConfiguration;
-import io.sirix.access.trx.node.HashType;
 import io.sirix.api.Database;
-import io.sirix.api.xml.XmlNodeReadOnlyTrx;
-import io.sirix.api.xml.XmlNodeTrx;
 import io.sirix.api.xml.XmlResourceSession;
-import io.sirix.exception.SirixException;
-import io.sirix.exception.SirixIOException;
-import io.sirix.service.InsertPosition;
-import io.sirix.utils.LogWrapper;
-import org.slf4j.LoggerFactory;
 
-import java.nio.file.Path;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static java.util.Objects.requireNonNull;
 
 /**
- * Database collection.
+ * An XML database collection backed by a Sirix {@link Database}.
  *
- * @author Johannes Lichtenberger
+ * <p>This is an interface (implemented by {@link XmlDBCollectionImpl}) so that cross-cutting
+ * concerns can be layered on by composition/delegation rather than by subclassing the concrete
+ * implementation. In particular the REST layer wraps a collection in an authorization-checking
+ * decorator that delegates every read to the real collection and re-checks the caller's role on
+ * the mutating methods.
+ *
+ * <p>The brackit {@link TemporalNodeCollection} supertype already declares the standard collection
+ * operations ({@code getDocument*}, {@code getDocuments}, {@code getDocumentCount}, {@code add},
+ * {@code delete}, {@code remove}, {@code getName}); this interface only adds the Sirix-specific
+ * accessors and the resource-named {@code add} overloads.
  */
-public final class XmlDBCollection extends AbstractNodeCollection<AbstractTemporalNode<XmlDBNode>>
-    implements TemporalNodeCollection<AbstractTemporalNode<XmlDBNode>>, AutoCloseable {
-
-  /**
-   * Logger.
-   */
-  private static final LogWrapper LOG_WRAPPER = new LogWrapper(LoggerFactory.getLogger(XmlDBCollection.class));
-
-  /**
-   * ID sequence.
-   */
-  private static final AtomicInteger ID_SEQUENCE = new AtomicInteger();
-
-  /**
-   * {@link Database} instance.
-   */
-  private final Database<XmlResourceSession> database;
-
-  /**
-   * Unique ID.
-   */
-  private final int id;
-
-  /**
-   * "Caches" document nodes.
-   */
-  private final Map<DocumentData, XmlDBNode> documentDataToXmlDBNodes;
-
-  /**
-   * "Caches" document nodes.
-   */
-  private final Map<InstantDocumentData, XmlDBNode> instantDocumentDataToXmlDBNodes;
-
-  /**
-   * Constructor.
-   *
-   * @param name collection name
-   * @param database Sirix {@link Database} reference
-   */
-  public XmlDBCollection(final String name, final Database<XmlResourceSession> database) {
-    super(requireNonNull(name));
-    this.database = requireNonNull(database);
-    id = ID_SEQUENCE.incrementAndGet();
-    documentDataToXmlDBNodes = new HashMap<>();
-    instantDocumentDataToXmlDBNodes = new HashMap<>();
-  }
-
-  @Override
-  public boolean equals(final @Nullable Object other) {
-    if (this == other)
-      return true;
-
-    if (!(other instanceof final XmlDBCollection coll))
-      return false;
-
-    return database.equals(coll.database);
-  }
-
-  @Override
-  public int hashCode() {
-    return database.hashCode();
-  }
-
-  /**
-   * Get the unique ID.
-   *
-   * @return unique ID
-   */
-  public int getID() {
-    return id;
-  }
+public interface XmlDBCollection extends TemporalNodeCollection<AbstractTemporalNode<XmlDBNode>>, AutoCloseable {
 
   /**
    * Get the underlying Sirix {@link Database}.
    *
-   * @return Sirix {@link Database}
+   * @return the Sirix {@link Database}
    */
-  public Database<XmlResourceSession> getDatabase() {
-    return database;
-  }
+  Database<XmlResourceSession> getDatabase();
+
+  /**
+   * Get the unique ID.
+   *
+   * @return the unique ID
+   */
+  int getID();
+
+  /**
+   * Add a resource to the collection from a subtree parser.
+   *
+   * @param resourceName the resource name
+   * @param parser the subtree parser
+   * @return the stored document node
+   */
+  XmlDBNode add(String resourceName, NodeSubtreeParser parser);
+
+  /**
+   * Add a resource to the collection from a subtree parser with a custom commit.
+   *
+   * @param resourceName the resource name
+   * @param parser the subtree parser
+   * @param commitMessage the commit message
+   * @param commitTimestamp the commit timestamp
+   * @return the stored document node
+   */
+  XmlDBNode add(String resourceName, NodeSubtreeParser parser, String commitMessage, Instant commitTimestamp);
+
+  // The concrete implementation narrows the brackit collection element type
+  // (AbstractTemporalNode<XmlDBNode>) to XmlDBNode; re-declare the read/add operations with the
+  // narrowed return type so callers holding the interface type keep seeing XmlDBNode.
 
   @Override
-  public XmlDBNode getDocument(Instant pointInTime) {
-    final List<Path> resources = database.listResources();
-    if (resources.size() > 1) {
-      throw new DocumentException("More than one document stored in database/collection!");
-    }
-
-    try {
-      final var resourceName = resources.get(0).getFileName().toString();
-      return getDocumentInternal(resourceName, pointInTime);
-    } catch (final SirixException e) {
-      throw new DocumentException(e.getCause());
-    }
-  }
+  XmlDBNode getDocument();
 
   @Override
-  public XmlDBNode getDocument(String name, Instant pointInTime) {
-    return getDocumentInternal(name, pointInTime);
-  }
-
-  private XmlDBNode getDocumentInternal(final String resName, final Instant pointInTime) {
-    return instantDocumentDataToXmlDBNodes.computeIfAbsent(new InstantDocumentData(resName, pointInTime), (unused) -> {
-      final XmlResourceSession resource = database.beginResourceSession(resName);
-      try {
-        XmlNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx(pointInTime);
-
-        if (trx.getRevisionTimestamp().isAfter(pointInTime)) {
-          final int revision = trx.getRevisionNumber();
-
-          if (revision > 1) {
-            trx.close();
-
-            trx = resource.beginNodeReadOnlyTrx(revision - 1);
-          } else {
-            // Even the earliest revision was committed after the requested point
-            // in time, i.e. the resource did not exist yet. Return the empty
-            // sequence instead of anachronistically yielding the first revision.
-            // (Returning null from computeIfAbsent leaves the cache untouched.)
-            trx.close();
-            resource.close();
-            return null;
-          }
-        }
-
-        return new XmlDBNode(new ThreadSafeXmlReadOnlyTrx(trx), this);
-      } catch (final Exception e) {
-        resource.close();
-        throw e;
-      }
-    });
-  }
-
-  private XmlDBNode getDocumentInternal(final String resName, final int revision) {
-    if (revision == -1) {
-      return createXmlDBNode(revision, resName);
-    } else {
-      return documentDataToXmlDBNodes.computeIfAbsent(new DocumentData(resName, revision),
-          (unused) -> createXmlDBNode(revision, resName));
-    }
-  }
+  XmlDBNode getDocument(int revision);
 
   @Override
-  public void delete() {
-    try {
-      final Path databaseFile = database.getDatabaseConfig().getDatabaseFile();
-      database.close();
-      Databases.removeDatabase(databaseFile);
-    } catch (final SirixIOException e) {
-      throw new DocumentException(e.getCause());
-    }
-  }
+  XmlDBNode getDocument(Instant pointInTime);
 
   @Override
-  public void remove(final long documentID) {
-    if (documentID >= 0) {
-      final String resourceName = database.getResourceName((int) documentID);
-      if (resourceName != null) {
-        database.removeResource(resourceName);
-
-        removeFromDocumentDataToXmlDBNodes(resourceName);
-        removeFromInstantDocumentDataToXmlDBNode(resourceName);
-      }
-    }
-  }
-
-  private void removeFromInstantDocumentDataToXmlDBNode(String resourceName) {
-    instantDocumentDataToXmlDBNodes.keySet().removeIf(documentData -> documentData.name.equals(resourceName));
-  }
-
-  private void removeFromDocumentDataToXmlDBNodes(String resourceName) {
-    documentDataToXmlDBNodes.keySet().removeIf(documentData -> documentData.name.equals(resourceName));
-  }
+  XmlDBNode getDocument(String name);
 
   @Override
-  public XmlDBNode getDocument(final int revision) {
-    final List<Path> resources = database.listResources();
-    if (resources.size() > 1) {
-      throw new DocumentException("More than one document stored in database/collection!");
-    }
-    try {
-      final var resourceName = resources.get(0).getFileName().toString();
-      if (revision == -1) {
-        return createXmlDBNode(revision, resourceName);
-      } else {
-        return documentDataToXmlDBNodes.computeIfAbsent(new DocumentData(resourceName, revision),
-            (unused) -> createXmlDBNode(revision, resourceName));
-      }
-    } catch (final SirixException e) {
-      throw new DocumentException(e.getCause());
-    }
-  }
-
-  private XmlDBNode createXmlDBNode(int revision, String resourceName) {
-    final XmlResourceSession resourceSession = database.beginResourceSession(resourceName);
-    try {
-      final int version = revision == -1
-          ? resourceSession.getMostRecentRevisionNumber()
-          : revision;
-      final XmlNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx(version);
-      return new XmlDBNode(new ThreadSafeXmlReadOnlyTrx(rtx), this);
-    } catch (final Exception e) {
-      resourceSession.close();
-      throw e;
-    }
-  }
-
-  public XmlDBNode add(final String resourceName, NodeSubtreeParser parser) {
-    try {
-      return createResource(parser, resourceName, null, null);
-    } catch (final SirixException e) {
-      LOG_WRAPPER.error(e.getMessage(), e);
-      return null;
-    }
-  }
-
-  public XmlDBNode add(final String resourceName, final NodeSubtreeParser parser, final String commitMessage,
-      final Instant commitTimestamp) {
-    try {
-      return createResource(parser, resourceName, commitMessage, commitTimestamp);
-    } catch (final SirixException e) {
-      LOG_WRAPPER.error(e.getMessage(), e);
-      return null;
-    }
-  }
+  XmlDBNode getDocument(String name, int revision);
 
   @Override
-  public XmlDBNode add(NodeSubtreeParser parser) throws DocumentException {
-    try {
-      final String resourceName = "resource" + (database.listResources().size() + 1);
-      return createResource(parser, resourceName, null, null);
-    } catch (final SirixException e) {
-      LOG_WRAPPER.error(e.getMessage(), e);
-      return null;
-    }
-  }
-
-  private XmlDBNode createResource(NodeSubtreeParser parser, final String resourceName, final String commitMessage,
-      final Instant commitTimestamp) {
-    database.createResource(ResourceConfiguration.newBuilder(resourceName)
-                                                 .useDeweyIDs(true)
-                                                 .useTextCompression(true)
-                                                 .buildPathSummary(true)
-                                                 .customCommitTimestamps(commitTimestamp != null)
-                                                 .hashKind(HashType.ROLLING)
-                                                 .build());
-    final XmlResourceSession resource = database.beginResourceSession(resourceName);
-    final XmlNodeTrx wtx;
-    try {
-      wtx = resource.beginNodeTrx();
-    } catch (final Exception e) {
-      resource.close();
-      throw e;
-    }
-
-    try {
-      final NodeSubtreeHandler handler =
-          new SubtreeBuilder(this, wtx, InsertPosition.AS_FIRST_CHILD, Collections.emptyList());
-
-      // Make sure the CollectionParser is used.
-      if (!(parser instanceof CollectionParser)) {
-        parser = new CollectionParser(parser);
-      }
-
-      parser.parse(handler);
-
-      wtx.commit(commitMessage, commitTimestamp);
-
-      final var xmlDBNode = new XmlDBNode(wtx, this);
-      documentDataToXmlDBNodes.put(new DocumentData(resourceName, 1), xmlDBNode);
-      instantDocumentDataToXmlDBNodes.put(new InstantDocumentData(resourceName, wtx.getRevisionTimestamp()), xmlDBNode);
-      return xmlDBNode;
-    } catch (final Exception e) {
-      wtx.close();
-      resource.close();
-      throw e;
-    }
-  }
+  XmlDBNode getDocument(String name, Instant pointInTime);
 
   @Override
-  public void close() {
-    database.close();
-  }
+  Stream<XmlDBNode> getDocuments();
 
   @Override
-  public long getDocumentCount() {
-    return database.listResources().size();
-  }
+  XmlDBNode add(NodeSubtreeParser parser);
 
   @Override
-  public XmlDBNode getDocument() {
-    return getDocument(-1);
-  }
-
-  @Override
-  public XmlDBNode getDocument(final String name, final int revision) {
-    return getDocumentInternal(name, revision);
-  }
-
-  @Override
-  public XmlDBNode getDocument(final String name) {
-    return getDocument(name, -1);
-  }
-
-  @Override
-  public Stream<XmlDBNode> getDocuments() {
-    final List<Path> resources = database.listResources();
-    final List<XmlDBNode> documents = new ArrayList<>(resources.size());
-
-    resources.forEach(resourcePath -> {
-      final String resourceName = resourcePath.getFileName().toString();
-      final XmlResourceSession resource = database.beginResourceSession(resourceName);
-      try {
-        final XmlNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx();
-        documents.add(new XmlDBNode(trx, this));
-      } catch (final SirixException e) {
-        resource.close();
-        throw new DocumentException(e.getCause());
-      } catch (final Exception e) {
-        resource.close();
-        throw e;
-      }
-    });
-
-    return new ArrayStream<>(documents.toArray(new XmlDBNode[0]));
-  }
-
-  private record DocumentData(String name, int revision) {
-  }
-
-  private record InstantDocumentData(String name, Instant revision) {
-  }
+  void close();
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollectionImpl.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/node/XmlDBCollectionImpl.java
@@ -1,0 +1,378 @@
+package io.sirix.query.node;
+
+import io.brackit.query.jdm.DocumentException;
+import io.brackit.query.jdm.Stream;
+import io.brackit.query.jdm.node.AbstractTemporalNode;
+import io.brackit.query.node.AbstractNodeCollection;
+import io.brackit.query.node.parser.CollectionParser;
+import io.brackit.query.node.parser.NodeSubtreeHandler;
+import io.brackit.query.node.parser.NodeSubtreeParser;
+import io.brackit.query.node.stream.ArrayStream;
+import org.jspecify.annotations.Nullable;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.api.xml.XmlResourceSession;
+import io.sirix.exception.SirixException;
+import io.sirix.exception.SirixIOException;
+import io.sirix.service.InsertPosition;
+import io.sirix.utils.LogWrapper;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Standard {@link XmlDBCollection} implementation backed by a Sirix {@link Database}.
+ *
+ * <p>{@link XmlDBCollection} is an interface so cross-cutting concerns (e.g. the REST layer's
+ * per-request authorization, see {@code AuthCheckingXmlDBCollection}) can be layered on by
+ * composition/delegation rather than by subclassing this class. equals/hashCode key on the
+ * database only, so a delegating wrapper over the same database compares equal to the original.
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class XmlDBCollectionImpl extends AbstractNodeCollection<AbstractTemporalNode<XmlDBNode>>
+    implements XmlDBCollection {
+
+  /**
+   * Logger.
+   */
+  private static final LogWrapper LOG_WRAPPER = new LogWrapper(LoggerFactory.getLogger(XmlDBCollectionImpl.class));
+
+  /**
+   * ID sequence.
+   */
+  private static final AtomicInteger ID_SEQUENCE = new AtomicInteger();
+
+  /**
+   * {@link Database} instance.
+   */
+  private final Database<XmlResourceSession> database;
+
+  /**
+   * Unique ID.
+   */
+  private final int id;
+
+  /**
+   * "Caches" document nodes.
+   */
+  private final Map<DocumentData, XmlDBNode> documentDataToXmlDBNodes;
+
+  /**
+   * "Caches" document nodes.
+   */
+  private final Map<InstantDocumentData, XmlDBNode> instantDocumentDataToXmlDBNodes;
+
+  /**
+   * Constructor.
+   *
+   * @param name collection name
+   * @param database Sirix {@link Database} reference
+   */
+  public XmlDBCollectionImpl(final String name, final Database<XmlResourceSession> database) {
+    super(requireNonNull(name));
+    this.database = requireNonNull(database);
+    id = ID_SEQUENCE.incrementAndGet();
+    documentDataToXmlDBNodes = new HashMap<>();
+    instantDocumentDataToXmlDBNodes = new HashMap<>();
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if (this == other)
+      return true;
+
+    if (!(other instanceof final XmlDBCollection coll))
+      return false;
+
+    return database.equals(coll.getDatabase());
+  }
+
+  @Override
+  public int hashCode() {
+    return database.hashCode();
+  }
+
+  /**
+   * Get the unique ID.
+   *
+   * @return unique ID
+   */
+  public int getID() {
+    return id;
+  }
+
+  /**
+   * Get the underlying Sirix {@link Database}.
+   *
+   * @return Sirix {@link Database}
+   */
+  public Database<XmlResourceSession> getDatabase() {
+    return database;
+  }
+
+  @Override
+  public XmlDBNode getDocument(Instant pointInTime) {
+    final List<Path> resources = database.listResources();
+    if (resources.size() > 1) {
+      throw new DocumentException("More than one document stored in database/collection!");
+    }
+
+    try {
+      final var resourceName = resources.get(0).getFileName().toString();
+      return getDocumentInternal(resourceName, pointInTime);
+    } catch (final SirixException e) {
+      throw new DocumentException(e.getCause());
+    }
+  }
+
+  @Override
+  public XmlDBNode getDocument(String name, Instant pointInTime) {
+    return getDocumentInternal(name, pointInTime);
+  }
+
+  private XmlDBNode getDocumentInternal(final String resName, final Instant pointInTime) {
+    return instantDocumentDataToXmlDBNodes.computeIfAbsent(new InstantDocumentData(resName, pointInTime), (unused) -> {
+      final XmlResourceSession resource = database.beginResourceSession(resName);
+      try {
+        XmlNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx(pointInTime);
+
+        if (trx.getRevisionTimestamp().isAfter(pointInTime)) {
+          final int revision = trx.getRevisionNumber();
+
+          if (revision > 1) {
+            trx.close();
+
+            trx = resource.beginNodeReadOnlyTrx(revision - 1);
+          } else {
+            // Even the earliest revision was committed after the requested point
+            // in time, i.e. the resource did not exist yet. Return the empty
+            // sequence instead of anachronistically yielding the first revision.
+            // (Returning null from computeIfAbsent leaves the cache untouched.)
+            trx.close();
+            resource.close();
+            return null;
+          }
+        }
+
+        return new XmlDBNode(new ThreadSafeXmlReadOnlyTrx(trx), this);
+      } catch (final Exception e) {
+        resource.close();
+        throw e;
+      }
+    });
+  }
+
+  private XmlDBNode getDocumentInternal(final String resName, final int revision) {
+    if (revision == -1) {
+      return createXmlDBNode(revision, resName);
+    } else {
+      return documentDataToXmlDBNodes.computeIfAbsent(new DocumentData(resName, revision),
+          (unused) -> createXmlDBNode(revision, resName));
+    }
+  }
+
+  @Override
+  public void delete() {
+    try {
+      final Path databaseFile = database.getDatabaseConfig().getDatabaseFile();
+      database.close();
+      Databases.removeDatabase(databaseFile);
+    } catch (final SirixIOException e) {
+      throw new DocumentException(e.getCause());
+    }
+  }
+
+  @Override
+  public void remove(final long documentID) {
+    if (documentID >= 0) {
+      final String resourceName = database.getResourceName((int) documentID);
+      if (resourceName != null) {
+        database.removeResource(resourceName);
+
+        removeFromDocumentDataToXmlDBNodes(resourceName);
+        removeFromInstantDocumentDataToXmlDBNode(resourceName);
+      }
+    }
+  }
+
+  private void removeFromInstantDocumentDataToXmlDBNode(String resourceName) {
+    instantDocumentDataToXmlDBNodes.keySet().removeIf(documentData -> documentData.name.equals(resourceName));
+  }
+
+  private void removeFromDocumentDataToXmlDBNodes(String resourceName) {
+    documentDataToXmlDBNodes.keySet().removeIf(documentData -> documentData.name.equals(resourceName));
+  }
+
+  @Override
+  public XmlDBNode getDocument(final int revision) {
+    final List<Path> resources = database.listResources();
+    if (resources.size() > 1) {
+      throw new DocumentException("More than one document stored in database/collection!");
+    }
+    try {
+      final var resourceName = resources.get(0).getFileName().toString();
+      if (revision == -1) {
+        return createXmlDBNode(revision, resourceName);
+      } else {
+        return documentDataToXmlDBNodes.computeIfAbsent(new DocumentData(resourceName, revision),
+            (unused) -> createXmlDBNode(revision, resourceName));
+      }
+    } catch (final SirixException e) {
+      throw new DocumentException(e.getCause());
+    }
+  }
+
+  private XmlDBNode createXmlDBNode(int revision, String resourceName) {
+    final XmlResourceSession resourceSession = database.beginResourceSession(resourceName);
+    try {
+      final int version = revision == -1
+          ? resourceSession.getMostRecentRevisionNumber()
+          : revision;
+      final XmlNodeReadOnlyTrx rtx = resourceSession.beginNodeReadOnlyTrx(version);
+      return new XmlDBNode(new ThreadSafeXmlReadOnlyTrx(rtx), this);
+    } catch (final Exception e) {
+      resourceSession.close();
+      throw e;
+    }
+  }
+
+  public XmlDBNode add(final String resourceName, NodeSubtreeParser parser) {
+    try {
+      return createResource(parser, resourceName, null, null);
+    } catch (final SirixException e) {
+      LOG_WRAPPER.error(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  public XmlDBNode add(final String resourceName, final NodeSubtreeParser parser, final String commitMessage,
+      final Instant commitTimestamp) {
+    try {
+      return createResource(parser, resourceName, commitMessage, commitTimestamp);
+    } catch (final SirixException e) {
+      LOG_WRAPPER.error(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  @Override
+  public XmlDBNode add(NodeSubtreeParser parser) throws DocumentException {
+    try {
+      final String resourceName = "resource" + (database.listResources().size() + 1);
+      return createResource(parser, resourceName, null, null);
+    } catch (final SirixException e) {
+      LOG_WRAPPER.error(e.getMessage(), e);
+      return null;
+    }
+  }
+
+  private XmlDBNode createResource(NodeSubtreeParser parser, final String resourceName, final String commitMessage,
+      final Instant commitTimestamp) {
+    database.createResource(ResourceConfiguration.newBuilder(resourceName)
+                                                 .useDeweyIDs(true)
+                                                 .useTextCompression(true)
+                                                 .buildPathSummary(true)
+                                                 .customCommitTimestamps(commitTimestamp != null)
+                                                 .hashKind(HashType.ROLLING)
+                                                 .build());
+    final XmlResourceSession resource = database.beginResourceSession(resourceName);
+    final XmlNodeTrx wtx;
+    try {
+      wtx = resource.beginNodeTrx();
+    } catch (final Exception e) {
+      resource.close();
+      throw e;
+    }
+
+    try {
+      final NodeSubtreeHandler handler =
+          new SubtreeBuilder(this, wtx, InsertPosition.AS_FIRST_CHILD, Collections.emptyList());
+
+      // Make sure the CollectionParser is used.
+      if (!(parser instanceof CollectionParser)) {
+        parser = new CollectionParser(parser);
+      }
+
+      parser.parse(handler);
+
+      wtx.commit(commitMessage, commitTimestamp);
+
+      final var xmlDBNode = new XmlDBNode(wtx, this);
+      documentDataToXmlDBNodes.put(new DocumentData(resourceName, 1), xmlDBNode);
+      instantDocumentDataToXmlDBNodes.put(new InstantDocumentData(resourceName, wtx.getRevisionTimestamp()), xmlDBNode);
+      return xmlDBNode;
+    } catch (final Exception e) {
+      wtx.close();
+      resource.close();
+      throw e;
+    }
+  }
+
+  @Override
+  public void close() {
+    database.close();
+  }
+
+  @Override
+  public long getDocumentCount() {
+    return database.listResources().size();
+  }
+
+  @Override
+  public XmlDBNode getDocument() {
+    return getDocument(-1);
+  }
+
+  @Override
+  public XmlDBNode getDocument(final String name, final int revision) {
+    return getDocumentInternal(name, revision);
+  }
+
+  @Override
+  public XmlDBNode getDocument(final String name) {
+    return getDocument(name, -1);
+  }
+
+  @Override
+  public Stream<XmlDBNode> getDocuments() {
+    final List<Path> resources = database.listResources();
+    final List<XmlDBNode> documents = new ArrayList<>(resources.size());
+
+    resources.forEach(resourcePath -> {
+      final String resourceName = resourcePath.getFileName().toString();
+      final XmlResourceSession resource = database.beginResourceSession(resourceName);
+      try {
+        final XmlNodeReadOnlyTrx trx = resource.beginNodeReadOnlyTrx();
+        documents.add(new XmlDBNode(trx, this));
+      } catch (final SirixException e) {
+        resource.close();
+        throw new DocumentException(e.getCause());
+      } catch (final Exception e) {
+        resource.close();
+        throw e;
+      }
+    });
+
+    return new ArrayStream<>(documents.toArray(new XmlDBNode[0]));
+  }
+
+  private record DocumentData(String name, int revision) {
+  }
+
+  private record InstantDocumentData(String name, Instant revision) {
+  }
+}

--- a/bundles/sirix-rest-api/build.gradle
+++ b/bundles/sirix-rest-api/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation testLibraries.junitPlatformLauncher
     testImplementation testLibraries.vertxJunit5
     testImplementation testLibraries.jsonassert
+    testImplementation testLibraries.mockitoCore
 
 }
 
@@ -103,6 +104,25 @@ dockerCompose {
     containerLogToDir = project.file('logs') // directory where composeLogs task stores output of the containers; default: build/containers-logs
 
     projectName = 'sirix-test'
+}
+
+// Task to run offline unit tests tagged 'offline' (e.g. the authorization-guard tests for the
+// REST session stores). These need neither Docker nor Keycloak, so unlike the main `test` task
+// they do not depend on composeUp and can run in isolation.
+tasks.register('offlineTest', Test) {
+    description = 'Run offline unit tests that need neither Docker nor Keycloak'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform {
+        includeTags 'offline'
+    }
+    jvmArgs = [
+        '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED',
+        '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
+        '--add-modules', 'jdk.incubator.vector',
+        '--enable-native-access=ALL-UNNAMED'
+    ]
 }
 
 // Task to run only native-image smoke tests on JVM (for validation before native compilation)

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/AuthCheckingJsonDBCollection.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/AuthCheckingJsonDBCollection.kt
@@ -1,0 +1,75 @@
+package io.sirix.rest.crud.json
+
+import com.google.gson.stream.JsonReader
+import io.brackit.query.jdm.json.Object
+import io.sirix.query.json.JsonDBCollection
+import io.sirix.query.json.JsonDBItem
+import io.sirix.rest.Auth
+import io.sirix.rest.AuthRole
+import io.vertx.ext.auth.User
+import io.vertx.ext.auth.authorization.AuthorizationProvider
+import java.io.InputStream
+import java.nio.file.Path
+
+/**
+ * A [JsonDBCollection] decorator that enforces per-request authorization on every mutating
+ * operation, by composition (Kotlin interface delegation) rather than inheritance.
+ *
+ * The REST query endpoint runs under the VIEW role and injects a [JsonSessionDBStore] into the
+ * brackit query context. Looking a collection up is a read (VIEW) and legitimately returns a
+ * collection, but the raw collection then exposes `add`/`remove`/`delete`, which a query such as
+ * `jn:store(...)` calls directly on the collection object — bypassing the store-level checks. Every
+ * read is delegated straight to [wrapped]; the mutating methods re-check the caller's role first,
+ * so a VIEW-only token cannot mutate through a looked-up collection.
+ */
+class AuthCheckingJsonDBCollection(
+    private val wrapped: JsonDBCollection,
+    private val user: User,
+    private val authz: AuthorizationProvider
+) : JsonDBCollection by wrapped {
+
+    private val collectionName: String = wrapped.getName()
+
+    override fun delete() {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.DELETE, authz)
+        wrapped.delete()
+    }
+
+    override fun remove(documentID: Long) {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.DELETE, authz)
+        wrapped.remove(documentID)
+    }
+
+    override fun add(resourceName: String, reader: JsonReader, options: Object): JsonDBItem {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(resourceName, reader, options)
+    }
+
+    override fun add(resourceName: String, reader: JsonReader): JsonDBItem {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(resourceName, reader)
+    }
+
+    override fun add(json: String): JsonDBItem {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(json)
+    }
+
+    override fun add(file: Path): JsonDBItem {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(file)
+    }
+
+    override fun add(inputStream: InputStream): JsonDBItem {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(inputStream)
+    }
+
+    // Interface delegation does not forward Object methods; key equality on the underlying
+    // database (as the concrete collection does) so the decorator remains a drop-in replacement.
+    override fun equals(other: Any?): Boolean = wrapped == other
+
+    override fun hashCode(): Int = wrapped.hashCode()
+
+    override fun toString(): String = wrapped.toString()
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonGet.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonGet.kt
@@ -23,6 +23,7 @@ import io.sirix.query.json.AtomicBooleanJsonDBItem
 import io.sirix.query.json.AtomicNullJsonDBItem
 import io.sirix.query.json.AtomicStrJsonDBItem
 import io.sirix.query.json.JsonDBCollection
+import io.sirix.query.json.JsonDBCollectionImpl
 import io.sirix.query.json.JsonDBObject
 import io.sirix.query.json.JsonItemFactory
 import io.sirix.query.json.NumericJsonDBItem
@@ -238,7 +239,7 @@ class JsonGet(location: Path, private val keycloak: OAuth2Auth, private val auth
         databaseName: String?,
         database: Database<JsonResourceSession>
     ): JsonDBCollection {
-        return JsonDBCollection(databaseName, database)
+        return JsonDBCollectionImpl(databaseName, database)
     }
 
     override fun handleQueryExtra(

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonSessionDBStore.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonSessionDBStore.kt
@@ -1,15 +1,17 @@
 package io.sirix.rest.crud.json
 
 import com.google.gson.stream.JsonReader
+import io.brackit.query.atomic.Str
+import io.brackit.query.jdm.Stream
 import io.brackit.query.jdm.json.Object
 import io.vertx.ext.auth.User
 import io.vertx.ext.auth.authorization.AuthorizationProvider
 import io.vertx.ext.web.RoutingContext
+import io.sirix.rest.Auth
 import io.sirix.rest.AuthRole
 import io.sirix.query.json.JsonDBCollection
 import io.sirix.query.json.JsonDBStore
 import java.nio.file.Path
-import java.time.Instant
 
 class JsonSessionDBStore(
     private val ctx: RoutingContext,
@@ -17,72 +19,87 @@ class JsonSessionDBStore(
     private val user: User,
     private val authz: AuthorizationProvider
 ) : JsonDBStore by dbStore {
-    override fun lookup(name: String): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.VIEW, authz)
 
-        return dbStore.lookup(name)
+    /**
+     * Wrap a collection so that every mutating operation performed through it re-checks the
+     * caller's authorization. Without this the store-level checks are bypassable: a VIEW token can
+     * [lookup] a collection (a read) and then call `add`/`remove`/`delete` directly on it.
+     */
+    private fun wrap(collection: JsonDBCollection): JsonDBCollection =
+        AuthCheckingJsonDBCollection(collection, user, authz)
+
+    override fun lookup(name: String): JsonDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.VIEW, authz)
+
+        return wrap(dbStore.lookup(name))
     }
 
     override fun create(name: String): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name)
+        return wrap(dbStore.create(name))
     }
 
     override fun create(name: String, path: String): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, path)
+        return wrap(dbStore.create(name, path))
     }
 
     override fun create(name: String, path: String, options: Object): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, path, options)
+        return wrap(dbStore.create(name, path, options))
     }
 
     override fun create(name: String, path: Path): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, path)
+        return wrap(dbStore.create(name, path))
     }
 
     override fun create(name: String, path: Path, options: Object): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, path, options)
+        return wrap(dbStore.create(name, path, options))
+    }
+
+    override fun createFromPaths(name: String, paths: Stream<Path>): JsonDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+
+        return wrap(dbStore.createFromPaths(name, paths))
     }
 
     override fun create(name: String, resourceName: String, path: Path): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, path)
+        return wrap(dbStore.create(name, resourceName, path))
     }
 
     override fun create(name: String, resourceName: String, path: Path, options: Object): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, path, options)
+        return wrap(dbStore.create(name, resourceName, path, options))
     }
 
     override fun create(name: String, resourceName: String, json: String): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, json)
+        return wrap(dbStore.create(name, resourceName, json))
     }
 
     override fun create(
         name: String, resourceName: String, json: String, options: Object
     ): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, json, options)
+        return wrap(dbStore.create(name, resourceName, json, options))
     }
 
     override fun create(name: String, resourceName: String, json: JsonReader): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, json)
+        return wrap(dbStore.create(name, resourceName, json))
     }
 
     override fun create(
@@ -91,20 +108,38 @@ class JsonSessionDBStore(
         json: JsonReader,
         options: Object
     ): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, resourceName, json, options)
+        return wrap(dbStore.create(name, resourceName, json, options))
     }
 
     override fun create(name: String, jsonReaders: Set<JsonReader>): JsonDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, jsonReaders)
+        return wrap(dbStore.create(name, jsonReaders))
+    }
+
+    override fun create(name: String, jsonReaders: Set<JsonReader>, options: Object): JsonDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+
+        return wrap(dbStore.create(name, jsonReaders, options))
+    }
+
+    override fun createFromJsonStrings(name: String, jsons: Stream<Str>): JsonDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+
+        return wrap(dbStore.createFromJsonStrings(name, jsons))
     }
 
     override fun drop(name: String) {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.DELETE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.DELETE, authz)
 
         return dbStore.drop(name)
+    }
+
+    override fun makeDir(path: String) {
+        Auth.checkIfAuthorized(user, path, AuthRole.CREATE, authz)
+
+        return dbStore.makeDir(path)
     }
 }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/AuthCheckingXmlDBCollection.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/AuthCheckingXmlDBCollection.kt
@@ -1,0 +1,68 @@
+package io.sirix.rest.crud.xml
+
+import io.brackit.query.node.parser.NodeSubtreeParser
+import io.sirix.query.node.XmlDBCollection
+import io.sirix.query.node.XmlDBNode
+import io.sirix.rest.Auth
+import io.sirix.rest.AuthRole
+import io.vertx.ext.auth.User
+import io.vertx.ext.auth.authorization.AuthorizationProvider
+import java.time.Instant
+
+/**
+ * An [XmlDBCollection] decorator that enforces per-request authorization on every mutating
+ * operation, by composition (Kotlin interface delegation) rather than inheritance.
+ *
+ * The REST query endpoint runs under the VIEW role and injects an [XmlSessionDBStore] into the
+ * brackit query context. Looking a collection up is a read (VIEW) and legitimately returns a
+ * collection, but the raw collection then exposes `add`/`remove`/`delete`, which a query calls
+ * directly on the collection object — bypassing the store-level checks. Every read is delegated
+ * straight to [wrapped]; the mutating methods re-check the caller's role first, so a VIEW-only
+ * token cannot mutate through a looked-up collection.
+ */
+class AuthCheckingXmlDBCollection(
+    private val wrapped: XmlDBCollection,
+    private val user: User,
+    private val authz: AuthorizationProvider
+) : XmlDBCollection by wrapped {
+
+    private val collectionName: String = wrapped.getName()
+
+    override fun delete() {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.DELETE, authz)
+        wrapped.delete()
+    }
+
+    override fun remove(documentID: Long) {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.DELETE, authz)
+        wrapped.remove(documentID)
+    }
+
+    override fun add(resourceName: String, parser: NodeSubtreeParser): XmlDBNode {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(resourceName, parser)
+    }
+
+    override fun add(
+        resourceName: String,
+        parser: NodeSubtreeParser,
+        commitMessage: String?,
+        commitTimestamp: Instant?
+    ): XmlDBNode {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(resourceName, parser, commitMessage, commitTimestamp)
+    }
+
+    override fun add(parser: NodeSubtreeParser): XmlDBNode {
+        Auth.checkIfAuthorized(user, collectionName, AuthRole.CREATE, authz)
+        return wrapped.add(parser)
+    }
+
+    // Interface delegation does not forward Object methods; key equality on the underlying
+    // database (as the concrete collection does) so the decorator remains a drop-in replacement.
+    override fun equals(other: Any?): Boolean = wrapped == other
+
+    override fun hashCode(): Int = wrapped.hashCode()
+
+    override fun toString(): String = wrapped.toString()
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlGet.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlGet.kt
@@ -17,6 +17,7 @@ import io.sirix.query.XmlDBSerializer
 import io.sirix.rest.crud.AbstractGetHandler
 import io.sirix.rest.crud.OutputWrapper
 import io.sirix.query.node.XmlDBCollection
+import io.sirix.query.node.XmlDBCollectionImpl
 import io.sirix.query.node.XmlDBNode
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.http.HttpHeaders
@@ -179,7 +180,7 @@ class XmlGet(private val location: Path, private val keycloak: OAuth2Auth, priva
     override suspend fun getDBCollection(
         databaseName: String?, database: Database<XmlResourceSession>
     ): XmlDBCollection {
-        return XmlDBCollection(databaseName, database)
+        return XmlDBCollectionImpl(databaseName, database)
     }
 
     override fun createOutputStream(): OutputWrapper =

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlSessionDBStore.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/xml/XmlSessionDBStore.kt
@@ -2,6 +2,7 @@ package io.sirix.rest.crud.xml
 
 import io.sirix.query.node.XmlDBCollection
 import io.sirix.query.node.XmlDBStore
+import io.sirix.rest.Auth
 import io.sirix.rest.AuthRole
 import io.vertx.ext.auth.User
 import io.vertx.ext.auth.authorization.AuthorizationProvider
@@ -16,22 +17,31 @@ class XmlSessionDBStore(
     private val user: User,
     private val authz: AuthorizationProvider
 ) : XmlDBStore by dbStore {
-    override fun lookup(name: String): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.VIEW, authz)
 
-        return dbStore.lookup(name)
+    /**
+     * Wrap a collection so that every mutating operation performed through it re-checks the
+     * caller's authorization. Without this the store-level checks are bypassable: a VIEW token can
+     * [lookup] a collection (a read) and then call `add`/`remove`/`delete` directly on it.
+     */
+    private fun wrap(collection: XmlDBCollection): XmlDBCollection =
+        AuthCheckingXmlDBCollection(collection, user, authz)
+
+    override fun lookup(name: String): XmlDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.VIEW, authz)
+
+        return wrap(dbStore.lookup(name))
     }
 
     override fun create(name: String): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name)
+        return wrap(dbStore.create(name))
     }
 
     override fun create(name: String, parser: NodeSubtreeParser): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, parser)
+        return wrap(dbStore.create(name, parser))
     }
 
     override fun create(
@@ -40,35 +50,41 @@ class XmlSessionDBStore(
         commitMessage: String?,
         commitTimestamp: Instant?
     ): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, parser, commitMessage, commitTimestamp)
+        return wrap(dbStore.create(name, parser, commitMessage, commitTimestamp))
     }
 
     override fun create(name: String, parsers: Stream<NodeSubtreeParser>): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
-        return dbStore.create(name, parsers)
+        return wrap(dbStore.create(name, parsers))
     }
 
     override fun create(dbName: String, resourceName: String, parsers: NodeSubtreeParser): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, dbName, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, dbName, AuthRole.CREATE, authz)
 
-        return dbStore.create(dbName, resourceName, parsers)
+        return wrap(dbStore.create(dbName, resourceName, parsers))
     }
 
     override fun create(
         dbName: String, resourceName: String, parser: NodeSubtreeParser, commitMessage: String?,
         commitTimestamp: Instant?
     ): XmlDBCollection {
-        io.sirix.rest.Auth.checkIfAuthorized(user, dbName, AuthRole.CREATE, authz)
+        Auth.checkIfAuthorized(user, dbName, AuthRole.CREATE, authz)
 
-        return dbStore.create(dbName, resourceName, parser, commitMessage, commitTimestamp)
+        return wrap(dbStore.create(dbName, resourceName, parser, commitMessage, commitTimestamp))
     }
 
     override fun drop(name: String) {
-        io.sirix.rest.Auth.checkIfAuthorized(user, name, AuthRole.DELETE, authz)
+        Auth.checkIfAuthorized(user, name, AuthRole.DELETE, authz)
 
         return dbStore.drop(name)
+    }
+
+    override fun makeDir(path: String) {
+        Auth.checkIfAuthorized(user, path, AuthRole.CREATE, authz)
+
+        return dbStore.makeDir(path)
     }
 }

--- a/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/crud/json/JsonSessionDBStoreAuthTest.kt
+++ b/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/crud/json/JsonSessionDBStoreAuthTest.kt
@@ -1,0 +1,166 @@
+package io.sirix.rest.crud.json
+
+import com.google.gson.stream.JsonReader
+import io.brackit.query.atomic.Str
+import io.brackit.query.jdm.Stream
+import io.brackit.query.jdm.json.Object
+import io.sirix.query.json.JsonDBCollection
+import io.sirix.query.json.JsonDBStore
+import io.vertx.ext.auth.User
+import io.vertx.ext.auth.authorization.Authorization
+import io.vertx.ext.auth.authorization.AuthorizationProvider
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.HttpException
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.nio.file.Path
+
+/**
+ * Offline regression tests for #1070: the REST query endpoint runs under the VIEW role and injects
+ * a [JsonSessionDBStore] into the brackit query context. A VIEW token must be rejected on every
+ * write path — both the store-level create/drop/makeDir methods and the mutating methods
+ * (`add`/`remove`/`delete`) of any collection it hands out (see [AuthCheckingJsonDBCollection],
+ * which guards by delegation).
+ *
+ * These tests use plain Vert.x [User] authorizations and Mockito stubs, so they need neither a
+ * running Keycloak nor Docker (run via the `offlineTest` Gradle task).
+ */
+@Tag("offline")
+@DisplayName("JSON REST session store rejects a VIEW token on every write path (#1070)")
+class JsonSessionDBStoreAuthTest {
+
+    private companion object {
+        const val DB = "mydb"
+    }
+
+    private fun userWith(vararg roles: String): User {
+        val user = User.fromName("test-user")
+        val authorizations: Set<Authorization> = roles.map { RoleBasedAuthorization.create(it) }.toSet()
+        user.authorizations().put("test-provider", authorizations)
+        return user
+    }
+
+    private fun stubCollection(): JsonDBCollection {
+        val collection = Mockito.mock(JsonDBCollection::class.java)
+        Mockito.`when`(collection.getName()).thenReturn(DB)
+        return collection
+    }
+
+    private fun assertForbidden(executable: () -> Unit) {
+        val exception = assertThrows(HttpException::class.java) { executable() }
+        assertEquals(403, exception.statusCode, "a VIEW token must be forbidden (403) on write paths")
+    }
+
+    @Test
+    @DisplayName("Every store-level write method throws 403 and never reaches the delegate")
+    fun viewTokenRejectedOnAllStoreWriteMethods() {
+        val delegate = Mockito.mock(JsonDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val reader = Mockito.mock(JsonReader::class.java)
+        val options = Mockito.mock(Object::class.java)
+        val path = Mockito.mock(Path::class.java)
+        @Suppress("UNCHECKED_CAST")
+        val pathStream = Mockito.mock(Stream::class.java) as Stream<Path>
+        @Suppress("UNCHECKED_CAST")
+        val strStream = Mockito.mock(Stream::class.java) as Stream<Str>
+
+        val store = JsonSessionDBStore(ctx, delegate, userWith("$DB-view"), authz)
+
+        assertForbidden { store.create(DB) }
+        assertForbidden { store.create(DB, "path") }
+        assertForbidden { store.create(DB, "path", options) }
+        assertForbidden { store.create(DB, path) }
+        assertForbidden { store.create(DB, path, options) }
+        assertForbidden { store.createFromPaths(DB, pathStream) }
+        assertForbidden { store.create(DB, "res", path) }
+        assertForbidden { store.create(DB, "res", path, options) }
+        assertForbidden { store.create(DB, "res", "json") }
+        assertForbidden { store.create(DB, "res", "json", options) }
+        assertForbidden { store.create(DB, "res", reader) }
+        assertForbidden { store.create(DB, "res", reader, options) }
+        assertForbidden { store.create(DB, setOf(reader)) }
+        assertForbidden { store.create(DB, setOf(reader), options) }
+        assertForbidden { store.createFromJsonStrings(DB, strStream) }
+        assertForbidden { store.makeDir(DB) }
+        assertForbidden { store.drop(DB) }
+
+        // Not a single write reached the underlying store.
+        Mockito.verifyNoInteractions(delegate)
+    }
+
+    @Test
+    @DisplayName("lookup is allowed for a VIEW token and returns an authorization-checking collection")
+    fun viewTokenMayLookUpButGetsGuardedCollection() {
+        val delegate = Mockito.mock(JsonDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val looked = stubCollection()
+        Mockito.`when`(delegate.lookup(DB)).thenReturn(looked)
+
+        val store = JsonSessionDBStore(ctx, delegate, userWith("$DB-view"), authz)
+
+        val collection = assertDoesNotThrow<JsonDBCollection> { store.lookup(DB) }
+        assertInstanceOf(AuthCheckingJsonDBCollection::class.java, collection)
+    }
+
+    @Test
+    @DisplayName("A collection handed to a VIEW token rejects add/remove/delete with 403")
+    fun guardedCollectionRejectsViewTokenMutations() {
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val reader = Mockito.mock(JsonReader::class.java)
+        val options = Mockito.mock(Object::class.java)
+        val path = Mockito.mock(Path::class.java)
+        val wrapped = stubCollection()
+
+        val guarded = AuthCheckingJsonDBCollection(wrapped, userWith("$DB-view"), authz)
+
+        assertForbidden { guarded.delete() }
+        assertForbidden { guarded.remove(1L) }
+        assertForbidden { guarded.add("res", reader, options) }
+        assertForbidden { guarded.add("res", reader) }
+        assertForbidden { guarded.add("{}") }
+        assertForbidden { guarded.add(path) }
+
+        // The writes were rejected before being delegated to the real collection.
+        Mockito.verify(wrapped, Mockito.never()).delete()
+        Mockito.verify(wrapped, Mockito.never()).remove(Mockito.anyLong())
+        Mockito.verify(wrapped, Mockito.never()).add(Mockito.anyString())
+        Mockito.verify(wrapped, Mockito.never()).add(Mockito.any(Path::class.java))
+    }
+
+    @Test
+    @DisplayName("The store-level check still authorizes a CREATE token and reaches the delegate")
+    fun createTokenIsAuthorizedAtStoreLevel() {
+        val delegate = Mockito.mock(JsonDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val created = stubCollection()
+        Mockito.`when`(delegate.create(DB)).thenReturn(created)
+
+        val store = JsonSessionDBStore(ctx, delegate, userWith("$DB-create"), authz)
+
+        val collection = assertDoesNotThrow<JsonDBCollection> { store.create(DB) }
+        assertInstanceOf(AuthCheckingJsonDBCollection::class.java, collection)
+        Mockito.verify(delegate).create(DB)
+    }
+
+    @Test
+    @DisplayName("The collection-level check still authorizes a DELETE token (remove is delegated)")
+    fun deleteTokenIsAuthorizedAtCollectionLevel() {
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val wrapped = stubCollection()
+
+        val guarded = AuthCheckingJsonDBCollection(wrapped, userWith("$DB-delete"), authz)
+
+        assertDoesNotThrow { guarded.remove(1L) }
+        Mockito.verify(wrapped).remove(1L)
+    }
+}

--- a/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/crud/xml/XmlSessionDBStoreAuthTest.kt
+++ b/bundles/sirix-rest-api/src/test/kotlin/io/sirix/rest/crud/xml/XmlSessionDBStoreAuthTest.kt
@@ -1,0 +1,143 @@
+package io.sirix.rest.crud.xml
+
+import io.brackit.query.jdm.Stream
+import io.brackit.query.node.parser.NodeSubtreeParser
+import io.sirix.query.node.XmlDBCollection
+import io.sirix.query.node.XmlDBStore
+import io.vertx.ext.auth.User
+import io.vertx.ext.auth.authorization.Authorization
+import io.vertx.ext.auth.authorization.AuthorizationProvider
+import io.vertx.ext.auth.authorization.RoleBasedAuthorization
+import io.vertx.ext.web.RoutingContext
+import io.vertx.ext.web.handler.HttpException
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+
+/**
+ * Offline regression tests for #1070, XML variant: a VIEW token injected into the brackit query
+ * context via [XmlSessionDBStore] must be rejected on every write path — the store-level
+ * create/drop/makeDir methods and the mutating methods of any collection it hands out (see
+ * [AuthCheckingXmlDBCollection], which guards by delegation).
+ *
+ * Uses plain Vert.x [User] authorizations and Mockito stubs, so it needs neither Keycloak nor
+ * Docker (run via the `offlineTest` Gradle task).
+ */
+@Tag("offline")
+@DisplayName("XML REST session store rejects a VIEW token on every write path (#1070)")
+class XmlSessionDBStoreAuthTest {
+
+    private companion object {
+        const val DB = "mydb"
+    }
+
+    private fun userWith(vararg roles: String): User {
+        val user = User.fromName("test-user")
+        val authorizations: Set<Authorization> = roles.map { RoleBasedAuthorization.create(it) }.toSet()
+        user.authorizations().put("test-provider", authorizations)
+        return user
+    }
+
+    private fun stubCollection(): XmlDBCollection {
+        val collection = Mockito.mock(XmlDBCollection::class.java)
+        Mockito.`when`(collection.getName()).thenReturn(DB)
+        return collection
+    }
+
+    private fun assertForbidden(executable: () -> Unit) {
+        val exception = assertThrows(HttpException::class.java) { executable() }
+        assertEquals(403, exception.statusCode, "a VIEW token must be forbidden (403) on write paths")
+    }
+
+    @Test
+    @DisplayName("Every store-level write method throws 403 and never reaches the delegate")
+    fun viewTokenRejectedOnAllStoreWriteMethods() {
+        val delegate = Mockito.mock(XmlDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val parser = Mockito.mock(NodeSubtreeParser::class.java)
+        @Suppress("UNCHECKED_CAST")
+        val parserStream = Mockito.mock(Stream::class.java) as Stream<NodeSubtreeParser>
+
+        val store = XmlSessionDBStore(ctx, delegate, userWith("$DB-view"), authz)
+
+        assertForbidden { store.create(DB) }
+        assertForbidden { store.create(DB, parser) }
+        assertForbidden { store.create(DB, parser, "message", null) }
+        assertForbidden { store.create(DB, parserStream) }
+        assertForbidden { store.create(DB, "res", parser) }
+        assertForbidden { store.create(DB, "res", parser, "message", null) }
+        assertForbidden { store.makeDir(DB) }
+        assertForbidden { store.drop(DB) }
+
+        Mockito.verifyNoInteractions(delegate)
+    }
+
+    @Test
+    @DisplayName("lookup is allowed for a VIEW token and returns an authorization-checking collection")
+    fun viewTokenMayLookUpButGetsGuardedCollection() {
+        val delegate = Mockito.mock(XmlDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val looked = stubCollection()
+        Mockito.`when`(delegate.lookup(DB)).thenReturn(looked)
+
+        val store = XmlSessionDBStore(ctx, delegate, userWith("$DB-view"), authz)
+
+        val collection = assertDoesNotThrow<XmlDBCollection> { store.lookup(DB) }
+        assertInstanceOf(AuthCheckingXmlDBCollection::class.java, collection)
+    }
+
+    @Test
+    @DisplayName("A collection handed to a VIEW token rejects add/remove/delete with 403")
+    fun guardedCollectionRejectsViewTokenMutations() {
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val parser = Mockito.mock(NodeSubtreeParser::class.java)
+        val wrapped = stubCollection()
+
+        val guarded = AuthCheckingXmlDBCollection(wrapped, userWith("$DB-view"), authz)
+
+        assertForbidden { guarded.delete() }
+        assertForbidden { guarded.remove(1L) }
+        assertForbidden { guarded.add("res", parser) }
+        assertForbidden { guarded.add("res", parser, "message", null) }
+        assertForbidden { guarded.add(parser) }
+
+        Mockito.verify(wrapped, Mockito.never()).delete()
+        Mockito.verify(wrapped, Mockito.never()).remove(Mockito.anyLong())
+        Mockito.verify(wrapped, Mockito.never()).add(Mockito.any(NodeSubtreeParser::class.java))
+    }
+
+    @Test
+    @DisplayName("The store-level check still authorizes a CREATE token and reaches the delegate")
+    fun createTokenIsAuthorizedAtStoreLevel() {
+        val delegate = Mockito.mock(XmlDBStore::class.java)
+        val ctx = Mockito.mock(RoutingContext::class.java)
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val created = stubCollection()
+        Mockito.`when`(delegate.create(DB)).thenReturn(created)
+
+        val store = XmlSessionDBStore(ctx, delegate, userWith("$DB-create"), authz)
+
+        val collection = assertDoesNotThrow<XmlDBCollection> { store.create(DB) }
+        assertInstanceOf(AuthCheckingXmlDBCollection::class.java, collection)
+        Mockito.verify(delegate).create(DB)
+    }
+
+    @Test
+    @DisplayName("The collection-level check still authorizes a DELETE token (remove is delegated)")
+    fun deleteTokenIsAuthorizedAtCollectionLevel() {
+        val authz = Mockito.mock(AuthorizationProvider::class.java)
+        val wrapped = stubCollection()
+
+        val guarded = AuthCheckingXmlDBCollection(wrapped, userWith("$DB-delete"), authz)
+
+        assertDoesNotThrow { guarded.remove(1L) }
+        Mockito.verify(wrapped).remove(1L)
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Closes an authorization bypass on the REST API. The query endpoint runs under the **VIEW** role and injects a session-scoped `JsonSessionDBStore` / `XmlSessionDBStore` into the brackit query context. Two gaps let a VIEW token mutate data through that read-only endpoint (e.g. via `jn:store(...)` / `jn:load(...)`):

1. **Missing store overrides.** `createFromPaths`, `create(name, Set<JsonReader>, options)`, `createFromJsonStrings` and `makeDir` (JSON), and `makeDir` (XML) were never overridden on the session store, so they delegated straight to the underlying store with **no authorization check**. `jn:store` with a multi-document sequence reaches `createFromJsonStrings` directly.
2. **Unguarded collections.** `lookup()` legitimately requires only VIEW and returns a collection, but the raw collection then exposes `add` / `remove` / `delete`, which `jn:store` calls **directly on the collection object**, bypassing the store-level checks entirely.

## Approach: composition (delegation), not inheritance

The collections are guarded by **delegation** rather than by subclassing the domain classes:

- `JsonDBCollection` / `XmlDBCollection` are now **interfaces** (the concrete classes become `JsonDBCollectionImpl` / `XmlDBCollectionImpl`). The brackit `TemporalJson/NodeCollection` supertypes already declare the standard operations, so each interface only adds the Sirix-specific accessors and the resource-named `add` overloads.
- The REST layer wraps every collection returned from `lookup`/`create` in `AuthCheckingJsonDBCollection` / `AuthCheckingXmlDBCollection`, which implement the interface via **Kotlin delegation** (`class … : JsonDBCollection by wrapped`) — mirroring the existing `JsonSessionDBStore by dbStore` idiom. Every read forwards straight to the real collection; `add` re-checks `CREATE` and `remove`/`delete` re-check `DELETE` before delegating.
- Added the missing store-method overrides with the correct role (`CREATE` for creation and `makeDir`).

No domain class is subclassed and no `final` is removed — the concrete implementations stay `final`.

Read-only queries are unaffected: only the mutating methods are guarded, so a VIEW token keeps working for reads while every write path now returns **403**. The other REST handlers are unaffected — the delete handler drives writes through `store.drop` (already DELETE-guarded) and the raw `Database`, not the wrapped collections.

## Related issue

Closes #1070

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Compiles across the touched modules (query, rest-api, mcp, kotlin-cli) on JDK 25
- [x] Added or updated tests covering the change — new offline suite is green (10/10); query-module `jn:store`/`jn:load` and XML collection integration tests pass against the refactored interface
- [ ] For behavioral changes to the storage engine: the relevant invariant in `docs/formal-verification.md` is still upheld — n/a (REST authorization layer, no storage-engine invariant touched)
- [ ] Updated documentation (README / docs) where relevant — n/a
- [x] No unrelated formatting churn

## Notes for reviewers

- **Interface extraction blast radius:** `JsonDBCollection`/`XmlDBCollection` become interfaces; the ~12 construction sites (`BasicJson/XmlDBStore`, `Json/XmlGet`, `kotlin-cli Query`) now build the `…Impl`. All other references use the type only and are unchanged. The XML interface re-declares `getDocument*`/`getDocuments`/`add(parser)` with the narrowed `XmlDBNode` return type (the concrete class already narrowed the brackit element type). `equals`/`hashCode` still key on the database only, and the delegating wrapper forwards them, so a wrapped collection compares equal to the original.
- **New tests:** `JsonSessionDBStoreAuthTest` / `XmlSessionDBStoreAuthTest` assert a VIEW token is rejected (403) on every store- and collection-level write path (including the brackit `add(InputStream)` default for JSON), that `CREATE`/`DELETE` tokens are still authorized, and that `lookup` returns a guarded collection. They use plain Vert.x `User` authorizations + Mockito, so they need **neither Keycloak nor Docker**, and run via the new Docker-free `:sirix-rest-api:offlineTest` Gradle task (they also run under the main `test` task in CI).
- The only behavioural change for legitimate users: a **GET** query that attempts to write (`jn:store` etc.) under a VIEW token now returns 403 instead of silently mutating. Writes should go through the `CREATE`/`MODIFY` POST/PUT endpoints, which are unaffected.