### PR TITLE
Allow manual release dispatch as a tag-push fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'sirix-*'
+  # Manual fallback when a tag cannot be pushed directly: the release action creates the
+  # tag at the dispatched commit. Tags created with the workflow's GITHUB_TOKEN do not
+  # re-trigger this workflow, so a dispatch runs the release exactly once.
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to create (must be sirix-<version> matching gradle.properties)"
+        required: true
+        type: string
 
 jobs:
   release:
@@ -14,6 +23,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate dispatched tag against gradle.properties
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          VERSION="$(grep '^version=' gradle.properties | cut -d= -f2)"
+          if [ "${{ inputs.tag_name }}" != "sirix-${VERSION}" ]; then
+            echo "::error::tag_name '${{ inputs.tag_name }}' does not match gradle.properties version 'sirix-${VERSION}'"
+            exit 1
+          fi
 
       - name: Install JDK
         uses: actions/setup-java@v4
@@ -42,6 +60,10 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # On tag push this is the pushed tag (unchanged behavior); on manual dispatch the
+          # action creates the tag at the dispatched commit.
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
+          target_commitish: ${{ github.sha }}
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
## What does this PR do?

Adds a `workflow_dispatch` trigger to `release.yml` so a release can be cut manually when a `sirix-*` tag cannot be pushed directly (e.g. from environments whose git access allows branch pushes but not tag pushes). The dispatch takes a required `tag_name` input; `softprops/action-gh-release` then creates the tag at the dispatched commit. Tags created with the workflow's `GITHUB_TOKEN` do not re-trigger the workflow, so a dispatch runs the release exactly once. A validation step fails fast if the dispatched `tag_name` doesn't match `sirix-<version>` from `gradle.properties`. Tag-push behavior is unchanged (`tag_name` resolves to `github.ref_name` there, as before).

## Related issue

No issue — needed to cut the `sirix-1.0.0-beta5` release for the already-merged #1092.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — CI-only change, no code affected
- [x] Added or updated tests covering the change — not applicable (workflow config); the validation step guards misuse
- [x] For behavioral changes to the storage engine: not applicable
- [x] Updated documentation (README / docs) where relevant — the workflow comments document the fallback
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

The `target_commitish: ${{ github.sha }}` on the release step is a no-op for tag pushes (the tag already exists) and pins tag creation to the exact dispatched commit for manual runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_