### PR TITLE
Fix path-summary corruption on nested-array removal

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -2917,6 +2917,11 @@ final class JsonNodeTrxImpl extends
           removeName();
         } else {
           removeValue();
+          // The PostOrderAxis loop above covers only DESCENDANTS: a removed subtree whose root
+          // is itself a plain ARRAY (removeArrayElement of a nested array) must de-index and
+          // decrement its own __array__ path-summary entry here, or that entry leaks with a
+          // reference count no document node backs (issue #1099).
+          removeArrayPathEntry();
         }
 
         // Adapt hashes and neighbour nodes as well as the name from the NamePage mapping if it's not a text

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryReader.java
@@ -43,6 +43,7 @@ import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongHash;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -642,60 +643,97 @@ public final class PathSummaryReader implements NodeReadOnlyTrx, NodeCursor {
     }
   }
 
+  /**
+   * Follow a direct in-memory {@link PathNode} reference only when it is provably coherent:
+   * the referenced instance must carry the node key the structural pointer names, and it must
+   * be the instance {@link #pathNodeMapping} currently holds for that key.
+   *
+   * <p>The in-memory parent/child/sibling references are wired once, at bulk-load time (see
+   * {@code LevelOrderSettingInMemoryInstancesAxis}). {@link PathSummaryWriter} mutations do NOT
+   * rewire them — a structural fix-up goes through {@code prepareRecordForModification}, which
+   * replaces the mapping's instance with a fresh copy while the stale twin stays referenced by
+   * its old neighbours. Following such a stale twin resurrects removed subtrees: a
+   * {@code PostOrderAxis} walk then computes node keys that no longer resolve
+   * ("Failed to move to nodeKey: N", issue #1099). The identity check against the mapping
+   * degrades those cases to the authoritative {@link #moveTo(long)} path; in read-only readers
+   * the mapping and the reference graph hold the same instances, so the fast path still always
+   * hits there.
+   *
+   * <p>During construction ({@code init}) the mapping is still being populated from the very
+   * instances being wired, so the reference is trusted as before.
+   *
+   * @param target      the in-memory referenced instance (may be {@code null})
+   * @param expectedKey the node key the structural pointer of the current node names
+   * @return {@code true} if the cursor moved to {@code target}
+   */
+  private boolean moveToInMemoryInstance(final @Nullable PathNode target, final long expectedKey) {
+    if (target == null || target.getNodeKey() != expectedKey) {
+      return false;
+    }
+    if (!init) {
+      final long key = target.getNodeKey();
+      if (key < 0 || key >= pathNodeMapping.length || pathNodeMapping[(int) key] != target) {
+        return false;
+      }
+    }
+    currentNode = target;
+    return true;
+  }
+
   @Override
   public boolean moveToParent() {
     assertNotClosed();
-    if (!getStructuralNode().hasParent()) {
+    final StructNode node = getStructuralNode();
+    if (!node.hasParent()) {
       return false;
     }
-    final var node = getStructuralNode();
-    if (node instanceof PathNode pathNode && pathNode.getParent() != null) {
-      currentNode = pathNode.getParent();
+    if (node instanceof PathNode pathNode
+        && moveToInMemoryInstance(pathNode.getParent(), pathNode.getParentKey())) {
       return true;
     }
-    return moveTo(getStructuralNode().getParentKey());
+    return moveTo(node.getParentKey());
   }
 
   @Override
   public boolean moveToFirstChild() {
     assertNotClosed();
-    if (!getStructuralNode().hasFirstChild()) {
+    final StructNode node = getStructuralNode();
+    if (!node.hasFirstChild()) {
       return false;
     }
-    final var node = getStructuralNode();
-    if (node instanceof PathNode pathNode && pathNode.getFirstChild() != null) {
-      currentNode = pathNode.getFirstChild();
+    if (node instanceof PathNode pathNode
+        && moveToInMemoryInstance(pathNode.getFirstChild(), pathNode.getFirstChildKey())) {
       return true;
     }
-    return moveTo(getStructuralNode().getFirstChildKey());
+    return moveTo(node.getFirstChildKey());
   }
 
   @Override
   public boolean moveToLeftSibling() {
     assertNotClosed();
-    if (!getStructuralNode().hasLeftSibling()) {
+    final StructNode node = getStructuralNode();
+    if (!node.hasLeftSibling()) {
       return false;
     }
-    final var node = getStructuralNode();
-    if (node instanceof PathNode pathNode && pathNode.getLeftSibling() != null) {
-      currentNode = pathNode.getLeftSibling();
+    if (node instanceof PathNode pathNode
+        && moveToInMemoryInstance(pathNode.getLeftSibling(), pathNode.getLeftSiblingKey())) {
       return true;
     }
-    return moveTo(getStructuralNode().getLeftSiblingKey());
+    return moveTo(node.getLeftSiblingKey());
   }
 
   @Override
   public boolean moveToRightSibling() {
     assertNotClosed();
-    if (!getStructuralNode().hasRightSibling()) {
+    final StructNode node = getStructuralNode();
+    if (!node.hasRightSibling()) {
       return false;
     }
-    final var node = getStructuralNode();
-    if (node instanceof PathNode pathNode && pathNode.getRightSibling() != null) {
-      currentNode = pathNode.getRightSibling();
+    if (node instanceof PathNode pathNode
+        && moveToInMemoryInstance(pathNode.getRightSibling(), pathNode.getRightSiblingKey())) {
       return true;
     }
-    return moveTo(getStructuralNode().getRightSiblingKey());
+    return moveTo(node.getRightSiblingKey());
   }
 
   @Override

--- a/bundles/sirix-core/src/test/java/io/sirix/property/Issue1099ReproTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/Issue1099ReproTest.java
@@ -1,0 +1,188 @@
+package io.sirix.property;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.trx.node.json.objectvalue.ArrayValue;
+import io.sirix.access.trx.node.json.objectvalue.NullValue;
+import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.node.NodeKind;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regression test for issue #1099 (found by the model-based oracle, seed 1207632449600).
+ *
+ * <p>Removing an array element whose subtree holds the only references to nested
+ * {@code __array__} path-summary entries removes those entries and fixes up the neighbouring
+ * records — but the fix-ups go through {@code prepareRecordForModification}, which installs
+ * fresh copies in the reader's node mapping while the stale twins stay wired into the
+ * in-memory parent/child/sibling references created at bulk-load. A subsequent
+ * {@code removeField} in the SAME transaction walked those stale references
+ * ({@code PathSummaryReader.moveToFirstChild} fast path), resurrected the removed
+ * {@code __array__} entry, and crashed with "Failed to move to nodeKey: N".
+ *
+ * <p>The distilled sequence needs: a field whose array gains a nested array in a later
+ * revision than the field itself, removal of that array element, then removal of the field —
+ * all without an intervening commit after the element removal.
+ */
+final class Issue1099ReproTest {
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  void removeFieldAfterNestedArrayElementRemovalInSameTransaction() {
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      wtx.insertObjectAsFirstChild();
+      wtx.commit();
+
+      // Churn on removed-and-recreated fields, mirroring the oracle sequence: exercises the
+      // path-summary remove/recreate machinery before the interesting revisions.
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsLastChild("k5109", new ArrayValue());
+      toRootObject(wtx);
+      moveToRecord(wtx, "k5109");
+      wtx.remove();
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsLastChild("k1208", new StringValue(""));
+      toRootObject(wtx);
+      moveToRecord(wtx, "k1208");
+      wtx.remove();
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsFirstChild("k2859", new NullValue());
+      wtx.commit();
+
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsLastChild("k6479", new NullValue());
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsLastChild("k3139", new ArrayValue());
+      wtx.commit();
+
+      // Build [[]] under k3139 across this revision: the inner arrays create the nested
+      // __array__ path-summary entries the later removal must clean up.
+      toRootObject(wtx);
+      moveToRecord(wtx, "k3139");
+      wtx.insertArrayAsFirstChild();
+      toRootObject(wtx);
+      moveToRecord(wtx, "k3139");
+      moveToChild(wtx, 0);
+      wtx.insertArrayAsFirstChild();
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsFirstChild("k2239", new StringValue("aizjotz"));
+      wtx.commit();
+
+      // Remove the array element (with its nested array), then every field — in ONE
+      // transaction. Before the fix, removing k3139 crashed with
+      // "Failed to move to nodeKey: 9" inside PathSummaryWriter.removePathSummaryNode.
+      toRootObject(wtx);
+      moveToRecord(wtx, "k3139");
+      moveToChild(wtx, 0);
+      wtx.remove();
+
+      for (final String key : new String[] {"k2239", "k2859", "k6479", "k3139"}) {
+        toRootObject(wtx);
+        moveToRecord(wtx, key);
+        wtx.remove();
+      }
+      wtx.commit();
+
+      toRootObject(wtx);
+      assertTrue(!wtx.hasFirstChild(), "root object must be empty after removing all fields");
+    }
+  }
+
+  /**
+   * Removing an array element that is itself an array must decrement the removed subtree
+   * ROOT's {@code __array__} path-summary entry too — the PostOrderAxis removal loop covers
+   * only descendants, so before the fix the root's entry leaked with a reference count no
+   * document node backs.
+   */
+  @Test
+  void removingNestedArrayElementReleasesItsArrayPathEntry() {
+    try (final var database = JsonTestHelper.getDatabaseWithHashesEnabled(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx wtx = session.beginNodeTrx()) {
+
+      wtx.insertObjectAsFirstChild();
+      wtx.commit();
+
+      // {"field": [[[]]]} — three __array__ path levels: field's own layer + two nested.
+      toRootObject(wtx);
+      wtx.insertObjectRecordAsLastChild("field", new ArrayValue());
+      toRootObject(wtx);
+      moveToRecord(wtx, "field");
+      wtx.insertArrayAsFirstChild();
+      wtx.insertArrayAsFirstChild();
+      wtx.commit();
+      assertEquals(3, countArrayPathEntries(session), "three nested array layers expected");
+
+      // Remove the outer element (an array containing an array): both nested layers must go;
+      // only the field's own __array__ layer stays (still referenced by the field itself).
+      toRootObject(wtx);
+      moveToRecord(wtx, "field");
+      moveToChild(wtx, 0);
+      wtx.remove();
+      wtx.commit();
+      assertEquals(1, countArrayPathEntries(session),
+          "removed nested arrays must release their __array__ path-summary entries");
+    }
+  }
+
+  private static int countArrayPathEntries(final JsonResourceSession session) {
+    try (final PathSummaryReader summary = session.openPathSummary()) {
+      summary.moveToDocumentRoot();
+      int count = 0;
+      for (final var axis = new DescendantAxis(summary); axis.hasNext();) {
+        axis.nextLong();
+        if (summary.getName() != null && "__array__".equals(summary.getName().getLocalName())) {
+          count++;
+        }
+      }
+      return count;
+    }
+  }
+
+  private static void toRootObject(final JsonNodeTrx wtx) {
+    wtx.moveToDocumentRoot();
+    assertTrue(wtx.moveToFirstChild(), "document root must have a child");
+  }
+
+  private static void moveToRecord(final JsonNodeTrx wtx, final String key) {
+    assertTrue(wtx.moveToFirstChild(), "object must have children when looking up key '" + key + "'");
+    while (true) {
+      final NodeKind kind = wtx.getKind();
+      if (kind.playsObjectKeyRole() && key.equals(wtx.getName().getLocalName())) {
+        return;
+      }
+      if (!wtx.moveToRightSibling()) {
+        fail("record '" + key + "' not found in object");
+      }
+    }
+  }
+
+  private static void moveToChild(final JsonNodeTrx wtx, final int index) {
+    assertTrue(wtx.moveToFirstChild(), "container must have children");
+    for (int i = 0; i < index; i++) {
+      assertTrue(wtx.moveToRightSibling(), "container must have a child at index " + index);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/property/JsonModelBasedOracleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/JsonModelBasedOracleTest.java
@@ -29,7 +29,7 @@ final class JsonModelBasedOracleTest {
 
   /** Fixed seeds so every CI run replays known operation sequences deterministically. */
   @ParameterizedTest
-  @ValueSource(longs = {1L, 42L, 4711L, 987654321L, -1348769044L})
+  @ValueSource(longs = {1L, 42L, 4711L, 987654321L, -1348769044L, 1207632449600L})
   void fixedSeedOperationSequenceMatchesOracle(final long seed) {
     JsonModelOracleHarness.runOracle(seed);
   }


### PR DESCRIPTION
Fixes #1099.

## The failure

The model-based oracle (seed `1207632449600`, first seen on the Windows CI lane, reproduced identically on Linux) found `removeField` crashing with `IllegalStateException: Failed to move to nodeKey: N` inside `PathSummaryWriter.removePathSummaryNode` whenever a nested array element had been removed earlier **in the same transaction**. An intervening commit made the crash disappear, which pointed at in-memory state rather than the persisted records — the pages were always correct.

## Root cause (two defects)

**1. Stale in-memory reference graph (the crash).** `PathSummaryReader` wires direct `PathNode` → `PathNode` parent/child/sibling **object references** once, at bulk-load (`LevelOrderSettingInMemoryInstancesAxis`). `PathSummaryWriter` mutations never rewire them: every structural fix-up goes through `prepareRecordForModification`, which installs a *fresh copy* in `pathNodeMapping` while the stale twin stays referenced by its old neighbours. The cursor's `moveToFirstChild` / `moveToRightSibling` / `moveToParent` / `moveToLeftSibling` fast paths followed those references unconditionally — so a later walk descended into an already-removed `__array__` entry and computed a node key that no longer resolves.

Fix: follow an in-memory reference only when it (a) carries the node key the structural pointer names and (b) **is** the instance `pathNodeMapping` currently holds for that key. Read-only readers always pass both checks (their mapping and reference graph hold the same instances), so the fast path is fully preserved where it matters; in write transactions any stale twin degrades to the authoritative `moveTo` — an array load and two compares.

**2. Leaked `__array__` reference count.** The `PostOrderAxis` removal loop in `JsonNodeTrxImpl.remove` covers only **descendants**; a removed subtree whose *root* is a plain `ARRAY` (exactly the `removeArrayElement`-of-a-nested-array case) never released its own `__array__` path entry — it stayed alive with a reference count no document node backs, and its stale record was what the later walk tripped over. Fix: call `removeArrayPathEntry()` for the subtree root too (also fires the matching PATH-index DELETE the insert side always registered).

## Tests

- `Issue1099ReproTest` (new): the distilled crash sequence and a leak assertion. Both scenarios verified to fail without their respective fix (`expected: <1> but was: <2>` for the leak; the original `IllegalStateException` for the crash).
- Seed `1207632449600` promoted to `JsonModelBasedOracleTest`'s fixed-seed list per the harness convention, so every CI run replays the full 17-op sequence.
- Full `io.sirix.property.*` and all path-summary suites green locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_