### PR TITLE
Large-value overflow storage: store and read records past the slotted-page cap (#1076)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -689,11 +689,20 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
 
     // Get slot data from page heap
     MemorySegment data = page.getSlot(slotOff);
+    boolean isOverflowData = false;
     if (data == null) {
-      if (newGuard != null) {
-        newGuard.close();
+      // Large-value overflow record (#1076): no slot, but the page carries a reference to an
+      // OverflowPage whose bytes are in record-persister format (kind byte + payload) — exactly
+      // what the legacy populate branch below parses. Without this, moveTo of an overflow record
+      // returned false and hasLeftSibling()/moveToLeftSibling() loops spun forever.
+      data = reader.readOverflowDataOrNull(page, nodeKey);
+      if (data == null) {
+        if (newGuard != null) {
+          newGuard.close();
+        }
+        return false;
       }
-      return false;
+      isOverflowData = true;
     }
 
     // Read node kind from first byte
@@ -721,8 +730,11 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     // Release previous page guard ONLY NOW (after we know the new page is valid)
     releaseCurrentPageGuard();
 
-    // Check if this is a flyweight record in slotted page
-    final boolean isFlyweight = page.getSlottedPage() != null && page.getSlotNodeKindId(slotOff) > 0
+    // Check if this is a flyweight record in slotted page. Overflow data is NEVER flyweight
+    // slot layout — and the directory entry of a cleared (overflowed) slot may still carry a
+    // stale nodeKindId, so the flag must be forced off for overflow-resolved records.
+    final boolean isFlyweight = !isOverflowData && page.getSlottedPage() != null
+        && page.getSlotNodeKindId(slotOff) > 0
         && singleton instanceof FlyweightNode;
     if (isFlyweight) {
       final FlyweightNode fn = (FlyweightNode) singleton;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -689,20 +689,20 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
 
     // Get slot data from page heap
     MemorySegment data = page.getSlot(slotOff);
-    boolean isOverflowData = false;
     if (data == null) {
-      // Large-value overflow record (#1076): no slot, but the page carries a reference to an
-      // OverflowPage whose bytes are in record-persister format (kind byte + payload) — exactly
-      // what the legacy populate branch below parses. Without this, moveTo of an overflow record
-      // returned false and hasLeftSibling()/moveToLeftSibling() loops spun forever.
-      data = reader.readOverflowDataOrNull(page, nodeKey);
-      if (data == null) {
-        if (newGuard != null) {
-          newGuard.close();
-        }
-        return false;
+      if (newGuard != null) {
+        newGuard.close();
       }
-      isOverflowData = true;
+      // Large-value overflow record (#1076): no slot, but the page carries an overflow
+      // reference. Resolve through the object path — its record-persister deserialization
+      // matches the overflow byte format for every node kind, whereas the singleton readFrom
+      // parsers expect the legacy slot layout (which e.g. carries a hash field for
+      // STRING_VALUE that the persister format does not). Without this, moveTo of an overflow
+      // record returned false and hasLeftSibling()/moveToLeftSibling() loops spun forever.
+      if (page.getPageReference(nodeKey) != null) {
+        return moveToLegacy(nodeKey);
+      }
+      return false;
     }
 
     // Read node kind from first byte
@@ -730,11 +730,8 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     // Release previous page guard ONLY NOW (after we know the new page is valid)
     releaseCurrentPageGuard();
 
-    // Check if this is a flyweight record in slotted page. Overflow data is NEVER flyweight
-    // slot layout — and the directory entry of a cleared (overflowed) slot may still carry a
-    // stale nodeKindId, so the flag must be forced off for overflow-resolved records.
-    final boolean isFlyweight = !isOverflowData && page.getSlottedPage() != null
-        && page.getSlotNodeKindId(slotOff) > 0
+    // Check if this is a flyweight record in slotted page
+    final boolean isFlyweight = page.getSlottedPage() != null && page.getSlotNodeKindId(slotOff) > 0
         && singleton instanceof FlyweightNode;
     if (isFlyweight) {
       final FlyweightNode fn = (FlyweightNode) singleton;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeFactoryImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeFactoryImpl.java
@@ -234,8 +234,18 @@ final class JsonNodeFactoryImpl implements JsonNodeFactory {
     final int slotOffset = storageEngineWriter.getAllocSlotOffset();
     final byte[] deweyIdBytes = (id != null && kvl.areDeweyIDsStored()) ? id.toBytes() : null;
     final int deweyIdLen = deweyIdBytes != null ? deweyIdBytes.length : 0;
-    final long absOffset = kvl.prepareHeapForDirectWrite(
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(
         55 + valueLen, deweyIdLen);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      // Large value (#1076): does not fit into the slotted page — store as a heap node so the
+      // page diverts it to an OverflowPage at commit time.
+      final byte[] valueCopy = new byte[valueLen];
+      System.arraycopy(value, valueOff, valueCopy, 0, valueLen);
+      final StringNode node = new StringNode(nodeKey, parentKey, Constants.NULL_REVISION_NUMBER, revisionNumber,
+          rightSibKey, leftSibKey, 0, valueCopy, hashFunction, id, false, null);
+      kvl.setRecord(node);
+      return node;
+    }
     final int recordBytes = StringNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
         reusableStringNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey,
         Constants.NULL_REVISION_NUMBER, revisionNumber, value, valueOff, valueLen, false);
@@ -356,8 +366,21 @@ final class JsonNodeFactoryImpl implements JsonNodeFactory {
     final byte[] deweyIdBytes = (id != null && kvl.areDeweyIDsStored()) ? id.toBytes() : null;
     final int deweyIdLen = deweyIdBytes != null ? deweyIdBytes.length : 0;
     final int valueLen = value != null ? len : 0;
-    final long absOffset = kvl.prepareHeapForDirectWrite(
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(
         64 + valueLen, deweyIdLen);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      // Large value (#1076): does not fit into the slotted page — store as a heap node so the
+      // page diverts it to an OverflowPage at commit time.
+      final byte[] valueCopy = new byte[valueLen];
+      if (valueLen > 0) {
+        System.arraycopy(value, off, valueCopy, 0, valueLen);
+      }
+      final ObjectNamedStringNode node = new ObjectNamedStringNode(nodeKey, parentKey, rightSibKey, leftSibKey,
+          localNameKey, pathNodeKey, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, valueCopy, hashFunction, id,
+          false, null);
+      kvl.setRecord(node);
+      return node;
+    }
     final int recordBytes = ObjectNamedStringNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
         reusableObjectNamedStringNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey,
         localNameKey, pathNodeKey,

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeFactoryImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeFactoryImpl.java
@@ -6,8 +6,6 @@ import io.sirix.index.path.summary.PathNode;
 import io.sirix.node.DeweyIDNode;
 import io.sirix.node.NodeKind;
 import io.sirix.node.SirixDeweyID;
-import io.sirix.node.delegates.NodeDelegate;
-import io.sirix.node.delegates.StructNodeDelegate;
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.json.ArrayNode;
 import io.sirix.node.json.BooleanNode;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
@@ -191,8 +191,16 @@ final class XmlNodeFactoryImpl implements XmlNodeFactory {
     final int slotOffset = storageEngineWriter.getAllocSlotOffset();
     final byte[] deweyIdBytes = (id != null && kvl.areDeweyIDsStored()) ? id.toBytes() : null;
     final int deweyIdLen = deweyIdBytes != null ? deweyIdBytes.length : 0;
-    final long absOffset = kvl.prepareHeapForDirectWrite(
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(
         55 + compressedValue.length, deweyIdLen);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      // Large value (#1076): does not fit into the slotted page — store as a heap node so the
+      // page diverts it to an OverflowPage at commit time.
+      final TextNode node = new TextNode(nodeKey, parentKey, Constants.NULL_REVISION_NUMBER, revisionNumber,
+          rightSibKey, leftSibKey, 0, compressedValue.clone(), compression, hashFunction, id);
+      kvl.setRecord(node);
+      return node;
+    }
     final int recordBytes = TextNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
         reusableTextNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey,
         Constants.NULL_REVISION_NUMBER, revisionNumber, compressedValue, compression);
@@ -217,8 +225,16 @@ final class XmlNodeFactoryImpl implements XmlNodeFactory {
     final int slotOffset = storageEngineWriter.getAllocSlotOffset();
     final byte[] deweyIdBytes = (id != null && kvl.areDeweyIDsStored()) ? id.toBytes() : null;
     final int deweyIdLen = deweyIdBytes != null ? deweyIdBytes.length : 0;
-    final long absOffset = kvl.prepareHeapForDirectWrite(
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(
         64 + value.length, deweyIdLen);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      // Large value (#1076): does not fit into the slotted page — store as a heap node so the
+      // page diverts it to an OverflowPage at commit time.
+      final AttributeNode node = new AttributeNode(nodeKey, parentKey, Constants.NULL_REVISION_NUMBER,
+          revisionNumber, pathNodeKey, prefixKey, localNameKey, uriKey, 0, value.clone(), hashFunction, id, name);
+      kvl.setRecord(node);
+      return node;
+    }
     final int recordBytes = AttributeNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
         reusableAttributeNode.getHeapOffsets(), nodeKey, parentKey, pathNodeKey,
         prefixKey, localNameKey, uriKey,

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
@@ -5,7 +5,6 @@ import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathNode;
 import io.sirix.node.NodeKind;
 import io.sirix.node.SirixDeweyID;
-import io.sirix.node.delegates.NodeDelegate;
 import io.sirix.node.delegates.StructNodeDelegate;
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.xml.AttributeNode;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -58,7 +58,6 @@ import io.sirix.page.IndirectPage;
 import io.sirix.page.KeyValueLeafPage;
 import io.sirix.page.NamePage;
 import io.sirix.page.OverflowPage;
-import io.sirix.page.PageKind;
 import io.sirix.page.PageLayout;
 import io.sirix.page.PageReference;
 import io.sirix.page.PathPage;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -492,30 +492,6 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     return overflowPage;
   }
 
-  /**
-   * Resolve the record-persister bytes of a large-value overflow record (#1076), or {@code null}
-   * if the record has no overflow reference. Serves the in-memory (not yet committed)
-   * {@link OverflowPage} when present, otherwise reads it through the reference's disk key
-   * (swizzling it for subsequent lookups). The returned bytes are in record-persister format
-   * (kind byte + payload) — the same layout as legacy slot data.
-   *
-   * @param page      the record page owning the overflow reference
-   * @param recordKey the record's node key
-   * @return the overflow record bytes, or {@code null}
-   */
-  public MemorySegment readOverflowDataOrNull(final KeyValueLeafPage page, final long recordKey) {
-    final PageReference reference = page.getPageReference(recordKey);
-    if (reference == null
-        || (reference.getKey() == Constants.NULL_ID_LONG && !(reference.getPage() instanceof OverflowPage))) {
-      return null;
-    }
-    try {
-      return readOverflowPage(reference).getData();
-    } catch (final SirixIOException e) {
-      return null;
-    }
-  }
-
   @SuppressWarnings({"unchecked", "rawtypes"})
   private DataRecord getDataRecord(long key, int offset, MemorySegment data, KeyValuePage<? extends DataRecord> page) {
     reusableBytesIn.reset(data, 0);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -492,6 +492,30 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     return overflowPage;
   }
 
+  /**
+   * Resolve the record-persister bytes of a large-value overflow record (#1076), or {@code null}
+   * if the record has no overflow reference. Serves the in-memory (not yet committed)
+   * {@link OverflowPage} when present, otherwise reads it through the reference's disk key
+   * (swizzling it for subsequent lookups). The returned bytes are in record-persister format
+   * (kind byte + payload) — the same layout as legacy slot data.
+   *
+   * @param page      the record page owning the overflow reference
+   * @param recordKey the record's node key
+   * @return the overflow record bytes, or {@code null}
+   */
+  public MemorySegment readOverflowDataOrNull(final KeyValueLeafPage page, final long recordKey) {
+    final PageReference reference = page.getPageReference(recordKey);
+    if (reference == null
+        || (reference.getKey() == Constants.NULL_ID_LONG && !(reference.getPage() instanceof OverflowPage))) {
+      return null;
+    }
+    try {
+      return readOverflowPage(reference).getData();
+    } catch (final SirixIOException e) {
+      return null;
+    }
+  }
+
   @SuppressWarnings({"unchecked", "rawtypes"})
   private DataRecord getDataRecord(long key, int offset, MemorySegment data, KeyValuePage<? extends DataRecord> page) {
     reusableBytesIn.reset(data, 0);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -411,7 +411,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       try {
         final PageReference reference = page.getPageReference(nodeKey);
         if (reference != null && reference.getKey() != Constants.NULL_ID_LONG) {
-          final var data = ((OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig())).getData();
+          final var data = readOverflowPage(reference).getData();
           record = getDataRecord(nodeKey, offset, data, page);
         } else {
           if (KeyValueLeafPage.DEBUG_MEMORY_LEAKS && page instanceof KeyValueLeafPage kvl) {
@@ -473,6 +473,23 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       }
       return null;
     }
+  }
+
+  /**
+   * Read an {@link OverflowPage} through its reference, swizzling the deserialized page onto the
+   * reference so subsequent lookups reuse it. Overflow records are re-resolved on every
+   * navigation step (they have no slot), so without the swizzle each {@code moveTo} would pay a
+   * full page read + decompression — quadratic cost for sibling walks over large values (#1076).
+   * The page wraps an immutable byte[], so racy swizzles by concurrent readers are benign.
+   */
+  private OverflowPage readOverflowPage(final PageReference reference) {
+    if (reference.getPage() instanceof OverflowPage overflowPage) {
+      return overflowPage;
+    }
+    final OverflowPage overflowPage =
+        (OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig());
+    reference.setPage(overflowPage);
+    return overflowPage;
   }
 
   @SuppressWarnings({"unchecked", "rawtypes"})
@@ -606,7 +623,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       try {
         final PageReference reference = page.getPageReference(recordKey);
         if (reference != null && reference.getKey() != Constants.NULL_ID_LONG) {
-          data = ((OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig())).getData();
+          data = readOverflowPage(reference).getData();
         }
       } catch (final SirixIOException e) {
         page.releaseGuard();
@@ -702,7 +719,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       try {
         final PageReference reference = page.getPageReference(recordKey);
         if (reference != null && reference.getKey() != Constants.NULL_ID_LONG) {
-          data = ((OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig())).getData();
+          data = readOverflowPage(reference).getData();
         }
       } catch (final SirixIOException e) {
         page.releaseGuard();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -51,6 +51,7 @@ import io.sirix.page.DeweyIDPage;
 import io.sirix.page.HOTIndirectPage;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.page.KeyValueLeafPage;
+import io.sirix.page.OverflowPage;
 import io.sirix.page.PageLayout;
 import io.sirix.page.NamePage;
 import io.sirix.page.PageKind;
@@ -880,6 +881,19 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     PageContainer container = log.get(reference);
 
     if (container == null) {
+      // Overflow pages (#1076) are created in-memory by KeyValueLeafPage#processEntries and
+      // hang off the owning leaf's references map WITHOUT a TransactionIntentLog entry (their
+      // logKey stays NULL, so the stale-claim guard below never applies to them). The leaf's
+      // Page#commit recursion lands here for them — write the page and record its disk key so
+      // the leaf serializes a resolvable key instead of NULL (the read path requires
+      // reference.getKey() != NULL_ID_LONG to load the overflow record).
+      if (reference.getPage() instanceof OverflowPage overflowPage
+          && reference.getKey() == Constants.NULL_ID_LONG) {
+        storagePageReaderWriter.write(getResourceSession().getResourceConfig(), reference, overflowPage,
+                                      bufferBytes);
+        reference.setPage(null);
+        return;
+      }
       // Fail loudly on an unresolvable TIL claim (#1077): a reference that still carries a
       // logKey after all three TIL layers missed — with no disk offset either — is a stale
       // CoW copy whose backing entry is gone. Returning silently here serialized the parent

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -276,6 +276,15 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    */
   private final ConcurrentHashMap<Long, Issued> liveByAddress = new ConcurrentHashMap<>();
 
+  /**
+   * Address → arena map for allocations LARGER than the largest size class (e.g. decompression
+   * buffers for {@code OverflowPage}s carrying large values, #1076). Frame slots cannot serve
+   * them, so each is backed by its own shared arena, closed on {@link #release(MemorySegment)}.
+   * Oversized allocations are rare by design — every slotted page fits a size class — so the
+   * extra map lookup on release is off the hot path.
+   */
+  private final ConcurrentHashMap<Long, Arena> oversizedByAddress = new ConcurrentHashMap<>();
+
   public static FrameSlotAllocator getInstance() {
     return INSTANCE;
   }
@@ -464,6 +473,15 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    */
   @Override
   public MemorySegment allocate(final long size) {
+    if (size > SIZE_CLASSES[SIZE_CLASSES.length - 1]) {
+      // Oversized request — larger than any frame-slot size class. These come from large-value
+      // overflow storage (#1076): OverflowPage (de)compression buffers can exceed 256 KiB. Serve
+      // them from a dedicated shared arena, tracked by address for release().
+      final Arena arena = Arena.ofShared();
+      final MemorySegment segment = arena.allocate(size);
+      oversizedByAddress.put(segment.address(), arena);
+      return segment;
+    }
     FrameSlot slot = allocateSlot(size);
     if (slot == null) {
       // First shot at relief before parking: the cache is the most likely
@@ -522,6 +540,14 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
       return;
     }
     final long address = segment.address();
+    // Oversized allocation (#1076): arena-backed, not slot-backed — close its arena and return.
+    // Checked first: oversized segments carry their own arena scope and can never match an
+    // Issued frame-slot era token below.
+    final Arena oversizedArena = oversizedByAddress.remove(address);
+    if (oversizedArena != null) {
+      oversizedArena.close();
+      return;
+    }
     final Issued issued = liveByAddress.get(address);
     if (issued == null) {
       return;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -45,7 +45,6 @@ import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.lang.ref.Cleaner;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -5,7 +5,9 @@ import io.sirix.access.ResourceConfiguration;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.cache.Allocators;
+import io.sirix.cache.FrameSlotAllocator;
 import io.sirix.cache.MemorySegmentAllocator;
+import io.sirix.exception.SirixIOException;
 import io.sirix.index.IndexType;
 import io.sirix.node.DeltaVarIntCodec;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -275,6 +277,21 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * Determines if references to {@link OverflowPage}s have been added or not.
    */
   private boolean addedReferences;
+
+  /**
+   * Hard ceiling for the slotted-page backing memory: the largest {@link FrameSlotAllocator}
+   * size class (256 KiB). {@link #growSlottedPage()} doubles the capacity, so any growth past
+   * this ceiling would throw in the allocator. Records that cannot fit within it are diverted
+   * to {@link OverflowPage}s instead (#1076).
+   */
+  public static final int MAX_SLOTTED_PAGE_CAPACITY =
+      (int) FrameSlotAllocator.SIZE_CLASSES[FrameSlotAllocator.SIZE_CLASSES.length - 1];
+
+  /**
+   * Sentinel returned by {@link #prepareHeapForDirectWriteOrOverflow(int, int)} when the record
+   * cannot fit into the slotted page and must be routed to overflow storage.
+   */
+  public static final long DIRECT_WRITE_OVERFLOW = -1L;
 
   /**
    * References to overflow pages.
@@ -654,7 +671,14 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
         if (fn.isBound()) {
           fn.unbind();
         }
-        serializeToHeap(fn, key, offset);
+        if (!serializeToHeap(fn, key, offset)) {
+          // The record does not fit within the largest slotted-page size class (#1076).
+          // Snapshot the singleton (it will be reused for the next node) into records[] so the
+          // record stays readable/mutable in-transaction; processEntries diverts it to an
+          // OverflowPage at serialization time.
+          ensureRecords();
+          records[offset] = fn.toSnapshot();
+        }
         return;
       }
       // Non-singleton FlyweightNode: unbind if bound, store in records[] for processEntries.
@@ -699,7 +723,14 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     addedReferences = false;
     compressedSegment = null;
     bytes = null;
-    serializeToHeap(fn, nodeKey, offset);
+    if (!serializeToHeap(fn, nodeKey, offset)) {
+      // Record does not fit within the largest slotted-page size class (#1076): keep a snapshot
+      // in records[] (the flyweight may be reused) — processEntries diverts it to an
+      // OverflowPage at serialization time. The node stays unbound in this case.
+      ensureRecords();
+      records[offset] = fn.toSnapshot();
+      return;
+    }
     // Node stays bound after creation — next factory clearBinding() handles transition
   }
 
@@ -712,8 +743,11 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @param fn      the flyweight node to serialize
    * @param nodeKey the node's key
    * @param offset  the slot index within the page (0-1023)
+   * @return {@code true} if the record was serialized to the heap; {@code false} if it does not
+   *         fit within {@link #MAX_SLOTTED_PAGE_CAPACITY} and must be diverted to an
+   *         {@link OverflowPage} by the caller (#1076) — the page is left unchanged then
    */
-  private void serializeToHeap(final FlyweightNode fn, final long nodeKey, final int offset) {
+  private boolean serializeToHeap(final FlyweightNode fn, final long nodeKey, final int offset) {
     ensureSlottedPage();
     // Get DeweyID bytes if stored (must capture BEFORE binding overwrites the node state)
     final byte[] deweyIdBytes = areDeweyIDsStored ? fn.getDeweyIDAsBytes() : null;
@@ -724,6 +758,10 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     final int estimatedSize = fn.estimateSerializedSize() + deweyIdLen
         + (areDeweyIDsStored ? PageLayout.DEWEY_ID_TRAILER_SIZE : 0);
     while (slottedPageCapacity - PageLayout.HEAP_START - heapEnd < estimatedSize) {
+      if (slottedPageCapacity * 2 > MAX_SLOTTED_PAGE_CAPACITY) {
+        // Growing further would exceed the largest allocator size class — divert to overflow.
+        return false;
+      }
       growSlottedPage();
     }
 
@@ -769,6 +807,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     // Bind flyweight — all subsequent mutations go directly to page memory
     fn.bind(slottedPage, absOffset, nodeKey, offset);
     fn.setOwnerPage(this);
+    return true;
   }
 
   // ==================== DIRECT-TO-HEAP CREATION ====================
@@ -780,14 +819,41 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @param estimatedRecordSize upper bound on record bytes (from estimateSerializedSize)
    * @param deweyIdLen          length of DeweyID bytes (0 if none)
    * @return absolute byte offset in the slotted page MemorySegment to write at
+   * @throws SirixIOException if the record cannot fit within the largest slotted-page size
+   *         class — value-carrying factories should use
+   *         {@link #prepareHeapForDirectWriteOrOverflow(int, int)} and divert to overflow storage
    */
   public long prepareHeapForDirectWrite(final int estimatedRecordSize, final int deweyIdLen) {
+    final long absOffset = prepareHeapForDirectWriteOrOverflow(estimatedRecordSize, deweyIdLen);
+    if (absOffset == DIRECT_WRITE_OVERFLOW) {
+      throw new SirixIOException("Record of estimated size " + estimatedRecordSize
+          + " bytes does not fit into the slotted page (capacity ceiling " + MAX_SLOTTED_PAGE_CAPACITY
+          + " bytes) and this record kind has no overflow-storage fallback");
+    }
+    return absOffset;
+  }
+
+  /**
+   * Like {@link #prepareHeapForDirectWrite(int, int)}, but returns {@link #DIRECT_WRITE_OVERFLOW}
+   * instead of throwing when the record cannot fit within {@link #MAX_SLOTTED_PAGE_CAPACITY}
+   * (either because the record alone is too large, or because the page heap is too full). The
+   * caller must then store the record as a heap object via {@link #setRecord(DataRecord)} so
+   * {@code processEntries} diverts it to an {@link OverflowPage} at serialization time (#1076).
+   *
+   * @param estimatedRecordSize upper bound on record bytes (from estimateSerializedSize)
+   * @param deweyIdLen          length of DeweyID bytes (0 if none)
+   * @return absolute byte offset to write at, or {@link #DIRECT_WRITE_OVERFLOW}
+   */
+  public long prepareHeapForDirectWriteOrOverflow(final int estimatedRecordSize, final int deweyIdLen) {
     ensureSlottedPage();
     final int deweyOverhead = areDeweyIDsStored
         ? deweyIdLen + PageLayout.DEWEY_ID_TRAILER_SIZE : 0;
     final int totalEstimated = estimatedRecordSize + deweyOverhead;
     final int heapEnd = cachedHeapEnd;
     while (slottedPageCapacity - PageLayout.HEAP_START - heapEnd < totalEstimated) {
+      if (slottedPageCapacity * 2 > MAX_SLOTTED_PAGE_CAPACITY) {
+        return DIRECT_WRITE_OVERFLOW;
+      }
       growSlottedPage();
     }
     return PageLayout.heapAbsoluteOffset(heapEnd);
@@ -3834,13 +3900,17 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
             records[i] = null;
             continue;
           }
-          // Unbound flyweight (e.g., value mutation caused unbind): re-serialize to slotted page heap.
+          // Unbound flyweight (e.g., value mutation caused unbind): re-serialize to slotted page
+          // heap. When the record does not fit within the largest slotted-page size class
+          // (#1076), fall through to the generic path below, which diverts it to an OverflowPage.
           if (slottedPage != null) {
             final long nodeKey = record.getNodeKey();
             final int offset = StorageEngineReader.recordPageOffset(nodeKey);
-            serializeToHeap(fn, nodeKey, offset);
-            records[i] = null;
-            continue;
+            if (serializeToHeap(fn, nodeKey, offset)) {
+              references.remove(nodeKey);
+              records[i] = null;
+              continue;
+            }
           }
         }
         final var recordID = record.getNodeKey();
@@ -3857,18 +3927,41 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
         final long usedSize = reusableOut.position();
         final MemorySegment base = reusableOut.baseSegment();
 
-        if (usedSize > PageConstants.MAX_RECORD_SIZE) {
-          // Overflow page: copy to byte array for storage
+        final long slotTotalSize = areDeweyIDsStored
+            ? usedSize + PageLayout.DEWEY_ID_TRAILER_SIZE
+            : usedSize;
+        if (usedSize > PageConstants.MAX_RECORD_SIZE
+            || slotTotalSize > (long) MAX_SLOTTED_PAGE_CAPACITY - PageLayout.HEAP_START - cachedHeapEnd) {
+          // Overflow page (#1076): the record is either larger than the per-record threshold or
+          // would not fit into the slotted page heap within the largest allocator size class.
+          // Copy the serialized bytes into a persistent buffer; the OverflowPage is written to
+          // disk in NodeStorageEngineWriter#commit and the read path falls back to it when the
+          // slot is empty but a reference with a valid disk key exists.
           byte[] persistentBuffer = new byte[(int) usedSize];
           MemorySegment.copy(base, 0L, MemorySegment.ofArray(persistentBuffer), 0L, usedSize);
 
           final var reference = new PageReference();
           reference.setPage(new OverflowPage(persistentBuffer));
           references.put(recordID, reference);
+          // An older, slot-resident version of this record may have been carried into the page
+          // by the versioning reconstruction — clear it so the read path falls through to the
+          // overflow reference instead of returning the stale slot bytes.
+          if (slottedPage != null && PageLayout.isSlotPopulated(slottedPage, offset)) {
+            PageLayout.clearSlotPopulated(slottedPage, offset);
+            updatePopulatedCount(cachedPopulatedCount - 1);
+          }
+          // Persist the DeweyID in the page's DeweyID region — the read path reconstructs the
+          // record from the overflow bytes + page.getDeweyIdAsByteArray(offset).
+          if (areDeweyIDsStored && record.getDeweyID() != null && record.getNodeKey() != 0) {
+            setDeweyId(record.getDeweyID().toBytes(), i);
+          }
         } else {
           // Normal record: setSlotDirect copies the leading {usedSize} bytes from {base}
           // into the slotted page heap. No intermediate slice.
           setSlotDirect(base, 0L, (int) usedSize, offset);
+          // A previous oversized version of this record may have left an overflow reference —
+          // the slot now carries the current version, so drop the stale reference.
+          references.remove(recordID);
         }
         // Clear record reference after serialization — snapshot isolation.
         // Data is now in slotMemory/slottedPage; prevents cross-transaction aliasing.
@@ -3887,6 +3980,14 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
   public boolean buildFsstSymbolTable(ResourceConfiguration resourceConfig) {
     if (resourceConfig.stringCompressionType != StringCompressionType.FSST) {
       return false;
+    }
+
+    // Idempotency: a page with unresolved overflow references is serialized twice per commit
+    // (its bytes are not cached until the overflow disk keys are assigned, see
+    // PageKind#serializePage). Rebuilding the table on the second pass would sample the
+    // already-FSST-compressed slot values and corrupt the symbol table.
+    if (fsstSymbolTable != null) {
+      return true;
     }
 
     final int stringValueId = NodeKind.STRING_VALUE.getId();

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -1403,8 +1403,23 @@ public enum PageKind {
             afterFsst - afterOverlong);
       }
 
-      // Compress the serialized data
-      compressAndCache(resourceConfig, sink, keyValueLeafPage);
+      // Compress the serialized data — but NOT when the page still carries unresolved overflow
+      // references (#1076). Their disk keys are only assigned when the OverflowPages are written
+      // during the recursive commit, which runs AFTER the parallel pre-serialization pass;
+      // caching now would freeze NULL keys into the page bytes and the records would be
+      // unreadable after reopen. Skipping the cache makes the page serialize again at write
+      // time with the real keys (buildFsstSymbolTable/compressStringValues/addReferences are
+      // idempotent for the second pass).
+      boolean hasUnresolvedOverflowReferences = false;
+      for (final PageReference overflowReference : references.values()) {
+        if (overflowReference.getKey() == Constants.NULL_ID_LONG) {
+          hasUnresolvedOverflowReferences = true;
+          break;
+        }
+      }
+      if (!hasUnresolvedOverflowReferences) {
+        compressAndCache(resourceConfig, sink, keyValueLeafPage);
+      }
 
       // Release node object references — all data is now in the slotted page + compressed cache
       keyValueLeafPage.clearRecordsForGC();

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -78,7 +78,6 @@ import java.util.BitSet;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;

--- a/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
@@ -224,11 +224,15 @@ public enum VersioningType {
         final KeyValueLeafPage fullDumpKvp = (KeyValueLeafPage) fullDump;
         final FsstAwareSlotCopier fullDumpCopier = new FsstAwareSlotCopier(fullDumpKvp.getFsstSymbolTable());
         final long[] filledBitmap = returnKvp.getSlotBitmap();
+        final boolean latestHasReferences = !latest.referenceEntrySet().isEmpty();
 
         final int[] fullDumpSlots = fullDumpKvp.populatedSlots();
         for (int i = 0; i < fullDumpSlots.length; i++) {
           final int offset = fullDumpSlots[i];
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (latestHasReferences && slotShadowedByNewerOverflowReference(pageToReturn, recordPageKey, offset)) {
             continue;
           }
 
@@ -241,6 +245,9 @@ public enum VersioningType {
         }
 
         for (final Entry<Long, PageReference> entry : fullDump.referenceEntrySet()) {
+          if (referenceShadowedByNewerSlot(filledBitmap, entry.getKey())) {
+            continue;
+          }
           if (pageToReturn.getPageReference(entry.getKey()) == null) {
             pageToReturn.setPageReference(entry.getKey(), entry.getValue());
             if (pageToReturn.size() == Constants.NDP_NODE_COUNT) {
@@ -317,11 +324,15 @@ public enum VersioningType {
         final KeyValueLeafPage fullDumpKvp = (KeyValueLeafPage) fullDump;
         final FsstAwareSlotCopier fullDumpCopier = new FsstAwareSlotCopier(fullDumpKvp.getFsstSymbolTable());
         final long[] filledBitmap = completeKvp.getSlotBitmap();
+        final boolean latestHasReferences = !latest.referenceEntrySet().isEmpty();
 
         final int[] fullDumpSlots = fullDumpKvp.populatedSlots();
         for (int j = 0; j < fullDumpSlots.length; j++) {
           final int offset = fullDumpSlots[j];
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (latestHasReferences && slotShadowedByNewerOverflowReference(completePage, recordPageKey, offset)) {
             continue;
           }
 
@@ -337,6 +348,9 @@ public enum VersioningType {
         }
 
         for (final Map.Entry<Long, PageReference> entry : fullDump.referenceEntrySet()) {
+          if (referenceShadowedByNewerSlot(filledBitmap, entry.getKey())) {
+            continue;
+          }
           if (completePage.getPageReference(entry.getKey()) == null) {
             completePage.setPageReference(entry.getKey(), entry.getValue());
           }
@@ -399,6 +413,8 @@ public enum VersioningType {
       
       // Track slot count incrementally - CRITICAL: don't call populatedSlotCount() in loop
       int filledSlotCount = 0;
+      // Overflow references claimed so far — fast guard for the large-value shadow check (#1076).
+      int claimedReferences = 0;
 
       final boolean singleFragment = pages.size() == 1;
 
@@ -418,6 +434,9 @@ public enum VersioningType {
 
         for (final int offset : populatedSlots) {
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (claimedReferences > 0 && slotShadowedByNewerOverflowReference(pageToReturn, recordPageKey, offset)) {
             continue;
           }
 
@@ -442,8 +461,12 @@ public enum VersioningType {
         if (filledSlotCount < Constants.NDP_NODE_COUNT) {
           for (final Entry<Long, PageReference> entry : page.referenceEntrySet()) {
             final Long key = entry.getKey();
+            if (referenceShadowedByNewerSlot(filledBitmap, key)) {
+              continue;
+            }
             if (pageToReturn.getPageReference(key) == null) {
               pageToReturn.setPageReference(key, entry.getValue());
+              claimedReferences++;
               if (pageToReturn.size() == Constants.NDP_NODE_COUNT) {
                 break;
               }
@@ -509,6 +532,8 @@ public enum VersioningType {
 
       // Track slot count incrementally - CRITICAL: don't call populatedSlotCount() in loop
       int filledSlotCount = 0;
+      // Overflow references claimed so far — fast guard for the large-value shadow check (#1076).
+      int claimedReferences = 0;
 
       final boolean singleFragment = pages.size() == 1;
 
@@ -525,6 +550,9 @@ public enum VersioningType {
 
         for (final int offset : populatedSlots) {
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (claimedReferences > 0 && slotShadowedByNewerOverflowReference(completePage, recordPageKey, offset)) {
             continue;
           }
 
@@ -554,8 +582,12 @@ public enum VersioningType {
           for (final Entry<Long, PageReference> entry : page.referenceEntrySet()) {
             final Long key = entry.getKey();
             assert key != null;
+            if (referenceShadowedByNewerSlot(filledBitmap, key)) {
+              continue;
+            }
             if (completePage.getPageReference(key) == null) {
               completePage.setPageReference(key, entry.getValue());
+              claimedReferences++;
 
               if (isFullDump && modifiedPage.getPageReference(key) == null) {
                 modifiedPage.setPageReference(key, entry.getValue());
@@ -638,6 +670,8 @@ public enum VersioningType {
 
       // Track slot count incrementally - CRITICAL: don't call populatedSlotCount() in loop
       int filledSlotCount = 0;
+      // Overflow references claimed so far — fast guard for the large-value shadow check (#1076).
+      int claimedReferences = 0;
 
       final boolean singleFragment = false;
 
@@ -654,6 +688,9 @@ public enum VersioningType {
 
         for (final int offset : populatedSlots) {
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (claimedReferences > 0 && slotShadowedByNewerOverflowReference(returnVal, recordPageKey, offset)) {
             continue;
           }
 
@@ -678,8 +715,12 @@ public enum VersioningType {
         if (filledSlotCount < Constants.NDP_NODE_COUNT) {
           for (final Entry<Long, PageReference> entry : page.referenceEntrySet()) {
             final Long key = entry.getKey();
+            if (referenceShadowedByNewerSlot(filledBitmap, key)) {
+              continue;
+            }
             if (returnVal.getPageReference(key) == null) {
               returnVal.setPageReference(key, entry.getValue());
+              claimedReferences++;
               if (returnVal.size() == Constants.NDP_NODE_COUNT) {
                 break;
               }
@@ -742,6 +783,8 @@ public enum VersioningType {
 
       // Track slot count incrementally - CRITICAL: don't call populatedSlotCount() in loop
       int filledSlotCount = 0;
+      // Overflow references claimed so far — fast guard for the large-value shadow check (#1076).
+      int claimedReferences = 0;
 
       // Phase 1: Process in-window fragments, track populated slots in bitmap
       for (int i = 0; i <= lastInWindowIndex; i++) {
@@ -757,6 +800,9 @@ public enum VersioningType {
           inWindowBitmap[offset >>> 6] |= (1L << (offset & 63));
 
           if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0) {
+            continue;
+          }
+          if (claimedReferences > 0 && slotShadowedByNewerOverflowReference(completePage, recordPageKey, offset)) {
             continue;
           }
 
@@ -780,8 +826,16 @@ public enum VersioningType {
 
         for (final Entry<Long, PageReference> entry : page.referenceEntrySet()) {
           final Long key = entry.getKey();
+          // The record IS represented in the window (as an overflow reference) — the
+          // out-of-window fragment's stale slot must be neither copied nor preserved.
+          final int refOffset = StorageEngineReader.recordPageOffset(key);
+          inWindowBitmap[refOffset >>> 6] |= (1L << (refOffset & 63));
+          if (referenceShadowedByNewerSlot(filledBitmap, key)) {
+            continue;
+          }
           if (completePage.getPageReference(key) == null) {
             completePage.setPageReference(key, entry.getValue());
+            claimedReferences++;
           }
         }
 
@@ -802,7 +856,9 @@ public enum VersioningType {
         for (final int offset : populatedSlots) {
           final var deweyId = outOfWindowPage.getDeweyId(offset);
 
-          if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) == 0) {
+          if ((filledBitmap[offset >>> 6] & (1L << (offset & 63))) == 0
+              && !(claimedReferences > 0
+                  && slotShadowedByNewerOverflowReference(completePage, recordPageKey, offset))) {
             copySlotDecompressing(outOfWindowKvp, completeKvp, offset, outOfWindowKvp.getSlotNodeKindId(offset),
                 outCopier);
             filledBitmap[offset >>> 6] |= (1L << (offset & 63));
@@ -818,6 +874,9 @@ public enum VersioningType {
 
         for (final Entry<Long, PageReference> entry : outOfWindowPage.referenceEntrySet()) {
           final Long key = entry.getKey();
+          if (referenceShadowedByNewerSlot(filledBitmap, key)) {
+            continue;
+          }
           if (completePage.getPageReference(key) == null) {
             completePage.setPageReference(key, entry.getValue());
             // Only an out-of-window reference NO in-window fragment shadows may enter the
@@ -871,6 +930,37 @@ public enum VersioningType {
   };
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VersioningType.class);
+
+  /**
+   * Large-value shadowing between page fragments (#1076): within one fragment a record lives
+   * EITHER in a slot OR in an overflow reference, and fragments are merged newest-first. A slot
+   * in an OLDER fragment is stale when a NEWER fragment already moved the record to overflow
+   * storage; without this check the stale slot wins on read (slots have lookup priority) and the
+   * record's old value resurrects.
+   *
+   * @param target        the combine target holding references claimed by newer fragments
+   * @param recordPageKey the record page key
+   * @param offset        the slot offset of the record within the page
+   * @return {@code true} if a newer fragment claimed this record as an overflow reference
+   */
+  private static boolean slotShadowedByNewerOverflowReference(final KeyValuePage<?> target,
+      final long recordPageKey, final int offset) {
+    return target.getPageReference((recordPageKey << Constants.NDP_NODE_COUNT_EXPONENT) + offset) != null;
+  }
+
+  /**
+   * Counterpart of {@link #slotShadowedByNewerOverflowReference(KeyValuePage, long, int)}: an
+   * overflow reference in an OLDER fragment is stale when a NEWER fragment stored the record in
+   * a slot again (the value shrank below the overflow threshold).
+   *
+   * @param filledBitmap the bitmap of slot offsets claimed by newer fragments
+   * @param recordKey    the record key of the overflow reference
+   * @return {@code true} if a newer fragment claimed this record as a slot
+   */
+  private static boolean referenceShadowedByNewerSlot(final long[] filledBitmap, final long recordKey) {
+    final int offset = StorageEngineReader.recordPageOffset(recordKey);
+    return (filledBitmap[offset >>> 6] & (1L << (offset & 63))) != 0;
+  }
 
   public static VersioningType fromString(String versioningType) {
     for (final var type : values()) {

--- a/bundles/sirix-core/src/test/java/io/sirix/page/LargeValueOverflowTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/LargeValueOverflowTest.java
@@ -1,0 +1,255 @@
+package io.sirix.page;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.JsonTestHelper;
+import io.sirix.XmlTestHelper;
+import io.sirix.access.Databases;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.api.xml.XmlResourceSession;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for #1076: values whose serialized size exceeds the slotted-page capacity
+ * ceiling ({@link KeyValueLeafPage#MAX_SLOTTED_PAGE_CAPACITY}, the largest allocator size class)
+ * or the per-record threshold ({@code PageConstants.MAX_RECORD_SIZE}) must be stored in
+ * {@link OverflowPage}s and round-trip through commit, fresh read-only transactions, and a full
+ * database reopen (cold read from disk). Previously such inserts/updates crashed with
+ * {@code IllegalArgumentException: requested size ... exceeds largest class} from the frame-slot
+ * allocator, and the (unreachable) overflow branch never persisted its pages.
+ */
+public final class LargeValueOverflowTest {
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.closeEverything();
+    XmlTestHelper.closeEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /** Deterministic content so full-equality assertions are meaningful. */
+  private static String bigValue(final int length, final char marker) {
+    final StringBuilder sb = new StringBuilder(length);
+    while (sb.length() < length) {
+      sb.append(marker).append(sb.length()).append('-');
+    }
+    sb.setLength(length);
+    return sb.toString();
+  }
+
+  @Test
+  public void jsonInsertLargeStringValuesRoundTrip() {
+    // Just over the 150k per-record overflow threshold, ~1 MiB, and ~5 MiB.
+    final String big200k = bigValue(200_000, 'a');
+    final String big1M = bigValue(1_048_576, 'b');
+    final String big5M = bigValue(5 * 1_048_576, 'c');
+    final String small = "small-value";
+
+    final long smallKey;
+    final long big200kKey;
+    final long big1MKey;
+    final long big5MKey;
+
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.insertArrayAsFirstChild();
+      wtx.insertStringValueAsFirstChild(small);
+      smallKey = wtx.getNodeKey();
+      wtx.insertStringValueAsRightSibling(big200k);
+      big200kKey = wtx.getNodeKey();
+      // In-transaction visibility before commit (record lives as a heap object).
+      assertEquals(big200k, wtx.getValue());
+      wtx.insertStringValueAsRightSibling(big1M);
+      big1MKey = wtx.getNodeKey();
+      wtx.insertStringValueAsRightSibling(big5M);
+      big5MKey = wtx.getNodeKey();
+      wtx.commit();
+
+      // Fresh read-only trx against the committed revision (overflow pages on disk).
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(smallKey));
+        assertEquals(small, rtx.getValue());
+        assertTrue(rtx.moveTo(big200kKey));
+        assertEquals(big200k, rtx.getValue());
+        assertTrue(rtx.moveTo(big1MKey));
+        assertEquals(big1M, rtx.getValue());
+        assertTrue(rtx.moveTo(big5MKey));
+        assertEquals(big5M, rtx.getValue());
+      }
+    }
+
+    // Full reopen with cold caches — forces the OverflowPage reads from persisted pages.
+    Databases.getGlobalBufferManager().clearAllCaches();
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      assertTrue(rtx.moveTo(smallKey));
+      assertEquals(small, rtx.getValue());
+      assertTrue(rtx.moveTo(big200kKey));
+      assertEquals(big200k, rtx.getValue());
+      assertTrue(rtx.moveTo(big1MKey));
+      assertEquals(big1M, rtx.getValue());
+      assertTrue(rtx.moveTo(big5MKey));
+      assertEquals(big5M, rtx.getValue());
+    }
+  }
+
+  @Test
+  public void jsonUpdateToLargeValueAndBackRoundTrip() {
+    final String big300k = bigValue(300_000, 'u');
+    final String tiny = "tiny";
+    final long stringKey;
+
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertArrayAsFirstChild();
+        wtx.insertStringValueAsFirstChild("initial");
+        stringKey = wtx.getNodeKey();
+        wtx.commit();
+      }
+
+      // Update the existing slotted record to an oversized value (unbound-flyweight path).
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        assertTrue(wtx.moveTo(stringKey));
+        wtx.setStringValue(big300k);
+        assertEquals(big300k, wtx.getValue());
+        wtx.commit();
+      }
+
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(stringKey));
+        assertEquals(big300k, rtx.getValue());
+      }
+
+      // Shrink back to a slotted value — the stale overflow reference must not resurrect.
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        assertTrue(wtx.moveTo(stringKey));
+        wtx.setStringValue(tiny);
+        wtx.commit();
+      }
+
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(stringKey));
+        assertEquals(tiny, rtx.getValue());
+      }
+
+      // The large value must still be readable in its historic revision.
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(2)) {
+        assertTrue(rtx.moveTo(stringKey));
+        assertEquals(big300k, rtx.getValue());
+      }
+    }
+
+    Databases.getGlobalBufferManager().clearAllCaches();
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(stringKey));
+        assertEquals(tiny, rtx.getValue());
+      }
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(2)) {
+        assertTrue(rtx.moveTo(stringKey));
+        assertEquals(big300k, rtx.getValue());
+      }
+    }
+  }
+
+  @Test
+  public void jsonLargeValueCarriedForwardAcrossRevisions() {
+    final String big400k = bigValue(400_000, 'r');
+    final long bigKey;
+    final long laterKey;
+
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertArrayAsFirstChild();
+        wtx.insertStringValueAsFirstChild(big400k);
+        bigKey = wtx.getNodeKey();
+        wtx.commit();
+      }
+      // Unrelated modification in the next revision — likely on the same record page, so the
+      // page is reconstructed and the overflow reference must be carried forward untouched.
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        assertTrue(wtx.moveTo(bigKey));
+        wtx.insertStringValueAsRightSibling("sibling");
+        laterKey = wtx.getNodeKey();
+        wtx.commit();
+      }
+
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(bigKey));
+        assertEquals(big400k, rtx.getValue());
+        assertTrue(rtx.moveTo(laterKey));
+        assertEquals("sibling", rtx.getValue());
+      }
+    }
+
+    Databases.getGlobalBufferManager().clearAllCaches();
+    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      // Most recent revision.
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(bigKey));
+        assertEquals(big400k, rtx.getValue());
+      }
+      // First revision.
+      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(1)) {
+        assertTrue(rtx.moveTo(bigKey));
+        assertEquals(big400k, rtx.getValue());
+      }
+    }
+  }
+
+  @Test
+  public void xmlLargeTextAndAttributeRoundTrip() {
+    final String bigText = bigValue(400_000, 'x');
+    final String bigAttribute = bigValue(200_000, 'y');
+    final long textKey;
+    final long attributeKey;
+
+    try (final Database<XmlResourceSession> database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+        final XmlResourceSession session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+        final XmlNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.insertElementAsFirstChild(new QNm("root"));
+      attributeKey = wtx.insertAttribute(new QNm("big"), bigAttribute).getNodeKey();
+      wtx.moveToParent();
+      textKey = wtx.insertTextAsFirstChild(bigText).getNodeKey();
+      wtx.commit();
+
+      try (final XmlNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+        assertTrue(rtx.moveTo(textKey));
+        assertEquals(bigText, rtx.getValue());
+        assertTrue(rtx.moveTo(attributeKey));
+        assertEquals(bigAttribute, rtx.getValue());
+      }
+    }
+
+    Databases.getGlobalBufferManager().clearAllCaches();
+    try (final Database<XmlResourceSession> database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+        final XmlResourceSession session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+        final XmlNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      assertTrue(rtx.moveTo(textKey));
+      assertEquals(bigText, rtx.getValue());
+      assertTrue(rtx.moveTo(attributeKey));
+      assertEquals(bigAttribute, rtx.getValue());
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/LargeValueOverflowTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/LargeValueOverflowTest.java
@@ -26,6 +26,9 @@ import static org.junit.Assert.assertTrue;
  * database reopen (cold read from disk). Previously such inserts/updates crashed with
  * {@code IllegalArgumentException: requested size ... exceeds largest class} from the frame-slot
  * allocator, and the (unreachable) overflow branch never persisted its pages.
+ *
+ * <p>Note: the test-helper databases are process-cached — they must not be closed directly;
+ * {@code closeEverything()} closes and evicts them, which is what the cold-reopen phases rely on.
  */
 public final class LargeValueOverflowTest {
 
@@ -52,6 +55,13 @@ public final class LargeValueOverflowTest {
     return sb.toString();
   }
 
+  private static void assertJsonValue(final JsonResourceSession session, final long nodeKey, final String expected) {
+    try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+      assertTrue(rtx.moveTo(nodeKey));
+      assertEquals(expected, rtx.getValue());
+    }
+  }
+
   @Test
   public void jsonInsertLargeStringValuesRoundTrip() {
     // Just over the 150k per-record overflow threshold, ~1 MiB, and ~5 MiB.
@@ -65,48 +75,39 @@ public final class LargeValueOverflowTest {
     final long big1MKey;
     final long big5MKey;
 
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
-        final JsonNodeTrx wtx = session.beginNodeTrx()) {
-      wtx.insertArrayAsFirstChild();
-      wtx.insertStringValueAsFirstChild(small);
-      smallKey = wtx.getNodeKey();
-      wtx.insertStringValueAsRightSibling(big200k);
-      big200kKey = wtx.getNodeKey();
-      // In-transaction visibility before commit (record lives as a heap object).
-      assertEquals(big200k, wtx.getValue());
-      wtx.insertStringValueAsRightSibling(big1M);
-      big1MKey = wtx.getNodeKey();
-      wtx.insertStringValueAsRightSibling(big5M);
-      big5MKey = wtx.getNodeKey();
-      wtx.commit();
-
-      // Fresh read-only trx against the committed revision (overflow pages on disk).
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(smallKey));
-        assertEquals(small, rtx.getValue());
-        assertTrue(rtx.moveTo(big200kKey));
-        assertEquals(big200k, rtx.getValue());
-        assertTrue(rtx.moveTo(big1MKey));
-        assertEquals(big1M, rtx.getValue());
-        assertTrue(rtx.moveTo(big5MKey));
-        assertEquals(big5M, rtx.getValue());
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertArrayAsFirstChild();
+        wtx.insertStringValueAsFirstChild(small);
+        smallKey = wtx.getNodeKey();
+        wtx.insertStringValueAsRightSibling(big200k);
+        big200kKey = wtx.getNodeKey();
+        // In-transaction visibility before commit (record lives as a heap object).
+        assertEquals(big200k, wtx.getValue());
+        wtx.insertStringValueAsRightSibling(big1M);
+        big1MKey = wtx.getNodeKey();
+        wtx.insertStringValueAsRightSibling(big5M);
+        big5MKey = wtx.getNodeKey();
+        wtx.commit();
       }
+
+      // Fresh read-only trx against the committed revision.
+      assertJsonValue(session, smallKey, small);
+      assertJsonValue(session, big200kKey, big200k);
+      assertJsonValue(session, big1MKey, big1M);
+      assertJsonValue(session, big5MKey, big5M);
     }
 
     // Full reopen with cold caches — forces the OverflowPage reads from persisted pages.
+    JsonTestHelper.closeEverything();
     Databases.getGlobalBufferManager().clearAllCaches();
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
-        final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-      assertTrue(rtx.moveTo(smallKey));
-      assertEquals(small, rtx.getValue());
-      assertTrue(rtx.moveTo(big200kKey));
-      assertEquals(big200k, rtx.getValue());
-      assertTrue(rtx.moveTo(big1MKey));
-      assertEquals(big1M, rtx.getValue());
-      assertTrue(rtx.moveTo(big5MKey));
-      assertEquals(big5M, rtx.getValue());
+    final Database<JsonResourceSession> reopened = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = reopened.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      assertJsonValue(session, smallKey, small);
+      assertJsonValue(session, big200kKey, big200k);
+      assertJsonValue(session, big1MKey, big1M);
+      assertJsonValue(session, big5MKey, big5M);
     }
   }
 
@@ -116,8 +117,8 @@ public final class LargeValueOverflowTest {
     final String tiny = "tiny";
     final long stringKey;
 
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
       try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
         wtx.insertArrayAsFirstChild();
         wtx.insertStringValueAsFirstChild("initial");
@@ -133,10 +134,7 @@ public final class LargeValueOverflowTest {
         wtx.commit();
       }
 
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(stringKey));
-        assertEquals(big300k, rtx.getValue());
-      }
+      assertJsonValue(session, stringKey, big300k);
 
       // Shrink back to a slotted value — the stale overflow reference must not resurrect.
       try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
@@ -145,10 +143,7 @@ public final class LargeValueOverflowTest {
         wtx.commit();
       }
 
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(stringKey));
-        assertEquals(tiny, rtx.getValue());
-      }
+      assertJsonValue(session, stringKey, tiny);
 
       // The large value must still be readable in its historic revision.
       try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(2)) {
@@ -157,13 +152,11 @@ public final class LargeValueOverflowTest {
       }
     }
 
+    JsonTestHelper.closeEverything();
     Databases.getGlobalBufferManager().clearAllCaches();
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(stringKey));
-        assertEquals(tiny, rtx.getValue());
-      }
+    final Database<JsonResourceSession> reopened = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = reopened.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      assertJsonValue(session, stringKey, tiny);
       try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(2)) {
         assertTrue(rtx.moveTo(stringKey));
         assertEquals(big300k, rtx.getValue());
@@ -177,8 +170,8 @@ public final class LargeValueOverflowTest {
     final long bigKey;
     final long laterKey;
 
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+    final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
       try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
         wtx.insertArrayAsFirstChild();
         wtx.insertStringValueAsFirstChild(big400k);
@@ -194,22 +187,16 @@ public final class LargeValueOverflowTest {
         wtx.commit();
       }
 
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(bigKey));
-        assertEquals(big400k, rtx.getValue());
-        assertTrue(rtx.moveTo(laterKey));
-        assertEquals("sibling", rtx.getValue());
-      }
+      assertJsonValue(session, bigKey, big400k);
+      assertJsonValue(session, laterKey, "sibling");
     }
 
+    JsonTestHelper.closeEverything();
     Databases.getGlobalBufferManager().clearAllCaches();
-    try (final Database<JsonResourceSession> database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
-        final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+    final Database<JsonResourceSession> reopened = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = reopened.beginResourceSession(JsonTestHelper.RESOURCE)) {
       // Most recent revision.
-      try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
-        assertTrue(rtx.moveTo(bigKey));
-        assertEquals(big400k, rtx.getValue());
-      }
+      assertJsonValue(session, bigKey, big400k);
       // First revision.
       try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(1)) {
         assertTrue(rtx.moveTo(bigKey));
@@ -225,14 +212,15 @@ public final class LargeValueOverflowTest {
     final long textKey;
     final long attributeKey;
 
-    try (final Database<XmlResourceSession> database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
-        final XmlResourceSession session = database.beginResourceSession(XmlTestHelper.RESOURCE);
-        final XmlNodeTrx wtx = session.beginNodeTrx()) {
-      wtx.insertElementAsFirstChild(new QNm("root"));
-      attributeKey = wtx.insertAttribute(new QNm("big"), bigAttribute).getNodeKey();
-      wtx.moveToParent();
-      textKey = wtx.insertTextAsFirstChild(bigText).getNodeKey();
-      wtx.commit();
+    final Database<XmlResourceSession> database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+    try (final XmlResourceSession session = database.beginResourceSession(XmlTestHelper.RESOURCE)) {
+      try (final XmlNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertElementAsFirstChild(new QNm("root"));
+        attributeKey = wtx.insertAttribute(new QNm("big"), bigAttribute).getNodeKey();
+        wtx.moveToParent();
+        textKey = wtx.insertTextAsFirstChild(bigText).getNodeKey();
+        wtx.commit();
+      }
 
       try (final XmlNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
         assertTrue(rtx.moveTo(textKey));
@@ -242,9 +230,10 @@ public final class LargeValueOverflowTest {
       }
     }
 
+    XmlTestHelper.closeEverything();
     Databases.getGlobalBufferManager().clearAllCaches();
-    try (final Database<XmlResourceSession> database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
-        final XmlResourceSession session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+    final Database<XmlResourceSession> reopened = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+    try (final XmlResourceSession session = reopened.beginResourceSession(XmlTestHelper.RESOURCE);
         final XmlNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
       assertTrue(rtx.moveTo(textKey));
       assertEquals(bigText, rtx.getValue());


### PR DESCRIPTION
Implements #1076: values whose serialized size exceeds `PageConstants.MAX_RECORD_SIZE` (150 KB) — or that no longer fit a slotted page within the largest frame-slot size class (256 KiB) — previously crashed at insert/update with `IllegalArgumentException: requested size ... exceeds largest class`, and the pre-existing overflow branch was unreachable dead code whose pages were never persisted (silent data loss). This PR makes large values first-class end to end.

## Write path

- **`KeyValueLeafPage.processEntries`**: the unbound-flyweight branch falls through to the generic record-persister path when the record cannot be re-serialized to the heap; the generic path's overflow condition now also covers heap exhaustion (aggregate page fullness, not just single oversized records), clears a stale slot-resident older version of the record, persists the DeweyID into the page's DeweyID region, and drops a stale overflow reference when a record shrinks back into a slot.
- **`setRecord`/`serializeNewRecord`**: when `serializeToHeap` cannot fit the record, snapshot it into `records[]` so it stays readable and mutable in-transaction; `processEntries` diverts it at serialization time.
- **Factories**: new `prepareHeapForDirectWriteOrOverflow` returns a sentinel instead of throwing; the JSON string / fused object-named-string and XML text / attribute factories fall back to heap-node storage for oversized values. Other direct-write kinds (fixed-size, can't be oversized alone) keep a loud failure with a clear message.

## Persistence

- **`NodeStorageEngineWriter.commit(PageReference)`**: in-memory `OverflowPage`s (which have no TransactionIntentLog entry) are written to disk and their key recorded during the leaf's commit recursion — previously `log.get(reference) == null` made the commit a silent no-op and the leaf serialized a `NULL` key (the original defect). Ordered before the #1077 stale-claim guard, which cannot apply to overflow references (their logKey stays NULL).
- **`PageKind.serializePage`**: byte-caching is skipped while the page carries unresolved overflow references (keys are only assigned during the recursive commit, *after* the parallel pre-serialization pass); the page re-serializes at write time with real keys. `buildFsstSymbolTable` is now idempotent so the second pass cannot rebuild the symbol table from already-compressed slot values. Pages without overflow references keep the cached fast path unchanged.
- **`FrameSlotAllocator`**: allocations larger than the largest size class (overflow-page (de)compression buffers) are served from a dedicated shared arena tracked by address and closed on release. Composed with #1086's era-token stale-release rejection: the oversized-arena check runs first and cannot collide with frame-slot era scopes.

## Read path

- **`NodeStorageEngineReader`**: `OverflowPage`s are swizzled onto their `PageReference` after the first read — without this, every navigation step re-read and decompressed the whole overflow page (observed: the commit-time JSON diff serializer re-reading a 5 MiB page per `moveTo`).
- **Singleton cursor** (`moveToSingletonFromPage`): overflow records (no slot) route through `moveToLegacy` → `getValue`, whose record-persister deserialization matches the overflow byte format for every node kind. The singleton `readFrom` parsers expect the legacy slot layout (e.g. a hash field for `STRING_VALUE`) and mis-parse persister bytes. Previously `moveTo` of an overflow record returned `false`, and `hasLeftSibling()`/`moveToLeftSibling()` loops spun forever. The write-path cursor already fell back correctly.

## Versioning

- **`VersioningType`** (DIFFERENTIAL / INCREMENTAL / SLIDING_SNAPSHOT, read + modification combines): within one fragment a record lives either in a slot or in an overflow reference, and fragments merge newest-first — but slots and references were claimed independently. Updating a slotted record to an oversized value resurrected the old value (newer fragment: reference only; older fragment: stale slot; slots win on read); shrinking back resurrected the stale reference symmetrically. The combines now shadow mutually: a slot from an older fragment is skipped when a newer fragment claimed the record as an overflow reference and vice versa. A claimed-reference counter keeps the common no-overflow path at one int comparison per slot. SLIDING_SNAPSHOT's in-window bitmap also covers in-window references so the out-of-window fragment's stale slot is neither copied nor preserved into the new fragment. (FULL pages are self-contained per fragment; carry-forward of untouched overflow references already worked via the existing reference copy.)

## Tests

**`LargeValueOverflowTest`** (new): insert 200 KB / 1 MiB / 5 MiB values; update to large and back (stale slot + stale reference shadowing, historic-revision reads); multi-revision carry-forward; XML text/attribute values — each verified in-transaction, from fresh read-only trxes, and after a full reopen with cold caches. All fail on `main` (allocator throw / silent wrong values).

Regression suites green (run in isolated JVMs due to this environment's 4096-fd limit; the full-suite-in-one-JVM run fails on `Too many open files` regardless of this change): `io.sirix.page.*`, `io.sirix.diff.*`, `io.sirix.node.*`, `io.sirix.access.*`, `io.sirix.axis.*`, `io.sirix.service.*`, `io.sirix.index.*`.

**Rebased onto main after #1084–#1088 merged**; the two overlaps (`FrameSlotAllocator.allocate/release` with #1086, `NodeStorageEngineWriter.commit` with #1085's #1077 guard) are resolved as described above, and re-verified post-rebase with `LargeValueOverflowTest`, `FrameSlotAllocatorTest` (incl. the stale-release ABA case), and `AsyncIntermediateCommitStaleRefTest` — all green.

Known limitations (documented, pre-existing): oversized records in fixed-size direct-write kinds (element/object/number nodes) cannot occur individually; if a page fills up with them, the loud `SirixIOException` from `prepareHeapForDirectWrite` still applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_