### PR TITLE
Treat emptied red-black tree index entries as absent (#1065, defect B)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/index/IndexFilterAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/IndexFilterAxis.java
@@ -40,7 +40,12 @@ public final class IndexFilterAxis<K extends Comparable<? super K>> extends Abst
       if (filterResult) {
         treeReader.moveTo(node.getValueNodeKey());
         assert treeReader.getCurrentNodeAsRBNodeValue() != null;
-        return treeReader.getCurrentNodeAsRBNodeValue().getValue();
+        final NodeReferences value = treeReader.getCurrentNodeAsRBNodeValue().getValue();
+        // Tombstone semantics (#1065): entries emptied by remove() stay in the tree but are
+        // logically absent — skip them instead of yielding an empty reference set.
+        if (value != null && value.hasNodeKeys()) {
+          return value;
+        }
       }
     }
     return endOfData();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
@@ -264,6 +264,14 @@ public final class RBTreeReader<K extends Comparable<? super K>, V extends Refer
         moveTo(valueNodeKey);
         final var value = Optional.ofNullable(getCurrentNodeAsRBNodeValue().getValue());
         setCurrentNode(node);
+        // Tombstone semantics (#1065): removing the last node key of an entry leaves the key
+        // node in the tree with an empty reference set (no structural delete/rebalance in the
+        // COW tree). Such an entry is logically absent — report a miss so existence probes do
+        // not hit on an empty set. Re-indexing the key revives the node in place (index()
+        // finds the key on its own descent and replaces the value).
+        if (value.isPresent() && !value.get().hasNodeKeys()) {
+          return Optional.empty();
+        }
         return value;
       }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeWriter.java
@@ -248,7 +248,11 @@ public final class RBTreeWriter<K extends Comparable<? super K>, V extends Refer
   }
 
   /**
-   * Remove a node key from the value, or remove the whole node, if no keys are stored anymore.
+   * Remove a node key from the value. If no node keys are stored anymore the entry becomes a
+   * tombstone: the {@link RBNodeKey}/{@link RBNodeValue} pair stays in the tree (no structural
+   * delete/rebalance in the copy-on-write tree), but lookups ({@link RBTreeReader#get}) and index
+   * scans ({@code IndexFilterAxis}) treat an empty reference set as absent.
+   * Re-indexing the same key via {@link #index} revives the tombstone in place.
    *
    * @param key the key for which to search the value
    * @param nodeKey the nodeKey to remove from the value

--- a/bundles/sirix-core/src/test/java/io/sirix/index/XmlRedBlackTreeIntegrationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/XmlRedBlackTreeIntegrationTest.java
@@ -122,7 +122,8 @@ public final class XmlRedBlackTreeIntegrationTest {
 
     final Optional<NodeReferences> bazRefs5 = reader.get(new CASValue(new Str("bbbb"), Type.STR, 8), SearchMode.EQUAL);
 
-    check(bazRefs5, new LongLinkedOpenHashSet());
+    // Removing the last node key leaves a tombstone (#1065): the entry is logically absent.
+    assertTrue(bazRefs5.isEmpty());
 
     // try (final var printStream = new PrintStream(new BufferedOutputStream(System.out))) {
     // reader.dump(printStream);
@@ -164,7 +165,8 @@ public final class XmlRedBlackTreeIntegrationTest {
 
     blablaRefs = reader.get(new CASValue(new Str("törööö"), Type.STR, 2), SearchMode.EQUAL);
 
-    check(blablaRefs, new LongLinkedOpenHashSet());
+    // Removing the last node key leaves a tombstone (#1065): the entry is logically absent.
+    assertTrue(blablaRefs.isEmpty());
 
     assertTrue(wtx.moveTo(blablaNodeKey));
     wtx.insertTextAsFirstChild("törööö");
@@ -177,7 +179,8 @@ public final class XmlRedBlackTreeIntegrationTest {
 
     blablaRefs = reader.get(new CASValue(new Str("törööö"), Type.STR, 2), SearchMode.EQUAL);
 
-    check(blablaRefs, new LongLinkedOpenHashSet());
+    // The re-inserted text revived the tombstone; removing the whole subtree empties it again.
+    assertTrue(blablaRefs.isEmpty());
 
     final var pathNodeKeys = wtx.getPathSummary().getPCRsForPath(Path.parse("//bla/blabla"));
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/XmlRedBlackTreeTombstoneTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/XmlRedBlackTreeTombstoneTest.java
@@ -1,0 +1,148 @@
+package io.sirix.index;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.access.trx.node.xml.XmlIndexController;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.index.path.xml.XmlPCRCollector;
+import io.sirix.index.redblacktree.RBTreeReader;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for #1065 (defect B): removing the last node key of an index entry leaves the
+ * {@code RBNodeKey}/{@code RBNodeValue} pair in the red-black tree (there is no structural
+ * delete/rebalance in the copy-on-write tree). Such a tombstone must be treated as absent by
+ * point lookups ({@code RBTreeReader#get}) and index scans ({@code IndexFilterAxis}), and
+ * re-indexing the same key must revive the entry in place.
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class XmlRedBlackTreeTombstoneTest {
+
+  private static final String PATH = "//bla/blabla";
+
+  private static final String VALUE = "duplicate";
+
+  /**
+   * {@link Holder} reference.
+   */
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    holder = Holder.openResourceSessionWithRedBlackTreeIndexes();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void emptiedEntryIsAbsentForLookupsAndScansAndIsRevivedByReindexing() {
+    final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx();
+
+    final XmlIndexController indexController =
+        holder.getResourceSession().getWtxIndexController(wtx.getRevisionNumber());
+
+    final IndexDef idxDef = IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(Path.parse(PATH)), 0,
+        IndexDef.DbType.XML);
+
+    indexController.createIndexes(Set.of(idxDef), wtx);
+
+    // //bla with two //bla/blabla children, both holding the same text value.
+    final long blaNodeKey = wtx.insertElementAsFirstChild(new QNm("bla")).getNodeKey();
+    final long firstBlablaNodeKey = wtx.insertElementAsFirstChild(new QNm("blabla")).getNodeKey();
+    final long firstTextNodeKey = wtx.insertTextAsFirstChild(VALUE).getNodeKey();
+    wtx.moveTo(firstBlablaNodeKey);
+    wtx.insertElementAsRightSibling(new QNm("blabla"));
+    final long secondTextNodeKey = wtx.insertTextAsFirstChild(VALUE).getNodeKey();
+    wtx.commit();
+
+    final IndexDef indexDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
+
+    final var pathNodeKeys = wtx.getPathSummary().getPCRsForPath(Path.parse(PATH));
+    assertEquals(1, pathNodeKeys.size());
+    final long pcr = pathNodeKeys.iterator().nextLong();
+    final CASValue casKey = new CASValue(new Str(VALUE), Type.STR, pcr);
+
+    // Both text nodes are indexed under the same key.
+    Optional<NodeReferences> refs = lookup(wtx, indexDef, casKey);
+    assertTrue(refs.isPresent());
+    assertEquals(2L, refs.get().getNodeKeys().getLongCardinality());
+
+    // Removing one of two node keys keeps the entry visible.
+    wtx.moveTo(firstTextNodeKey);
+    wtx.remove();
+    wtx.commit();
+
+    refs = lookup(wtx, indexDef, casKey);
+    assertTrue(refs.isPresent());
+    assertEquals(1L, refs.get().getNodeKeys().getLongCardinality());
+    assertTrue(refs.get().contains(secondTextNodeKey));
+    assertEquals(1L, scanCardinality(wtx, indexController, indexDef));
+
+    // Removing the last node key leaves a tombstone: point lookups miss...
+    wtx.moveTo(secondTextNodeKey);
+    wtx.remove();
+    wtx.commit();
+
+    refs = lookup(wtx, indexDef, casKey);
+    assertTrue(refs.isEmpty());
+
+    // ...and scans skip the entry instead of yielding an empty reference set.
+    assertEquals(0L, scanCardinality(wtx, indexController, indexDef));
+
+    // Re-indexing the same value revives the tombstone in place.
+    assertTrue(wtx.moveTo(firstBlablaNodeKey));
+    final long revivedTextNodeKey = wtx.insertTextAsFirstChild(VALUE).getNodeKey();
+    wtx.commit();
+
+    refs = lookup(wtx, indexDef, casKey);
+    assertTrue(refs.isPresent());
+    assertEquals(1L, refs.get().getNodeKeys().getLongCardinality());
+    assertTrue(refs.get().contains(revivedTextNodeKey));
+    assertFalse(refs.get().contains(secondTextNodeKey));
+    assertEquals(1L, scanCardinality(wtx, indexController, indexDef));
+
+    assertTrue(wtx.moveTo(blaNodeKey));
+    wtx.close();
+  }
+
+  private Optional<NodeReferences> lookup(final XmlNodeTrx wtx, final IndexDef indexDef, final CASValue casKey) {
+    final RBTreeReader<CASValue, NodeReferences> reader =
+        RBTreeReader.getInstance(holder.getResourceSession().getIndexCache(), wtx.getStorageEngineReader(),
+            indexDef.getType(), indexDef.getID());
+    return reader.get(casKey, SearchMode.EQUAL);
+  }
+
+  private long scanCardinality(final XmlNodeTrx wtx, final XmlIndexController indexController,
+      final IndexDef indexDef) {
+    final Iterator<NodeReferences> iter = indexController.openCASIndex(wtx.getStorageEngineReader(), indexDef,
+        indexController.createCASFilter(Set.of(PATH), new Str(VALUE), SearchMode.EQUAL, new XmlPCRCollector(wtx)));
+    long cardinality = 0L;
+    while (iter.hasNext()) {
+      cardinality += iter.next().getNodeKeys().getLongCardinality();
+    }
+    return cardinality;
+  }
+}


### PR DESCRIPTION
Fixes defect B of #1065.

## Problem

`RBTreeWriter.remove(key, nodeKey)` removes a node key from an index entry's reference set, but when the set becomes empty the `RBNodeKey`/`RBNodeValue` pair stays in the red-black tree — there is no structural delete/rebalance in the copy-on-write tree. These emptied entries surfaced as *present-but-empty*:

- `RBTreeReader.get(key, EQUAL)` returned a hit with an empty `NodeReferences` set, so existence probes reported keys that logically no longer exist in the index.
- Index scans through `IndexFilterAxis` yielded empty `NodeReferences` objects for such entries.

## Fix — tombstone semantics

A structural red-black delete (with rebalancing) in the copy-on-write, page-versioned tree would be invasive and risky. Instead, an emptied entry is treated as a tombstone that is logically absent:

- **`RBTreeReader.getNode`** (backs both `get()` overloads): when the matched entry's value has no node keys, report a miss (`Optional.empty()`).
- **`IndexFilterAxis.computeNext`**: skip entries whose reference set is empty instead of yielding them.
- **`RBTreeWriter.remove`**: Javadoc now documents the tombstone contract.

Revival is already safe: the insert path (`RBTreeWriter.index()`) performs its own descent, finds the tombstoned key at `c == 0`, and replaces the value in place via `prepareRecordForModification` — no duplicate key nodes are created. All production lookups use `SearchMode.EQUAL`; range scans go through `getCurrentNodeAsRBNodeKey` + `IndexFilterAxis`, which now skips tombstones.

## Tests

- **`XmlRedBlackTreeTombstoneTest`** (new): CAS index lifecycle — two node keys under one value; removing one keeps the entry visible (lookup + scan); removing the last makes the entry absent for point lookups **and** scans; re-inserting the same value revives the tombstone in place with only the new node key. Mutation-checked: fails without the fix, passes with it.
- **`XmlRedBlackTreeIntegrationTest`**: three assertions that pinned the old present-but-empty behaviour updated to expect a miss.
- `io.sirix.index.*` suite passes.

Note: `ValidTimeIndexScanDifferentialTest` in sirix-query currently fails identically **with and without** this change (deterministic seed, reproduced on `main`) — pre-existing, tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_