### PR TITLE
Fix off-heap allocator startup on macOS; document platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ When you modify data:
 
 ## Quick Start
 
+> **Platform support:** Linux is the fully supported, CI-tested platform (native JVM,
+> native binaries, Docker). On **macOS and Windows** the supported path is **Docker**
+> (via Docker Desktop) — the REST server, CLI images, and the demo stack all work there.
+> Running the JVM natively on macOS is **experimental**: the off-heap allocator now
+> carries Darwin mmap flags, but this is not yet CI-verified on Apple hardware —
+> reports welcome. Windows has a dedicated allocator, likewise not CI-verified.
+
 ### Using the CLI (Native Binaries)
 
 SirixDB provides two CLI tools, both available as instant-startup native binaries:

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/Allocators.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/Allocators.java
@@ -21,7 +21,9 @@ import io.sirix.utils.OS;
  *       recycling race that surfaces under 20-thread parallel scans.</li>
  *   <li><b>Linux with {@code -Dsirix.allocator=pool}</b>:
  *       {@link LinuxMemorySegmentAllocator} — the legacy pool-based allocator.
- *       Retained for emergency rollback only.</li>
+ *       Retained for emergency rollback only. Linux-only: on other platforms the
+ *       request falls back to {@link FrameSlotAllocator} (which carries the
+ *       per-OS mmap flags) instead of failing at first use.</li>
  * </ul>
  *
  * <p>The returned allocator is a process-wide singleton per implementation.
@@ -43,7 +45,12 @@ public final class Allocators {
     }
     final String choice = System.getProperty("sirix.allocator", "frame");
     if ("pool".equalsIgnoreCase(choice)) {
-      return LinuxMemorySegmentAllocator.getInstance();
+      if (OS.isLinux()) {
+        return LinuxMemorySegmentAllocator.getInstance();
+      }
+      // The pool allocator hard-codes Linux mmap semantics; honoring the toggle elsewhere
+      // would fail on the first region reservation.
+      System.err.println("sirix.allocator=pool is Linux-only; using the frame-slot allocator instead");
     }
     return FrameSlotAllocator.getInstance();
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.cache;
 
+import io.sirix.utils.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,9 +149,14 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   private static final int PROT_READ = 0x1;
   private static final int PROT_WRITE = 0x2;
   private static final int MAP_PRIVATE = 0x02;
-  private static final int MAP_ANONYMOUS = 0x20;
-  private static final int MAP_NORESERVE = 0x4000;
+  // mmap flag VALUES differ between Linux and Darwin: MAP_ANON is 0x20 on Linux but 0x1000 on
+  // macOS, and Darwin has no MAP_NORESERVE (anonymous memory is not reserved there anyway).
+  // Passing the Linux values through libc on macOS makes mmap fail with EINVAL, which used to
+  // kill the engine on the first database open on a Mac.
+  private static final int MAP_ANONYMOUS = OS.isMacOSX() ? 0x1000 : 0x20;
+  private static final int MAP_NORESERVE = OS.isMacOSX() ? 0 : 0x4000;
   private static final int MADV_DONTNEED = 4;
+  /** Linux 5.14+ only — {@link #populate} is a no-op on macOS (pages commit lazily on first write). */
   private static final int MADV_POPULATE_WRITE = 23;
 
   static {
@@ -375,10 +381,14 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
           PROT_READ | PROT_WRITE,
           MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
           -1, 0L);
-      if (addr.address() == 0) {
+      // mmap signals failure with MAP_FAILED (-1), not NULL — the old NULL-only check let a
+      // failed mapping through as a segment at address -1 that SIGSEGV'd on first touch.
+      if (addr.address() == 0 || addr.address() == -1L) {
         throw new OutOfMemoryError("mmap failed for " + bytes + " bytes");
       }
       return addr.reinterpret(bytes);
+    } catch (final OutOfMemoryError oom) {
+      throw oom;
     } catch (final Throwable t) {
       throw new RuntimeException("Failed to mmap allocator region", t);
     }
@@ -696,6 +706,10 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
 
   /** Pre-commit physical pages for a freshly-allocated slot. */
   private static void populate(final MemorySegment slot, final long sizeBytes) {
+    if (OS.isMacOSX()) {
+      // Darwin has no MADV_POPULATE_WRITE; anonymous pages commit lazily on first write.
+      return;
+    }
     try {
       final int rc = (int) MADVISE.invokeExact(slot, sizeBytes, MADV_POPULATE_WRITE);
       if (rc != 0) {


### PR DESCRIPTION
## What does this PR do?

Running the JVM natively on macOS failed on the first database open: `FrameSlotAllocator` passed **Linux** mmap flag values through libc on every platform. `MAP_ANON` is `0x20` on Linux but `0x1000` on Darwin, and Darwin has no `MAP_NORESERVE` — so the region reservation failed with EINVAL and the engine never started (the Docker path was unaffected, since Docker Desktop runs Linux containers).

- Select `MAP_ANONYMOUS`/`MAP_NORESERVE` values per OS (`OS.isMacOSX()`); Linux values are unchanged by construction.
- Skip `MADV_POPULATE_WRITE` on Darwin — it's Linux 5.14+ only; anonymous pages commit lazily on first write there.
- Check mmap failure against `MAP_FAILED` (-1): the previous NULL-only check let a failed mapping through as a segment at address -1 that SIGSEGV'd on first touch (latent on all platforms).
- `-Dsirix.allocator=pool` now falls back to the frame-slot allocator with a warning on non-Linux instead of failing at first use (`LinuxMemorySegmentAllocator` hard-codes Linux mmap semantics).
- README gains a platform-support note: Linux fully supported and CI-tested; macOS/Windows supported via Docker; native macOS **experimental** pending verification on Apple hardware.

## Related issue

Follow-up to the 2023 Show HN feedback ("fails immediately on macOS") — the Docker path was fixed earlier; this addresses the native-JVM path.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation only (README platform note)

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — core compiles; `FrameSlotAllocatorTest` and `PinCountDiagnosticsTest` pass
- [x] Added or updated tests covering the change — Linux behavior is value-identical by construction; a Darwin-specific test cannot run in CI (ubuntu-only), hence the explicit "experimental" labeling until verified on Apple hardware
- [x] For behavioral changes to the storage engine: no on-disk format change; allocator invariants (versioned slots, era checks) untouched
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

**This is expected-to-work on macOS but not yet verified on real Apple hardware** — the flag values are the documented Darwin constants (`MAP_ANON=0x1000`, `MADV_DONTNEED=4` on both platforms, no `MAP_NORESERVE`), and the populate skip matches Darwin's lazy-commit behavior. A smoke test on an M-series Mac (create a resource, commit, read back) would let us drop the "experimental" label.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_