### PR TITLE
Reject stale releases of recycled frame slots (#1073 Defect A)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -6,6 +6,7 @@ package io.sirix.cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
@@ -255,11 +256,25 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   }
 
   /**
-   * Address → live FrameSlot map used by the {@link #release(MemorySegment)}
+   * A slot issued through {@link #allocate(long)}, paired with the per-allocation scope that
+   * identifies THIS allocation era of the slot's address (#1073 Defect A). The free stack is
+   * LIFO, so a just-released slot is re-issued first — at the same stable address. An
+   * address-only release then lets a stale, dangling segment reference (a delayed
+   * double-release) look up and close the NEXT owner's live slot: silent use-after-free plus a
+   * double budget decrement. Each allocation is therefore issued under a fresh
+   * {@link Arena#ofShared()} whose scope acts as an unforgeable identity token: reinterpret/
+   * slice-derived segments inherit the issuing scope (so all legitimate release patterns still
+   * match), while a segment from a prior era carries the prior era's scope and is rejected.
+   */
+  private record Issued(FrameSlot slot, MemorySegment.Scope scope) {
+  }
+
+  /**
+   * Address → live issued-slot map used by the {@link #release(MemorySegment)}
    * implementation of the {@link MemorySegmentAllocator} interface. Callers
    * using the native {@link FrameSlot} handle API don't hit this map.
    */
-  private final ConcurrentHashMap<Long, FrameSlot> liveByAddress = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, Issued> liveByAddress = new ConcurrentHashMap<>();
 
   public static FrameSlotAllocator getInstance() {
     return INSTANCE;
@@ -481,8 +496,12 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
             + (totalWaitedNanos / 1_000_000L) + " ms of retry");
       }
     }
-    final MemorySegment seg = slot.segment();
-    liveByAddress.put(seg.address(), slot);
+    // Issue the slot under a fresh shared arena: the arena's scope is this allocation era's
+    // identity token (see Issued). reinterpret keeps the address and bounds; no memory is owned
+    // by the arena, it exists purely so release() can tell this era's segments from a stale
+    // segment of a previous era at the same recycled address (#1073 Defect A).
+    final MemorySegment seg = slot.segment().reinterpret(slot.segment().byteSize(), Arena.ofShared(), null);
+    liveByAddress.put(seg.address(), new Issued(slot, seg.scope()));
     return seg;
   }
 
@@ -492,16 +511,30 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    * it — which bumps the slot's version, {@code MADV_DONTNEED}s its pages,
    * and returns the slot to the free stack at the same virtual address.
    *
-   * <p>Idempotent: a second release for the same address is a no-op.
+   * <p>Idempotent: a second release for the same address is a no-op. A release whose segment
+   * belongs to a PRIOR allocation era of the address (a stale, dangling reference arriving
+   * after the slot was recycled and re-issued) is detected via the per-allocation scope token
+   * and rejected — it must not close the current owner's live slot (#1073 Defect A).
    */
   @Override
   public void release(final MemorySegment segment) {
     if (segment == null) {
       return;
     }
-    final FrameSlot slot = liveByAddress.remove(segment.address());
-    if (slot != null) {
-      slot.close();
+    final long address = segment.address();
+    final Issued issued = liveByAddress.get(address);
+    if (issued == null) {
+      return;
+    }
+    if (!issued.scope().equals(segment.scope())) {
+      // Stale double-release from a previous era of this (recycled) address. The current
+      // mapping belongs to a different, live allocation — leave it untouched.
+      LOGGER.warn("Rejected stale release of address {} ({} bytes): the segment belongs to a prior "
+          + "allocation era of this slot (double-release detected).", address, segment.byteSize());
+      return;
+    }
+    if (liveByAddress.remove(address, issued)) {
+      issued.slot().close();
     }
   }
 
@@ -587,9 +620,21 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   }
 
   /** Called by {@link FrameSlot#close()} — not usually invoked directly. */
-  void releaseSlot(final int classIdx, final int slotIdx) {
+  void releaseSlot(final int classIdx, final int slotIdx, final long versionAtAlloc) {
     final SizeClass c = classes[classIdx];
     final long prior = c.slotVersion.get(slotIdx);
+
+    // Era check (#1073 Defect A, handle-API layer): a FrameSlot may only release the slot if the
+    // slot's version is still the one it was allocated with. A stale handle from a previous
+    // allocation era (the slot was already released and re-issued) sees an advanced version and
+    // must be a no-op — otherwise it would push the slot index onto the free stack a second time
+    // (two owners of one slot) and double-decrement the physical budget. The handle's own CAS
+    // close-guard only protects against double-close of the SAME handle object.
+    if (prior != versionAtAlloc) {
+      LOGGER.warn("Rejected stale slot release: class {} slot {} (handle era {}, current era {}).",
+          classIdx, slotIdx, versionAtAlloc, prior);
+      return;
+    }
 
     // Step 1: bump to odd ("writer in progress"). Any reader that sees this
     // value between its pre and post snapshots detects the race.
@@ -766,7 +811,7 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
       if (!CLOSED.compareAndSet(this, false, true)) {
         return;
       }
-      owner.releaseSlot(classIdx, slotIdx);
+      owner.releaseSlot(classIdx, slotIdx, versionAtAlloc);
     }
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
@@ -233,4 +233,67 @@ class FrameSlotAllocatorTest {
     assertTrue(totalAllocations.get() > 10_000L,
         "stress test should complete many allocations; got " + totalAllocations.get());
   }
+  /**
+   * Regression test for #1073 Defect A: the free stack is LIFO, so a released slot is re-issued
+   * first — at the same stable address. A stale, dangling segment from the PRIOR allocation era
+   * (a delayed double-release) used to look up the address and close the NEXT owner's live slot:
+   * the slot went back on the free stack while still owned, and the following allocation handed
+   * the same memory to a third owner (silent use-after-free, double budget decrement).
+   */
+  @Test
+  void staleReleaseOfRecycledAddressMustNotFreeTheNewOwnersSlot() {
+    final MemorySegment segA = allocator.allocate(4096);
+    assertNotNull(segA);
+    final long address = segA.address();
+
+    // Legitimate release; slot goes on the free stack.
+    allocator.release(segA);
+
+    // LIFO recycling: the next allocation of the class reuses the same slot/address.
+    final MemorySegment segB = allocator.allocate(4096);
+    assertNotNull(segB);
+    assertEquals(address, segB.address(), "precondition: LIFO free stack must recycle the slot");
+
+    // STALE double-release of the prior era's segment. Must be rejected — B still owns the slot.
+    allocator.release(segA);
+
+    // If the stale release had freed B's slot, this allocation would be handed B's address again
+    // (two live owners of one slot). It must come from a different slot.
+    final MemorySegment segC = allocator.allocate(4096);
+    assertNotNull(segC);
+    assertFalse(segC.address() == address,
+        "stale release must not free the new owner's slot (ABA use-after-free)");
+
+    // B's release must still work (its era is the current one for that address).
+    allocator.release(segB);
+    final MemorySegment segD = allocator.allocate(4096);
+    assertNotNull(segD);
+    assertEquals(address, segD.address(), "the current owner's release must still free the slot");
+
+    allocator.release(segC);
+    allocator.release(segD);
+  }
+
+  /**
+   * Companion to the ABA regression: reinterpret-derived segments inherit the issuing
+   * allocation's scope, so the legitimate release patterns used across the codebase
+   * (e.g. {@code release(slottedPage.reinterpret(capacity))}) keep working.
+   */
+  @Test
+  void reinterpretDerivedReleaseIsAccepted() {
+    final MemorySegment seg = allocator.allocate(8192);
+    assertNotNull(seg);
+    final long address = seg.address();
+
+    // Simulate the KeyValueLeafPage pattern: hold a truncated view, release a re-widened view.
+    final MemorySegment truncated = seg.reinterpret(4096);
+    allocator.release(truncated.reinterpret(8192));
+
+    // The slot must actually be free again: same class allocation recycles the address.
+    final MemorySegment again = allocator.allocate(8192);
+    assertNotNull(again);
+    assertEquals(address, again.address(), "derived-segment release must free the slot");
+    allocator.release(again);
+  }
+
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the remaining defect from #1073 (Defects B and C landed in #1081): the ABA-unsafe, address-keyed release in `FrameSlotAllocator`.

`release(MemorySegment)` resolved the slot to close by **address alone**. The free stack is LIFO, so a released slot is re-issued first — at the same stable virtual address. A stale, dangling segment reference (a delayed double-release — the pattern the legacy `LinuxMemorySegmentAllocator` explicitly defends against with refcounts) could look up the address **after** the slot was recycled and close the **new owner's live slot**: the slot returned to the free stack while still owned (two owners of one slot → silent use-after-free) and the physical budget was double-decremented.

### The fix

**Map layer (identity token via scope):** every `allocate()` issues the slot under a fresh `Arena.ofShared()` whose scope is an unforgeable per-allocation identity token (the arena owns no memory — `reinterpret` only re-associates the scope). `release()` rejects, with a warning, any segment whose scope doesn't match the current mapping's issuing scope. Crucially, `reinterpret`/slice-**derived** segments inherit the issuing scope, so every legitimate release pattern in the codebase — e.g. `release(slottedPage.reinterpret(capacity))` in `KeyValueLeafPage`, the `HOTLeafPage`/`PageKind` releasers, `SerializationBufferPool` — still matches; only a segment from a **prior allocation era** of the same address is turned away. The removal uses the atomic two-arg `remove(key, value)`, so two concurrent legitimate releases still close exactly once.

**Handle layer (era check):** `releaseSlot()` now takes the handle's `versionAtAlloc` and no-ops (with a warning) when the slot's current version differs — a stale `FrameSlot` from a previous era can no longer double-push the slot index or double-decrement the budget. The handle's CAS close-guard (from #1081) only protects double-close of the *same* handle object; this closes the cross-era hole for the direct `allocateSlot` API (`HOTTrieWriter`).

## Related issue

Closes #1073

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] Compiles on JDK 25
- [x] Added or updated tests covering the change — `staleReleaseOfRecycledAddressMustNotFreeTheNewOwnersSlot` **fails on the previous code** (the third allocation observably received the still-owned slot) and passes with the fix; `reinterpretDerivedReleaseIsAccepted` guards the derived-segment release patterns
- [x] For behavioral changes to the storage engine: strengthens the slot-ownership invariant (a slot has at most one owner; only the owning era can release it)
- [x] No unrelated formatting churn

## Notes for reviewers

- Cost: one small `Arena.ofShared()` object per `allocate()` (page-granularity, not per-record) and one scope comparison per `release()`. The arenas are never closed — they hold no memory and exist only as identity tokens; they're garbage-collected with the segments that reference them.
- Regression-checked: full page suite (1602 tests), cache suite (incl. the 20-thread allocator stress test), async auto-commit suites — all green.
- The rejected-release warnings are deliberate: with all call sites following the null-after-release discipline, a rejection means a real double-release bug upstream — precisely what should be loud.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_