### PR TITLE
Fix silent data loss under KEEP_OPEN_ASYNC intermediate commits (#1077)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -776,16 +776,22 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     final int slotOffset = (int) (nodeKey & ((1 << Constants.NDP_NODE_COUNT_EXPONENT) - 1));
     KeyValueLeafPage page;
 
-    // Same-page fast path: reuse cached modified page
-    if (currentPageKey == targetPageKey && currentPage != null && !currentPage.isClosed()) {
-      page = currentPage;
-    } else {
-      // Different page: get modified page from writer's TIL
-      page = writer.getModifiedPageForRead(targetPageKey, IndexType.DOCUMENT, -1);
-      if (page == null) {
-        // Page not in TIL — fall back to legacy (allocating) moveTo
-        return moveToLegacy(nodeKey);
-      }
+    // Resolve through the writer's TIL on EVERY move (getModifiedPageForRead has an O(1)
+    // most-recent-container fast path). Do NOT reuse currentPage by (pageKey, !isClosed) alone:
+    // after an async epoch rotation the TIL container is CoW'd to a NEW modified-page instance
+    // while the superseded frozen instance stays OPEN for the background flush — an
+    // isClosed()-based reuse check keeps serving the frozen instance for the rest of the epoch,
+    // splitting reads (stale frozen page) from writes (CoW page). For a hot parent whose
+    // firstChildKey advances with every insert, that durably corrupts the sibling chain: each
+    // new node links to the stale first child, silently orphaning everything inserted after the
+    // epoch boundary (#1077). On the synchronous path the superseded instance is closed by
+    // TransactionIntentLog.put, which is why the old fast path appeared safe.
+    page = writer.getModifiedPageForRead(targetPageKey, IndexType.DOCUMENT, -1);
+    if (page == null) {
+      // Page not in TIL — fall back to legacy (allocating) moveTo
+      return moveToLegacy(nodeKey);
+    }
+    if (page != currentPage) {
       // Release previous guard (if any) and update page tracking
       // TIL pages don't need guarding — they're pinned by the transaction
       if (currentPageGuard != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -1044,6 +1044,24 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
+   * Invalidate the most-recently-read record page for the given index (async CoW, #1077).
+   *
+   * <p>On the synchronous path this cache self-invalidates: {@code TransactionIntentLog.put}
+   * closes the superseded page instance, so the next read's {@code tryAcquireGuard} on the cached
+   * instance fails and the lookup falls through to the trie/TIL. On the ASYNC path the superseded
+   * instance is the frozen snapshot page, which must stay open for the background flush — the
+   * guard succeeds and every read for the rest of the epoch keeps returning the frozen (stale)
+   * instance while writes go into the CoW copy. For a hot page like the one holding a parent
+   * whose {@code firstChildKey} advances with each insert, that split durably corrupts the
+   * sibling chain: each new node links to the stale first child, orphaning everything inserted
+   * after the epoch boundary. The writer calls this after CoW-ing a frozen container so the next
+   * read re-resolves through the TIL.
+   */
+  void invalidateMostRecentlyReadRecordPage(final IndexType indexType, final int index) {
+    setMostRecentPage(indexType, index, null);
+  }
+
+  /**
    * Set the most recent page for a given index type and index number.
    */
   private void setMostRecentPage(IndexType indexType, int index, RecordPage page) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -880,6 +880,19 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     PageContainer container = log.get(reference);
 
     if (container == null) {
+      // Fail loudly on an unresolvable TIL claim (#1077): a reference that still carries a
+      // logKey after all three TIL layers missed — with no disk offset either — is a stale
+      // CoW copy whose backing entry is gone. Returning silently here serialized the parent
+      // with child key -1, making the flushed subtree vanish from the committed revision
+      // without any error. (A Layer-3 resolution resets the logKey and assigns the disk key,
+      // so a resolved stale copy never trips this guard.)
+      if (reference.getLogKey() >= 0 && reference.getKey() == Constants.NULL_ID_LONG) {
+        throw new SirixIOException(
+            "Commit traversal hit an unresolvable stale page reference (logKey=" + reference.getLogKey()
+                + ", generation=" + reference.getActiveTilGeneration()
+                + "): the referenced page is in no TIL layer and has no disk offset — refusing to"
+                + " serialize a dangling child pointer (data would silently be lost).");
+      }
       return;
     }
 
@@ -1295,17 +1308,25 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       return cached;
     }
 
-    return pageContainerCache.computeIfAbsent(
-        new IndexLogKey(indexType, recordPageKey, indexNumber, revision), _ -> {
-          final PageReference pageReference = storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
-          // Use writer's TIL-aware trie traversal instead of reader's disk-only traversal.
-          // After async epoch rotation, IndirectPages may be in the TIL but not yet on disk;
-          // the reader's getLeafPageReference would try to load them from disk with key=-1.
-          final PageReference reference = keyedTrieWriter.prepareLeafOfTree(this, log,
-              getUberPage().getPageCountExp(indexType), pageReference, recordPageKey, indexNumber,
-              indexType, newRevisionRootPage);
-          return log.get(reference);
-        });
+    final PageReference pageReference = storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
+    // Use writer's TIL-aware trie traversal instead of reader's disk-only traversal.
+    // After async epoch rotation, IndirectPages may be in the TIL but not yet on disk;
+    // the reader's getLeafPageReference would try to load them from disk with key=-1.
+    final PageReference reference = keyedTrieWriter.prepareLeafOfTree(this, log,
+        getUberPage().getPageCountExp(indexType), pageReference, recordPageKey, indexNumber,
+        indexType, newRevisionRootPage);
+    final PageContainer resolved = log.get(reference);
+
+    // NEVER cache a FROZEN container here (#1077): this read-path helper runs between an async
+    // epoch rotation and the first write to the page. Caching the frozen container would let
+    // prepareRecordPageViaKeyedTrie's cache-hit fast path hand it to a WRITE without the
+    // deep-copy CoW — mutating a frozen page the background thread is concurrently serializing.
+    // Frozen results are returned (their content is current until the CoW) but resolved fresh on
+    // each call; the container is cached once the write path has CoW'd it into the current TIL.
+    if (resolved != null && !log.isFrozen(reference)) {
+      pageContainerCache.put(new IndexLogKey(indexType, recordPageKey, indexNumber, revision), resolved);
+    }
+    return resolved;
   }
 
   @Nullable
@@ -1381,6 +1402,11 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         if (log.isFrozen(reference)) {
           pageContainer = deepCopyFrozenContainer(pageContainer);
           log.put(reference, pageContainer);
+          // The reader's most-recently-read cache may still hold the FROZEN instance, which
+          // stays open for the background flush — so the guard-based invalidation that covers
+          // the synchronous CoW path never fires. Without this, every read for the rest of the
+          // epoch returns the frozen (stale) page while writes go into the copy (#1077).
+          storageEngineReader.invalidateMostRecentlyReadRecordPage(indexType, indexNumber);
         }
         return pageContainer;
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -81,7 +81,7 @@ public final class TransactionIntentLog implements AutoCloseable {
   // When cleanupSnapshot() writes KVL disk offsets to the original references, copies of
   // those references (in CoW'd IndirectPages) don't get updated. This map stores
   // (generation << 32 | logKey) → diskOffset so that stale copies can be transparently
-  // resolved in get(). Entries are removed on access (auto-pruning).
+  // resolved in get(). Entries are retained until clear() (#1077).
 
   /** Completed disk offsets indexed by packed (generation << 32 | logKey). No autoboxing. */
   private final Long2LongOpenHashMap completedDiskOffsets;
@@ -91,6 +91,23 @@ public final class TransactionIntentLog implements AutoCloseable {
 
   /** Counter: Layer 3 hits (stale references resolved from completed disk offsets). */
   private long layer3Hits;
+
+  // ==================== FORWARDED ENTRIES (superseded-flush fix, #1077) ====================
+  // When a frozen page is CoW'd into the current generation (put() with a prior-generation
+  // reference), the old (generation, logKey) identity is SUPERSEDED: the frozen page's flush —
+  // whose offset lands in completedDiskOffsets at cleanupSnapshot() — describes an OUTDATED
+  // version of the page. Stale reference copies still carrying the old identity (in CoW'd
+  // IndirectPages that are never rewalked, e.g. for a leaf page that straddles an epoch
+  // boundary during monotonic bulk inserts) must resolve to the NEW entry, not to the stale
+  // flush — otherwise the final commit durably serializes the outdated page and every record
+  // added after the boundary silently vanishes. This map stores packed(oldGen, oldLogKey) →
+  // packed(newGen, newLogKey); get() follows the chain to the terminal identity before
+  // consulting the TIL layers. Entries are retained until clear().
+
+  /** Forwarding chain for superseded (generation << 32 | logKey) identities. */
+  private final Long2LongOpenHashMap forwardedEntries = new Long2LongOpenHashMap();
+
+  { forwardedEntries.defaultReturnValue(-1L); }
 
   // ==================== BUFFER MANAGER ====================
 
@@ -125,33 +142,72 @@ public final class TransactionIntentLog implements AutoCloseable {
    * @return the page container, or {@code null} if not in any TIL layer
    */
   public PageContainer get(final PageReference ref) {
-    final int logKey = ref.getLogKey();
+    int logKey = ref.getLogKey();
     if (logKey < 0) {
       return null;
     }
 
+    int generation = ref.getActiveTilGeneration();
+
     // Layer 1: Current TIL (fast path)
-    if (ref.getActiveTilGeneration() == currentGeneration && logKey < size) {
+    if (generation == currentGeneration && logKey < size) {
       return entries[logKey];
     }
 
     // Layer 2: Active snapshot (if any)
-    if (snapshotEntries != null
-        && ref.getActiveTilGeneration() == snapshotGeneration
-        && logKey < snapshotSize) {
+    if (snapshotEntries != null && generation == snapshotGeneration && logKey < snapshotSize) {
       return snapshotEntries[logKey];
+    }
+
+    // Layer 2.5: Forwarding chain for superseded identities (#1077). A frozen page that was
+    // CoW'd into a newer generation was re-logged under a new (generation, logKey); this stale
+    // copy must resolve to that newer entry — NOT to the frozen page's (outdated) flush in the
+    // completed-offsets map. Follow the chain to the terminal identity, then retry the layers.
+    if (!forwardedEntries.isEmpty()) {
+      long packed = ((long) generation << 32) | (logKey & 0xFFFFFFFFL);
+      long forwarded = forwardedEntries.get(packed);
+      if (forwarded >= 0) {
+        while (true) {
+          final long next = forwardedEntries.get(forwarded);
+          if (next < 0) {
+            break;
+          }
+          forwarded = next;
+        }
+        generation = (int) (forwarded >> 32);
+        logKey = (int) forwarded;
+
+        if (generation == currentGeneration && logKey < size) {
+          // Rebind the stale copy to its terminal identity so later lookups take the fast path.
+          ref.setLogKey(logKey);
+          ref.setActiveTilGeneration(generation);
+          return entries[logKey];
+        }
+        if (snapshotEntries != null && generation == snapshotGeneration && logKey < snapshotSize) {
+          ref.setLogKey(logKey);
+          ref.setActiveTilGeneration(generation);
+          return snapshotEntries[logKey];
+        }
+        // Fall through to Layer 3 with the terminal identity (the newest flushed version).
+      }
     }
 
     // Layer 3: Completed disk offsets — stale reference fix.
     // When an IndirectPage is CoW'd, its child references are copied. If cleanupSnapshot()
     // later applies a disk offset to the ORIGINAL reference, the COPY doesn't get updated.
     // This layer resolves stale copies by applying the disk offset from the completed map.
+    //
+    // Resolution is NON-destructive (#1077): an IndirectPage can be CoW'd more than once, so
+    // several stale copies may carry the same (generation, logKey). The former remove() served
+    // only the first copy; every later copy missed all three layers and was silently serialized
+    // with child key -1 (or resurrected as a brand-new empty page on the write path). Entries
+    // stay resolvable until clear() at commit/rollback.
     if (!completedDiskOffsets.isEmpty()) {
-      final long packedKey = ((long) ref.getActiveTilGeneration() << 32) | (logKey & 0xFFFFFFFFL);
-      final long diskOffset = completedDiskOffsets.remove(packedKey);
+      final long packedKey = ((long) generation << 32) | (logKey & 0xFFFFFFFFL);
+      final long diskOffset = completedDiskOffsets.get(packedKey);
       if (diskOffset != Constants.NULL_ID_LONG) {
         ref.setKey(diskOffset);
-        final byte[] hash = completedDiskHashes.remove(packedKey);
+        final byte[] hash = completedDiskHashes.get(packedKey);
         if (hash != null) {
           ref.setHash(hash);
         }
@@ -236,12 +292,29 @@ public final class TransactionIntentLog implements AutoCloseable {
       entryRefs[existingKey] = ref;
       ref.setActiveTilGeneration(currentGeneration);
     } else {
+      // A cross-generation re-put supersedes the frozen entry this reference used to identify:
+      // the CoW'd page in the NEW entry is now the authoritative version, and the frozen page's
+      // upcoming (or already completed) flush is outdated. Record a forwarding link so stale
+      // reference copies that still carry the old identity resolve to the new entry instead of
+      // the stale disk offset (#1077).
+      final int priorGeneration = ref.getActiveTilGeneration();
+      final boolean supersedesPriorEntry =
+          existingKey != Constants.NULL_ID_INT && existingKey >= 0 && priorGeneration >= 0
+              && priorGeneration != currentGeneration;
+
       // New entry
       ensureCapacity();
       ref.setLogKey(size);
       ref.setActiveTilGeneration(currentGeneration);
       entries[size] = value;
       entryRefs[size] = ref;
+
+      if (supersedesPriorEntry) {
+        final long oldPacked = ((long) priorGeneration << 32) | (existingKey & 0xFFFFFFFFL);
+        final long newPacked = ((long) currentGeneration << 32) | (size & 0xFFFFFFFFL);
+        forwardedEntries.put(oldPacked, newPacked);
+      }
+
       size++;
     }
 
@@ -435,6 +508,16 @@ public final class TransactionIntentLog implements AutoCloseable {
         final Page modified = container.getModified();
         final PageReference ref = snapshotRefs[i];
 
+        // A snapshot slot is SUPERSEDED when its reference object no longer identifies it: page
+        // references are shared and mutated in place, so a CoW during the just-finished epoch
+        // re-bound this very object to a NEWER container (a fresh clone of the same logical
+        // page). Applying this slot's (outdated) state to the re-bound reference would hijack
+        // the live trie back to the stale version — the observed symptom was a leaf page that
+        // straddled an epoch boundary being committed from its first, nearly-empty flush, with
+        // every record added after the boundary silently lost (#1077).
+        final boolean refStillIdentifiesSlot =
+            ref.getActiveTilGeneration() == snapshotGeneration && ref.getLogKey() == i;
+
         if (modified instanceof KeyValueLeafPage) {
           // KVL page: already written to disk by background thread.
           // Validate: side-channel offset must be valid (not sentinel).
@@ -443,18 +526,29 @@ public final class TransactionIntentLog implements AutoCloseable {
             throw new SirixIOException(
                 "Snapshot entry " + i + " has no disk offset — background write incomplete or failed");
           }
-          // Apply disk offset from side-channel
-          ref.setKey(diskOffset);
-          if (snapshotHashes[i] != null) {
-            ref.setHash(snapshotHashes[i]);
+          // Apply disk offset from side-channel — but ONLY if the reference still identifies
+          // this slot (see above; a re-bound reference identifies a newer version).
+          if (refStillIdentifiesSlot) {
+            ref.setKey(diskOffset);
+            if (snapshotHashes[i] != null) {
+              ref.setHash(snapshotHashes[i]);
+            }
           }
           // Store in completed map for stale-reference resolution (Layer 3 in get()).
           // When IndirectPages are CoW'd, their child references are COPIES that don't get
           // this disk offset update. The map allows get() to resolve stale copies.
+          //
+          // Superseded entries excluded (#1077): if this frozen page was CoW'd into a newer
+          // generation while the snapshot was active (forwarding entry present), the flush we
+          // just completed is an OUTDATED version — storing its offset would let stale copies
+          // resolve to it and silently drop every record added after the epoch boundary. The
+          // forwarding chain in get() routes such copies to the newer entry instead.
           final long packedKey = ((long) snapshotGeneration << 32) | (i & 0xFFFFFFFFL);
-          completedDiskOffsets.put(packedKey, diskOffset);
-          if (snapshotHashes[i] != null) {
-            completedDiskHashes.put(packedKey, snapshotHashes[i]);
+          if (forwardedEntries.get(packedKey) < 0) {
+            completedDiskOffsets.put(packedKey, diskOffset);
+            if (snapshotHashes[i] != null) {
+              completedDiskHashes.put(packedKey, snapshotHashes[i]);
+            }
           }
           // Close both complete and modified pages (release MemorySegment)
           closePageContainer(container);
@@ -464,11 +558,13 @@ public final class TransactionIntentLog implements AutoCloseable {
           // IndirectPage / structural page: promote to current TIL
           // so final commit traversal can find them via Layer 1 lookup.
           //
-          // GUARD: Skip if ref was already moved to currentGeneration.
-          // This happens when reAddStructuralPagesToTil() re-added this page
-          // (same ref object, generation already updated). Without this check,
-          // put() would overwrite the ref's logKey, orphaning the earlier entry.
-          if (ref.getActiveTilGeneration() != currentGeneration) {
+          // GUARD: promote ONLY if the reference still identifies this slot. It does not when
+          // (a) reAddStructuralPagesToTil() already re-added this page (same ref object,
+          // generation already moved to currentGeneration) — re-putting would overwrite the
+          // ref's logKey and orphan the earlier entry — or (b) the page was CoW'd during the
+          // just-finished epoch (the ref was re-bound to the newer clone) — re-putting would
+          // rebind the live trie to the STALE frozen page (#1077, see refStillIdentifiesSlot).
+          if (refStillIdentifiesSlot && ref.getActiveTilGeneration() != currentGeneration) {
             put(ref, container);
           }
           snapshotEntries[i] = null;
@@ -476,24 +572,14 @@ public final class TransactionIntentLog implements AutoCloseable {
         }
       }
 
-      // Prune stale entries from completedDiskOffsets/completedDiskHashes that belong
-      // to generations older than 2 epochs back. Entries that haven't been accessed by now
-      // are from orphaned COW references that will never be read.
-      if (!completedDiskOffsets.isEmpty()) {
-        final int pruneThreshold = currentGeneration - 2;
-        final var offsetIt = completedDiskOffsets.long2LongEntrySet().fastIterator();
-        while (offsetIt.hasNext()) {
-          if ((int) (offsetIt.next().getLongKey() >> 32) < pruneThreshold) {
-            offsetIt.remove();
-          }
-        }
-        final var hashIt = completedDiskHashes.long2ObjectEntrySet().fastIterator();
-        while (hashIt.hasNext()) {
-          if ((int) (hashIt.next().getLongKey() >> 32) < pruneThreshold) {
-            hashIt.remove();
-          }
-        }
-      }
+      // NO generation-age pruning of completedDiskOffsets/completedDiskHashes (#1077). A stale
+      // reference copy inside a CoW'd IndirectPage can legitimately stay untouched for many
+      // epochs and only be dereferenced by the final commit traversal — the former
+      // "currentGeneration - 2" prune deleted exactly the entry that traversal needed, so the
+      // parent was serialized with child key -1 and the flushed subtree silently vanished from
+      // the committed revision. Entries are retained until clear() (final commit or rollback);
+      // the memory bound is one primitive long->long pair (plus an 8-byte hash) per leaf page
+      // flushed by an async intermediate commit during this transaction's lifetime.
     } finally {
       // Release snapshot arrays for GC even if processing fails
       snapshotEntries = null;
@@ -535,6 +621,7 @@ public final class TransactionIntentLog implements AutoCloseable {
 
     // Clear completed disk offsets map
     completedDiskOffsets.clear();
+    forwardedEntries.clear();
     completedDiskHashes.clear();
   }
 
@@ -565,6 +652,7 @@ public final class TransactionIntentLog implements AutoCloseable {
     // Clear completed disk offsets map
     completedDiskOffsets.clear();
     completedDiskHashes.clear();
+    forwardedEntries.clear();
   }
 
   /**

--- a/bundles/sirix-core/src/test/java/io/sirix/access/AsyncIntermediateCommitStaleRefTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/AsyncIntermediateCommitStaleRefTest.java
@@ -1,0 +1,146 @@
+package io.sirix.access;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for #1077: silent record loss under {@code KEEP_OPEN_ASYNC} intermediate
+ * commits (and the stale-reference resolution the final commit depends on).
+ *
+ * <p>Monotonic inserts at the head of an array make every epoch (a) freeze the TIL, (b) flush the
+ * frozen leaf pages in the background, and (c) copy-on-write the still-hot pages into the new
+ * epoch. Three defects conspired to silently lose every record of an epoch:
+ *
+ * <ol>
+ * <li>The write-transaction cursor cached the TIL's modified page instance keyed by page key and
+ * validated it only via {@code isClosed()}. The superseded frozen instance must stay OPEN for the
+ * background flush, so the cursor kept reading it for the whole epoch while writes went into the
+ * CoW copy — each new node linked to a stale first child, orphaning everything inserted after the
+ * epoch boundary.</li>
+ * <li>The completed-disk-offsets map (Layer 3 stale-reference resolution) deleted entries on
+ * first access and pruned entries older than two generations, so a stale CoW'd reference
+ * dereferenced only by the final commit could resolve to nothing — the parent was serialized
+ * with child key -1.</li>
+ * <li>An epoch-straddling page's outdated flush could shadow its newer content: the snapshot
+ * cleanup applied disk offsets and re-promoted containers through reference objects that a CoW
+ * had already re-bound to newer entries.</li>
+ * </ol>
+ *
+ * <p>Each test drives dozens of async epochs and then verifies every inserted record is present
+ * in the committed revision (the sync variant guards against regressions on the synchronous
+ * path).
+ */
+final class AsyncIntermediateCommitStaleRefTest {
+
+  private static final int RECORD_COUNT = 20_000;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  private void insertManyEpochsAndVerify(final int maxNodesPerEpoch, final AfterCommitState afterCommitState,
+      final String resource) {
+    Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
+      db.createResource(ResourceConfiguration.newBuilder(resource)
+          .storeDiffs(false)
+          .hashKind(HashType.NONE)
+          .buildPathSummary(false)
+          .versioningApproach(VersioningType.FULL)
+          .storageType(StorageType.FILE_CHANNEL)
+          .build());
+
+      try (final JsonResourceSession session = db.beginResourceSession(resource);
+           final JsonNodeTrx wtx = session.beginNodeTrx(maxNodesPerEpoch, afterCommitState)) {
+        final long arrayNodeKey = wtx.insertArrayAsFirstChild().getNodeKey();
+        for (int i = 0; i < RECORD_COUNT; i++) {
+          wtx.moveTo(arrayNodeKey);
+          wtx.insertStringValueAsFirstChild("item-" + i);
+        }
+        wtx.commit();
+      }
+    }
+
+    // Reopen from disk and traverse the sibling chain: a stale read at insert time (or a stale
+    // reference at final commit) manifests as records missing from the committed revision.
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(resource);
+         final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      rtx.moveToDocumentRoot();
+      rtx.moveToFirstChild(); // the array
+      final boolean[] seen = new boolean[RECORD_COUNT];
+      int count = 0;
+      if (rtx.hasFirstChild()) {
+        rtx.moveToFirstChild();
+        count++;
+        seen[Integer.parseInt(rtx.getValue().substring("item-".length()))] = true;
+        while (rtx.hasRightSibling()) {
+          rtx.moveToRightSibling();
+          count++;
+          seen[Integer.parseInt(rtx.getValue().substring("item-".length()))] = true;
+        }
+      }
+      if (count != RECORD_COUNT) {
+        // Diagnostic: report which contiguous record ranges vanished.
+        final StringBuilder missing = new StringBuilder("missing ranges: ");
+        int start = -1;
+        for (int i = 0; i <= RECORD_COUNT; i++) {
+          final boolean present = i < RECORD_COUNT && seen[i];
+          if (!present && i < RECORD_COUNT && start < 0) {
+            start = i;
+          } else if ((present || i == RECORD_COUNT) && start >= 0) {
+            missing.append('[').append(start).append("..").append(i - 1).append("] ");
+            start = -1;
+          }
+        }
+        System.err.println(missing);
+      }
+      assertEquals(RECORD_COUNT, count,
+          "every record inserted across the auto-commit epochs must be present in the committed revision");
+    }
+  }
+
+  @Test
+  @DisplayName("Records survive many async epochs (page-aligned rotation threshold)")
+  void asyncAligned512() {
+    insertManyEpochsAndVerify(512, AfterCommitState.KEEP_OPEN_ASYNC, "async-512");
+  }
+
+  @Test
+  @DisplayName("Records survive many async epochs (unaligned rotation threshold)")
+  void asyncUnaligned300() {
+    insertManyEpochsAndVerify(300, AfterCommitState.KEEP_OPEN_ASYNC, "async-300");
+  }
+
+  @Test
+  @DisplayName("Records survive fewer, larger async epochs")
+  void asyncLarge2048() {
+    insertManyEpochsAndVerify(2048, AfterCommitState.KEEP_OPEN_ASYNC, "async-2048");
+  }
+
+  @Test
+  @DisplayName("Synchronous KEEP_OPEN auto-commit path is unaffected")
+  void syncKeepOpen512() {
+    insertManyEpochsAndVerify(512, AfterCommitState.KEEP_OPEN, "sync-512");
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Building a deterministic reproducer for #1077 (monotonic bulk inserts across dozens of async epochs, then **counting every record** after the final commit) showed the filed pruning defect is one of *several* data-loss bugs in the `KEEP_OPEN_ASYNC` path. On current `main` the reproducer **silently loses an entire epoch's records (~511 of 20,000)** — deterministically. This PR fixes all of them; the reproducer now passes in every variant.

### The five defects (in causal order for the observed loss)

1. **Write-cursor reads a superseded frozen page for a whole epoch** (`AbstractNodeReadOnlyTrx.moveToSingletonWrite`). The cursor cached the TIL's modified-page instance keyed by page key, validated only via `isClosed()`. Sync path: the superseded instance is closed by `TIL.put` → check works. Async path: the superseded instance is the **frozen** page, which must stay open for the background flush — the cursor served it all epoch while writes went into the CoW copy. Every insert then linked its node to a stale first child, durably orphaning everything inserted after the epoch boundary. **Fix:** re-resolve through the writer's TIL on every move (`getModifiedPageForRead`'s most-recent-container fast path keeps it O(1) — a few field compares).
2. **Read path could poison the write path with a frozen container** (`NodeStorageEngineWriter.getPageContainer`): caching a frozen container in `pageContainerCache` let the write path's cache-hit fast path mutate a frozen page the background thread is concurrently serializing. Frozen containers are still returned for reads but never cached.
3. **Layer-3 resolution was destructive and age-pruned** (`TransactionIntentLog`) — the defect as filed in #1077: `completedDiskOffsets.remove()` on access + a `currentGeneration - 2` prune, but a stale CoW'd reference can legitimately be dereferenced only by the final commit → all layers miss → parent serialized with child key `-1`. Resolution is now non-destructive; entries are retained until `clear()` (bounded: one primitive pair per flushed leaf per transaction).
4. **Superseded flushes could shadow newer content**: an epoch-straddling page is flushed once nearly-empty, then CoW'd and filled. `put()` now records a forwarding link (old `(generation, logKey)` → new) that `get()` follows before Layer 3; `cleanupSnapshot()` skips storing offsets for superseded entries and no longer applies offsets to — or re-promotes containers through — reference objects a CoW already re-bound (page references are shared and mutated in place; re-binding them to the stale frozen state hijacked the live trie).
5. **Loud failure instead of silent `-1`**: `commit(PageReference)` now throws on an unresolvable reference that still claims TIL membership, instead of silently serializing a dangling child pointer.

Plus: the reader's most-recently-read record-page cache gets explicitly invalidated when a frozen container is CoW'd (its guard-based self-invalidation only works when the superseded instance is closed — true only on the sync path).

## Related issue

Closes #1077

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Compiles on JDK 25
- [x] Added or updated tests covering the change — new `AsyncIntermediateCommitStaleRefTest`: 20k inserts across many async epochs (page-aligned 512, unaligned 300, large 2048 thresholds + sync `KEEP_OPEN` control), verifying **every record** survives into the committed revision. Fails on `main` (19,489/20,000; missing range `[511..1021]` = exactly one epoch), passes with the fix.
- [x] For behavioral changes to the storage engine: this restores the async-commit invariant that a committed revision contains exactly the data written (no silent loss, no stale shadowing)
- [x] No unrelated formatting churn

## Notes for reviewers

- The existing `AsyncAutoCommitTest` passes on `main` only because it checks reachability of the array root, not record count — the new test counts.
- Regression-checked in isolation: JSON node-trx suite (339), XML node-trx suite, `JsonShredderTest`, `PreallocatedCommitTest`, `KeyedTrieIntegrationTest` (10), `AutoCommitRevisionReadStressTest`, `AsyncAutoCommitTest`, index integration + page suites — all green.
- Perf note on the cursor change: the removed "same-page instance" fast path saved an O(1) container-cache lookup (4 field compares) per `moveTo`; correctness requires the lookup because instance identity is not a validity token under async CoW. The lookup path itself is unchanged and allocation-free.
- The memory previously reclaimed by the generation prune is now retained until commit/rollback — one `long→long` pair (plus an 8-byte hash array) per leaf page flushed by an async epoch, freed at `clear()`. For a 10M-page bulk load that's ~240 MB worst case; if that matters we can follow up with reachability-based pruning, but correctness has to come first (the prune deleted exactly the entries the final commit needed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_