### PR TITLE
Fix enterprise StorageProvider SPI selection: silent FILE_CHANNEL substitution, locale-sensitive names, silent fallback

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageProvider.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageProvider.java
@@ -50,7 +50,10 @@ import io.sirix.access.ResourceConfiguration;
  *   public class FFMIOUringStorageProvider implements StorageProvider {
  *     &#64;Override
  *     public String getName() {
- *       return "IO_URING_FFM";
+ *       // MUST match a StorageType constant name (here: StorageType.IO_URING) — resource
+ *       // configurations carry the enum constant and provider dispatch resolves by that
+ *       // name. A free-form name (e.g. "IO_URING_FFM") is registered but never selected.
+ *       return "IO_URING";
  *     }
  *
  *     &#64;Override
@@ -75,8 +78,12 @@ public interface StorageProvider {
    * Get the unique name of this storage provider.
    *
    * <p>
-   * This name is used to select the provider via configuration. Convention: uppercase with
-   * underscores (e.g., "IO_URING_FFM", "SPDK").
+   * This name is used to select the provider via configuration. It MUST equal the name of a
+   * {@link StorageType} constant (e.g. "IO_URING", "S3", or a built-in name like "FILE_CHANNEL"
+   * to override the default implementation): resource configurations persist the enum constant,
+   * and {@code StorageType#getStorage} dispatches to providers by that constant's name. A name
+   * matching no constant is discoverable via {@link StorageProviders} but never selected for a
+   * resource — {@code StorageType#fromString} rejects it. Convention: uppercase with underscores.
    *
    * @return the provider name, never null
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageProviders.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageProviders.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
@@ -79,7 +80,10 @@ public final class StorageProviders {
 
     // Register providers, highest priority wins for each name
     for (StorageProvider provider : ALL_PROVIDERS) {
-      String name = provider.getName().toUpperCase();
+      // Locale.ROOT: provider names are ASCII identifiers — the default locale must not
+      // influence canonicalization (e.g. Turkish dotless-I turns "io_uring" into "\u0130O_UR\u0130NG",
+      // breaking registration and every subsequent lookup on tr_TR JVMs).
+      String name = provider.getName().toUpperCase(Locale.ROOT);
       StorageProvider existing = PROVIDERS.get(name);
 
       if (existing == null || provider.getPriority() > existing.getPriority()) {
@@ -115,7 +119,7 @@ public final class StorageProviders {
    * @return the provider, or empty if not found
    */
   public static Optional<StorageProvider> get(String name) {
-    return Optional.ofNullable(PROVIDERS.get(name.toUpperCase()));
+    return Optional.ofNullable(PROVIDERS.get(name.toUpperCase(Locale.ROOT)));
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -254,11 +254,17 @@ public enum StorageType {
       }
     }
 
-    // Check if there's an external provider with this name
     if (StorageProviders.isAvailable(storageType)) {
-      LOGGER.info("Storage type '{}' resolved to external provider", storageType);
-      // Return a marker type - actual creation happens via getStorageWithProviders
-      return FILE_CHANNEL; // Default fallback, but getStorageWithProviders handles it
+      // The provider exists, but ResourceConfiguration can only carry a StorageType enum
+      // constant — there is no carrier for an arbitrary provider name, so dispatch by that
+      // name can never happen later. A previous version returned FILE_CHANNEL here as a
+      // "marker" for a getStorageWithProviders method that does not exist: the marker was
+      // persisted into the resource configuration and every subsequent open silently used the
+      // built-in FileChannelStorage instead of the requested provider. Fail fast instead.
+      throw new IllegalArgumentException("Storage provider '" + storageType
+          + "' is registered but cannot be selected by free-form name: resource configurations carry a "
+          + "StorageType constant. Use the matching built-in constant (e.g. IO_URING, S3) whose name the "
+          + "provider registers, or a provider that overrides a built-in type name — see StorageProvider#getName.");
     }
 
     throw new IllegalArgumentException("No storage type or provider with name '" + storageType + "' found. "
@@ -312,13 +318,24 @@ public enum StorageType {
     // Check if an external provider wants to handle this storage type
     // Enterprise providers can override built-in types with higher-performance implementations
     Optional<StorageProvider> provider = StorageProviders.get(typeName);
-    if (provider.isPresent() && provider.get().isAvailable()) {
+    if (provider.isPresent()) {
       StorageProvider p = provider.get();
-      if (p.isEnterprise()) {
-        LOGGER.info("Using enterprise storage provider for {}: {} (priority={})", typeName,
-            p.getClass().getSimpleName(), p.getPriority());
+      if (p.isAvailable()) {
+        if (p.isEnterprise()) {
+          LOGGER.info("Using enterprise storage provider for {}: {} (priority={})", typeName,
+              p.getClass().getSimpleName(), p.getPriority());
+        }
+        return p.createStorage(resourceConf);
       }
-      return p.createStorage(resourceConf);
+      // A provider that overrides a built-in type name previously served this resource's data —
+      // silently swapping back to the built-in implementation risks reading a provider-specific
+      // layout with the wrong backend (the same convention-only-compatibility hazard that got the
+      // legacy jasyncfio io_uring backend removed). The built-in superblock check still guards
+      // hard format mismatches, but make the swap loud so operators see WHY reads changed engine.
+      LOGGER.warn("Storage provider {} for type {} is registered but unavailable ({}); falling back to the "
+              + "built-in implementation. If this resource was written by the provider, verify layout "
+              + "compatibility before continuing.", p.getClass().getSimpleName(), typeName,
+          p.getUnavailabilityReason());
     }
 
     // Fall back to built-in implementation

--- a/bundles/sirix-core/src/test/java/io/sirix/io/StorageProviderSpiTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/StorageProviderSpiTest.java
@@ -1,0 +1,98 @@
+package io.sirix.io;
+
+import io.sirix.access.ResourceConfiguration;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link StorageProvider} SPI — the integration surface the sirix-enterprise
+ * modules (io_uring, S3) plug into.
+ *
+ * <p>Two test providers are registered via {@code META-INF/services/io.sirix.io.StorageProvider}:
+ * {@code TEST_STORAGE} (available) and {@code UNAVAILABLE_TEST_STORAGE} (unavailable). Their
+ * names deliberately match no {@link StorageType} constant so they never interfere with other
+ * tests' storage dispatch.
+ *
+ * <p>Regression coverage: {@link StorageType#fromString} used to map any registered external
+ * provider name to a {@code FILE_CHANNEL} "marker" (referencing a dispatch method that never
+ * existed). The marker was persisted into the resource configuration, so a resource configured
+ * for an enterprise provider silently used the built-in FileChannelStorage on every open — the
+ * requested backend was never selected and no error surfaced.
+ */
+public final class StorageProviderSpiTest {
+
+  @Test
+  public void builtInTypesResolveCaseInsensitively() {
+    assertSame(StorageType.FILE_CHANNEL, StorageType.fromString("file_channel"));
+    assertSame(StorageType.MEMORY_MAPPED, StorageType.fromString("Memory_Mapped"));
+    assertSame(StorageType.S3, StorageType.fromString("s3"));
+  }
+
+  @Test
+  public void unknownNameFailsWithAvailableAlternatives() {
+    final IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> StorageType.fromString("BOGUS_BACKEND"));
+    assertTrue(e.getMessage(), e.getMessage().contains("No storage type or provider"));
+  }
+
+  @Test
+  public void freeFormProviderNameFailsFastInsteadOfSilentlyBecomingFileChannel() {
+    // The provider IS registered and available…
+    assertTrue(StorageProviders.isAvailable(TestStorageProvider.NAME));
+    // …but it cannot be carried by a resource configuration, so selecting it by name must fail
+    // loudly rather than silently persisting FILE_CHANNEL (the pre-fix behavior).
+    final IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> StorageType.fromString(TestStorageProvider.NAME));
+    assertTrue(e.getMessage(), e.getMessage().contains("cannot be selected by free-form name"));
+  }
+
+  @Test
+  public void providerLookupIsCaseInsensitiveWithRootLocale() {
+    final Optional<StorageProvider> lower = StorageProviders.get("test_storage");
+    assertTrue(lower.isPresent());
+    assertEquals(TestStorageProvider.NAME, lower.get().getName());
+  }
+
+  @Test
+  public void createStorageDispatchesToAvailableProvider() {
+    final IOStorage storage = StorageProviders.createStorage(TestStorageProvider.NAME, null);
+    assertNotNull(storage);
+    assertTrue(storage instanceof TestStorageProvider.DummyStorage);
+  }
+
+  @Test
+  public void createStorageRejectsUnavailableProviderWithReason() {
+    final IllegalStateException e = assertThrows(IllegalStateException.class,
+        () -> StorageProviders.createStorage(UnavailableTestStorageProvider.NAME, null));
+    assertTrue(e.getMessage(), e.getMessage().contains(UnavailableTestStorageProvider.REASON));
+  }
+
+  @Test
+  public void isExternalProviderDistinguishesBuiltInsFromProviders() {
+    assertFalse(StorageType.isExternalProvider("FILE_CHANNEL"));
+    assertTrue(StorageType.isExternalProvider(TestStorageProvider.NAME));
+    assertFalse(StorageType.isExternalProvider("BOGUS_BACKEND"));
+  }
+
+  @Test
+  public void unavailableProviderIsRegisteredButNotAvailable() {
+    assertTrue(StorageProviders.get(UnavailableTestStorageProvider.NAME).isPresent());
+    assertFalse(StorageProviders.isAvailable(UnavailableTestStorageProvider.NAME));
+    assertFalse(StorageProviders.getAvailableProviderNames().contains(UnavailableTestStorageProvider.NAME));
+    assertTrue(StorageProviders.getProviderNames().contains(UnavailableTestStorageProvider.NAME));
+  }
+
+  /** Compile-time-only reference so the config parameter type stays honest. */
+  @SuppressWarnings("unused")
+  private static void signatureCheck(final ResourceConfiguration config) {
+    // no-op
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/io/TestStorageProvider.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/TestStorageProvider.java
@@ -1,0 +1,62 @@
+package io.sirix.io;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.io.bytepipe.ByteHandler;
+
+/**
+ * ServiceLoader-registered test provider for {@link StorageProviderSpiTest}. The name matches no
+ * {@link StorageType} constant on purpose: it must never be dispatched for real resources.
+ */
+public final class TestStorageProvider implements StorageProvider {
+
+  public static final String NAME = "TEST_STORAGE";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public IOStorage createStorage(final ResourceConfiguration resourceConfig) {
+    return new DummyStorage();
+  }
+
+  /** Inert storage — only identity matters to the tests. */
+  public static final class DummyStorage implements IOStorage {
+
+    @Override
+    public Reader createReader() {
+      throw new UnsupportedOperationException("test-only storage");
+    }
+
+    @Override
+    public Writer createWriter() {
+      throw new UnsupportedOperationException("test-only storage");
+    }
+
+    @Override
+    public void close() {
+      // no-op
+    }
+
+    @Override
+    public boolean exists() {
+      return false;
+    }
+
+    @Override
+    public ByteHandler getByteHandler() {
+      throw new UnsupportedOperationException("test-only storage");
+    }
+
+    @Override
+    public RevisionIndexHolder getRevisionIndexHolder() {
+      throw new UnsupportedOperationException("test-only storage");
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/io/UnavailableTestStorageProvider.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/UnavailableTestStorageProvider.java
@@ -1,0 +1,34 @@
+package io.sirix.io;
+
+import io.sirix.access.ResourceConfiguration;
+
+/**
+ * ServiceLoader-registered test provider that reports itself unavailable — models an enterprise
+ * provider whose native library or license check fails (see {@link StorageProviderSpiTest}).
+ */
+public final class UnavailableTestStorageProvider implements StorageProvider {
+
+  public static final String NAME = "UNAVAILABLE_TEST_STORAGE";
+
+  public static final String REASON = "test provider is always unavailable";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return false;
+  }
+
+  @Override
+  public String getUnavailabilityReason() {
+    return REASON;
+  }
+
+  @Override
+  public IOStorage createStorage(final ResourceConfiguration resourceConfig) {
+    throw new IllegalStateException(REASON);
+  }
+}

--- a/bundles/sirix-core/src/test/resources/META-INF/services/io.sirix.io.StorageProvider
+++ b/bundles/sirix-core/src/test/resources/META-INF/services/io.sirix.io.StorageProvider
@@ -1,0 +1,2 @@
+io.sirix.io.TestStorageProvider
+io.sirix.io.UnavailableTestStorageProvider


### PR DESCRIPTION
Audit of the sirix-enterprise integration surface — the `StorageProvider` SPI that `sirix-enterprise-core` (io_uring) and `sirix-enterprise-s3` plug into. The enterprise repository itself wasn't accessible from this session, so this covers the sirix-core half of the contract; all three findings are verified against the code and reachable.

## Findings and fixes

**1. `StorageType.fromString` silently substituted FILE_CHANNEL for external provider names (silent wrong backend).**
The external-provider branch returned `FILE_CHANNEL` as a "marker type", with a comment deferring to a `getStorageWithProviders` method that does not exist anywhere in the codebase. The marker was then persisted into the resource configuration (`storageType.name()` → `"FILE_CHANNEL"`), so a resource configured with an enterprise provider's free-form name — reachable via `-DstorageType=<name>` through `BasicJsonDBStore`/`BasicXmlDBStore` — silently used the built-in `FileChannelStorage` on every open, forever. The requested backend was never selected and no error surfaced. `fromString` now fails fast with an actionable message: providers are selected via the matching `StorageType` constant (`IO_URING`, `S3`) or by overriding a built-in type name.

**2. Locale-sensitive provider-name canonicalization.**
`StorageProviders` used `toUpperCase()` without a locale at both the registration and lookup sites. Under `tr_TR` default locale, `"io_uring"` canonicalizes to `"İO_URİNG"` (dotted capital I), so any provider name containing `i` fails registration/lookup. Both sites now use `Locale.ROOT`.

**3. Silent engine swap when an overriding provider becomes unavailable.**
`getStorage` fell back to the built-in implementation without a trace when a provider that overrides a built-in type name (e.g. an enterprise `FILE_CHANNEL` replacement) is registered but unavailable — native library missing, license lapsed. That is the same convention-only layout-compatibility swap hazard that got the legacy jasyncfio io_uring backend removed (per the `IO_URING` javadoc); the superblock still guards hard format mismatches, but the swap itself was invisible. The fallback now logs a WARN naming the provider and its `getUnavailabilityReason()`.

**4. (Docs) `StorageProvider#getName` contract.**
The SPI's own javadoc example returned `"IO_URING_FFM"` — a name that finding 1 shows can never be dispatched. The naming contract (must equal a `StorageType` constant name, or a built-in name to override it) is now documented on `getName()` and in the example.

## Tests

`StorageProviderSpiTest` (new), with two ServiceLoader-registered test providers (`TEST_STORAGE` available, `UNAVAILABLE_TEST_STORAGE` unavailable — names deliberately match no enum constant so they can't affect other tests' storage dispatch): built-in case-insensitive resolution, fail-fast on free-form provider names (fails against the old marker behavior — mutation-checked), case-insensitive provider lookup, dispatch to an available provider, `IllegalStateException` with reason for unavailable providers, and `isExternalProvider` semantics. `io.sirix.io.*` suite green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_