### PR TITLE
Record update operations for JSON subtree moves (#1074) + regression-test batch for the audit fixes

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -1044,6 +1044,36 @@ final class JsonNodeTrxImpl extends
   }
 
   /**
+   * Record a subtree move in the update-operations maps as DELETED at the old position +
+   * INSERTED at the new one — the same representation a remove+copy produces, which diff
+   * consumers (replay, change feeds) already understand. Without these tuples a move-only
+   * transaction wrote an empty diff for a revision whose tree order changed (#1074).
+   *
+   * @param oldDeweyID the moved node's DeweyID before the move ({@code null} without DeweyIDs)
+   * @param newDeweyID the moved node's DeweyID after the move ({@code null} without DeweyIDs)
+   * @param nodeKey    the moved node's key (unchanged by the move)
+   */
+  private void adaptUpdateOperationsForMove(final SirixDeweyID oldDeweyID, final SirixDeweyID newDeweyID,
+      final long nodeKey) {
+    final var deleteTuple = new DiffTuple(DiffFactory.DiffType.DELETED, 0, nodeKey, oldDeweyID == null
+        ? null
+        : new DiffDepth(0, oldDeweyID.getLevel()));
+    final var insertTuple = new DiffTuple(DiffFactory.DiffType.INSERTED, nodeKey, 0, newDeweyID == null
+        ? null
+        : new DiffDepth(newDeweyID.getLevel(), 0));
+    if (oldDeweyID != null && newDeweyID != null) {
+      updateOperationsOrdered.put(oldDeweyID, deleteTuple);
+      updateOperationsOrdered.put(newDeweyID, insertTuple);
+    } else {
+      // The unordered map is keyed by node key purely for uniqueness (consumers iterate
+      // values()); a move needs TWO tuples for one node key, so the DELETED entry is keyed by
+      // the negated key to avoid colliding with the INSERTED entry. Real node keys are > 0.
+      updateOperationsUnordered.put(-nodeKey, deleteTuple);
+      updateOperationsUnordered.put(nodeKey, insertTuple);
+    }
+  }
+
+  /**
    * Get the path node key by restoring the cursor position via moveTo instead of setCurrentNode.
    * This avoids retaining a reference to the singleton structural node across cursor moves.
    *
@@ -2368,6 +2398,9 @@ final class JsonNodeTrxImpl extends
           // Save original parent key before the move (toMove may be a flyweight singleton that gets
           // mutated during adaptForMove).
           final long originalParentKey = toMove.getParentKey();
+          // Capture position identity BEFORE the move for the update-operations tuples (#1074).
+          final long movedNodeKey = toMove.getNodeKey();
+          final SirixDeweyID oldDeweyID = storeDeweyIDs() ? toMove.getDeweyID() : null;
 
           // Adapt index-structures (before move).
           adaptSubtreeForMove(toMove, IndexController.ChangeType.DELETE);
@@ -2397,6 +2430,12 @@ final class JsonNodeTrxImpl extends
           if (storeDeweyIDs()) {
             deweyIDManager.computeNewDeweyIDs();
           }
+
+          // Record the move in the persisted update operations (#1074): DELETED at the old
+          // position + INSERTED at the new one, so a move-only revision no longer serializes
+          // an empty diff.
+          nodeReadOnlyTrx.moveTo(movedNodeKey);
+          adaptUpdateOperationsForMove(oldDeweyID, storeDeweyIDs() ? getDeweyID() : null, movedNodeKey);
         }
         return this;
       } else {
@@ -2437,6 +2476,9 @@ final class JsonNodeTrxImpl extends
         if (nodeAnchor.getRightSiblingKey() != toMove.getNodeKey()) {
           final long parentKey = nodeAnchor.getParentKey();
           final long originalParentKey = toMove.getParentKey();
+          // Capture position identity BEFORE the move for the update-operations tuples (#1074).
+          final long movedNodeKey = toMove.getNodeKey();
+          final SirixDeweyID oldDeweyID = storeDeweyIDs() ? toMove.getDeweyID() : null;
 
           // Adapt index-structures (before move).
           adaptSubtreeForMove(toMove, IndexController.ChangeType.DELETE);
@@ -2471,6 +2513,12 @@ final class JsonNodeTrxImpl extends
           if (storeDeweyIDs()) {
             deweyIDManager.computeNewDeweyIDs();
           }
+
+          // Record the move in the persisted update operations (#1074): DELETED at the old
+          // position + INSERTED at the new one, so a move-only revision no longer serializes
+          // an empty diff.
+          nodeReadOnlyTrx.moveTo(movedNodeKey);
+          adaptUpdateOperationsForMove(oldDeweyID, storeDeweyIDs() ? getDeweyID() : null, movedNodeKey);
         }
         return this;
       } else {

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/DiffFileCreationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/DiffFileCreationTest.java
@@ -148,6 +148,84 @@ public class DiffFileCreationTest {
   }
 
   @Test
+  public void testDiffFileForMoveOperations() throws IOException {
+    // Create test document with Dewey IDs - creates revision 1
+    JsonTestHelper.createTestDocumentWithDeweyIdsEnabled();
+
+    try (final var database = JsonTestHelper.getDatabaseWithDeweyIdsEnabled(JsonTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final var wtx = manager.beginNodeTrx()) {
+
+      // Navigate dynamically: "foo" array (fused OBJECT_NAMED_ARRAY) is the document's first
+      // grandchild; move its LAST child to the front. A move-only transaction previously
+      // serialized an EMPTY diff (#1074) because the move paths recorded no update operations.
+      assertTrue(wtx.moveToDocumentRoot());
+      assertTrue(wtx.moveToFirstChild()); // top-level object
+      assertTrue(wtx.moveToFirstChild()); // "foo" fused array
+      final long arrayKey = wtx.getNodeKey();
+      assertTrue(wtx.moveToFirstChild());
+      while (wtx.hasRightSibling()) {
+        wtx.moveToRightSibling();
+      }
+      final long lastChildKey = wtx.getNodeKey();
+      assertTrue(wtx.moveTo(arrayKey));
+      wtx.moveSubtreeToFirstChild(lastChildKey);
+      wtx.commit();
+
+      final Path diffFile = manager.getResourceConfig()
+                                   .getResource()
+                                   .resolve(ResourceConfiguration.ResourcePaths.UPDATE_OPERATIONS.getPath())
+                                   .resolve("diffFromRev1toRev2.json");
+
+      assertTrue("Diff file should exist after a move-only transaction: " + diffFile, Files.exists(diffFile));
+
+      final String diffContent = Files.readString(diffFile);
+      assertTrue("Move diff should contain a 'delete' operation (old position), but was: " + diffContent,
+          diffContent.contains("\"delete\""));
+      assertTrue("Move diff should contain an 'insert' operation (new position), but was: " + diffContent,
+          diffContent.contains("\"insert\""));
+    }
+  }
+
+  @Test
+  public void testDiffFileForMoveOperationsWithoutDeweyIds() throws IOException {
+    // Same as testDiffFileForMoveOperations but WITHOUT DeweyIDs — exercises the unordered
+    // update-operations map, where a move's DELETED and INSERTED tuples share one node key.
+    JsonTestHelper.createTestDocument();
+
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final var wtx = manager.beginNodeTrx()) {
+
+      assertTrue(wtx.moveToDocumentRoot());
+      assertTrue(wtx.moveToFirstChild()); // top-level object
+      assertTrue(wtx.moveToFirstChild()); // "foo" fused array
+      final long arrayKey = wtx.getNodeKey();
+      assertTrue(wtx.moveToFirstChild());
+      while (wtx.hasRightSibling()) {
+        wtx.moveToRightSibling();
+      }
+      final long lastChildKey = wtx.getNodeKey();
+      assertTrue(wtx.moveTo(arrayKey));
+      wtx.moveSubtreeToFirstChild(lastChildKey);
+      wtx.commit();
+
+      final Path diffFile = manager.getResourceConfig()
+                                   .getResource()
+                                   .resolve(ResourceConfiguration.ResourcePaths.UPDATE_OPERATIONS.getPath())
+                                   .resolve("diffFromRev1toRev2.json");
+
+      assertTrue("Diff file should exist after a move-only transaction: " + diffFile, Files.exists(diffFile));
+
+      final String diffContent = Files.readString(diffFile);
+      assertTrue("Move diff should contain a 'delete' operation (old position), but was: " + diffContent,
+          diffContent.contains("\"delete\""));
+      assertTrue("Move diff should contain an 'insert' operation (new position), but was: " + diffContent,
+          diffContent.contains("\"insert\""));
+    }
+  }
+
+  @Test
   public void testMultipleDiffFilesForMultipleCommits() throws IOException {
     // Create test document - creates revision 1
     JsonTestHelper.createTestDocumentWithDeweyIdsEnabled();

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonNodeTrxCopyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/JsonNodeTrxCopyTest.java
@@ -17,6 +17,7 @@ import java.io.StringWriter;
 import static io.sirix.JsonTestHelper.RESOURCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -552,6 +553,71 @@ public final class JsonNodeTrxCopyTest {
 
         // Fused leaf carries the string value inline.
         assertEquals("value", wtx.getValue());
+      }
+
+      wtx.commit();
+    }
+  }
+
+  @Test
+  void testCopyFusedPrimitiveObjectRecordAsLeftSibling() {
+    // Regression test for #1059: copyFusedObjectRecord routed AS_LEFT_SIBLING through
+    // insertObjectRecordWithPrimitiveAsRightSibling, so the copy landed RIGHT of the anchor
+    // and the returned cursor pointed at the wrong node.
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final var session = database.beginResourceSession(RESOURCE);
+         final var wtx = session.beginNodeTrx()) {
+      // Fused OBJECT_NAMED_NUMBER records under default fusion.
+      wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"a\":1,\"b\":2}"));
+      wtx.commit();
+
+      try (final var rtx = session.beginNodeReadOnlyTrx()) {
+        // Position rtx on field "a" (a fused primitive record).
+        rtx.moveToDocumentRoot();
+        rtx.moveToFirstChild(); // object
+        rtx.moveToFirstChild(); // "a"
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, rtx.getKind());
+        assertEquals("a", rtx.getName().getLocalName());
+        final long aKey = rtx.getNodeKey();
+
+        // Position wtx on field "b".
+        wtx.moveToDocumentRoot();
+        wtx.moveToFirstChild(); // object
+        final long objectKey = wtx.getNodeKey();
+        wtx.moveToFirstChild(); // "a"
+        wtx.moveToRightSibling(); // "b"
+        assertEquals("b", wtx.getName().getLocalName());
+        final long bKey = wtx.getNodeKey();
+
+        wtx.copySubtreeAsLeftSibling(rtx);
+        final long cursorKeyAfterCopy = wtx.getNodeKey();
+
+        // Expected order of the object's children: a, a-copy, b.
+        wtx.moveTo(objectKey);
+        wtx.moveToFirstChild();
+        assertEquals(aKey, wtx.getNodeKey());
+        assertEquals("a", wtx.getName().getLocalName());
+        assertEquals(1, wtx.getNumberValue().intValue());
+
+        assertTrue(wtx.hasRightSibling());
+        wtx.moveToRightSibling();
+        final long copyKey = wtx.getNodeKey();
+        assertNotEquals(aKey, copyKey);
+        assertNotEquals(bKey, copyKey);
+        assertEquals(NodeKind.OBJECT_NAMED_NUMBER, wtx.getKind());
+        assertEquals("a", wtx.getName().getLocalName());
+        assertEquals(1, wtx.getNumberValue().intValue());
+
+        assertTrue(wtx.hasRightSibling());
+        wtx.moveToRightSibling();
+        assertEquals(bKey, wtx.getNodeKey());
+        assertEquals("b", wtx.getName().getLocalName());
+        assertEquals(2, wtx.getNumberValue().intValue());
+        assertFalse(wtx.hasRightSibling());
+
+        // The cursor returned by copySubtreeAsLeftSibling must be positioned ON the copy.
+        assertEquals(copyKey, cursorKeyAfterCopy,
+            "cursor must end on the copied record, not on the anchor's right side");
       }
 
       wtx.commit();

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/RollbackStateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/RollbackStateTest.java
@@ -1,0 +1,104 @@
+package io.sirix.access.node.json;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.service.json.serialize.JsonSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for {@code AbstractNodeTrxImpl#rollback()} (issue #1060).
+ * <p>
+ * Before the fix, rollback did not re-instantiate the node-hashing writer (the first mutation
+ * after a rollback on a hash-enabled resource hit a closed page transaction) and did not clear
+ * the recorded update operations (a later commit serialized phantom diff tuples for the
+ * rolled-back changes).
+ */
+public final class RollbackStateTest {
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  public void testInsertAndCommitAfterRollbackWithDefaultHashType() {
+    // Default resource configuration => HashType.ROLLING.
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final var wtx = session.beginNodeTrx()) {
+      wtx.insertArrayAsFirstChild();
+      wtx.rollback();
+
+      // Pre-fix this threw from the stale nodeHashing writer (assertNotClosed on the closed
+      // page transaction).
+      wtx.moveToDocumentRoot();
+      wtx.insertObjectAsFirstChild();
+      wtx.commit();
+
+      assertEquals(1, session.getMostRecentRevisionNumber());
+
+      // Verify the committed content survived (the rolled-back array must be gone).
+      final var writer = new StringWriter();
+      JsonSerializer.newBuilder(session, writer).build().call();
+      assertEquals("{}", writer.toString());
+    }
+  }
+
+  @Test
+  public void testRolledBackUpdateOperationsDoNotLeakIntoNextDiff() throws IOException {
+    // Creates revision 1 with the standard test document (Dewey IDs enabled, diffs stored).
+    JsonTestHelper.createTestDocumentWithDeweyIdsEnabled();
+
+    try (final var database = JsonTestHelper.getDatabaseWithDeweyIdsEnabled(JsonTestHelper.PATHS.PATH1.getFile());
+        final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final var wtx = manager.beginNodeTrx()) {
+
+      // Navigate to the "bar" string value inside the "foo" array.
+      assertTrue(wtx.moveToDocumentRoot());
+      assertTrue(wtx.moveToFirstChild()); // top-level object
+      assertTrue(wtx.moveToFirstChild()); // "foo" fused array
+      final long arrayKey = wtx.getNodeKey();
+      assertTrue(wtx.moveToFirstChild()); // "bar" string value
+
+      // Record an update op, then abandon it.
+      wtx.setStringValue("phantom-rolled-back");
+      wtx.rollback();
+
+      // Perform a DIFFERENT change (an insert, so the only legitimate diff op is "insert").
+      assertTrue(wtx.moveTo(arrayKey));
+      wtx.insertStringValueAsFirstChild("committed-insert");
+      wtx.commit();
+
+      final Path diffFile = manager.getResourceConfig()
+                                   .getResource()
+                                   .resolve(ResourceConfiguration.ResourcePaths.UPDATE_OPERATIONS.getPath())
+                                   .resolve("diffFromRev1toRev2.json");
+
+      assertTrue("Diff file should exist for second commit: " + diffFile, Files.exists(diffFile));
+
+      final String diffContent = Files.readString(diffFile);
+      assertTrue("Diff must contain the committed insert, but was: " + diffContent,
+          diffContent.contains("\"insert\""));
+      assertFalse("Rolled-back update op must not leak into the diff, but was: " + diffContent,
+          diffContent.contains("\"update\""));
+      assertFalse("Rolled-back value must not appear in the diff, but was: " + diffContent,
+          diffContent.contains("phantom-rolled-back"));
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/xml/InsertTextAsLeftSiblingTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/xml/InsertTextAsLeftSiblingTest.java
@@ -1,0 +1,129 @@
+package io.sirix.access.node.xml;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.XmlTestHelper;
+import io.sirix.XmlTestHelper.PATHS;
+import io.sirix.node.NodeKind;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for {@code XmlNodeTrxImpl#insertTextAsLeftSibling(String)} (issue #1058).
+ * <p>
+ * Before the fix, the anchor node's value was unconditionally appended to the text to insert:
+ * an ELEMENT anchor took the {@code setValue} branch and threw a {@code SirixUsageException},
+ * while a COMMENT (or PI) anchor silently rewrote its own value instead of inserting a new
+ * text node. Only a TEXT anchor may merge values.
+ */
+public final class InsertTextAsLeftSiblingTest {
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testInsertTextAsLeftSiblingOfElement() {
+    try (final var database = XmlTestHelper.getDatabase(PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+        final var wtx = session.beginNodeTrx()) {
+      final long rootKey = wtx.insertElementAsFirstChild(new QNm("root")).getNodeKey();
+      final long childKey = wtx.insertElementAsFirstChild(new QNm("child")).getNodeKey();
+
+      // Cursor is on the "child" element which has the "root" element as parent.
+      wtx.insertTextAsLeftSibling("txt");
+
+      // The cursor must be located on the freshly inserted TEXT node.
+      assertEquals(NodeKind.TEXT, wtx.getKind());
+      assertEquals("txt", wtx.getValue());
+      final long textKey = wtx.getNodeKey();
+
+      // The text node is the LEFT sibling of the element anchor.
+      assertTrue(wtx.moveTo(childKey));
+      assertTrue(wtx.hasLeftSibling());
+      assertTrue(wtx.moveToLeftSibling());
+      assertEquals(textKey, wtx.getNodeKey());
+      assertEquals(NodeKind.TEXT, wtx.getKind());
+      assertEquals("txt", wtx.getValue());
+
+      // The parent element now has two children: the text node and the element.
+      assertTrue(wtx.moveToParent());
+      assertEquals(rootKey, wtx.getNodeKey());
+      assertEquals(2, wtx.getChildCount());
+
+      wtx.commit();
+    }
+  }
+
+  @Test
+  public void testInsertTextAsLeftSiblingOfCommentDoesNotRewriteComment() {
+    try (final var database = XmlTestHelper.getDatabase(PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+        final var wtx = session.beginNodeTrx()) {
+      final long rootKey = wtx.insertElementAsFirstChild(new QNm("root")).getNodeKey();
+      final long commentKey = wtx.insertCommentAsFirstChild("my comment").getNodeKey();
+
+      // Cursor is on the comment node.
+      assertEquals(NodeKind.COMMENT, wtx.getKind());
+      wtx.insertTextAsLeftSibling("txt");
+
+      // A new TEXT node must have been created (pre-fix the insert was dropped and the
+      // comment's value was rewritten instead).
+      assertEquals(NodeKind.TEXT, wtx.getKind());
+      assertEquals("txt", wtx.getValue());
+      final long textKey = wtx.getNodeKey();
+
+      // The comment itself must be untouched.
+      assertTrue(wtx.moveTo(commentKey));
+      assertEquals(NodeKind.COMMENT, wtx.getKind());
+      assertEquals("my comment", wtx.getValue());
+
+      // And the text node is its left sibling.
+      assertTrue(wtx.moveToLeftSibling());
+      assertEquals(textKey, wtx.getNodeKey());
+      assertEquals(NodeKind.TEXT, wtx.getKind());
+      assertEquals("txt", wtx.getValue());
+
+      assertTrue(wtx.moveToParent());
+      assertEquals(rootKey, wtx.getNodeKey());
+      assertEquals(2, wtx.getChildCount());
+
+      wtx.commit();
+    }
+  }
+
+  @Test
+  public void testInsertTextAsLeftSiblingOfTextMergesValues() {
+    try (final var database = XmlTestHelper.getDatabase(PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(XmlTestHelper.RESOURCE);
+        final var wtx = session.beginNodeTrx()) {
+      final long rootKey = wtx.insertElementAsFirstChild(new QNm("root")).getNodeKey();
+      final long textKey = wtx.insertTextAsFirstChild("world").getNodeKey();
+
+      // Cursor is on the TEXT node: adjacent text must be merged, no new node created.
+      wtx.insertTextAsLeftSibling("hello ");
+
+      assertEquals(NodeKind.TEXT, wtx.getKind());
+      assertEquals("hello world", wtx.getValue());
+      assertEquals("the merge must reuse the anchor text node", textKey, wtx.getNodeKey());
+      assertFalse(wtx.hasLeftSibling());
+      assertFalse(wtx.hasRightSibling());
+
+      assertTrue(wtx.moveToParent());
+      assertEquals(rootKey, wtx.getNodeKey());
+      assertEquals(1, wtx.getChildCount());
+
+      wtx.commit();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/diff/FireInsertsNonStructuralDiffTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/diff/FireInsertsNonStructuralDiffTest.java
@@ -1,0 +1,134 @@
+package io.sirix.diff;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.Movement;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.diff.DiffFactory.DiffOptimized;
+import io.sirix.diff.DiffFactory.DiffType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for {@code AbstractDiff#fireInserts()} (issue #1066).
+ * <p>
+ * When the old-revision start node cannot be resolved, the whole new subtree is reported as
+ * inserted. The subtree walk must emit non-structural diffs (attributes/namespaces) as
+ * {@link DiffType#INSERTED}. Before the fix it passed {@link DiffType#DELETED}, which iterated
+ * the OLD cursor's attributes (emitting spurious deletes) and never reported the new subtree's
+ * attribute nodes as inserted.
+ */
+public final class FireInsertsNonStructuralDiffTest {
+
+  /** Simple observed (diff type, new node key) tuple. */
+  private record Observed(DiffType diffType, long newNodeKey) {
+  }
+
+  /** Observer collecting all emitted (diff type, new node key) tuples. */
+  private static final class CollectingObserver implements DiffObserver {
+
+    private final List<Observed> observed = new ArrayList<>();
+
+    private boolean done;
+
+    @Override
+    public void diffListener(final DiffType diffType, final long newNodeKey, final long oldNodeKey,
+        final DiffDepth depth) {
+      observed.add(new Observed(diffType, newNodeKey));
+    }
+
+    @Override
+    public void diffDone() {
+      done = true;
+    }
+
+    private boolean contains(final DiffType diffType, final long newNodeKey) {
+      for (final Observed tuple : observed) {
+        if (tuple.diffType() == diffType && tuple.newNodeKey() == newNodeKey) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    private long count(final DiffType diffType) {
+      long count = 0;
+      for (final Observed tuple : observed) {
+        if (tuple.diffType() == diffType) {
+          count++;
+        }
+      }
+      return count;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testFireInsertsReportsAttributesAsInserted() {
+    try (final var database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(XmlTestHelper.RESOURCE)) {
+      final long subKey;
+      final long childKey;
+      final long attributeAKey;
+      final long attributeBKey;
+
+      try (final XmlNodeTrx wtx = session.beginNodeTrx()) {
+        // Revision 1: a root element WITH an attribute (pre-fix the DELETED branch iterated the
+        // old cursor, which is parked on this element, and emitted spurious deletes for it).
+        wtx.insertElementAsFirstChild(new QNm("root"));
+        wtx.insertAttribute(new QNm("oldAttr"), "old", Movement.TOPARENT);
+        wtx.commit();
+
+        // Revision 2: insert a subtree whose node keys do not exist in revision 1. The inner
+        // element carries attributes.
+        wtx.moveToDocumentRoot();
+        wtx.moveToFirstChild(); // root element
+        subKey = wtx.insertElementAsFirstChild(new QNm("sub")).getNodeKey();
+        childKey = wtx.insertElementAsFirstChild(new QNm("child")).getNodeKey();
+        attributeAKey = wtx.insertAttribute(new QNm("a"), "1").getNodeKey();
+        wtx.moveToParent();
+        attributeBKey = wtx.insertAttribute(new QNm("b"), "2").getNodeKey();
+        wtx.moveToParent();
+        wtx.commit();
+      }
+
+      final CollectingObserver observer = new CollectingObserver();
+
+      // The old start key does not resolve in revision 1 => fireInserts() reports the whole new
+      // subtree. oldDepth > 0 keeps fireDeletes() out of the picture (GUI mode is the default).
+      DiffFactory.invokeFullXmlDiff(
+          new DiffFactory.Builder<XmlNodeReadOnlyTrx, XmlNodeTrx>(session, 2, 1, DiffOptimized.NO, Set.of(observer))
+              .newStartKey(subKey)
+              .oldStartKey(subKey)
+              .oldDepth(1));
+
+      assertTrue("diffDone() must be signalled", observer.done);
+      assertTrue("subtree root must be reported INSERTED", observer.contains(DiffType.INSERTED, subKey));
+      assertTrue("child element must be reported INSERTED", observer.contains(DiffType.INSERTED, childKey));
+      assertTrue("attribute 'a' must be reported INSERTED (pre-fix it was never reported)",
+          observer.contains(DiffType.INSERTED, attributeAKey));
+      assertTrue("attribute 'b' must be reported INSERTED (pre-fix it was never reported)",
+          observer.contains(DiffType.INSERTED, attributeBKey));
+      assertEquals("no DELETED tuples may be emitted while walking the inserted subtree", 0,
+          observer.count(DiffType.DELETED));
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/diff/algorithm/FMSECloseGuardTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/diff/algorithm/FMSECloseGuardTest.java
@@ -1,0 +1,92 @@
+package io.sirix.diff.algorithm;
+
+import io.sirix.XmlTestHelper;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.api.xml.XmlResourceSession;
+import io.sirix.diff.algorithm.fmse.DefaultNodeComparisonFactory;
+import io.sirix.diff.algorithm.fmse.FMSE;
+import io.sirix.diff.algorithm.fmse.json.JsonFMSE;
+import io.sirix.service.xml.shredder.XmlShredder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Regression tests for {@code FMSE#close()} and {@code JsonFMSE#close()} (issue #1067).
+ * <p>
+ * Before the fix, {@code close()} unconditionally dereferenced the write transaction: calling
+ * {@code close()} without a prior successful {@code diff()} threw a {@link NullPointerException}
+ * (e.g. from try-with-resources after a failed construction of the transactions).
+ */
+public final class FMSECloseGuardTest {
+
+  private static final String NEW_RESOURCE = "imported";
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testCloseWithoutDiffDoesNotThrow() {
+    // Pre-fix: NPE from wtx.commit() on the never-assigned write transaction.
+    try (final FMSE fmse = FMSE.createInstance(new DefaultNodeComparisonFactory())) {
+      assertEquals("Fast Matching / Edit Script", fmse.getName());
+    }
+  }
+
+  @Test
+  public void testJsonFmseCloseWithoutDiffDoesNotThrow() {
+    // Pre-fix: NPE from wtx.commit() on the never-assigned write transaction.
+    try (final JsonFMSE fmse = JsonFMSE.createInstance()) {
+      assertEquals("Fast Matching / Edit Script (JSON)", fmse.getName());
+    }
+  }
+
+  @Test
+  public void testCloseAfterSuccessfulDiffCommits() {
+    try (final var database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile())) {
+      database.createResource(
+          new ResourceConfiguration.Builder(NEW_RESOURCE).buildPathSummary(true).useDeweyIDs(true).build());
+
+      // Old revision (the resource to update).
+      try (final XmlResourceSession oldSession = database.beginResourceSession(XmlTestHelper.RESOURCE);
+          final XmlNodeTrx wtx = oldSession.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(XmlShredder.createStringReader("<root><a>foo</a></root>"), XmlNodeTrx.Commit.No);
+        wtx.commit();
+      }
+
+      // New document (shredded into a second resource).
+      try (final XmlResourceSession newSession = database.beginResourceSession(NEW_RESOURCE);
+          final XmlNodeTrx wtx = newSession.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(XmlShredder.createStringReader("<root><a>foo</a><b>bar</b></root>"),
+            XmlNodeTrx.Commit.No);
+        wtx.commit();
+      }
+
+      try (final XmlResourceSession oldSession = database.beginResourceSession(XmlTestHelper.RESOURCE);
+          final XmlResourceSession newSession = database.beginResourceSession(NEW_RESOURCE)) {
+        final int revisionsBeforeDiff = oldSession.getMostRecentRevisionNumber();
+        assertEquals(1, revisionsBeforeDiff);
+
+        try (final XmlNodeTrx wtx = oldSession.beginNodeTrx();
+            final XmlNodeReadOnlyTrx rtx = newSession.beginNodeReadOnlyTrx();
+            final FMSE fmse = FMSE.createInstance(new DefaultNodeComparisonFactory())) {
+          fmse.diff(wtx, rtx);
+        }
+
+        assertEquals("a successful diff() followed by close() must commit a new revision",
+            revisionsBeforeDiff + 1, oldSession.getMostRecentRevisionNumber());
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/diff/export/EditScriptTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/diff/export/EditScriptTest.java
@@ -1,0 +1,73 @@
+package io.sirix.diff.export;
+
+import io.sirix.diff.DiffFactory.DiffType;
+import io.sirix.diff.DiffTuple;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression tests for {@link EditScript} (issue #1074, item 3).
+ * <p>
+ * Before the fix, {@code hasNext()} used {@code index < size() - 1}, so the idiomatic
+ * {@code while (hasNext()) next()} loop dropped the final change, and {@code add(change)}
+ * returned {@code null} for changes with previously unseen node keys.
+ */
+public final class EditScriptTest {
+
+  // Node keys above the Long autobox cache (|key| > 127) to exercise realistic keys.
+  private static final long INSERTED_NODE_KEY = 1_000L;
+
+  private static final long DELETED_NODE_KEY = 2_000L;
+
+  @Test
+  public void testIterationYieldsAllChanges() {
+    final EditScript script = new EditScript();
+    final DiffTuple firstChange = new DiffTuple(DiffType.INSERTED, INSERTED_NODE_KEY, 0, null);
+    final DiffTuple secondChange = new DiffTuple(DiffType.DELETED, 0, DELETED_NODE_KEY, null);
+
+    script.add(firstChange);
+    script.add(secondChange);
+    assertEquals(2, script.size());
+
+    // Idiomatic iterator loop: pre-fix hasNext() returned false while the LAST element was
+    // still pending, yielding only one tuple.
+    final List<DiffTuple> consumed = new ArrayList<>(2);
+    while (script.hasNext()) {
+      consumed.add(script.next());
+    }
+
+    assertEquals("while (hasNext()) next() must yield every added change", 2, consumed.size());
+    assertSame(firstChange, consumed.get(0));
+    assertSame(secondChange, consumed.get(1));
+    assertFalse(script.hasNext());
+  }
+
+  @Test
+  public void testAddReturnsTheChangePassedIn() {
+    final EditScript script = new EditScript();
+    final DiffTuple firstChange = new DiffTuple(DiffType.INSERTED, INSERTED_NODE_KEY, 0, null);
+    final DiffTuple secondChange = new DiffTuple(DiffType.DELETED, 0, DELETED_NODE_KEY, null);
+
+    // Pre-fix add() returned null for changes with new node keys.
+    assertSame("add() must return the change for a new node key", firstChange, script.add(firstChange));
+    assertSame("add() must return the change for a new node key", secondChange, script.add(secondChange));
+
+    // Adding a change for an already-tracked node key must return the passed change as well and
+    // must not register a duplicate.
+    final DiffTuple duplicateKeyChange = new DiffTuple(DiffType.UPDATED, INSERTED_NODE_KEY, 0, null);
+    assertSame(duplicateKeyChange, script.add(duplicateKeyChange));
+    assertEquals(2, script.size());
+
+    assertTrue(script.containsNode(INSERTED_NODE_KEY));
+    assertTrue(script.containsNode(DELETED_NODE_KEY));
+    assertSame(firstChange, script.get(INSERTED_NODE_KEY));
+    assertSame(secondChange, script.get(DELETED_NODE_KEY));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/redblacktree/RBTreeReaderWarmCacheTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/redblacktree/RBTreeReaderWarmCacheTest.java
@@ -1,0 +1,126 @@
+package io.sirix.index.redblacktree;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.access.trx.node.xml.XmlIndexController;
+import io.sirix.api.Movement;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.xml.XmlNodeReadOnlyTrx;
+import io.sirix.api.xml.XmlNodeTrx;
+import io.sirix.cache.Cache;
+import io.sirix.cache.RBIndexKey;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.IndexType;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.node.interfaces.Node;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for the {@link RBTreeReader} constructor warm-up loop (issue #1063).
+ * <p>
+ * The warm-up loop must cache each {@link RBNodeKey} under its OWN {@link RBIndexKey}. Before
+ * the fix it cached the read-cursor's current node, which the iterator's stack operation had
+ * already parked on the node's LEFT CHILD — so index searches that hit the cache compared
+ * against the wrong key and descended the wrong subtree.
+ */
+public final class RBTreeReaderWarmCacheTest {
+
+  private Holder holder;
+
+  @Before
+  public void setUp() {
+    XmlTestHelper.deleteEverything();
+    holder = Holder.openResourceSessionWithRedBlackTreeIndexes();
+  }
+
+  @After
+  public void tearDown() {
+    holder.close();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testWarmUpCachesEachNodeUnderItsOwnKey() {
+    final XmlNodeTrx wtx = holder.getResourceSession().beginNodeTrx();
+
+    final XmlIndexController indexController =
+        holder.getResourceSession().getWtxIndexController(wtx.getRevisionNumber());
+
+    final IndexDef idxDef = IndexDefs.createCASIdxDef(false, Type.STR,
+        Collections.singleton(Path.parse("//bla/@foobar")), 0, IndexDef.DbType.XML);
+
+    indexController.createIndexes(Set.of(idxDef), wtx);
+
+    // Five distinct attribute values on the matching path => at least five CAS index entries,
+    // so the red-black tree has inner nodes with left children.
+    wtx.insertElementAsFirstChild(new QNm("bla"));
+    wtx.insertAttribute(new QNm("foobar"), "value-1", Movement.TOPARENT);
+    wtx.insertElementAsFirstChild(new QNm("bla"));
+    wtx.insertAttribute(new QNm("foobar"), "value-2", Movement.TOPARENT);
+    wtx.insertElementAsFirstChild(new QNm("bla"));
+    wtx.insertAttribute(new QNm("foobar"), "value-3", Movement.TOPARENT);
+    wtx.insertElementAsFirstChild(new QNm("bla"));
+    wtx.insertAttribute(new QNm("foobar"), "value-4", Movement.TOPARENT);
+    wtx.insertElementAsFirstChild(new QNm("bla"));
+    wtx.insertAttribute(new QNm("foobar"), "value-5", Movement.TOPARENT);
+    wtx.commit();
+
+    final IndexDef indexDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
+    wtx.close();
+
+    try (final XmlNodeReadOnlyTrx rtx = holder.getResourceSession().beginNodeReadOnlyTrx()) {
+      final StorageEngineReader storageEngineReader = rtx.getStorageEngineReader();
+      final Cache<RBIndexKey, Node> cache = holder.getResourceSession().getIndexCache();
+
+      // Constructing the reader with a read-only storage engine reader runs the warm-up loop
+      // that populates the shared index cache.
+      final RBTreeReader<CASValue, NodeReferences> reader =
+          RBTreeReader.getInstance(cache, storageEngineReader, indexDef.getType(), indexDef.getID());
+
+      final long databaseId = storageEngineReader.getDatabaseId();
+      final long resourceId = storageEngineReader.getResourceId();
+      final int revisionNumber = storageEngineReader.getRevisionNumber();
+
+      int entryCount = 0;
+      int checkedCacheHits = 0;
+      boolean sawNodeWithLeftChild = false;
+
+      for (final RBTreeReader<CASValue, NodeReferences>.RBNodeIterator it = reader.new RBNodeIterator(0);
+          it.hasNext();) {
+        final RBNodeKey<CASValue> node = it.next();
+        entryCount++;
+        if (node.hasLeftChild()) {
+          sawNodeWithLeftChild = true;
+        }
+
+        final RBIndexKey cacheKey = new RBIndexKey(databaseId, resourceId, node.getNodeKey(), revisionNumber,
+            indexDef.getType(), indexDef.getID());
+        final Node cached = cache.get(cacheKey);
+        if (cached != null) {
+          // Pre-fix the cached node was the LEFT CHILD of the node the key was built from, so
+          // the node keys mismatched for every inner node with a left child.
+          assertEquals("cached node must be stored under its own node key", node.getNodeKey(), cached.getNodeKey());
+          checkedCacheHits++;
+        }
+      }
+
+      assertTrue("expected at least three index entries, but got " + entryCount, entryCount >= 3);
+      assertTrue("the tree must contain at least one node with a left child (guard against a vacuous pass)",
+          sawNodeWithLeftChild);
+      assertTrue("expected at least one non-null cache hit (guard against a vacuous pass)", checkedCacheHits >= 1);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/delegates/ReferencesPageCloneTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/delegates/ReferencesPageCloneTest.java
@@ -1,0 +1,119 @@
+package io.sirix.page.delegates;
+
+import io.sirix.page.OverflowPage;
+import io.sirix.page.PageFragmentKeyImpl;
+import io.sirix.page.PageReference;
+import io.sirix.page.interfaces.PageFragmentKey;
+import io.sirix.settings.Constants;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Regression tests for the clone constructors of {@link ReferencesPage4},
+ * {@link BitmapReferencesPage} and {@link FullReferencesPage} (issue #1079).
+ * <p>
+ * Every reference must be routed through the {@link PageReference} copy constructor: a manual
+ * field-by-field copy dropped the page-fragment hash ({@code hashInBytes}), aliased the fragment
+ * list, and eagerly copied the swizzled in-memory page pointer (which can go stale and be read
+ * after free through recycled frames).
+ */
+public final class ReferencesPageCloneTest {
+
+  private static final long PERSISTENT_KEY = 123L;
+
+  private static final byte[] HASH = {1, 2, 3, 4, 5};
+
+  /**
+   * Configure a source reference: a persistent storage key, a hash, a page-fragments list and a
+   * swizzled in-memory page.
+   *
+   * @param reference the reference to configure
+   */
+  private static void configureSourceReference(final PageReference reference) {
+    reference.setKey(PERSISTENT_KEY);
+    reference.setHash(HASH.clone());
+    final List<PageFragmentKey> pageFragments = new ArrayList<>(2);
+    pageFragments.add(new PageFragmentKeyImpl(1, 42L, 7L, 8L));
+    pageFragments.add(new PageFragmentKeyImpl(2, 43L, 7L, 8L));
+    reference.setPageFragments(pageFragments);
+    // Swizzled in-memory page; the reference is resolvable via its disk key, so a clone must
+    // NOT alias this pointer.
+    reference.setPage(new OverflowPage(new byte[] {9}));
+  }
+
+  /**
+   * Assert the clone semantics of the {@link PageReference} copy constructor.
+   *
+   * @param source the configured source reference
+   * @param clone the reference from the cloned page
+   */
+  private static void assertReferenceCloneSemantics(final PageReference source, final PageReference clone) {
+    assertNotNull("cloned reference must exist", clone);
+    assertNotSame("clone must be an independent PageReference instance", source, clone);
+    assertEquals(PERSISTENT_KEY, clone.getKey());
+
+    // (a) The hash bytes must be copied (pre-fix: null on the clone).
+    assertArrayEquals("hash bytes must survive the clone", HASH, clone.getHash());
+
+    // (b) The fragment list must be equal but must not alias the source list.
+    assertEquals("page fragments must be equal", source.getPageFragments(), clone.getPageFragments());
+    assertNotSame("page fragments must not alias the source list", source.getPageFragments(),
+        clone.getPageFragments());
+
+    // (c) The swizzled page pointer must NOT be copied when the reference is resolvable via a
+    // persistent key (pre-fix: the raw pointer was copied and could be read after free).
+    assertEquals(PERSISTENT_KEY, source.getKey());
+    assertNotNull(source.getPage());
+    assertNull("swizzled page pointer must not be aliased by the clone", clone.getPage());
+  }
+
+  @Test
+  public void testReferencesPage4CloneConstructor() {
+    final ReferencesPage4 source = new ReferencesPage4();
+    final PageReference sourceReference = source.getOrCreateReference(0);
+    assertNotNull(sourceReference);
+    configureSourceReference(sourceReference);
+
+    final ReferencesPage4 clone = new ReferencesPage4(source);
+    final PageReference clonedReference = clone.getOrCreateReference(0);
+
+    assertReferenceCloneSemantics(sourceReference, clonedReference);
+  }
+
+  @Test
+  public void testBitmapReferencesPageCloneConstructor() {
+    final BitmapReferencesPage source = new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT);
+    final PageReference sourceReference = source.getOrCreateReference(3);
+    assertNotNull(sourceReference);
+    configureSourceReference(sourceReference);
+
+    final BitmapReferencesPage clone = new BitmapReferencesPage(source, source.getBitmap());
+    final PageReference clonedReference = clone.getOrCreateReference(3);
+
+    assertReferenceCloneSemantics(sourceReference, clonedReference);
+  }
+
+  @Test
+  public void testFullReferencesPageCloneConstructor() {
+    // A FullReferencesPage is only constructible from an existing page; an empty bitmap page
+    // yields an all-null full page to which the source reference is added directly.
+    final FullReferencesPage source =
+        new FullReferencesPage(new BitmapReferencesPage(Constants.INP_REFERENCE_COUNT));
+    final PageReference sourceReference = source.getOrCreateReference(5);
+    assertNotNull(sourceReference);
+    configureSourceReference(sourceReference);
+
+    final FullReferencesPage clone = new FullReferencesPage(source);
+    final PageReference clonedReference = clone.getOrCreateReference(5);
+
+    assertReferenceCloneSemantics(sourceReference, clonedReference);
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/service/SerializerIOExceptionPropagationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/SerializerIOExceptionPropagationTest.java
@@ -1,0 +1,102 @@
+package io.sirix.service;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.JsonTestHelper;
+import io.sirix.XmlTestHelper;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.service.xml.serialize.XmlSerializer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Regression tests for issue #1068: the JSON and XML serializers must propagate I/O failures of
+ * the target sink as {@link UncheckedIOException} from {@code call()} instead of swallowing them
+ * and completing "successfully" with truncated/absent output.
+ */
+public final class SerializerIOExceptionPropagationTest {
+
+  /** A {@link Writer} whose write/flush methods always fail. */
+  private static final class ThrowingWriter extends Writer {
+
+    @Override
+    public void write(final char[] buffer, final int offset, final int length) throws IOException {
+      throw new IOException("sink failure (write)");
+    }
+
+    @Override
+    public void flush() throws IOException {
+      throw new IOException("sink failure (flush)");
+    }
+
+    @Override
+    public void close() {
+      // Nothing to close.
+    }
+  }
+
+  /** An {@link OutputStream} whose write/flush methods always fail. */
+  private static final class ThrowingOutputStream extends OutputStream {
+
+    @Override
+    public void write(final int b) throws IOException {
+      throw new IOException("sink failure (write)");
+    }
+
+    @Override
+    public void flush() throws IOException {
+      throw new IOException("sink failure (flush)");
+    }
+  }
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    XmlTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.closeEverything();
+    XmlTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testJsonSerializerPropagatesSinkFailure() {
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"foo\":\"bar\"}"));
+      }
+
+      final JsonSerializer serializer = JsonSerializer.newBuilder(session, new ThrowingWriter()).build();
+
+      // Pre-fix call() completed normally although not a single character reached the sink.
+      assertThrows(UncheckedIOException.class, serializer::call);
+    }
+  }
+
+  @Test
+  public void testXmlSerializerPropagatesSinkFailure() {
+    try (final var database = XmlTestHelper.getDatabase(XmlTestHelper.PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(XmlTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        wtx.insertElementAsFirstChild(new QNm("root"));
+        wtx.commit();
+      }
+
+      final XmlSerializer serializer = XmlSerializer.newBuilder(session, new ThrowingOutputStream()).build();
+
+      // Pre-fix call() completed normally although not a single byte reached the sink.
+      assertThrows(UncheckedIOException.class, serializer::call);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/service/json/serialize/JsonSerializerAllRevisionsWithLimitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/json/serialize/JsonSerializerAllRevisionsWithLimitTest.java
@@ -1,0 +1,75 @@
+package io.sirix.service.json.serialize;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Regression test for issue #1069: {@link JsonSerializer#call()} delegates to the limited
+ * serializer whenever a limit (e.g. {@code maxLevel}) is set. The "serialize all revisions"
+ * convention ({@code revisions[0] < 0}) must be expanded into an explicit revision list before
+ * delegating — pre-fix the limited serializer tried to open revision {@code -1} and threw.
+ */
+public final class JsonSerializerAllRevisionsWithLimitTest {
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.closeEverything();
+  }
+
+  @Test
+  public void testAllRevisionsWithMaxLevelSerializesEveryRevision() {
+    try (final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+        final var session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final var wtx = session.beginNodeTrx()) {
+        // Revision 1 (insertSubtreeAsFirstChild commits implicitly).
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"a\":\"one\"}"));
+
+        // Revision 2: add a second field.
+        wtx.moveToDocumentRoot();
+        wtx.moveToFirstChild(); // top-level object
+        wtx.insertObjectRecordAsFirstChild("b", new StringValue("two"));
+        wtx.commit();
+      }
+
+      assertEquals(2, session.getMostRecentRevisionNumber());
+
+      // Pre-fix this threw while trying to open revision -1.
+      final StringWriter allRevisionsWriter = new StringWriter();
+      JsonSerializer.newBuilder(session, allRevisionsWriter)
+                    .revisions(new int[] {-1})
+                    .maxLevel(3)
+                    .build()
+                    .call();
+      final String allRevisions = allRevisionsWriter.toString();
+
+      final StringWriter explicitRevisionsWriter = new StringWriter();
+      JsonSerializer.newBuilder(session, explicitRevisionsWriter)
+                    .revisions(new int[] {1, 2})
+                    .maxLevel(3)
+                    .build()
+                    .call();
+      final String explicitRevisions = explicitRevisionsWriter.toString();
+
+      assertFalse("serialization output must not be empty", allRevisions.isEmpty());
+      assertEquals("revisions {-1} must serialize the same output as the explicit list {1, 2}", explicitRevisions,
+          allRevisions);
+      assertTrue("output must contain revision 1 content, but was: " + allRevisions, allRevisions.contains("\"a\""));
+      assertTrue("output must contain revision 2 content, but was: " + allRevisions, allRevisions.contains("\"b\""));
+    }
+  }
+}


### PR DESCRIPTION
Completes the audit-issue backlog: the one remaining unfixed finding, plus dedicated regression tests for the batch of fixes that merged in #1081 without them.

## Fix — #1074 item 5: JSON `moveSubtree*` recorded no update operations

A move-only transaction adapted indexes, hashes, path summary and DeweyIDs but never called `adaptUpdateOperations*`, so with `storeDiffs()` enabled the persisted diff for a revision whose tree order changed was **empty** — replay and change-feed consumers saw "no change".

Each move is now recorded as **DELETED at the old position + INSERTED at the new one** — the same representation a remove+copy produces, which diff consumers already understand. A move keeps its node key, and the unordered update-operations map is keyed by node key purely for uniqueness (consumers iterate `values()`), so the DELETED tuple is keyed by the negated key to avoid colliding with the INSERTED entry; with DeweyIDs the tuples key naturally under the old and new DeweyID in the ordered map.

`DiffFileCreationTest` gains move coverage with and without DeweyIDs; both tests fail without the fix (empty diff file).

## Tests — regression coverage for the #1081 audit-fix batch

#1081 fixed sixteen findings but shipped without dedicated regression tests (verified via existing suites + inspection). This PR adds deterministic tests for the testable ones, each written against the pre-fix defect:

| Issue | Test |
|---|---|
| #1058 XML `insertTextAsLeftSibling` on non-TEXT anchors | `InsertTextAsLeftSiblingTest` (element inserts instead of throwing; comment no longer silently drops; TEXT still merges) |
| #1059 fused-primitive copy as left sibling | `JsonNodeTrxCopyTest#testCopyFusedPrimitiveObjectRecordAsLeftSibling` (lands LEFT of anchor, cursor on the copy) |
| #1060 `rollback()` stale hashing + phantom diff tuples | `RollbackStateTest` |
| #1063 RB-tree warm cache poisoned with left child | `RBTreeReaderWarmCacheTest` |
| #1066 inserted-subtree attribute diffs emitted as DELETED | `FireInsertsNonStructuralDiffTest` |
| #1067 FMSE `close()` committing half-applied edit scripts | `FMSECloseGuardTest` |
| #1068 serializers swallowing per-node `IOException` | `SerializerIOExceptionPropagationTest` |
| #1069 `revisions[0] < 0` + limits opening revision −1 | `JsonSerializerAllRevisionsWithLimitTest` |
| #1074 item 3 `EditScript` off-by-one / `add()` return | `EditScriptTest` |
| #1079 delegate clone ctors dropping hash / aliasing / raw swizzle | `ReferencesPageCloneTest` |

**Mutation-checked:** spot-reverting three of the one-line fixes (#1063, #1066, #1074's `EditScript`) makes exactly the corresponding tests fail; the move-diff tests fail with the move fix stashed.

**Deliberately not covered**, with reasons: #1071 (Windows-only `VirtualAlloc` paths), #1072 (needs superblock-corruption injection into `MMStorage` internals), #1064/#1078 (thread-leak / cache-race timing not deterministically assertable), #1074 items 1–2/4 (error-injection plumbing disproportionate to the guards under test), #1075 (needs the Vert.x integration harness; the fix is a five-line guard).

All new classes green individually; `io.sirix.access.node.json.*`, `io.sirix.diff.*` suites green in isolated JVMs (this environment's 4096-fd limit makes combined-JVM runs fail on `Too many open files` independent of any change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DhpxdwbxvypB2adtLbha1p)_