### PR TITLE
Persist the index catalogue before the uber-page beacon (#1080)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/KeyedTrieWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/KeyedTrieWriter.java
@@ -82,10 +82,10 @@ final class KeyedTrieWriter {
       revisionRootPage =
           new RevisionRootPage(storageEngineReader.loadRevRoot(baseRevision), representRevision + 1);
 
-      // Link the prepared revision root nodePageReference with the prepared indirect tree.
-      final var revRootRef = new PageReference().setDatabaseId(storageEngineReader.getDatabaseId())
-                                                .setResourceId(storageEngineReader.getResourceId());
-      log.put(revRootRef, PageContainer.getInstance(revisionRootPage, revisionRootPage));
+      // NB: the prepared RevisionRootPage is logged (under the uber-page's revision-root reference)
+      // by StorageEngineWriterFactory, which is the reference the uber-page actually commits. A
+      // second log.put here under a throwaway PageReference only added a TIL entry unreachable from
+      // the uber-page — never serialized, but held (and double-closed on log.clear) until commit.
     }
 
     // Return prepared revision root nodePageReference.

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -75,6 +75,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.foreign.MemorySegment;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -90,6 +91,7 @@ import static io.sirix.cache.LinuxMemorySegmentAllocator.SIXTYFOUR_KB;
 import static java.nio.file.Files.deleteIfExists;
 import static java.nio.file.Files.newOutputStream;
 import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -960,32 +962,38 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
       final long t2 = timing ? System.nanoTime() : 0;
 
-      // CRITICAL crash-safety invariant (write-ahead property): all data pages MUST be durable
-      // BEFORE either uber-page beacon is written. writeUberPageReference OWNS the entire
-      // durability protocol — it flushes the buffered page tail, forces the data file, and
-      // writes both beacons through a write-through (DSYNC) channel, so its RETURN is the
-      // commit acknowledge (see the Writer#writeUberPageReference durability contract). The
-      // former extra barriers here (a pre-beacon forceAll that covered strictly less than the
-      // internal barrier, plus a post-beacon acknowledge fsync — sync vs async pendingFsync
-      // depending on auto-commit) were duplicated kernel/journal work: 7 sync calls per commit,
-      // whose accumulated pressure measurably degraded long commit-heavy runs.
-      final long t3 = timing ? System.nanoTime() : 0;
-      final long t4 = timing ? System.nanoTime() : 0;
-      storagePageReaderWriter.writeUberPageReference(getResourceSession().getResourceConfig(), uberPageReference,
-          uberPage, bufferBytes);
-
-      final long t5 = timing ? System.nanoTime() : 0;
-      final long t6 = timing ? System.nanoTime() : 0;
       final int revision = uberPage.getRevisionNumber();
 
-      // Skip index definition serialization on intermediate auto-commits when indexes are unchanged.
-      // Final/explicit commits always serialize to ensure the last revision has a valid XML snapshot.
+      // Persist the index catalogue BEFORE the uber-page beacon. The beacon (writeUberPageReference)
+      // is the durable commit point; writing {revision}.xml AFTER it opened a crash window in which a
+      // committed revision had no index catalogue, so a reopen resurrected a stale catalogue from an
+      // older revision's file (the load side falls back to the most recent {N}.xml <= the requested
+      // revision — see AbstractResourceSession#initializeIndexController). Serializing and fsync'ing it
+      // first means either the catalogue is durable before the revision is acknowledged, or the
+      // revision was never committed and the orphaned file (named for an uncommitted, higher revision)
+      // is never consulted.
+      //
+      // Intermediate auto-commits skip this when indexes are unchanged; final/explicit commits always
+      // serialize so the last revision has a valid catalogue snapshot.
       if (!isIntermediateCommit || indexController.getIndexes().isDirty()) {
         serializeIndexDefinitions(revision);
         indexController.getIndexes().clearDirty();
       }
 
-      final long t7 = timing ? System.nanoTime() : 0;
+      final long t3 = timing ? System.nanoTime() : 0;
+
+      // CRITICAL crash-safety invariant (write-ahead property): all data pages AND the index
+      // catalogue (above) MUST be durable BEFORE either uber-page beacon is written.
+      // writeUberPageReference OWNS the entire data-durability protocol — it flushes the buffered
+      // page tail, forces the data file, and writes both beacons through a write-through (DSYNC)
+      // channel, so its RETURN is the commit acknowledge (see the Writer#writeUberPageReference
+      // durability contract). The former extra barriers here (a pre-beacon forceAll that covered
+      // strictly less than the internal barrier, plus a post-beacon acknowledge fsync) were
+      // duplicated kernel/journal work whose accumulated pressure degraded long commit-heavy runs.
+      storagePageReaderWriter.writeUberPageReference(getResourceSession().getResourceConfig(), uberPageReference,
+          uberPage, bufferBytes);
+
+      final long t4 = timing ? System.nanoTime() : 0;
 
       // CRITICAL: Release current page guard BEFORE TIL.clear()
       // If guard is on a TIL page, the page won't close (guardCount > 0 check)
@@ -1002,7 +1010,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       secondMostRecentPageContainer.set(IndexType.DOCUMENT, -1, -1, -1, null);
       mostRecentPathSummaryPageContainer.set(IndexType.PATH_SUMMARY, -1, -1, -1, null);
 
-      final long t8 = timing ? System.nanoTime() : 0;
+      final long t5 = timing ? System.nanoTime() : 0;
 
       // Delete commit file which denotes that a commit must write the log in the data file.
       try {
@@ -1012,10 +1020,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       }
 
       if (timing) {
-        LOGGER.debug("Commit r{}: serialize={}ms recursive={}ms waitFsync={}ms "
-            + "force={}ms uberWrite={}ms fsync={}ms indexDefs={}ms tilClear={}ms total={}ms",
-            revision, ms(t1 - t0), ms(t2 - t1), ms(t3 - t2), ms(t4 - t3), ms(t5 - t4),
-            ms(t6 - t5), ms(t7 - t6), ms(t8 - t7), ms(t8 - t0));
+        LOGGER.debug("Commit r{}: serialize={}ms recursive={}ms indexDefs={}ms uberWrite={}ms "
+            + "tilClear={}ms total={}ms",
+            revision, ms(t1 - t0), ms(t2 - t1), ms(t3 - t2), ms(t4 - t3), ms(t5 - t4), ms(t5 - t0));
       }
 
       // Return the in-memory UberPage directly — it was modified in-place by uberPage.commit(this)
@@ -1054,6 +1061,17 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         indexController.serialize(out);
       } catch (final IOException e) {
         throw new SirixIOException("Index definitions couldn't be serialized!", e);
+      }
+
+      // fsync the catalogue so it is durable BEFORE the uber-page beacon acknowledges the revision.
+      // commit() serializes index definitions ahead of writeUberPageReference precisely so a crash
+      // cannot leave a committed revision without its {revision}.xml; that guarantee only holds if the
+      // bytes have actually reached stable storage here (a bare OutputStream.close only flushes to the
+      // OS page cache).
+      try (final FileChannel channel = FileChannel.open(indexes, WRITE)) {
+        channel.force(true);
+      } catch (final IOException e) {
+        throw new SirixIOException("Index definitions couldn't be fsync'd!", e);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/SerializationType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/SerializationType.java
@@ -142,7 +142,9 @@ public enum SerializationType {
 
         for (final PageReference pageReference : pageReferences) {
           if (pageReference != null) {
-            out.writeLong(pageReference.getKey());
+            // writePageFragments already writes pageReference.getKey() as its trailing long, so the
+            // former explicit out.writeLong(getKey()) here duplicated the key (8 wasted bytes/ref).
+            // Mirrors serializeBitmapReferencesPage / serializeReferencesPage4, which never wrote it.
             writePageFragments(out, pageReference);
             writeHash(out, pageReference);
           }
@@ -160,7 +162,8 @@ public enum SerializationType {
 
         for (int i = bitSet.nextSetBit(0); i >= 0; i = bitSet.nextSetBit(i + 1)) {
           final var pageReference = new PageReference();
-          pageReference.setKey(in.readLong());
+          // readPageFragments reads the trailing key long and setKey()s it (mirrors the serialize
+          // side); the former explicit setKey(readLong()) here consumed a duplicate 8-byte key.
           readPageFragments(in, pageReference);
           readHash(in, pageReference);
           references[i] = pageReference;

--- a/bundles/sirix-core/src/test/java/io/sirix/page/FullReferencesPageSerializationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/FullReferencesPageSerializationTest.java
@@ -1,0 +1,77 @@
+package io.sirix.page;
+
+import io.sirix.node.Bytes;
+import io.sirix.node.BytesOut;
+import io.sirix.page.interfaces.PageFragmentKey;
+import io.sirix.settings.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trips a full references page through {@link SerializationType#serializeFullReferencesPage}
+ * and {@link SerializationType#deserializeFullReferencesPage}. Guards the wire format after the key
+ * was written/read exactly once (previously the reference key was serialized twice — once
+ * explicitly and once inside {@code writePageFragments} — and read twice on the way back).
+ */
+public final class FullReferencesPageSerializationTest {
+
+  @Test
+  public void fullReferencesPageRoundTripsKeysFragmentsAndHashes() {
+    final PageReference[] refs = new PageReference[Constants.INP_REFERENCE_COUNT];
+
+    // A reference with a key, two page fragments and an 8-byte hash.
+    final PageReference first = new PageReference();
+    first.setKey(42L);
+    first.setPageFragments(List.of(new PageFragmentKeyImpl(1, 200L, 0L, 0L),
+        new PageFragmentKeyImpl(2, 763L, 0L, 0L)));
+    first.setHash(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+    refs[0] = first;
+
+    // A reference in the middle with only a key (no fragments, no hash).
+    final PageReference middle = new PageReference();
+    middle.setKey(9_999_999L);
+    refs[500] = middle;
+
+    // The last slot, to exercise the bitset's high bit.
+    final PageReference last = new PageReference();
+    last.setKey(123_456L);
+    refs[Constants.INP_REFERENCE_COUNT - 1] = last;
+
+    final BytesOut<?> out = Bytes.elasticOffHeapByteBuffer();
+    SerializationType.DATA.serializeFullReferencesPage(out, refs);
+
+    final PageReference[] back =
+        SerializationType.DATA.deserializeFullReferencesPage(Bytes.wrapForRead(out.toByteArray()));
+
+    // Exactly the three populated offsets survive; everything else is null.
+    for (int i = 0; i < Constants.INP_REFERENCE_COUNT; i++) {
+      if (i == 0 || i == 500 || i == Constants.INP_REFERENCE_COUNT - 1) {
+        assertNotNull(back[i], "reference at offset " + i + " must round-trip");
+      } else {
+        assertNull(back[i], "offset " + i + " must stay empty");
+      }
+    }
+
+    assertEquals(42L, back[0].getKey());
+    assertArrayEquals(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}, back[0].getHash());
+    final List<PageFragmentKey> fragments = back[0].getPageFragments();
+    assertEquals(2, fragments.size());
+    assertEquals(1, fragments.get(0).revision());
+    assertEquals(200L, fragments.get(0).key());
+    assertEquals(2, fragments.get(1).revision());
+    assertEquals(763L, fragments.get(1).key());
+
+    assertEquals(9_999_999L, back[500].getKey());
+    assertTrue(back[500].getPageFragments().isEmpty());
+    assertNull(back[500].getHash());
+
+    assertEquals(123_456L, back[Constants.INP_REFERENCE_COUNT - 1].getKey());
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a crash-recovery inconsistency in the commit path, plus two small cleanups noted in the same issue.

### Main fix (#1080)

In `NodeStorageEngineWriter.commit`, `writeUberPageReference` (the durable commit point / beacon) ran **before** `serializeIndexDefinitions(revision)`. A crash in that window produced a committed revision whose `{revision}.xml` index catalogue was never written. On reopen, the load side (`AbstractResourceSession#initializeIndexController`) falls back to the most recent `{N}.xml` at or below the requested revision — resurrecting the pre-commit catalogue from an older revision's file while the data pages already reflect the change. Concretely: drop the last index and commit, crash in the window, and a reopen brings the dropped index definition back to life.

The fix makes the ordering write-ahead:

- Move index-catalogue serialization to **before** `writeUberPageReference`, and **fsync** it there (`FileChannel.force(true)`). A bare `OutputStream.close()` only reaches the OS page cache, so without the force the beacon could still be acknowledged ahead of the catalogue's durability.
- Result: either the catalogue is durable before the revision is acknowledged, or the revision was never committed and the orphaned `{revision}.xml` (named for an uncommitted, *higher* revision) is never consulted by the at-or-below fallback.
- Common path unchanged: a resource with no index definitions still writes nothing.

### Folded-in cleanups (the two "minor notes" from #1080)

1. **`KeyedTrieWriter.preparePreviousRevisionRootPage`** logged the prepared `RevisionRootPage` under a throwaway `PageReference`, in addition to the reference `StorageEngineWriterFactory` logs and links into the uber-page. That second TIL entry was unreachable from the uber-page (never serialized) but was held — and double-closed on `log.clear()` — until commit. Removed; the factory's reference is the one that actually commits.
2. **`SerializationType.serializeFullReferencesPage`** wrote each reference's `key` twice — once explicitly and once as the trailing long inside `writePageFragments` (deserialize read it twice, the second `setKey` overwriting the first). Dropped the explicit write/read pair so the key is stored once, matching `serializeBitmapReferencesPage` / `serializeReferencesPage4`. Saves 8 bytes per non-null reference.

> ⚠️ **Format change (cleanup 2):** this changes the on-disk layout of `FullReferencesPage` — databases written before this change carry the extra 8 bytes/reference and are not readable by the new code (and vice versa). No committed fixtures depend on the old layout; flagging it explicitly so you can decide whether to keep it in this PR or split it out.

## Related issue

Closes #1080

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Minor cleanup / micro-optimization (cleanup 2 is an on-disk format change — see caveat above)

## Checklist

- [x] `./gradlew :sirix-core:compileJava` passes (JDK 25)
- [x] Added or updated tests covering the change — new `FullReferencesPageSerializationTest` (direct serialize/deserialize round-trip of keys, fragments and hashes); exercised the index create/drop/reopen suites (`ProjectionIndexIntegrationTest`, `ValidTimeIndexDropTest`, `ValidTimeIndexEndToEndTest`), the page round-trip suite (`PageTest`, `ReferencesPage4Test`), `KeyedTrieIntegrationTest` (10), dense-key (`HOTDenseKeyScaleTest`) and the plain commit path (`PreallocatedCommitTest`, `JsonNodeTrxUpdateTest`) — all green
- [x] No unrelated formatting churn

## Notes for reviewers

- `serializeIndexDefinitions` is called from exactly one place (the commit path), so adding the fsync there has no other callers to consider.
- `revision = uberPage.getRevisionNumber()` is read after `uberPage.commit(this)` (unchanged value; the beacon write doesn't alter it), just moved a few lines up so the catalogue can be named before the beacon.
- The two cleanups are in a separate commit from the durability fix; happy to drop cleanup 2 if you'd rather not take the format change here.
