### PR TITLE
Don't silently drop records on read failures in the valid-time predicate; bound fd usage in valid-time tests

### DIFF
--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
@@ -364,32 +364,36 @@ public final class ValidTimeIndexScan {
    * treated as unbounded on that side — a missing {@code validTo} is "valid from {@code validFrom}
    * onward", a missing {@code validFrom} is "valid up to {@code validTo}". A record with neither bound
    * carries no interval and never matches.
+   *
+   * <p>
+   * Data-shape problems (absent fields, non-string values, unparseable dates) are handled explicitly
+   * above; anything else — notably I/O failures while reading the fields — propagates. A previous
+   * catch-all here mapped such failures to {@code false}, silently dropping records from query
+   * results (e.g. under file-descriptor exhaustion every record read failed and {@code jn:valid-at}
+   * returned an empty sequence instead of an error).
+   * </p>
    */
   static boolean isValidAtTime(final io.brackit.query.jdm.json.Object obj, final Instant validTime,
       final String validFromField, final String validToField) {
-    try {
-      final Sequence validFromSeq = obj.get(new QNm(validFromField));
-      final Sequence validToSeq = obj.get(new QNm(validToField));
+    final Sequence validFromSeq = obj.get(new QNm(validFromField));
+    final Sequence validToSeq = obj.get(new QNm(validToField));
 
-      // Open-ended intervals: a null (absent/unparseable) bound is unbounded on that side. This mirrors
-      // the interval index exactly — its writer maps a null bound to the domain min/max and registers
-      // the record (ValidTimeIntervalIndexWriter.toInterval) — so all paths still return the same set.
-      final Instant validFrom = validFromSeq == null ? null : parseInstant(validFromSeq);
-      final Instant validTo = validToSeq == null ? null : parseInstant(validToSeq);
+    // Open-ended intervals: a null (absent/unparseable) bound is unbounded on that side. This mirrors
+    // the interval index exactly — its writer maps a null bound to the domain min/max and registers
+    // the record (ValidTimeIntervalIndexWriter.toInterval) — so all paths still return the same set.
+    final Instant validFrom = validFromSeq == null ? null : parseInstant(validFromSeq);
+    final Instant validTo = validToSeq == null ? null : parseInstant(validToSeq);
 
-      if (validFrom == null && validTo == null) {
-        return false;
-      }
-      if (validFrom != null && validTime.isBefore(validFrom)) {
-        return false;
-      }
-      if (validTo != null && validTime.isAfter(validTo)) {
-        return false;
-      }
-      return true;
-    } catch (Exception e) {
+    if (validFrom == null && validTo == null) {
       return false;
     }
+    if (validFrom != null && validTime.isBefore(validFrom)) {
+      return false;
+    }
+    if (validTo != null && validTime.isAfter(validTo)) {
+      return false;
+    }
+    return true;
   }
 
   private static Instant parseInstant(final Sequence seq) {

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexEndToEndTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexEndToEndTest.java
@@ -67,6 +67,12 @@ public final class ValidTimeIndexEndToEndTest {
   private static final String VALID_FROM = "validFrom";
   private static final String VALID_TO = "validTo";
 
+  /**
+   * Test times per store instance. Each query/getDocument pins a read-only trx (and its file
+   * descriptors) until the store closes, so chunking bounds concurrent open trxes.
+   */
+  private static final int QUERY_CHUNK_SIZE = 100;
+
   private record Record(int id, Instant validFrom, Instant validTo) {
     boolean validAt(final Instant t) {
       return !t.isBefore(validFrom) && !t.isAfter(validTo);
@@ -142,47 +148,57 @@ public final class ValidTimeIndexEndToEndTest {
     int allMatch = 0;
     int fastPathTaken = 0;
 
-    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
-      store.lookup(DB_NAME);
-      try (var ctx = SirixQueryContext.createWithJsonStore(store);
-          var chain = SirixCompileChain.createWithJsonStore(store)) {
+    // Every jn:valid-at evaluation and every getDocument(...) opens a read-only trx (holding file
+    // descriptors) that lives until the store closes; chunking the times over fresh stores bounds
+    // the number of concurrently open trxes so the test also passes under low open-file limits.
+    for (int chunkStart = 0; chunkStart < testTimes.size(); chunkStart += QUERY_CHUNK_SIZE) {
+      final List<Instant> chunk =
+          testTimes.subList(chunkStart, Math.min(chunkStart + QUERY_CHUNK_SIZE, testTimes.size()));
 
-        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+      try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+        store.lookup(DB_NAME);
+        try (var ctx = SirixQueryContext.createWithJsonStore(store);
+            var chain = SirixCompileChain.createWithJsonStore(store)) {
 
-        for (final Instant t : testTimes) {
-          final Set<Integer> brute = bruteForce(records, t);
-          if (brute.isEmpty()) {
-            zeroMatch++;
-          }
-          if (brute.size() == records.size()) {
-            allMatch++;
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validFrom())) {
-              boundaryFrom++;
-              break;
+          final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+
+          for (final Instant t : chunk) {
+            final Set<Integer> brute = bruteForce(records, t);
+            if (brute.isEmpty()) {
+              zeroMatch++;
             }
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validTo())) {
-              boundaryTo++;
-              break;
+            if (brute.size() == records.size()) {
+              allMatch++;
             }
+            for (final Record r : records) {
+              if (t.equals(r.validFrom())) {
+                boundaryFrom++;
+                break;
+              }
+            }
+            for (final Record r : records) {
+              if (t.equals(r.validTo())) {
+                boundaryTo++;
+                break;
+              }
+            }
+
+            // (a) The interval-index FAST PATH must be taken (a VALIDTIME index exists + is usable).
+            final JsonDBItem doc = collection.getDocument(RESOURCE);
+            final ValidTimeIntervalIndex.Result fast =
+                ValidTimeIntervalIndex.tryIndexScan(doc, t, validTimeConfig);
+            assertNotNull(fast, "Interval-index fast path must be taken at t=" + t
+                + " (the index was created via jn:create-valid-time-index)");
+            fastPathTaken++;
+            assertEquals(brute, idsOfItems(fast.items()),
+                "Direct interval-index result must equal brute force at t=" + t);
+            // All result items wrap the document's trx; ids are materialized, so release it now.
+            doc.getTrx().close();
+
+            // (b) The jn:valid-at function (which prefers the interval index) must agree.
+            assertEquals(brute, idsFromValidAt(chain, ctx, t),
+                "jn:valid-at must equal brute force at t=" + t);
           }
-
-          // (a) The interval-index FAST PATH must be taken (a VALIDTIME index exists + is usable).
-          final JsonDBItem doc = collection.getDocument(RESOURCE);
-          final ValidTimeIntervalIndex.Result fast =
-              ValidTimeIntervalIndex.tryIndexScan(doc, t, validTimeConfig);
-          assertNotNull(fast, "Interval-index fast path must be taken at t=" + t
-              + " (the index was created via jn:create-valid-time-index)");
-          fastPathTaken++;
-          assertEquals(brute, idsOfItems(fast.items()),
-              "Direct interval-index result must equal brute force at t=" + t);
-
-          // (b) The jn:valid-at function (which prefers the interval index) must agree.
-          assertEquals(brute, idsFromValidAt(chain, ctx, t),
-              "jn:valid-at must equal brute force at t=" + t);
         }
       }
     }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScanDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScanDifferentialTest.java
@@ -84,6 +84,13 @@ public final class ValidTimeIndexScanDifferentialTest {
   private static final String VALID_FROM = "validFrom";
   private static final String VALID_TO = "validTo";
 
+  /**
+   * Test times per store instance. Each query/getDocument pins a read-only trx (and its file
+   * descriptors) until the store closes, so chunking bounds concurrent open trxes to
+   * ~3 × chunk size — safe even under a 1024 open-file limit.
+   */
+  private static final int QUERY_CHUNK_SIZE = 100;
+
   /** A record in the dataset (the brute-force oracle's source of truth). */
   private record Record(int id, Instant validFrom, Instant validTo) {
     boolean validAt(final Instant t) {
@@ -152,68 +159,84 @@ public final class ValidTimeIndexScanDifferentialTest {
     int allMatchTimes = 0;
     int indexPathTakenCount = 0;
 
-    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
-      store.lookup(DB_NAME);
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
 
-      try (var ctx = SirixQueryContext.createWithJsonStore(store);
-          var chain = SirixCompileChain.createWithJsonStore(store)) {
+    // Every jn:valid-at evaluation and every getDocument(...) opens a read-only trx (holding file
+    // descriptors) that lives until the store closes. With ~900 test times × 3 lookups each, one
+    // store for the whole run exhausts low open-file limits (e.g. 1024/4096 on dev machines).
+    // Process the times in chunks over a fresh store so the number of concurrently open trxes
+    // stays bounded — semantics are unchanged, every t is still verified.
+    for (int chunkStart = 0; chunkStart < testTimes.size(); chunkStart += QUERY_CHUNK_SIZE) {
+      final List<Instant> chunk =
+          testTimes.subList(chunkStart, Math.min(chunkStart + QUERY_CHUNK_SIZE, testTimes.size()));
 
-        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+      try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+        store.lookup(DB_NAME);
 
-        for (final Instant t : testTimes) {
-          // (0) brute-force oracle
-          final Set<Integer> brute = new TreeSet<>();
-          for (final Record r : records) {
-            if (r.validAt(t)) {
-              brute.add(r.id());
+        try (var ctx = SirixQueryContext.createWithJsonStore(store);
+            var chain = SirixCompileChain.createWithJsonStore(store)) {
+
+          final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+
+          for (final Instant t : chunk) {
+            // (0) brute-force oracle
+            final Set<Integer> brute = new TreeSet<>();
+            for (final Record r : records) {
+              if (r.validAt(t)) {
+                brute.add(r.id());
+              }
             }
-          }
-          if (brute.isEmpty()) {
-            zeroMatchTimes++;
-          }
-          if (brute.size() == records.size()) {
-            allMatchTimes++;
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validFrom())) {
-              boundaryEqualsFrom++;
-              break;
+            if (brute.isEmpty()) {
+              zeroMatchTimes++;
             }
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validTo())) {
-              boundaryEqualsTo++;
-              break;
+            if (brute.size() == records.size()) {
+              allMatchTimes++;
             }
+            for (final Record r : records) {
+              if (t.equals(r.validFrom())) {
+                boundaryEqualsFrom++;
+                break;
+              }
+            }
+            for (final Record r : records) {
+              if (t.equals(r.validTo())) {
+                boundaryEqualsTo++;
+                break;
+              }
+            }
+
+            // (1) DIRECT index path — assert it is actually taken, then compare its result set.
+            final JsonDBItem indexedDoc = collection.getDocument(INDEXED_RESOURCE);
+            final ValidTimeIndexScan.Result indexScan =
+                ValidTimeIndexScan.tryIndexScan(indexedDoc, t, validTimeConfig);
+            assertNotNull(indexScan,
+                "Index path must be taken on the indexed resource (a CAS index exists) at t=" + t);
+            indexPathTakenCount++;
+            final Set<Integer> directIndexIds = idsOfItems(indexScan.items());
+            assertEquals(brute, directIndexIds,
+                "Direct index-scan result must equal brute force at t=" + t + " (field used: "
+                    + indexScan.indexedField() + ", candidates examined: " + indexScan.candidatesExamined() + ")");
+            // All result items wrap the document's trx; ids are materialized, so release it now.
+            indexedDoc.getTrx().close();
+
+            // (2) jn:valid-at over the INDEXED resource (fast path through execute()).
+            final Set<Integer> indexedQueryIds = idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t);
+            assertEquals(brute, indexedQueryIds, "jn:valid-at over indexed resource must equal brute force at t=" + t);
+
+            // (3) jn:valid-at over the PLAIN resource (linear-scan fallback).
+            final Set<Integer> plainQueryIds = idsFromValidAtQuery(chain, ctx, PLAIN_RESOURCE, t);
+            assertEquals(brute, plainQueryIds, "jn:valid-at over plain resource (scan) must equal brute force at t=" + t);
           }
-
-          // (1) DIRECT index path — assert it is actually taken, then compare its result set.
-          final JsonDBItem indexedDoc = collection.getDocument(INDEXED_RESOURCE);
-          final ValidTimeIndexScan.Result indexScan =
-              ValidTimeIndexScan.tryIndexScan(indexedDoc, t, validTimeConfig);
-          assertNotNull(indexScan,
-              "Index path must be taken on the indexed resource (a CAS index exists) at t=" + t);
-          indexPathTakenCount++;
-          final Set<Integer> directIndexIds = idsOfItems(indexScan.items());
-          assertEquals(brute, directIndexIds,
-              "Direct index-scan result must equal brute force at t=" + t + " (field used: "
-                  + indexScan.indexedField() + ", candidates examined: " + indexScan.candidatesExamined() + ")");
-
-          // (2) jn:valid-at over the INDEXED resource (fast path through execute()).
-          final Set<Integer> indexedQueryIds = idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t);
-          assertEquals(brute, indexedQueryIds, "jn:valid-at over indexed resource must equal brute force at t=" + t);
-
-          // (3) jn:valid-at over the PLAIN resource (linear-scan fallback).
-          final Set<Integer> plainQueryIds = idsFromValidAtQuery(chain, ctx, PLAIN_RESOURCE, t);
-          assertEquals(brute, plainQueryIds, "jn:valid-at over plain resource (scan) must equal brute force at t=" + t);
         }
-
-        // Sanity: the plain resource really has NO usable index (the fallback path is exercised).
-        final JsonDBItem plainDoc = collection.getDocument(PLAIN_RESOURCE);
-        assertNull(ValidTimeIndexScan.tryIndexScan(plainDoc, testTimes.get(0), validTimeConfig),
-            "Plain resource must have no usable CAS index (linear-scan fallback)");
       }
+    }
+
+    // Sanity: the plain resource really has NO usable index (the fallback path is exercised).
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+      final JsonDBItem plainDoc = collection.getDocument(PLAIN_RESOURCE);
+      assertNull(ValidTimeIndexScan.tryIndexScan(plainDoc, testTimes.get(0), validTimeConfig),
+          "Plain resource must have no usable CAS index (linear-scan fallback)");
     }
 
     // Make sure the curated boundary cases were actually present in the run (901 times over 178
@@ -250,34 +273,41 @@ public final class ValidTimeIndexScanDifferentialTest {
     }
 
     final List<Instant> testTimes = buildTestTimes(records);
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
 
-    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
-      store.lookup(DB_NAME);
-      try (var ctx = SirixQueryContext.createWithJsonStore(store);
-          var chain = SirixCompileChain.createWithJsonStore(store)) {
+    // Chunked for the same open-file-limit reason as indexEqualsScanEqualsBruteForceForAllT.
+    for (int chunkStart = 0; chunkStart < testTimes.size(); chunkStart += QUERY_CHUNK_SIZE) {
+      final List<Instant> chunk =
+          testTimes.subList(chunkStart, Math.min(chunkStart + QUERY_CHUNK_SIZE, testTimes.size()));
 
-        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+      try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+        store.lookup(DB_NAME);
+        try (var ctx = SirixQueryContext.createWithJsonStore(store);
+            var chain = SirixCompileChain.createWithJsonStore(store)) {
 
-        for (final Instant t : testTimes) {
-          final Set<Integer> brute = new TreeSet<>();
-          for (final Record r : records) {
-            if (r.validAt(t)) {
-              brute.add(r.id());
+          final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+
+          for (final Instant t : chunk) {
+            final Set<Integer> brute = new TreeSet<>();
+            for (final Record r : records) {
+              if (r.validAt(t)) {
+                brute.add(r.id());
+              }
             }
+
+            final JsonDBItem doc = collection.getDocument(INDEXED_RESOURCE);
+            final ValidTimeIndexScan.Result indexScan = ValidTimeIndexScan.tryIndexScan(doc, t, validTimeConfig);
+            assertNotNull(indexScan, "Index path must be taken (validFrom index exists) at t=" + t);
+            assertEquals(ValidTimeIndexScan.ValidField.VALID_FROM, indexScan.indexedField(),
+                "Only the validFrom index exists, so it must be the one used at t=" + t);
+            assertEquals(brute, idsOfItems(indexScan.items()),
+                "validFrom-only index path must equal brute force at t=" + t);
+            doc.getTrx().close();
+
+            // And the function as a whole (through execute()).
+            assertEquals(brute, idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t),
+                "jn:valid-at (validFrom-only index) must equal brute force at t=" + t);
           }
-
-          final JsonDBItem doc = collection.getDocument(INDEXED_RESOURCE);
-          final ValidTimeIndexScan.Result indexScan = ValidTimeIndexScan.tryIndexScan(doc, t, validTimeConfig);
-          assertNotNull(indexScan, "Index path must be taken (validFrom index exists) at t=" + t);
-          assertEquals(ValidTimeIndexScan.ValidField.VALID_FROM, indexScan.indexedField(),
-              "Only the validFrom index exists, so it must be the one used at t=" + t);
-          assertEquals(brute, idsOfItems(indexScan.items()),
-              "validFrom-only index path must equal brute force at t=" + t);
-
-          // And the function as a whole (through execute()).
-          assertEquals(brute, idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t),
-              "jn:valid-at (validFrom-only index) must equal brute force at t=" + t);
         }
       }
     }
@@ -314,23 +344,29 @@ public final class ValidTimeIndexScanDifferentialTest {
     final List<Instant> testTimes = buildTestTimes(records);
     final String txTimeStr = txTime.plus(1, ChronoUnit.SECONDS).toString();
 
-    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
-      store.lookup(DB_NAME);
-      try (var ctx = SirixQueryContext.createWithJsonStore(store);
-          var chain = SirixCompileChain.createWithJsonStore(store)) {
+    // Chunked for the same open-file-limit reason as indexEqualsScanEqualsBruteForceForAllT.
+    for (int chunkStart = 0; chunkStart < testTimes.size(); chunkStart += QUERY_CHUNK_SIZE) {
+      final List<Instant> chunk =
+          testTimes.subList(chunkStart, Math.min(chunkStart + QUERY_CHUNK_SIZE, testTimes.size()));
 
-        for (final Instant t : testTimes) {
-          final Set<Integer> brute = new TreeSet<>();
-          for (final Record r : records) {
-            if (r.validAt(t)) {
-              brute.add(r.id());
+      try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+        store.lookup(DB_NAME);
+        try (var ctx = SirixQueryContext.createWithJsonStore(store);
+            var chain = SirixCompileChain.createWithJsonStore(store)) {
+
+          for (final Instant t : chunk) {
+            final Set<Integer> brute = new TreeSet<>();
+            for (final Record r : records) {
+              if (r.validAt(t)) {
+                brute.add(r.id());
+              }
             }
-          }
 
-          final String query = "jn:open-bitemporal('" + DB_NAME + "', '" + INDEXED_RESOURCE + "', xs:dateTime('"
-              + txTimeStr + "'), xs:dateTime('" + t + "'))";
-          final Set<Integer> got = idsFromObjectQuery(chain, ctx, query);
-          assertEquals(brute, got, "jn:open-bitemporal (indexed) must equal brute force at t=" + t);
+            final String query = "jn:open-bitemporal('" + DB_NAME + "', '" + INDEXED_RESOURCE + "', xs:dateTime('"
+                + txTimeStr + "'), xs:dateTime('" + t + "'))";
+            final Set<Integer> got = idsFromObjectQuery(chain, ctx, query);
+            assertEquals(brute, got, "jn:open-bitemporal (indexed) must equal brute force at t=" + t);
+          }
         }
       }
     }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIntervalIndexDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIntervalIndexDifferentialTest.java
@@ -83,6 +83,12 @@ public final class ValidTimeIntervalIndexDifferentialTest {
   private static final String VALID_FROM = "validFrom";
   private static final String VALID_TO = "validTo";
 
+  /**
+   * Test times per store instance. Each query/getDocument pins a read-only trx (and its file
+   * descriptors) until the store closes, so chunking bounds concurrent open trxes.
+   */
+  private static final int QUERY_CHUNK_SIZE = 100;
+
   /** A record in the dataset (the brute-force oracle's source of truth). */
   private record Record(int id, Instant validFrom, Instant validTo) {
     boolean validAt(final Instant t) {
@@ -174,56 +180,66 @@ public final class ValidTimeIntervalIndexDifferentialTest {
     int subSecondTimes = 0;
     int indexPathTakenCount = 0;
 
-    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
-      store.lookup(DB_NAME);
-      try (var ctx = SirixQueryContext.createWithJsonStore(store);
-          var chain = SirixCompileChain.createWithJsonStore(store)) {
+    // Every jn:valid-at evaluation and every getDocument(...) opens a read-only trx (holding file
+    // descriptors) that lives until the store closes; chunking the times over fresh stores bounds
+    // the number of concurrently open trxes so the test also passes under low open-file limits.
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+    for (int chunkStart = 0; chunkStart < testTimes.size(); chunkStart += QUERY_CHUNK_SIZE) {
+      final List<Instant> chunk =
+          testTimes.subList(chunkStart, Math.min(chunkStart + QUERY_CHUNK_SIZE, testTimes.size()));
 
-        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+      try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+        store.lookup(DB_NAME);
+        try (var ctx = SirixQueryContext.createWithJsonStore(store);
+            var chain = SirixCompileChain.createWithJsonStore(store)) {
 
-        for (final Instant t : testTimes) {
-          final Set<Integer> brute = bruteForce(records, t);
-          if (brute.isEmpty()) {
-            zeroMatchTimes++;
-          }
-          if (brute.size() == records.size()) {
-            allMatchTimes++;
-          }
-          if (t.getNano() != 0) { // a sub-second (fractional, e.g. millisecond) instant
-            subSecondTimes++;
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validFrom())) {
-              boundaryEqualsFrom++;
-              break;
+          final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
+
+          for (final Instant t : chunk) {
+            final Set<Integer> brute = bruteForce(records, t);
+            if (brute.isEmpty()) {
+              zeroMatchTimes++;
             }
-          }
-          for (final Record r : records) {
-            if (t.equals(r.validTo())) {
-              boundaryEqualsTo++;
-              break;
+            if (brute.size() == records.size()) {
+              allMatchTimes++;
             }
+            if (t.getNano() != 0) { // a sub-second (fractional, e.g. millisecond) instant
+              subSecondTimes++;
+            }
+            for (final Record r : records) {
+              if (t.equals(r.validFrom())) {
+                boundaryEqualsFrom++;
+                break;
+              }
+            }
+            for (final Record r : records) {
+              if (t.equals(r.validTo())) {
+                boundaryEqualsTo++;
+                break;
+              }
+            }
+
+            // (1) DIRECT interval-index path — assert it is taken, then compare its result set.
+            final JsonDBItem indexedDoc = collection.getDocument(INDEXED_RESOURCE);
+            final ValidTimeIntervalIndex.Result indexScan =
+                ValidTimeIntervalIndex.tryIndexScan(indexedDoc, t, validTimeConfig);
+            assertNotNull(indexScan,
+                "Interval-index path must be taken on the indexed resource (a VALIDTIME index exists) at t=" + t);
+            indexPathTakenCount++;
+            assertEquals(brute, idsOfItems(indexScan.items()),
+                "Direct interval-index result must equal brute force at t=" + t
+                    + " (candidates examined: " + indexScan.candidatesExamined() + ")");
+            // All result items wrap the document's trx; ids are materialized, so release it now.
+            indexedDoc.getTrx().close();
+
+            // (2) jn:valid-at over the INDEXED resource (interval-index fast path through execute()).
+            assertEquals(brute, idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t),
+                "jn:valid-at over indexed resource must equal brute force at t=" + t);
+
+            // (3) jn:valid-at over the PLAIN resource (linear-scan fallback — the second oracle).
+            assertEquals(brute, idsFromValidAtQuery(chain, ctx, PLAIN_RESOURCE, t),
+                "jn:valid-at over plain resource (scan) must equal brute force at t=" + t);
           }
-
-          // (1) DIRECT interval-index path — assert it is taken, then compare its result set.
-          final JsonDBItem indexedDoc = collection.getDocument(INDEXED_RESOURCE);
-          final ValidTimeIntervalIndex.Result indexScan =
-              ValidTimeIntervalIndex.tryIndexScan(indexedDoc, t, validTimeConfig);
-          assertNotNull(indexScan,
-              "Interval-index path must be taken on the indexed resource (a VALIDTIME index exists) at t=" + t);
-          indexPathTakenCount++;
-          assertEquals(brute, idsOfItems(indexScan.items()),
-              "Direct interval-index result must equal brute force at t=" + t
-                  + " (candidates examined: " + indexScan.candidatesExamined() + ")");
-
-          // (2) jn:valid-at over the INDEXED resource (interval-index fast path through execute()).
-          assertEquals(brute, idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t),
-              "jn:valid-at over indexed resource must equal brute force at t=" + t);
-
-          // (3) jn:valid-at over the PLAIN resource (linear-scan fallback — the second oracle).
-          assertEquals(brute, idsFromValidAtQuery(chain, ctx, PLAIN_RESOURCE, t),
-              "jn:valid-at over plain resource (scan) must equal brute force at t=" + t);
         }
       }
     }
@@ -248,7 +264,6 @@ public final class ValidTimeIntervalIndexDifferentialTest {
       try (var ctx = SirixQueryContext.createWithJsonStore(store);
           var chain = SirixCompileChain.createWithJsonStore(store)) {
         final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
         for (final Instant t : reopenSampleTimes(records)) {
           final Set<Integer> brute = bruteForce(records, t);
           final JsonDBItem indexedDoc = collection.getDocument(INDEXED_RESOURCE);
@@ -301,7 +316,6 @@ public final class ValidTimeIntervalIndexDifferentialTest {
       try (var ctx = SirixQueryContext.createWithJsonStore(store);
           var chain = SirixCompileChain.createWithJsonStore(store)) {
         final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
 
         // Sample instants that specifically exercise the inserted + deleted records' boundaries,
         // plus a broad sweep.
@@ -388,12 +402,12 @@ public final class ValidTimeIntervalIndexDifferentialTest {
         List.of(Set.of(3), Set.of(3), Set.of(1), Set.of(2), Set.of(2), Set.of(2));
 
     Databases.getGlobalBufferManager().clearAllCaches();
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
     try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
       store.lookup(DB_NAME);
       try (var ctx = SirixQueryContext.createWithJsonStore(store);
           var chain = SirixCompileChain.createWithJsonStore(store)) {
         final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB_NAME);
-        final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
 
         for (int i = 0; i < times.size(); i++) {
           final Instant t = times.get(i);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIsValidAtTimePredicateTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIsValidAtTimePredicateTest.java
@@ -1,0 +1,161 @@
+package io.sirix.query.function.jn.temporal;
+
+import io.brackit.query.atomic.IntNumeric;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.json.Array;
+import io.brackit.query.jdm.json.Object;
+import io.brackit.query.jsonitem.object.AbstractObject;
+import io.brackit.query.jsonitem.object.ArrayObject;
+import io.sirix.exception.SirixIOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link ValidTimeIndexScan#isValidAtTime} — the single validity predicate shared
+ * by the linear-scan fallback, the CAS-index verification, and the interval-index re-verification.
+ *
+ * <p>
+ * Data-shape problems (absent fields, non-string values, unparseable dates) must degrade to
+ * "unbounded on that side" / "no interval", but genuine failures while reading the fields (e.g.
+ * I/O errors) must propagate: a former catch-all mapped them to {@code false}, silently dropping
+ * every record from query results instead of surfacing the error.
+ * </p>
+ */
+@DisplayName("ValidTimeIndexScan.isValidAtTime predicate")
+final class ValidTimeIsValidAtTimePredicateTest {
+
+  private static final String FROM = "validFrom";
+  private static final String TO = "validTo";
+
+  private static final Instant T = Instant.parse("2020-06-01T12:00:00Z");
+
+  private static Object obj(final String validFrom, final String validTo) {
+    if (validFrom == null && validTo == null) {
+      return new ArrayObject(new QNm[0], new Sequence[0]);
+    }
+    if (validFrom == null) {
+      return new ArrayObject(new QNm[] {new QNm(TO)}, new Sequence[] {new Str(validTo)});
+    }
+    if (validTo == null) {
+      return new ArrayObject(new QNm[] {new QNm(FROM)}, new Sequence[] {new Str(validFrom)});
+    }
+    return new ArrayObject(new QNm[] {new QNm(FROM), new QNm(TO)},
+        new Sequence[] {new Str(validFrom), new Str(validTo)});
+  }
+
+  @Test
+  @DisplayName("t inside / at boundaries / outside a closed interval")
+  void closedInterval() {
+    final Object o = obj("2020-06-01T00:00:00Z", "2020-06-02T00:00:00Z");
+    assertTrue(ValidTimeIndexScan.isValidAtTime(o, T, FROM, TO));
+    assertTrue(ValidTimeIndexScan.isValidAtTime(o, Instant.parse("2020-06-01T00:00:00Z"), FROM, TO));
+    assertTrue(ValidTimeIndexScan.isValidAtTime(o, Instant.parse("2020-06-02T00:00:00Z"), FROM, TO));
+    assertFalse(ValidTimeIndexScan.isValidAtTime(o, Instant.parse("2020-05-31T23:59:59.999Z"), FROM, TO));
+    assertFalse(ValidTimeIndexScan.isValidAtTime(o, Instant.parse("2020-06-02T00:00:00.001Z"), FROM, TO));
+  }
+
+  @Test
+  @DisplayName("absent or unparseable bounds are unbounded on that side; neither bound never matches")
+  void openAndDegenerateIntervals() {
+    assertTrue(ValidTimeIndexScan.isValidAtTime(obj("2020-06-01T00:00:00Z", null), T, FROM, TO));
+    assertTrue(ValidTimeIndexScan.isValidAtTime(obj(null, "2020-06-02T00:00:00Z"), T, FROM, TO));
+    assertFalse(ValidTimeIndexScan.isValidAtTime(obj(null, null), T, FROM, TO));
+    // Unparseable dates degrade to "absent", not to an error and not to a hard mismatch.
+    assertTrue(ValidTimeIndexScan.isValidAtTime(obj("not-a-date", "2020-06-02T00:00:00Z"), T, FROM, TO));
+    assertFalse(ValidTimeIndexScan.isValidAtTime(obj("not-a-date", "junk"), T, FROM, TO));
+  }
+
+  @Test
+  @DisplayName("failures while reading the fields propagate instead of silently dropping the record")
+  void readFailurePropagates() {
+    final Object failing = new AbstractObject() {
+      @Override
+      public Sequence get(final QNm field) {
+        throw new SirixIOException("simulated I/O failure reading field " + field);
+      }
+
+      @Override
+      public Object replace(final QNm field, final Sequence value) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object rename(final QNm field, final QNm newFieldName) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object insert(final QNm field, final Sequence value) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object remove(final QNm field) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object remove(final IntNumeric index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object remove(final int index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Sequence value(final IntNumeric index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Sequence value(final int index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Array names() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Array values() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public QNm name(final IntNumeric index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public QNm name(final int index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public IntNumeric length() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public int len() {
+        throw new UnsupportedOperationException();
+      }
+    };
+
+    final SirixIOException e =
+        assertThrows(SirixIOException.class, () -> ValidTimeIndexScan.isValidAtTime(failing, T, FROM, TO));
+    assertEquals("simulated I/O failure reading field validFrom", e.getMessage());
+  }
+}


### PR DESCRIPTION
## Problem

While verifying an unrelated change, `ValidTimeIndexScanDifferentialTest` failed deterministically on `main` in a low-open-file-limit environment (ulimit 4096): at test-time iteration ~662, `jn:valid-at` over the plain resource returned an **empty sequence** while the brute-force oracle expected 58 records — a silent wrong result, not an error.

Root cause chain:

1. Every `jn:valid-at` evaluation and every `JsonDBCollection.getDocument(...)` opens a read-only trx whose reader pins two file descriptors (data + revisions channel) until the store closes. The valid-time differential/E2E tests run ~900 timestamps × 3 lookups against one store, so the JVM exhausts common open-file limits (1024 on macOS defaults, 4096 here). CI runners have higher limits, which is why CI stayed green.
2. `ValidTimeIndexScan.isValidAtTime` — the single validity predicate shared by the linear-scan fallback, the CAS-index verification, and the interval-index re-verification — wrapped its body in `catch (Exception) { return false; }`. The resulting `SirixIOException`s ("Too many open files") were mapped to *"record not valid"*, so every record was silently filtered out and the query returned `[]` instead of failing.

## Fix

- **`ValidTimeIndexScan.isValidAtTime`**: remove the catch-all. Data-shape problems (absent fields, non-string values, unparseable dates) are already handled explicitly and still degrade to "unbounded on that side" / "no interval"; genuine failures while reading the fields now propagate instead of silently shrinking result sets.
- **`ValidTimeIndexScanDifferentialTest`, `ValidTimeIntervalIndexDifferentialTest`, `ValidTimeIndexEndToEndTest`**: process the test times in chunks of 100 over a fresh store, and close the direct-scan document trxes once their result sets are materialized. This bounds concurrently open read-only trxes so the suites pass under a 1024 open-file limit; every timestamp is still verified, semantics unchanged.

## Tests

- **`ValidTimeIsValidAtTimePredicateTest`** (new): unit-tests the predicate — closed/open/degenerate intervals, boundary equality on both ends, unparseable bounds degrading to absent — and asserts that a failure thrown while reading the fields propagates. Mutation-checked: the propagation test fails with the old catch-all restored.
- `io.sirix.query.function.jn.temporal.*` (52 tests) green; previously two more suites (`ValidTimeIndexEndToEndTest`, `ValidTimeIntervalIndexDifferentialTest`) hit the same fd exhaustion once the swallow was removed — both now pass with chunking.
- Full `:sirix-query:test` suite green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_