### PR TITLE
README: state the sub-page versioning mechanism explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ session.beginNodeReadOnlyTrx(Instant.parse("2024-01-15T03:00:00Z"))
 // Both return the same thing: a readable snapshot, as fast as querying "now"
 ```
 
-This works because SirixDB uses **structural sharing**: when you modify data, only changed pages are written. Unchanged data is shared between revisions via copy-on-write. Revision 1000 doesn't store 1000 copies—it stores the current state plus pointers to shared history.
+This works because SirixDB uses **structural sharing with sub-page versioning**. Unchanged pages are shared between revisions via copy-on-write — and versioning continues *below* the page: a commit writes page fragments containing only the changed records, and the sliding-snapshot algorithm guarantees any page is reconstructible from at most N fragments. Block-level COW (ZFS-style) copies a whole page when one byte in it changes; delta-based systems make reads replay ever-growing diff chains. SirixDB pays neither cost. Revision 1000 doesn't store 1000 copies—it stores the current state plus pointers to shared history.
 
 **The result:**
-- Storage: O(changes per revision), not O(total size × revisions)
+- Storage: O(changed records per revision), not O(total size × revisions) — and not O(changed pages) either
 - Read any page from any revision: O(N) page fragment reads, where N is the configurable snapshot window (default 3)
 - No event replay, no log scanning—direct page access
 


### PR DESCRIPTION
## What does this PR do?

The Solution section said "only changed pages are written" — that describes ordinary block-level copy-on-write (ZFS-style) and undersells the actual mechanism, which is the project's core novelty: versioning continues *below* the page. Commits write page fragments containing only the changed records, and the sliding-snapshot algorithm bounds any page's reconstruction to N fragments. The "O(N) page fragment reads" bullet referenced fragments without ever introducing them.

Also tightens the storage bound from O(changes per revision) to O(changed *records* per revision) — explicitly not O(changed pages).

## Related issue

No issue — aligning the README's framing with the sub-page-versioning positioning ahead of a Show HN post.

## Type of change

- [x] Documentation only

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — README-only
- [x] Added or updated tests covering the change — not applicable
- [x] For behavioral changes to the storage engine: not applicable
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

Wording deliberately matches the announcement copy: block-level COW pays whole-page write amplification, delta chains pay replay read amplification, SirixDB's sliding snapshot pays neither.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_