### PR TITLE
Run the frame-slot allocator on Windows via a VirtualMemory backend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 # autocrlf otherwise converts them to CRLF at checkout and the comparisons fail).
 *.json text eol=lf
 *.xml text eol=lf
+
+# XMark query tests (brackit XMarkTest) read *.xq queries and *.out expected results with
+# Files.readString and compare the raw string against the serializer's \n-delimited output.
+*.out text eol=lf
+*.xq text eol=lf

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -122,8 +122,11 @@ jobs:
       # -PexcludeHeavyTests skips @Tag("heavy") soak-style suites (20+ min per test on these
       # 3-core runners — the round-2 macOS lane spent its whole hour inside two of them).
       # Full heavy coverage stays on the Linux jobs above.
+      # --continue: without it a sirix-core failure aborts the invocation and the remaining
+      # modules never run on that platform — which is how the sirix-query XMark CRLF failure
+      # stayed invisible for five rounds. One module's failure must not mask another's result.
       - name: Test core, query, and kotlin modules
-        run: ./gradlew :sirix-core:test :sirix-query:test :sirix-kotlin-api:test :sirix-kotlin-cli:test -PexcludeHeavyTests=true --stacktrace
+        run: ./gradlew :sirix-core:test :sirix-query:test :sirix-kotlin-api:test :sirix-kotlin-cli:test -PexcludeHeavyTests=true --continue --stacktrace
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ When you modify data:
 > **Platform support:** Linux is the fully supported, CI-tested platform (native JVM,
 > native binaries, Docker). On **macOS and Windows** the supported path is **Docker**
 > (via Docker Desktop) — the REST server, CLI images, and the demo stack all work there.
-> Running the JVM natively on macOS or Windows is **experimental**: the off-heap
-> allocator carries per-OS mmap flags (macOS) and a dedicated Windows implementation,
-> and advisory CI lanes now run the core, query, and Kotlin test suites on
-> `macos-latest` and `windows-latest`. The experimental label drops once those lanes
-> are consistently green — reports from real hardware welcome.
+> Running the JVM natively on macOS or Windows is **experimental**: all platforms run
+> the same Umbra-style frame-slot allocator (platform-specific reserve/commit plumbing:
+> POSIX `mmap`, Windows `VirtualAlloc`), and advisory CI lanes run the core, query, and
+> Kotlin test suites on `macos-latest` and `windows-latest`. The experimental label
+> drops once those lanes are consistently green — reports from real hardware welcome.
 
 ### Using the CLI (Native Binaries)
 

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/Allocators.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/Allocators.java
@@ -14,11 +14,15 @@ import io.sirix.utils.OS;
  * <h2>Dispatch</h2>
  *
  * <ul>
- *   <li><b>Windows</b>: always {@link WindowsMemorySegmentAllocator}.</li>
- *   <li><b>Linux default</b>: {@link FrameSlotAllocator} — Umbra/LeanStore-style
+ *   <li><b>Default (all platforms)</b>: {@link FrameSlotAllocator} — Umbra/LeanStore-style
  *       fixed-address frame slots with optimistic versioned reads. Stable slot
  *       addresses for the lifetime of the process eliminate the cross-thread
- *       recycling race that surfaces under 20-thread parallel scans.</li>
+ *       recycling race that surfaces under 20-thread parallel scans. The
+ *       platform-specific reserve/commit plumbing lives behind
+ *       {@link VirtualMemory} (POSIX mmap; Windows VirtualAlloc).</li>
+ *   <li><b>Windows with {@code -Dsirix.allocator=windowspool}</b>:
+ *       {@link WindowsMemorySegmentAllocator} — the legacy VirtualAlloc pool.
+ *       Retained for emergency rollback only.</li>
  *   <li><b>Linux with {@code -Dsirix.allocator=pool}</b>:
  *       {@link LinuxMemorySegmentAllocator} — the legacy pool-based allocator.
  *       Retained for emergency rollback only. Linux-only: on other platforms the
@@ -40,10 +44,15 @@ public final class Allocators {
   private static final MemorySegmentAllocator INSTANCE = resolve();
 
   private static MemorySegmentAllocator resolve() {
-    if (OS.isWindows()) {
-      return WindowsMemorySegmentAllocator.getInstance();
-    }
     final String choice = System.getProperty("sirix.allocator", "frame");
+    if (OS.isWindows()) {
+      // Same frame-slot allocator as everywhere else (VirtualAlloc-backed via VirtualMemory);
+      // the legacy Windows pool stays available for emergency rollback.
+      if ("windowspool".equalsIgnoreCase(choice)) {
+        return WindowsMemorySegmentAllocator.getInstance();
+      }
+      return FrameSlotAllocator.getInstance();
+    }
     if ("pool".equalsIgnoreCase(choice)) {
       if (OS.isLinux()) {
         return LinuxMemorySegmentAllocator.getInstance();

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -3,16 +3,11 @@
  */
 package io.sirix.cache;
 
-import io.sirix.utils.OS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.foreign.Arena;
-import java.lang.foreign.FunctionDescriptor;
-import java.lang.foreign.Linker;
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,9 +34,10 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * <h2>Umbra's solution, ported</h2>
  *
  * <ol>
- *   <li>One {@code mmap} at startup per size class, subdivided into
- *       fixed-position slots. A slot's virtual address is stable for the
- *       lifetime of the process.</li>
+ *   <li>One virtual-memory reservation at startup per size class ({@code mmap} on POSIX,
+ *       {@code VirtualAlloc(MEM_RESERVE)} on Windows — see {@link VirtualMemory}), subdivided
+ *       into fixed-position slots. A slot's virtual address is stable for the lifetime of the
+ *       process.</li>
  *   <li>A {@code long} version counter per slot. Even = slot is quiescent
  *       (either free or stably owned by readers); odd = slot is being
  *       modified by a writer (allocate/release).</li>
@@ -117,10 +113,10 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * <h2>HFT-grade cost</h2>
  *
  * <ul>
- *   <li>Allocate: one {@code AtomicInteger.compareAndSet} on the class's
- *       free-stack top, one {@code long} version bump, one {@code MADV_POPULATE_WRITE}.</li>
- *   <li>Release: one version bump + one {@code madvise(DONTNEED)} + one free-slot
- *       push. No unmapping; virtual address stays valid for reuse.</li>
+ *   <li>Allocate: one free-stack pop + one {@code long} version bump; a fresh slot's
+ *       one-time commit happens in the {@link VirtualMemory} backend (no-op on POSIX).</li>
+ *   <li>Release: one version bump + one free-slot push. No unmapping, no decommit;
+ *       the virtual address stays valid and committed for reuse.</li>
  *   <li>Read: two {@code getAcquire} loads of the version. Zero CAS,
  *       zero syscall in the common case.</li>
  * </ul>
@@ -140,45 +136,10 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
       256L * 1024          // 256 KiB
   };
 
-  // ===== POSIX plumbing ======================================================
-  private static final Linker LINKER = Linker.nativeLinker();
-  private static final MethodHandle MMAP;
-  private static final MethodHandle MUNMAP;
-  private static final MethodHandle MADVISE;
-
-  private static final int PROT_READ = 0x1;
-  private static final int PROT_WRITE = 0x2;
-  private static final int MAP_PRIVATE = 0x02;
-  // mmap flag VALUES differ between Linux and Darwin: MAP_ANON is 0x20 on Linux but 0x1000 on
-  // macOS, and Darwin has no MAP_NORESERVE (anonymous memory is not reserved there anyway).
-  // Passing the Linux values through libc on macOS makes mmap fail with EINVAL, which used to
-  // kill the engine on the first database open on a Mac.
-  private static final int MAP_ANONYMOUS = OS.isMacOSX() ? 0x1000 : 0x20;
-  private static final int MAP_NORESERVE = OS.isMacOSX() ? 0 : 0x4000;
-  private static final int MADV_DONTNEED = 4;
-  /** Linux 5.14+ only — {@link #populate} is a no-op on macOS (pages commit lazily on first write). */
-  private static final int MADV_POPULATE_WRITE = 23;
-
-  static {
-    // SOFT bindings: class-loading must never throw on a platform without these POSIX symbols —
-    // KeyValueLeafPage (and the PressureListener wiring) touch this class even on Windows, where
-    // the Windows allocator serves all actual allocations. Missing symbols leave null handles;
-    // mapRegion fails fast with an actionable message if this allocator is actually USED there.
-    MMAP = bind("mmap",
-        FunctionDescriptor.of(ValueLayout.ADDRESS,
-            ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT,
-            ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG));
-    MUNMAP = bind("munmap",
-        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
-    MADVISE = bind("madvise",
-        FunctionDescriptor.of(ValueLayout.JAVA_INT,
-            ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
-  }
-
-  /** Bind a libc symbol, or return {@code null} when the platform does not provide it. */
-  private static MethodHandle bind(final String symbol, final FunctionDescriptor descriptor) {
-    return LINKER.defaultLookup().find(symbol).map(s -> LINKER.downcallHandle(s, descriptor)).orElse(null);
-  }
+  // ===== Virtual-memory plumbing =============================================
+  // All syscall-shaped work (reserve / commit-fresh / discard / release) lives behind the
+  // per-platform VirtualMemory backend; everything below is portable Java.
+  private static final VirtualMemory VM = VirtualMemory.forCurrentPlatform();
 
   /**
    * Per-size-class state. One instance per entry in {@link #SIZE_CLASSES}.
@@ -381,27 +342,7 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   }
 
   private static MemorySegment mapRegion(final long bytes) {
-    if (MMAP == null) {
-      throw new IllegalStateException("FrameSlotAllocator requires a POSIX libc (mmap); "
-          + "on Windows the Windows allocator is selected automatically via Allocators");
-    }
-    try {
-      final MemorySegment addr = (MemorySegment) MMAP.invokeExact(
-          MemorySegment.NULL, bytes,
-          PROT_READ | PROT_WRITE,
-          MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
-          -1, 0L);
-      // mmap signals failure with MAP_FAILED (-1), not NULL — the old NULL-only check let a
-      // failed mapping through as a segment at address -1 that SIGSEGV'd on first touch.
-      if (addr.address() == 0 || addr.address() == -1L) {
-        throw new OutOfMemoryError("mmap failed for " + bytes + " bytes");
-      }
-      return addr.reinterpret(bytes);
-    } catch (final OutOfMemoryError oom) {
-      throw oom;
-    } catch (final Throwable t) {
-      throw new RuntimeException("Failed to mmap allocator region", t);
-    }
+    return VM.reserve(bytes);
   }
 
   /**
@@ -594,17 +535,7 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
     if (segment == null) {
       return;
     }
-    try {
-      if (MADVISE == null) {
-        return;
-      }
-      final int rc = (int) MADVISE.invokeExact(segment, segment.byteSize(), MADV_DONTNEED);
-      if (rc != 0) {
-        LOGGER.debug("resetSegment MADV_DONTNEED rc={} on address 0x{}", rc, Long.toHexString(segment.address()));
-      }
-    } catch (final Throwable t) {
-      LOGGER.debug("resetSegment madvise threw: {}", t.getMessage());
-    }
+    VM.discardToZeros(segment);
   }
 
   /**
@@ -654,10 +585,14 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   private static int popFreeSlot(final SizeClass c) {
     final Integer recycled = c.freeSlots.pollLast();
     if (recycled != null) {
+      // Recycled slots stay committed across allocate/release cycles — no syscall.
       return recycled.intValue();
     }
     final int fresh = c.nextFreshIndex.getAndIncrement();
     if (fresh < c.slotCount) {
+      // First hand-out of this slot: POSIX overcommits (no-op); Windows must MEM_COMMIT here,
+      // since reserved-but-uncommitted pages fault on first touch.
+      VM.commitFresh(c.region.asSlice((long) fresh * c.slotSize, c.slotSize));
       return fresh;
     }
     c.nextFreshIndex.decrementAndGet();
@@ -717,26 +652,6 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
     physicalBytes.addAndGet(-c.slotSize);
   }
 
-  /** Pre-commit physical pages for a freshly-allocated slot. */
-  private static void populate(final MemorySegment slot, final long sizeBytes) {
-    if (OS.isMacOSX() || MADVISE == null) {
-      // Darwin has no MADV_POPULATE_WRITE; anonymous pages commit lazily on first write.
-      return;
-    }
-    try {
-      final int rc = (int) MADVISE.invokeExact(slot, sizeBytes, MADV_POPULATE_WRITE);
-      if (rc != 0) {
-        throw new OutOfMemoryError("MADV_POPULATE_WRITE failed (rc=" + rc
-            + ") — physical memory exhausted during slot populate");
-      }
-    } catch (final OutOfMemoryError oom) {
-      throw oom;
-    } catch (final Throwable t) {
-      // Older kernels lack MADV_POPULATE_WRITE (EINVAL). Fall back to
-      // lazy-commit; if RAM is tight, kernel OOM-kills the process rather
-      // than handing us a SIGSEGV on first write.
-    }
-  }
 
   // ===== Reader-side optimistic validation ===================================
 
@@ -793,21 +708,9 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    */
   public void shutdown() {
     for (final SizeClass c : classes) {
-      try {
-        // Capture int return per the FunctionDescriptor signature —
-        // invokeExact is strict about matching return type even when
-        // the value is discarded.
-        if (MUNMAP == null) {
-          continue;
-        }
-        final int rc = (int) MUNMAP.invokeExact(c.region, c.region.byteSize());
-        if (rc != 0) {
-          LOGGER.warn("munmap returned {} for class region size {}", rc, c.region.byteSize());
-        }
-      } catch (final Throwable t) {
-        LOGGER.warn("munmap failed on shutdown: {}", t.getMessage());
-      }
+      VM.release(c.region);
     }
+
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/PosixVirtualMemory.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/PosixVirtualMemory.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.utils.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * {@link VirtualMemory} over POSIX {@code mmap}/{@code madvise}/{@code munmap}. Linux and macOS
+ * differ only in mmap FLAG VALUES ({@code MAP_ANON} is {@code 0x20} on Linux but {@code 0x1000}
+ * on Darwin, and Darwin has no {@code MAP_NORESERVE}); the calls are otherwise identical.
+ *
+ * <p>Symbols are bound SOFTLY: class-loading never throws on a platform that lacks them (Windows
+ * class-loads this via {@link VirtualMemory#forCurrentPlatform} resolution paths); actually using
+ * an unbound operation fails fast with an actionable message.
+ */
+final class PosixVirtualMemory implements VirtualMemory {
+
+  static final PosixVirtualMemory INSTANCE = new PosixVirtualMemory();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PosixVirtualMemory.class);
+
+  private static final Linker LINKER = Linker.nativeLinker();
+  private static final MethodHandle MMAP;
+  private static final MethodHandle MUNMAP;
+  private static final MethodHandle MADVISE;
+
+  private static final int PROT_READ = 0x1;
+  private static final int PROT_WRITE = 0x2;
+  private static final int MAP_PRIVATE = 0x02;
+  private static final int MAP_ANONYMOUS = OS.isMacOSX() ? 0x1000 : 0x20;
+  private static final int MAP_NORESERVE = OS.isMacOSX() ? 0 : 0x4000;
+  private static final int MADV_DONTNEED = 4;
+
+  static {
+    MMAP = bind("mmap",
+        FunctionDescriptor.of(ValueLayout.ADDRESS,
+            ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT,
+            ValueLayout.JAVA_INT, ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG));
+    MUNMAP = bind("munmap",
+        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+    MADVISE = bind("madvise",
+        FunctionDescriptor.of(ValueLayout.JAVA_INT,
+            ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT));
+  }
+
+  private static MethodHandle bind(final String symbol, final FunctionDescriptor descriptor) {
+    return LINKER.defaultLookup().find(symbol).map(s -> LINKER.downcallHandle(s, descriptor)).orElse(null);
+  }
+
+  private PosixVirtualMemory() {
+  }
+
+  @Override
+  public MemorySegment reserve(final long bytes) {
+    if (MMAP == null) {
+      throw new IllegalStateException("FrameSlotAllocator requires a POSIX libc (mmap); "
+          + "on Windows the Windows virtual-memory backend is selected automatically");
+    }
+    try {
+      final MemorySegment addr = (MemorySegment) MMAP.invokeExact(
+          MemorySegment.NULL, bytes,
+          PROT_READ | PROT_WRITE,
+          MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE,
+          -1, 0L);
+      // mmap signals failure with MAP_FAILED (-1), not NULL.
+      if (addr.address() == 0 || addr.address() == -1L) {
+        throw new OutOfMemoryError("mmap failed for " + bytes + " bytes");
+      }
+      return addr.reinterpret(bytes);
+    } catch (final OutOfMemoryError oom) {
+      throw oom;
+    } catch (final Throwable t) {
+      throw new RuntimeException("Failed to mmap allocator region", t);
+    }
+  }
+
+  @Override
+  public void commitFresh(final MemorySegment slot) {
+    // POSIX overcommits: the first write faults in a zero page. No syscall needed.
+  }
+
+  @Override
+  public void discardToZeros(final MemorySegment segment) {
+    if (MADVISE == null) {
+      return;
+    }
+    try {
+      final int rc = (int) MADVISE.invokeExact(segment, segment.byteSize(), MADV_DONTNEED);
+      if (rc != 0) {
+        LOGGER.debug("discardToZeros MADV_DONTNEED rc={} on address 0x{}", rc,
+            Long.toHexString(segment.address()));
+      }
+    } catch (final Throwable t) {
+      LOGGER.debug("discardToZeros madvise failed: {}", t.getMessage());
+    }
+  }
+
+  @Override
+  public void release(final MemorySegment region) {
+    if (MUNMAP == null) {
+      return;
+    }
+    try {
+      final int rc = (int) MUNMAP.invokeExact(region, region.byteSize());
+      if (rc != 0) {
+        LOGGER.warn("munmap returned {} for region size {}", rc, region.byteSize());
+      }
+    } catch (final Throwable t) {
+      LOGGER.warn("munmap failed on shutdown: {}", t.getMessage());
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/VirtualMemory.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/VirtualMemory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.utils.OS;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * The platform-specific virtual-memory plumbing behind {@link FrameSlotAllocator} — everything
+ * else in the allocator (size classes, fixed-position slots, optimistic version counters, the
+ * free-slot stacks) is portable Java. All four operations are COLD paths: a region is reserved
+ * once per size class at init, a slot is committed once when first handed out, and regions are
+ * released once at shutdown. The allocator's hot path never enters this interface.
+ *
+ * <p>Semantics the allocator relies on:
+ *
+ * <ul>
+ *   <li>{@link #reserve} returns a region of stable virtual addresses with no physical memory
+ *       committed up front (POSIX: {@code mmap(MAP_NORESERVE)}; Windows:
+ *       {@code VirtualAlloc(MEM_RESERVE)}).</li>
+ *   <li>{@link #commitFresh} makes a slot writable before its FIRST use. POSIX overcommits, so
+ *       first-touch faults are served from the zero page and this is a no-op; Windows has no
+ *       overcommit — reserved pages must be committed explicitly or the first touch faults.</li>
+ *   <li>Once committed, a slot STAYS committed across recycle cycles — nothing here decommits,
+ *       so recycled slots are always touch-safe on every platform.</li>
+ *   <li>{@link #discardToZeros} discards a segment's contents such that the next read observes
+ *       zeros, without invalidating the address (POSIX anonymous memory: {@code MADV_DONTNEED};
+ *       Windows: decommit + recommit).</li>
+ * </ul>
+ */
+public interface VirtualMemory {
+
+  /** Reserve {@code bytes} of stable virtual address space without committing physical memory. */
+  MemorySegment reserve(long bytes);
+
+  /** Make a freshly handed-out slot writable; throws {@link OutOfMemoryError} when memory is exhausted. */
+  void commitFresh(MemorySegment slot);
+
+  /** Discard contents so the next read observes zeros; the address stays valid and committed. */
+  void discardToZeros(MemorySegment segment);
+
+  /** Release a whole region reserved by {@link #reserve} (shutdown only). */
+  void release(MemorySegment region);
+
+  /** The backend for the OS this JVM runs on. */
+  static VirtualMemory forCurrentPlatform() {
+    return OS.isWindows() ? WindowsVirtualMemory.INSTANCE : PosixVirtualMemory.INSTANCE;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/WindowsVirtualMemory.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/WindowsVirtualMemory.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.utils.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * {@link VirtualMemory} over kernel32 {@code VirtualAlloc}/{@code VirtualFree} — the faithful
+ * Windows port of the frame-slot allocator's plumbing:
+ *
+ * <ul>
+ *   <li>{@code VirtualAlloc(MEM_RESERVE)} reserves the per-size-class region: address space only,
+ *       no commit charge — the analogue of {@code mmap(MAP_NORESERVE)}.</li>
+ *   <li>{@code VirtualAlloc(addr, size, MEM_COMMIT)} commits a fresh slot before first use.
+ *       Windows has NO overcommit: touching reserved-but-uncommitted pages faults, so unlike
+ *       POSIX this step is mandatory. Commit charge is bounded by the allocator's physical
+ *       budget, never the 32 GiB-per-class reservation.</li>
+ *   <li>{@code VirtualFree(MEM_DECOMMIT)} + recommit implements discard-to-zeros (Windows
+ *       guarantees committed pages start zeroed; {@code MEM_RESET} would NOT guarantee that).</li>
+ *   <li>{@code VirtualFree(MEM_RELEASE)} drops a whole region at shutdown.</li>
+ * </ul>
+ *
+ * <p>Bindings are attempted only on Windows, so class-loading is side-effect free elsewhere.
+ */
+final class WindowsVirtualMemory implements VirtualMemory {
+
+  static final WindowsVirtualMemory INSTANCE = new WindowsVirtualMemory();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WindowsVirtualMemory.class);
+
+  private static final long MEM_COMMIT = 0x1000;
+  private static final long MEM_RESERVE = 0x2000;
+  private static final long MEM_DECOMMIT = 0x4000;
+  private static final long MEM_RELEASE = 0x8000;
+  private static final long PAGE_READWRITE = 0x04;
+
+  private static final MethodHandle VIRTUAL_ALLOC;
+  private static final MethodHandle VIRTUAL_FREE;
+
+  static {
+    MethodHandle alloc = null;
+    MethodHandle free = null;
+    if (OS.isWindows()) {
+      // VirtualAlloc/VirtualFree live in kernel32.dll; the nativeLinker default lookup only
+      // covers the C runtime.
+      final Linker linker = Linker.nativeLinker();
+      final SymbolLookup kernel32 = SymbolLookup.libraryLookup("kernel32.dll", Arena.global());
+      alloc = linker.downcallHandle(
+          kernel32.find("VirtualAlloc").orElseThrow(() -> new RuntimeException("VirtualAlloc not found in kernel32.dll")),
+          FunctionDescriptor.of(ValueLayout.ADDRESS,
+              ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG));
+      free = linker.downcallHandle(
+          kernel32.find("VirtualFree").orElseThrow(() -> new RuntimeException("VirtualFree not found in kernel32.dll")),
+          FunctionDescriptor.of(ValueLayout.JAVA_INT,
+              ValueLayout.ADDRESS, ValueLayout.JAVA_LONG, ValueLayout.JAVA_LONG));
+    }
+    VIRTUAL_ALLOC = alloc;
+    VIRTUAL_FREE = free;
+  }
+
+  private WindowsVirtualMemory() {
+  }
+
+  @Override
+  public MemorySegment reserve(final long bytes) {
+    if (VIRTUAL_ALLOC == null) {
+      throw new IllegalStateException("WindowsVirtualMemory requires Windows (kernel32 VirtualAlloc)");
+    }
+    try {
+      final MemorySegment addr = (MemorySegment) VIRTUAL_ALLOC.invokeExact(
+          MemorySegment.NULL, bytes, MEM_RESERVE, PAGE_READWRITE);
+      if (addr.address() == 0) {
+        throw new OutOfMemoryError("VirtualAlloc(MEM_RESERVE) failed for " + bytes + " bytes");
+      }
+      return addr.reinterpret(bytes);
+    } catch (final OutOfMemoryError oom) {
+      throw oom;
+    } catch (final Throwable t) {
+      throw new RuntimeException("Failed to reserve allocator region", t);
+    }
+  }
+
+  @Override
+  public void commitFresh(final MemorySegment slot) {
+    try {
+      final MemorySegment addr = (MemorySegment) VIRTUAL_ALLOC.invokeExact(
+          slot, slot.byteSize(), MEM_COMMIT, PAGE_READWRITE);
+      if (addr.address() == 0) {
+        throw new OutOfMemoryError("VirtualAlloc(MEM_COMMIT) failed for slot of "
+            + slot.byteSize() + " bytes — physical memory (commit charge) exhausted");
+      }
+    } catch (final OutOfMemoryError oom) {
+      throw oom;
+    } catch (final Throwable t) {
+      throw new RuntimeException("Failed to commit slot", t);
+    }
+  }
+
+  @Override
+  public void discardToZeros(final MemorySegment segment) {
+    try {
+      final int freed = (int) VIRTUAL_FREE.invokeExact(segment, segment.byteSize(), MEM_DECOMMIT);
+      if (freed == 0) {
+        LOGGER.debug("VirtualFree(MEM_DECOMMIT) failed on address 0x{}", Long.toHexString(segment.address()));
+        return;
+      }
+      // Recommit immediately: committed pages are guaranteed zeroed, and the slot must stay
+      // touch-safe for its next owner (nothing else in the allocator commits recycled slots).
+      final MemorySegment addr = (MemorySegment) VIRTUAL_ALLOC.invokeExact(
+          segment, segment.byteSize(), MEM_COMMIT, PAGE_READWRITE);
+      if (addr.address() == 0) {
+        throw new OutOfMemoryError("VirtualAlloc(MEM_COMMIT) failed re-committing a discarded slot");
+      }
+    } catch (final OutOfMemoryError oom) {
+      throw oom;
+    } catch (final Throwable t) {
+      throw new RuntimeException("Failed to discard slot contents", t);
+    }
+  }
+
+  @Override
+  public void release(final MemorySegment region) {
+    try {
+      final int freed = (int) VIRTUAL_FREE.invokeExact(region, 0L, MEM_RELEASE);
+      if (freed == 0) {
+        LOGGER.warn("VirtualFree(MEM_RELEASE) failed for region size {}", region.byteSize());
+      }
+    } catch (final Throwable t) {
+      LOGGER.warn("VirtualFree failed on shutdown: {}", t.getMessage());
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
@@ -5,10 +5,8 @@ package io.sirix.cache;
 
 import io.sirix.cache.FrameSlotAllocator.FrameSlot;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.OS;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
@@ -36,8 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * sees the writer's canary pattern or detects the race via the version
  * mismatch.
  */
-// The frame-slot allocator is POSIX-only (mmap); Windows uses WindowsMemorySegmentAllocator.
-@DisabledOnOs(OS.WINDOWS)
 class FrameSlotAllocatorTest {
 
   private FrameSlotAllocator allocator;

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTFormalVerificationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTFormalVerificationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -46,6 +47,12 @@ import static org.junit.jupiter.api.Assertions.fail;
  * exact same workload across runs, so any failure is bit-reproducible.</p>
  */
 @DisplayName("HOT formal verification")
+// Soak-style suite: 100K-value workloads with per-test @Timeout budgets sized for the Linux
+// runners. On the 3-core macOS runners the "two distinct values alternating" case trips its
+// 60 s timeout, which leaks the shared write transaction and cascades "No read-write
+// transaction available" failures through the rest of the module. Full coverage stays on the
+// Linux jobs; the platform lanes exclude 'heavy' via -PexcludeHeavyTests.
+@Tag("heavy")
 final class HOTFormalVerificationTest {
 
   private static String originalHOTSetting;

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTMergeSplitStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTMergeSplitStressTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -47,6 +48,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * page creation and navigation
  */
 @DisplayName("HOT Merge/Split Stress Tests")
+// Soak-style suite with 2-5 minute per-test @Timeout budgets sized for the Linux runners;
+// on the 3-core macOS runners testCASIndex10000Integers trips its 120 s timeout and poisons
+// the shared session for the rest of the module. Full coverage stays on the Linux jobs; the
+// platform lanes exclude 'heavy' via -PexcludeHeavyTests.
+@Tag("heavy")
 class HOTMergeSplitStressTest {
 
   private static final String RESOURCE_NAME = "testResource";

--- a/bundles/sirix-kotlin-cli/src/test/kotlin/io/sirix/cli/commands/CliCommandTestConstants.kt
+++ b/bundles/sirix-kotlin-cli/src/test/kotlin/io/sirix/cli/commands/CliCommandTestConstants.kt
@@ -1,7 +1,8 @@
 package io.sirix.cli.commands
 
 import io.sirix.access.User
-import java.util.*
+import java.nio.file.Paths
+import java.util.UUID
 
 class CliCommandTestConstants {
 
@@ -21,8 +22,11 @@ class CliCommandTestConstants {
             "<xml-data><bar><helloo>world</helloo><hello>true</hello></bar><baz>hello</baz><foo><element>bar</element><element null=\"true\"/><element>2.33</element></foo><tatrata-tada><element><foo>bar</foo></element><element><baz>false</baz></element><element>boo</element><element/><element/></tatrata-tada></xml-data>"
 
 
+        // URL.path yields "/D:/..." on Windows, which Paths.get rejects (InvalidPathException);
+        // toURI() -> Paths.get() produces a proper platform path on every OS.
         @JvmField
-        val TEST_XML_DATA_PATH: String = {}::class.java.getResource("/io/sirix/cli/commands/test_data.xml").path
+        val TEST_XML_DATA_PATH: String =
+            Paths.get({}::class.java.getResource("/io/sirix/cli/commands/test_data.xml")!!.toURI()).toString()
 
         @JvmField
         val TEST_JSON_DATA: String =
@@ -33,7 +37,8 @@ class CliCommandTestConstants {
             "{\"foo\":[\"bar\",null,2.33],\"bar\":{\"helloo\":\"world\",\"hello\":true},\"baz\":\"hello\",\"tadara tada\":[{\"foo\":\"bar\"},{\"baz\":false},\"boo\",{},[]]}"
 
         @JvmField
-        val TEST_JSON_DATA_PATH: String = {}::class.java.getResource("/io/sirix/cli/commands/test_data.json").path
+        val TEST_JSON_DATA_PATH: String =
+            Paths.get({}::class.java.getResource("/io/sirix/cli/commands/test_data.json")!!.toURI()).toString()
 
         @JvmField
         val RESOURCE_LIST = listOf("resource1", "resource2", "resource3", "resource4", "resource5", "resource6")

--- a/bundles/sirix-kotlin-cli/src/test/kotlin/io/sirix/cli/commands/QueryTest.kt
+++ b/bundles/sirix-kotlin-cli/src/test/kotlin/io/sirix/cli/commands/QueryTest.kt
@@ -224,7 +224,8 @@ internal class QueryTest : CliCommandTest() {
 }
 
 private fun prepareQueryResult(outputStream: OutputStream): String {
-    return outputStream.toString().trim().replace("\\d+ms".toRegex(), "123")
+    // println emits \r\n on Windows while the expected literals use \n — normalize before comparing.
+    return outputStream.toString().replace("\r\n", "\n").trim().replace("\\d+ms".toRegex(), "123")
 }
 
 


### PR DESCRIPTION
## What

Makes the Umbra/LeanStore-style `FrameSlotAllocator` — until now Linux/macOS-only — the default allocator on **Windows** too, by extracting its platform plumbing behind a small `VirtualMemory` SPI:

- **`VirtualMemory`** (new): four operations the allocator actually needs — `reserve` (large virtual region, no physical backing), `commitFresh` (make a never-used slot writable), `discardToZeros` (return a slot's pages, guarantee zeros on reuse), `release`.
- **`PosixVirtualMemory`** (new): the existing mmap path, unchanged in behavior — `MAP_NORESERVE` reservation, overcommit makes `commitFresh` a no-op, `madvise(MADV_DONTNEED)` for discard, with the per-OS flag differences (Darwin `MAP_ANONYMOUS=0x1000`, no `MAP_NORESERVE`) kept from #1097.
- **`WindowsVirtualMemory`** (new): the faithful port. `VirtualAlloc(MEM_RESERVE)` gives the same 32 GiB fixed-address reservation per size class; since Windows has no overcommit, `commitFresh` does `VirtualAlloc(MEM_COMMIT)` on the slot before first touch; `discardToZeros` is `MEM_DECOMMIT` + recommit, which contractually returns zeroed pages (`MEM_RESET` does not guarantee zeros, so it is not used); `VirtualFree(MEM_RELEASE)` on shutdown. kernel32 is bound via `SymbolLookup.libraryLookup("kernel32.dll")` and only when actually on Windows.
- `FrameSlotAllocator` itself loses all direct libc calls and goes through the SPI; the fixed-address slot design, per-slot version counters, and optimistic-read protocol are untouched, so Windows gets the same cross-thread recycling-race protection as Linux.
- `Allocators.resolve()`: Windows now defaults to the frame-slot allocator; the legacy `WindowsMemorySegmentAllocator` pool stays reachable via `-Dsirix.allocator=windowspool` for emergency rollback.

## Platform-lane fixes the first run exposed

This PR's first Windows run was the first ever to get past `sirix-core` on Windows (previous rounds aborted there, masking downstream modules). That exposed three lane issues, fixed here:

- **XMark CRLF**: `q13.out` is the only XMark fixture containing newlines, so it was the only file autocrlf rewrote to CRLF on the Windows checkout; brackit's `XMarkTest` compares raw `Files.readString` content against the serializer's `\n` output. `*.out` and `*.xq` are now covered in `.gitattributes`.
- **macOS timeout cascade**: `HOTFormalVerificationTest` and `HOTMergeSplitStressTest` carry per-test `@Timeout` budgets sized for Linux runners; on the 3-core macOS runners one test in each trips its timeout, leaks the shared write transaction, and cascades ~360 "No read-write transaction available" failures through the module (identical counts on this PR and the #1098 baseline — pre-existing, not an allocator regression). Both are now `@Tag("heavy")`; full coverage stays on the Linux jobs.
- **`--continue`** on the platform-lane Gradle invocation, so one module's failure can't hide another's results again.

## Testing

- Linux: full `sirix-core` suite green locally (POSIX path is behaviorally identical to before the refactor).
- Windows lane (first commit): `sirix-core` fully green on the new VirtualAlloc-backed frame-slot path — 0 failures, including the HOT and concurrency suites. The lone lane failure was the XMark CRLF fixture issue above.
- Merge gate: green Linux jobs + Windows lane green (or at worst the known pre-existing engine bug #1099, which is random-seeded).