### PR TITLE
Commit safety: recover from failed commits (#1061) and suppress auto-commits inside compound operations (#1062)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -334,52 +334,80 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   private W commitInternal(@Nullable final String commitMessage, @Nullable final Instant commitTimestamp,
       final boolean isIntermediateCommit) {
     runLocked(() -> {
-      state = State.COMMITTING;
-
-      // Flush deferred PathSummary statistics into real PathNodes before
-      // commit. Each recordValue() call during the transaction buffered its
-      // delta in PathSummaryWriter.pendingStats rather than paying a
-      // prepareRecordForModification COW per insert; applying them all here
-      // reduces per-shred PathSummary COW traffic by several orders of
-      // magnitude on analytical workloads.
-      if (pathSummaryWriter != null) {
-        pathSummaryWriter.flushPendingStats();
-      }
-
-      // Execute pre-commit hooks.
-      for (final PreCommitHook hook : preCommitHooks) {
-        hook.preCommit(this);
-      }
-
-      // Reset modification counter.
-      modificationCount = 0L;
-
       final var preCommitRevision = getRevisionNumber();
 
-      // Await any pending async background flush before sync commit
-      storageEngineWriter.awaitPendingAsyncCommit();
+      state = State.COMMITTING;
 
-      final UberPage uberPage = storageEngineWriter.commit(commitMessage, commitTimestamp,
-          isAutoCommitting, isIntermediateCommit);
+      final UberPage uberPage;
+      try {
+        // Flush deferred PathSummary statistics into real PathNodes before
+        // commit. Each recordValue() call during the transaction buffered its
+        // delta in PathSummaryWriter.pendingStats rather than paying a
+        // prepareRecordForModification COW per insert; applying them all here
+        // reduces per-shred PathSummary COW traffic by several orders of
+        // magnitude on analytical workloads.
+        if (pathSummaryWriter != null) {
+          pathSummaryWriter.flushPendingStats();
+        }
+
+        // Execute pre-commit hooks.
+        for (final PreCommitHook hook : preCommitHooks) {
+          hook.preCommit(this);
+        }
+
+        // Await any pending async background flush before sync commit
+        storageEngineWriter.awaitPendingAsyncCommit();
+
+        uberPage = storageEngineWriter.commit(commitMessage, commitTimestamp, isAutoCommitting, isIntermediateCommit);
+      } catch (final RuntimeException | Error e) {
+        // Nothing is durable yet: restore the state machine so the transaction stays usable
+        // (retry, further work, or an explicit rollback all remain possible) instead of being
+        // stranded in COMMITTING where assertRunning() rejects everything. The modification
+        // counter is untouched here — it is only cleared after durability — so the dirty-close
+        // guard keeps refusing to silently drop the uncommitted work (#1061).
+        state = State.RUNNING;
+        throw e;
+      }
+
+      // The revision is durable from this point on. Clear the dirty counter only now: resetting
+      // it before the storage commit let a failed commit followed by close() silently discard
+      // uncommitted work (close() only refuses when modificationCount > 0).
+      modificationCount = 0L;
 
       // Remember successfully committed uber page in resource session.
       resourceSession.setLastCommittedUberPage(uberPage);
 
       if (resourceSession.getResourceConfig().storeDiffs()) {
-        serializeUpdateDiffs(preCommitRevision);
+        try {
+          serializeUpdateDiffs(preCommitRevision);
+        } catch (final RuntimeException | Error e) {
+          // Post-durability failure: the revision IS committed; a failed diff-sidecar write must
+          // neither strand the transaction in COMMITTING nor pretend the commit failed. Surface
+          // it loudly and keep the transaction alive.
+          LOGGER.error("Update-diff serialization failed after revision {} was durably committed — "
+              + "the diff file for this revision is missing.", preCommitRevision, e);
+        }
       }
 
-      // Reinstantiate everything.
-      if (afterCommitState == AfterCommitState.KEEP_OPEN
-          || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
-        // Use the newly committed revision number, not the pre-commit revision.
-        // After commit, uberPage represents the new revision, and we need to
-        // create a page transaction that will prepare the NEXT revision.
-        final int newlyCommittedRevision = uberPage.getRevisionNumber();
-        reInstantiate(getId(), newlyCommittedRevision);
-        state = State.RUNNING;
-      } else {
+      try {
+        // Reinstantiate everything.
+        if (afterCommitState == AfterCommitState.KEEP_OPEN
+            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
+          // Use the newly committed revision number, not the pre-commit revision.
+          // After commit, uberPage represents the new revision, and we need to
+          // create a page transaction that will prepare the NEXT revision.
+          final int newlyCommittedRevision = uberPage.getRevisionNumber();
+          reInstantiate(getId(), newlyCommittedRevision);
+          state = State.RUNNING;
+        } else {
+          state = State.COMMITTED;
+        }
+      } catch (final RuntimeException | Error e) {
+        // The data is durable but the transaction could not be re-bound to the new revision.
+        // Terminal COMMITTED (never stuck COMMITTING): further mutations are rejected with a
+        // truthful state, and close() is clean because nothing uncommitted remains.
         state = State.COMMITTED;
+        throw e;
       }
     });
 
@@ -389,6 +417,32 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
     }
 
     return self();
+  }
+
+  /**
+   * Depth of nested compound structural operations (move, replace, …). While > 0, count-based
+   * intermediate auto-commits are suppressed: compound operations internally call public mutators
+   * (each running {@link #checkAccessAndCommit()}), and an auto-commit firing between the internal
+   * steps would durably persist a structurally inconsistent tree — e.g. a moved subtree already
+   * detached from its old position but not yet re-attached (#1062). The counter keeps growing, so
+   * the deferred auto-commit fires on the next top-level mutation once the tree is consistent
+   * again. Guarded by the transaction lock like all mutations; no extra synchronization needed.
+   */
+  private int compoundOperationDepth;
+
+  /**
+   * Mark the start of a compound structural operation. Must be balanced with
+   * {@link #endCompoundOperation()} in a {@code finally} block so an exception mid-operation
+   * cannot leave auto-commits suppressed forever.
+   */
+  protected final void beginCompoundOperation() {
+    compoundOperationDepth++;
+  }
+
+  /** Mark the end of a compound structural operation (see {@link #beginCompoundOperation()}). */
+  protected final void endCompoundOperation() {
+    assert compoundOperationDepth > 0 : "unbalanced endCompoundOperation()";
+    compoundOperationDepth--;
   }
 
   /**
@@ -409,7 +463,7 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
    */
   protected final void checkAccessAndCommitBulk() {
     modificationCount++;
-    if (maxNodeCount > 0 && modificationCount > maxNodeCount) {
+    if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
       if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
         storageEngineWriter.asyncIntermediateCommit();
         modificationCount = 0;
@@ -443,7 +497,7 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
    */
   private void intermediateCommitIfRequired() {
     nodeReadOnlyTrx.assertNotClosed();
-    if (maxNodeCount > 0 && modificationCount > maxNodeCount) {
+    if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
       if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
         storageEngineWriter.asyncIntermediateCommit();
         modificationCount = 0;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -1844,15 +1844,24 @@ final class JsonNodeTrxImpl extends
       final InsertPosition insertPos = hasLeft
           ? InsertPosition.AS_RIGHT_SIBLING
           : InsertPosition.AS_FIRST_CHILD;
-      canRemoveValue = true;
-      remove();
-      moveTo(anchorKey);
-      if (insertPos == InsertPosition.AS_FIRST_CHILD) {
-        insertObjectRecordAsFirstChild(keyName, value);
-      } else {
-        insertObjectRecordAsRightSibling(keyName, value);
+      // Compound operation: remove + insert must not be split by an auto-commit (#1062) — a
+      // mid-replace commit would durably persist a tree with the field removed but not yet
+      // re-inserted, and its reInstantiate would wipe the update-operation maps so the
+      // REPLACEDNEW tuple recorded below references an unresolvable oldNodeKey.
+      beginCompoundOperation();
+      try {
+        canRemoveValue = true;
+        remove();
+        moveTo(anchorKey);
+        if (insertPos == InsertPosition.AS_FIRST_CHILD) {
+          insertObjectRecordAsFirstChild(keyName, value);
+        } else {
+          insertObjectRecordAsRightSibling(keyName, value);
+        }
+        adaptUpdateOperationsForReplace(getDeweyID(), oldValueNodeKey, getNodeKey());
+      } finally {
+        endCompoundOperation();
       }
-      adaptUpdateOperationsForReplace(getDeweyID(), oldValueNodeKey, getNodeKey());
       return this;
     } finally {
       if (lock != null) {
@@ -2761,128 +2770,136 @@ final class JsonNodeTrxImpl extends
 
   @Override
   public JsonNodeTrx remove() {
-    checkAccessAndCommit();
     if (lock != null) {
       lock.lock();
     }
 
-    // CRITICAL FIX: Acquire a separate guard on the current node's page
-    // to prevent it from being modified/evicted during the PostOrderAxis traversal
-    final var nodePageGuard = storageEngineWriter.acquireGuardForCurrentNode();
-
     try {
-      final StructNode node = nodeReadOnlyTrx.getStructuralNode();
-      if (node.getKind() == NodeKind.JSON_DOCUMENT) {
-        throw new SirixUsageException("Document root can not be removed.");
-      }
+      // Inside the lock, like every other mutator: running the count/auto-commit check unlocked
+      // raced against the delay-scheduled commit thread (#1062). Must also run BEFORE the page
+      // guard below — an auto-commit re-instantiates the page transaction, and the guard has to
+      // come from the current one.
+      checkAccessAndCommit();
 
-      final var parentNodeKind = getParentKind();
+      // CRITICAL FIX: Acquire a separate guard on the current node's page
+      // to prevent it from being modified/evicted during the PostOrderAxis traversal
+      final var nodePageGuard = storageEngineWriter.acquireGuardForCurrentNode();
 
-      // OBJECT_NAMED_OBJECT and OBJECT_NAMED_ARRAY (records) play the
-      // OBJECT/ARRAY role under fusion — their direct children are full object-fields, removable
-      // exactly the same way as legacy OBJECT/ARRAY children. Accept them as valid removable-
-      // child parents alongside the legacy kinds.
-      if ((parentNodeKind != NodeKind.JSON_DOCUMENT && parentNodeKind != NodeKind.OBJECT
-          && parentNodeKind != NodeKind.ARRAY
-          && parentNodeKind != NodeKind.OBJECT_NAMED_OBJECT
-          && parentNodeKind != NodeKind.OBJECT_NAMED_ARRAY) && !canRemoveValue) {
-        throw new SirixUsageException(
-            "An object record value can not be removed, you have to remove the whole object record (parent of this value).");
-      }
+      try {
+        final StructNode node = nodeReadOnlyTrx.getStructuralNode();
+        if (node.getKind() == NodeKind.JSON_DOCUMENT) {
+          throw new SirixUsageException("Document root can not be removed.");
+        }
 
-      canRemoveValue = false;
+        final var parentNodeKind = getParentKind();
 
-      // iter#32: Legacy `parentNodeKind != OBJECT_KEY` was meant to skip the DELETE
-      // diff entry when callers asked to remove the inner value-record of an
-      // OBJECT_KEY pair (a half-removal that left a dangling key wrapper). Under
-      // fusion the inner-value record no longer exists — every OBJECT_NAMED_*
-      // record IS the field — so this skip-condition does not apply. Removing a
-      // child of OBJECT_NAMED_OBJECT or OBJECT_NAMED_ARRAY is a real object/array
-      // field removal and must register a DELETE tuple, otherwise downstream
-      // consumers (BasicJsonDiff, jn:diff serializer) lose the entry entirely.
-      adaptUpdateOperationsForRemove(node.getDeweyID(), node.getNodeKey());
+        // OBJECT_NAMED_OBJECT and OBJECT_NAMED_ARRAY (records) play the
+        // OBJECT/ARRAY role under fusion — their direct children are full object-fields, removable
+        // exactly the same way as legacy OBJECT/ARRAY children. Accept them as valid removable-
+        // child parents alongside the legacy kinds.
+        if ((parentNodeKind != NodeKind.JSON_DOCUMENT && parentNodeKind != NodeKind.OBJECT
+            && parentNodeKind != NodeKind.ARRAY
+            && parentNodeKind != NodeKind.OBJECT_NAMED_OBJECT
+            && parentNodeKind != NodeKind.OBJECT_NAMED_ARRAY) && !canRemoveValue) {
+          throw new SirixUsageException(
+              "An object record value can not be removed, you have to remove the whole object record (parent of this value).");
+        }
 
-      // Removing a subtree must also purge INSERTED/UPDATED/REPLACEDNEW diff tuples recorded
-      // earlier in this transaction for DESCENDANTS of the removed node: their node keys no
-      // longer resolve in the new revision, and a stale tuple makes the commit-time diff
-      // serializer read from an unpositioned cursor (NPE or silently corrupt diff files). The
-      // subtree root's own tuple is already handled by adaptUpdateOperationsForRemove; the
-      // DELETED tuple of the root subsumes all descendant operations.
-      final LongOpenHashSet removedDescendantKeys = storeDeweyIDs() ? new LongOpenHashSet() : null;
+        canRemoveValue = false;
 
-      // Remove subtree.
-      for (final var axis = new PostOrderAxis(this); axis.hasNext();) {
-        final long currentNodeKey = axis.nextLong();
+        // iter#32: Legacy `parentNodeKind != OBJECT_KEY` was meant to skip the DELETE
+        // diff entry when callers asked to remove the inner value-record of an
+        // OBJECT_KEY pair (a half-removal that left a dangling key wrapper). Under
+        // fusion the inner-value record no longer exists — every OBJECT_NAMED_*
+        // record IS the field — so this skip-condition does not apply. Removing a
+        // child of OBJECT_NAMED_OBJECT or OBJECT_NAMED_ARRAY is a real object/array
+        // field removal and must register a DELETE tuple, otherwise downstream
+        // consumers (BasicJsonDiff, jn:diff serializer) lose the entry entirely.
+        adaptUpdateOperationsForRemove(node.getDeweyID(), node.getNodeKey());
 
-        if (removedDescendantKeys != null) {
-          removedDescendantKeys.add(currentNodeKey);
-        } else {
-          final DiffTuple staleTuple = updateOperationsUnordered.get(currentNodeKey);
-          if (staleTuple != null && staleTuple.getDiff() != DiffFactory.DiffType.DELETED) {
-            updateOperationsUnordered.remove(currentNodeKey);
+        // Removing a subtree must also purge INSERTED/UPDATED/REPLACEDNEW diff tuples recorded
+        // earlier in this transaction for DESCENDANTS of the removed node: their node keys no
+        // longer resolve in the new revision, and a stale tuple makes the commit-time diff
+        // serializer read from an unpositioned cursor (NPE or silently corrupt diff files). The
+        // subtree root's own tuple is already handled by adaptUpdateOperationsForRemove; the
+        // DELETED tuple of the root subsumes all descendant operations.
+        final LongOpenHashSet removedDescendantKeys = storeDeweyIDs() ? new LongOpenHashSet() : null;
+
+        // Remove subtree.
+        for (final var axis = new PostOrderAxis(this); axis.hasNext();) {
+          final long currentNodeKey = axis.nextLong();
+
+          if (removedDescendantKeys != null) {
+            removedDescendantKeys.add(currentNodeKey);
+          } else {
+            final DiffTuple staleTuple = updateOperationsUnordered.get(currentNodeKey);
+            if (staleTuple != null && staleTuple.getDiff() != DiffFactory.DiffType.DELETED) {
+              updateOperationsUnordered.remove(currentNodeKey);
+            }
+          }
+
+          // Remove name.
+          removeName();
+
+          // Remove text value.
+          removeValue();
+
+          // De-index plain ARRAY nodes (and decrement their __array__ path-summary refcount):
+          // the insert side fires a PATH-index INSERT for ARRAY nodes (see insertArrayAsFirstChild),
+          // but removeName/removeValue only cover fused + primitive kinds — so a removed ARRAY left
+          // a stale path-index entry (a scan-path-index would still return the deleted nodeKey) and
+          // leaked the __array__ refcount.
+          removeArrayPathEntry();
+
+          // Then remove node.
+          storageEngineWriter.removeRecord(currentNodeKey, IndexType.DOCUMENT, -1);
+
+          if (storeNodeHistory) {
+            nodeToRevisionsIndex.addRevisionToRecordToRevisionsIndex(currentNodeKey);
           }
         }
 
-        // Remove name.
-        removeName();
+        if (removedDescendantKeys != null && !removedDescendantKeys.isEmpty()) {
+          updateOperationsOrdered.values()
+                                 .removeIf(tuple -> tuple.getDiff() != DiffFactory.DiffType.DELETED
+                                     && removedDescendantKeys.contains(tuple.getNewNodeKey()));
+        }
 
-        // Remove text value.
-        removeValue();
+        if (node.getKind().playsObjectKeyRole()) {
+          removeName();
+        } else {
+          removeValue();
+        }
 
-        // De-index plain ARRAY nodes (and decrement their __array__ path-summary refcount):
-        // the insert side fires a PATH-index INSERT for ARRAY nodes (see insertArrayAsFirstChild),
-        // but removeName/removeValue only cover fused + primitive kinds — so a removed ARRAY left
-        // a stale path-index entry (a scan-path-index would still return the deleted nodeKey) and
-        // leaked the __array__ refcount.
-        removeArrayPathEntry();
-
-        // Then remove node.
-        storageEngineWriter.removeRecord(currentNodeKey, IndexType.DOCUMENT, -1);
+        // Adapt hashes and neighbour nodes as well as the name from the NamePage mapping if it's not a text
+        // node.
+        final ImmutableJsonNode jsonNode = (ImmutableJsonNode) node;
+        nodeReadOnlyTrx.setCurrentNode(jsonNode);
+        nodeHashing.adaptHashesWithRemove();
+        adaptForRemove(node);
+        nodeReadOnlyTrx.setCurrentNode(jsonNode);
 
         if (storeNodeHistory) {
-          nodeToRevisionsIndex.addRevisionToRecordToRevisionsIndex(currentNodeKey);
+          nodeToRevisionsIndex.addRevisionToRecordToRevisionsIndex(node.getNodeKey());
         }
+
+        if (node.hasRightSibling()) {
+          moveTo(node.getRightSiblingKey());
+        } else if (node.hasLeftSibling()) {
+          moveTo(node.getLeftSiblingKey());
+        } else {
+          moveTo(node.getParentKey());
+        }
+
+        return this;
+      } finally {
+        // Release the guard on the node's page
+        nodePageGuard.close();
       }
-
-      if (removedDescendantKeys != null && !removedDescendantKeys.isEmpty()) {
-        updateOperationsOrdered.values()
-                               .removeIf(tuple -> tuple.getDiff() != DiffFactory.DiffType.DELETED
-                                   && removedDescendantKeys.contains(tuple.getNewNodeKey()));
-      }
-
-      if (node.getKind().playsObjectKeyRole()) {
-        removeName();
-      } else {
-        removeValue();
-      }
-
-      // Adapt hashes and neighbour nodes as well as the name from the NamePage mapping if it's not a text
-      // node.
-      final ImmutableJsonNode jsonNode = (ImmutableJsonNode) node;
-      nodeReadOnlyTrx.setCurrentNode(jsonNode);
-      nodeHashing.adaptHashesWithRemove();
-      adaptForRemove(node);
-      nodeReadOnlyTrx.setCurrentNode(jsonNode);
-
-      if (storeNodeHistory) {
-        nodeToRevisionsIndex.addRevisionToRecordToRevisionsIndex(node.getNodeKey());
-      }
-
-      if (node.hasRightSibling()) {
-        moveTo(node.getRightSiblingKey());
-      } else if (node.hasLeftSibling()) {
-        moveTo(node.getLeftSiblingKey());
-      } else {
-        moveTo(node.getParentKey());
-      }
-
-      return this;
     } finally {
       if (lock != null) {
         lock.unlock();
       }
-      // Release the guard on the node's page
-      nodePageGuard.close();
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
@@ -194,29 +194,37 @@ final class XmlNodeTrxImpl extends
         if (nodeAnchor.getFirstChildKey() != nodeToMove.getNodeKey()) {
           final StructNode toMove = (StructNode) nodeToMove;
 
-          // Adapt index-structures (before move).
-          adaptSubtreeForMove(toMove, IndexController.ChangeType.DELETE);
+          // Compound operation: adaptForMove internally calls remove()/setValue(), whose
+          // checkAccessAndCommit() must not fire an auto-commit while the moved subtree is
+          // detached from its old position but not yet re-attached (#1062).
+          beginCompoundOperation();
+          try {
+            // Adapt index-structures (before move).
+            adaptSubtreeForMove(toMove, IndexController.ChangeType.DELETE);
 
-          // Adapt hashes.
-          adaptHashesForMove(toMove);
+            // Adapt hashes.
+            adaptHashesForMove(toMove);
 
-          // Adapt pointers and merge sibling text nodes.
-          adaptForMove(toMove, nodeAnchor, InsertPos.ASFIRSTCHILD);
-          nodeReadOnlyTrx.moveTo(toMove.getNodeKey());
-          nodeHashing.adaptHashesWithAdd();
+            // Adapt pointers and merge sibling text nodes.
+            adaptForMove(toMove, nodeAnchor, InsertPos.ASFIRSTCHILD);
+            nodeReadOnlyTrx.moveTo(toMove.getNodeKey());
+            nodeHashing.adaptHashesWithAdd();
 
-          // Adapt path summary.
-          if (buildPathSummary && toMove instanceof NameNode moved) {
-            pathSummaryWriter.adaptPathForChangedNode(moved, getName(), moved.getURIKey(), moved.getPrefixKey(),
-                moved.getLocalNameKey(), PathSummaryWriter.OPType.MOVED);
-          }
+            // Adapt path summary.
+            if (buildPathSummary && toMove instanceof NameNode moved) {
+              pathSummaryWriter.adaptPathForChangedNode(moved, getName(), moved.getURIKey(), moved.getPrefixKey(),
+                  moved.getLocalNameKey(), PathSummaryWriter.OPType.MOVED);
+            }
 
-          // Adapt index-structures (after move).
-          adaptSubtreeForMove(toMove, IndexController.ChangeType.INSERT);
+            // Adapt index-structures (after move).
+            adaptSubtreeForMove(toMove, IndexController.ChangeType.INSERT);
 
-          // Compute and assign new DeweyIDs.
-          if (storeDeweyIDs()) {
-            deweyIDManager.computeNewDeweyIDs();
+            // Compute and assign new DeweyIDs.
+            if (storeDeweyIDs()) {
+              deweyIDManager.computeNewDeweyIDs();
+            }
+          } finally {
+            endCompoundOperation();
           }
         }
         return this;
@@ -358,29 +366,37 @@ final class XmlNodeTrxImpl extends
         if (nodeAnchor.getRightSiblingKey() != nodeToMove.getNodeKey()) {
           final long parentKey = nodeAnchor.getParentKey();
 
-          // Adapt hashes.
-          adaptHashesForMove(toMove);
+          // Compound operation: adaptForMove internally calls remove()/setValue(), whose
+          // checkAccessAndCommit() must not fire an auto-commit while the moved subtree is
+          // detached from its old position but not yet re-attached (#1062).
+          beginCompoundOperation();
+          try {
+            // Adapt hashes.
+            adaptHashesForMove(toMove);
 
-          // Adapt pointers and merge sibling text nodes.
-          adaptForMove(toMove, nodeAnchor, InsertPos.ASRIGHTSIBLING);
-          nodeReadOnlyTrx.moveTo(toMove.getNodeKey());
-          nodeHashing.adaptHashesWithAdd();
+            // Adapt pointers and merge sibling text nodes.
+            adaptForMove(toMove, nodeAnchor, InsertPos.ASRIGHTSIBLING);
+            nodeReadOnlyTrx.moveTo(toMove.getNodeKey());
+            nodeHashing.adaptHashesWithAdd();
 
-          // Adapt path summary.
-          if (buildPathSummary && toMove instanceof NameNode moved) {
-            final PathSummaryWriter.OPType type = moved.getParentKey() == parentKey
-                ? PathSummaryWriter.OPType.MOVED_ON_SAME_LEVEL
-                : PathSummaryWriter.OPType.MOVED;
+            // Adapt path summary.
+            if (buildPathSummary && toMove instanceof NameNode moved) {
+              final PathSummaryWriter.OPType type = moved.getParentKey() == parentKey
+                  ? PathSummaryWriter.OPType.MOVED_ON_SAME_LEVEL
+                  : PathSummaryWriter.OPType.MOVED;
 
-            if (type != PathSummaryWriter.OPType.MOVED_ON_SAME_LEVEL) {
-              pathSummaryWriter.adaptPathForChangedNode(moved, getName(), moved.getURIKey(), moved.getPrefixKey(),
-                  moved.getLocalNameKey(), type);
+              if (type != PathSummaryWriter.OPType.MOVED_ON_SAME_LEVEL) {
+                pathSummaryWriter.adaptPathForChangedNode(moved, getName(), moved.getURIKey(), moved.getPrefixKey(),
+                    moved.getLocalNameKey(), type);
+              }
             }
-          }
 
-          // Recompute DeweyIDs if they are used.
-          if (storeDeweyIDs()) {
-            deweyIDManager.computeNewDeweyIDs();
+            // Recompute DeweyIDs if they are used.
+            if (storeDeweyIDs()) {
+              deweyIDManager.computeNewDeweyIDs();
+            }
+          } finally {
+            endCompoundOperation();
           }
         }
         return this;
@@ -1327,12 +1343,15 @@ final class XmlNodeTrxImpl extends
 
   @Override
   public XmlNodeTrx remove() {
-    checkAccessAndCommit();
     if (lock != null) {
       lock.lock();
     }
 
     try {
+      // Inside the lock, like every other mutator: running the count/auto-commit check unlocked
+      // raced against the delay-scheduled commit thread (#1062).
+      checkAccessAndCommit();
+
       final NodeKind kind = getKind();
       if (kind == NodeKind.XML_DOCUMENT) {
         throw new SirixUsageException("Document root can not be removed.");
@@ -2068,7 +2087,15 @@ final class XmlNodeTrxImpl extends
           pos = InsertPosition.AS_FIRST_CHILD;
         }
 
-        insertAndThenRemove(reader, pos, anchorNodeKey);
+        // Compound operation: insert + remove must not be split by an auto-commit (#1062) —
+        // a mid-replace commit would durably persist both the old and the new subtree, and
+        // wipe the update-operation maps between the two steps.
+        beginCompoundOperation();
+        try {
+          insertAndThenRemove(reader, pos, anchorNodeKey);
+        } finally {
+          endCompoundOperation();
+        }
         return this;
       } else {
         throw new IllegalArgumentException("Not supported for attributes / namespaces.");
@@ -2112,31 +2139,39 @@ final class XmlNodeTrxImpl extends
        *
        * Replace 2nd node each time => with text node
        */
-      // $CASES-OMITTED$
-      switch (rtx.getKind()) {
-        case ELEMENT, TEXT, COMMENT, PROCESSING_INSTRUCTION -> {
-          checkCurrentNode();
-          if (isText()) {
-            removeAndThenInsert(rtx);
-          } else {
-            insertAndThenRemove(rtx);
+      // Compound operation: each branch chains remove + insert (or vice versa) and must not be
+      // split by an auto-commit (#1062) — a mid-replace commit would durably persist a tree with
+      // the target removed but its replacement not yet inserted.
+      beginCompoundOperation();
+      try {
+        // $CASES-OMITTED$
+        switch (rtx.getKind()) {
+          case ELEMENT, TEXT, COMMENT, PROCESSING_INSTRUCTION -> {
+            checkCurrentNode();
+            if (isText()) {
+              removeAndThenInsert(rtx);
+            } else {
+              insertAndThenRemove(rtx);
+            }
           }
-        }
-        case ATTRIBUTE -> {
-          if (getKind() != NodeKind.ATTRIBUTE) {
-            throw new IllegalStateException("Current node must be an attribute node!");
+          case ATTRIBUTE -> {
+            if (getKind() != NodeKind.ATTRIBUTE) {
+              throw new IllegalStateException("Current node must be an attribute node!");
+            }
+            remove();
+            insertAttribute(rtx.getName(), rtx.getValue());
           }
-          remove();
-          insertAttribute(rtx.getName(), rtx.getValue());
-        }
-        case NAMESPACE -> {
-          if (getKind() != NodeKind.NAMESPACE) {
-            throw new IllegalStateException("Current node must be a namespace node!");
+          case NAMESPACE -> {
+            if (getKind() != NodeKind.NAMESPACE) {
+              throw new IllegalStateException("Current node must be a namespace node!");
+            }
+            remove();
+            insertNamespace(rtx.getName());
           }
-          remove();
-          insertNamespace(rtx.getName());
+          default -> throw new UnsupportedOperationException("Node type not supported!");
         }
-        default -> throw new UnsupportedOperationException("Node type not supported!");
+      } finally {
+        endCompoundOperation();
       }
       return this;
     } finally {

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/CommitSafetyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/CommitSafetyTest.java
@@ -1,0 +1,187 @@
+package io.sirix.access.trx.node;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.XmlTestHelper;
+import io.sirix.access.trx.node.json.objectvalue.ObjectValue;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.exception.SirixUsageException;
+import io.sirix.node.NodeKind;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for the commit-safety pair #1061/#1062.
+ *
+ * <p>#1061: a failed commit used to flip the state machine to COMMITTING and zero the modification
+ * counter before anything was durable — stranding the transaction (every further operation threw
+ * "state is not running") while close() silently discarded the uncommitted work.
+ *
+ * <p>#1062: compound structural operations (move, replace) internally call public mutators, each
+ * of which runs the count-based auto-commit check; crossing maxNodeCount mid-operation durably
+ * committed a structurally inconsistent tree (e.g. a moved subtree detached from its old position
+ * but not yet re-attached).
+ */
+public final class CommitSafetyTest {
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+    XmlTestHelper.closeEverything();
+    XmlTestHelper.deleteEverything();
+  }
+
+  @Test
+  public void failedCommitKeepsTransactionUsableAndGuardsClose() {
+    JsonTestHelper.createTestDocument();
+
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      final var wtx = manager.beginNodeTrx();
+      final var failFirstCommit = new AtomicBoolean(true);
+      wtx.addPreCommitHook(rtx -> {
+        if (failFirstCommit.getAndSet(false)) {
+          throw new IllegalStateException("injected pre-commit failure");
+        }
+      });
+
+      // Dirty the transaction: remove the first field of the root object.
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // root OBJECT
+      wtx.moveToFirstChild(); // first field
+      wtx.remove();
+
+      // First commit fails before anything is durable.
+      final var thrown = assertThrows(IllegalStateException.class, () -> wtx.commit());
+      assertEquals("injected pre-commit failure", thrown.getMessage());
+
+      // Nothing was committed.
+      assertEquals(1, manager.getMostRecentRevisionNumber());
+
+      // The dirty-close guard still protects the uncommitted work (it used to be defeated
+      // because modificationCount was zeroed before the commit was attempted).
+      assertThrows(SirixUsageException.class, wtx::close);
+
+      // The transaction is NOT stranded in COMMITTING: further mutations work...
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // root OBJECT
+      wtx.moveToFirstChild(); // (new) first field
+      wtx.remove();
+
+      // ...and a retried commit succeeds and persists everything.
+      wtx.commit();
+      assertEquals(2, manager.getMostRecentRevisionNumber());
+      wtx.close();
+
+      try (final var rtx = manager.beginNodeReadOnlyTrx()) {
+        rtx.moveToFirstChild(); // root OBJECT
+        // The original test document has 4 top-level fields; two were removed.
+        assertEquals(2, rtx.getChildCount());
+      }
+    }
+  }
+
+  @Test
+  public void autoCommitDoesNotSplitJsonReplaceObjectRecordValue() {
+    JsonTestHelper.createTestDocument();
+
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      // maxNodeCount = 2: the threshold check runs at the START of each mutator, so with the
+      // top-level replace counting 1 and the nested remove() counting 2, the nested INSERT
+      // (count 3) crosses the threshold — without the compound-operation guard the auto-commit
+      // fires after the field was removed but before its replacement is inserted, durably
+      // committing the half-replaced tree.
+      try (final var wtx = manager.beginNodeTrx(2)) {
+        wtx.moveToFirstChild(); // root OBJECT
+        wtx.moveToFirstChild(); // first field
+        // Find the fused string field "baz" and replace its value with an object (a different
+        // kind, so the same-kind fast path is skipped and the remove + insert path runs).
+        while (wtx.getKind() != NodeKind.OBJECT_NAMED_STRING || !"baz".equals(wtx.getName().getLocalName())) {
+          assertTrue("test document must contain the string field \"baz\"", wtx.hasRightSibling());
+          wtx.moveToRightSibling();
+        }
+        wtx.replaceObjectRecordValue(ObjectValue.INSTANCE);
+        wtx.commit();
+      }
+
+      // Every durable revision must contain exactly one "baz" field — never the mid-replace
+      // state with the field missing.
+      final int mostRecent = manager.getMostRecentRevisionNumber();
+      for (int revision = 1; revision <= mostRecent; revision++) {
+        try (final var rtx = manager.beginNodeReadOnlyTrx(revision)) {
+          rtx.moveToFirstChild(); // root OBJECT
+          int bazCount = 0;
+          if (rtx.hasFirstChild()) {
+            rtx.moveToFirstChild();
+            while (true) {
+              if (rtx.getKind().name().startsWith("OBJECT_NAMED") && "baz".equals(rtx.getName().getLocalName())) {
+                bazCount++;
+              }
+              if (!rtx.hasRightSibling()) {
+                break;
+              }
+              rtx.moveToRightSibling();
+            }
+          }
+          assertEquals("revision " + revision + " must contain the \"baz\" field exactly once", 1, bazCount);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void autoCommitDoesNotSplitXmlMoveSubtree() {
+    XmlTestHelper.createTestDocument();
+
+    try (final var database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(XmlTestHelper.RESOURCE)) {
+      final long movedNodeKey;
+      // maxNodeCount = 1: without the compound-operation guard, the text-merge remove() inside
+      // adaptForMove crosses the threshold and durably commits while the moved subtree is
+      // detached from its old position but not yet re-attached (an orphaned subtree in a
+      // persisted revision).
+      try (final var wtx = manager.beginNodeTrx(1)) {
+        wtx.moveToFirstChild(); // p:a element
+        final long anchorKey = wtx.getNodeKey();
+        // First <b> child: has TEXT siblings on both sides ("oops1", "oops2"), which forces the
+        // text-node merge (nested remove() + setValue()) during the move.
+        wtx.moveToFirstChild(); // text "oops1"
+        wtx.moveToRightSibling(); // first <b>
+        movedNodeKey = wtx.getNodeKey();
+        wtx.moveTo(anchorKey);
+        wtx.moveSubtreeToFirstChild(movedNodeKey);
+        wtx.commit();
+      }
+
+      // The moved element must be reachable from the document root in EVERY durable revision.
+      final int mostRecent = manager.getMostRecentRevisionNumber();
+      for (int revision = 1; revision <= mostRecent; revision++) {
+        try (final var rtx = manager.beginNodeReadOnlyTrx(revision)) {
+          rtx.moveToDocumentRoot();
+          boolean found = false;
+          for (final var axis = new DescendantAxis(rtx, IncludeSelf.YES); axis.hasNext(); ) {
+            if (axis.nextLong() == movedNodeKey) {
+              found = true;
+              break;
+            }
+          }
+          assertTrue("moved node " + movedNodeKey + " must be reachable in revision " + revision, found);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes the two commit-path safety bugs from the audit, as one PR since both live in the same state machine.

### #1061 — a failed commit stranded the transaction in COMMITTING and defeated the dirty-close guard

`commitInternal` flipped `state = COMMITTING` and zeroed `modificationCount` **before** anything was durable, with no failure handling. Any exception from a pre-commit hook, the storage commit, diff serialization (real file I/O), or `reInstantiate` left the transaction stuck in COMMITTING — every further operation rejected — while `close()` silently discarded the uncommitted work (the dirty guard checks `modificationCount`, already reset).

Now:
- **Pre-durability failures** (pending-stats flush, pre-commit hooks, awaiting the async flush, the storage commit itself) restore `state = RUNNING` and leave the modification counter untouched — the transaction stays usable (retry / more work / rollback) and `close()` keeps refusing to drop uncommitted work.
- `modificationCount` is cleared only **after** the storage commit returns (the durability acknowledge).
- **Post-durability failures** are handled distinctly: a failed diff-sidecar write is logged loudly but doesn't pretend the (already durable) commit failed; a failed `reInstantiate` transitions to terminal **COMMITTED** — never a stuck COMMITTING — so further mutations are rejected with a truthful state and `close()` is clean.

### #1062 — count-based auto-commit fired inside compound structural operations

Compound operations internally call public mutators, each running the count-based auto-commit check. Crossing `maxNodeCount` mid-operation durably committed a structurally inconsistent tree: XML `moveSubtreeTo*`'s text-merge `remove()` fires while the moved subtree is detached from its old position but not yet re-attached (an orphaned subtree in a persisted revision of an MVCC store); JSON `replaceObjectRecordValue`'s nested insert fires after the field was removed but before its replacement exists — and the commit's `reInstantiate` wipes the update-operation maps, so the subsequent REPLACEDNEW tuple references an unresolvable key.

Now a `compoundOperationDepth` counter (`begin`/`endCompoundOperation`, balanced in `finally`) suppresses intermediate auto-commits while > 0. The modification counter keeps growing, so the deferred auto-commit fires on the next top-level mutation, once the tree is consistent. Guarded sites: XML `moveSubtreeToFirstChild`/`ToRightSibling` (around `adaptForMove`), both `replaceNode` variants, and JSON `replaceObjectRecordValue`.

Also per the issue's "related smell": `checkAccessAndCommit()` moves **inside the transaction lock** in both `remove()` implementations (the only mutators running the count/auto-commit check unlocked, racing the delay-scheduled commit thread). In JSON `remove()` the whole body is now protected by the lock's `try` — a throw from the access check or page-guard acquisition used to leak the lock — and the page guard is released before unlock (LIFO).

## Related issues

Closes #1061
Closes #1062

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Compiles on JDK 25
- [x] Added or updated tests covering the change — new `CommitSafetyTest` (3 tests): a failed commit keeps the transaction usable, the dirty-close guard intact, and a retried commit working; with auto-commit enabled, JSON replace and XML move never persist a half-applied revision. **All three fail on the previous code and pass with the fix** (verified by stashing the fix and re-running).
- [x] For behavioral changes to the storage engine: this *strengthens* the commit atomicity contract (no durable revision of a half-applied compound operation; no silent discard of uncommitted work)
- [x] No unrelated formatting churn

## Notes for reviewers

- Regression-checked: JSON node-trx suite (339 tests), XML node-trx suite (85), `AutoCommitRevisionReadStressTest`, `AsyncAutoCommitTest`, `JsonShredderTest` — all green.
- The auto-commit threshold semantics change only *inside* compound operations: the commit is deferred to the next top-level mutation (counter keeps accumulating), so threshold crossings are still honored — just at structurally consistent points.
- A subtle test-design note: the threshold check runs at the *start* of each mutator, so the JSON replace test uses `maxNodeCount = 2` — with 1, the old code's auto-commit fired before the nested remove had detached anything and the mid-replace state was never durable; with 2 it fired between the remove and the insert (the actual corruption), which the test now pins.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_