### PR TITLE
Fix RevisionEpochTracker poisoning on double-deregister

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/RevisionEpochTracker.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/RevisionEpochTracker.java
@@ -35,12 +35,12 @@ import java.lang.invoke.VarHandle;
  *
  * <h2>Memory ordering</h2>
  * <p>{@code register} writes the packed state via {@link VarHandle#setVolatile} <em>after</em>
- * popping the index under the lock; {@code deregister} writes {@code 0L} via
- * {@code setVolatile} <em>before</em> pushing the index back. {@code minActiveRevision}
- * reads each slot via {@link VarHandle#getVolatile}. The volatile write/read pair establishes
- * happens-before from the registering transaction's revision assignment to any subsequent
- * sweeper observation, which is the safety the eviction watermark requires (see
- * docs/formal-verification.md, Inv 8).
+ * popping the index under the lock; {@code deregister} clears the active bit via a
+ * {@code compareAndSet} (which also rejects stale tickets — see {@link #deregister})
+ * <em>before</em> pushing the index back. {@code minActiveRevision} reads each slot via
+ * {@link VarHandle#getVolatile}. The volatile write/read pair establishes happens-before from
+ * the registering transaction's revision assignment to any subsequent sweeper observation,
+ * which is the safety the eviction watermark requires (see docs/formal-verification.md, Inv 8).
  *
  * @author Johannes Lichtenberger
  */
@@ -59,19 +59,33 @@ public final class RevisionEpochTracker {
   /** Bit set in the packed state when the slot is active. The low 32 bits hold the revision. */
   private static final long ACTIVE_BIT = 1L << 63;
 
+  /**
+   * Bits 32..62 of the packed state hold a per-slot generation counter (31 bits, wraps).
+   * The generation is bumped on every {@link #register} and echoed in the returned
+   * {@link Ticket}, which makes {@link #deregister} ABA-safe: a stale ticket (double
+   * deregister, or a deregister racing a slot that was already released and re-registered)
+   * no longer matches the slot's current generation and is ignored instead of corrupting
+   * the free stack / clearing another transaction's slot (issue #1102).
+   */
+  private static final int GENERATION_SHIFT = 32;
+  private static final long GENERATION_MASK = 0x7FFF_FFFFL;
+
   /** Volatile-access handle for the slot-state array. */
   private static final VarHandle SLOT_VH = MethodHandles.arrayElementVarHandle(long[].class);
 
   /**
    * Ticket returned when registering a transaction. Used to deregister the transaction later in
-   * O(1). The slot index is final; one Ticket per register call — escape-analysis-friendly and,
-   * since the field is a final {@code int}, cheap to allocate.
+   * O(1). The fields are final; one Ticket per register call — escape-analysis-friendly and,
+   * since the fields are primitive, cheap to allocate. The generation binds the ticket to this
+   * specific registration of the slot, so stale tickets are rejected on deregistration.
    */
   public static final class Ticket {
     private final int slotIndex;
+    private final int generation;
 
-    private Ticket(int slotIndex) {
+    private Ticket(final int slotIndex, final int generation) {
       this.slotIndex = slotIndex;
+      this.generation = generation;
     }
 
     public int getSlotIndex() {
@@ -150,14 +164,25 @@ public final class RevisionEpochTracker {
         highWaterMark = active;
       }
     }
-    // Volatile write: bit 63 set (active) + revision in the low 32 bits. After this returns,
-    // any subsequent volatile read of the slot observes the active state with the right revision.
-    SLOT_VH.setVolatile(slotStates, slotIndex, ACTIVE_BIT | (revision & 0xFFFF_FFFFL));
-    return new Ticket(slotIndex);
+    // The slot is exclusively ours between pop and push-back, so a plain read of the retired
+    // generation is safe; bump it so tickets from earlier registrations of this slot go stale.
+    final long previousState = (long) SLOT_VH.getVolatile(slotStates, slotIndex);
+    final int generation = (int) (((previousState >>> GENERATION_SHIFT) + 1) & GENERATION_MASK);
+    // Volatile write: bit 63 set (active) + generation in bits 32..62 + revision in the low
+    // 32 bits. After this returns, any subsequent volatile read of the slot observes the
+    // active state with the right revision.
+    SLOT_VH.setVolatile(slotStates, slotIndex,
+        ACTIVE_BIT | ((long) generation << GENERATION_SHIFT) | (revision & 0xFFFF_FFFFL));
+    return new Ticket(slotIndex, generation);
   }
 
   /**
-   * Deregister a transaction.
+   * Deregister a transaction. Idempotent: a ticket that was already deregistered — or whose slot
+   * has since been released and handed to another transaction — no longer matches the slot's
+   * current generation and is ignored. Before this ABA guard existed, a double-deregister pushed
+   * the slot index onto an already-full free stack; the failed store still incremented
+   * {@code freeTop} (the index expression is evaluated before the bounds check), permanently
+   * poisoning the tracker so every later {@link #register} threw (issue #1102).
    *
    * @param ticket the ticket from registration
    */
@@ -167,8 +192,29 @@ public final class RevisionEpochTracker {
     }
     // Clear the slot first so a concurrent minActiveRevision can no longer see it as active —
     // we only re-push the index onto the free stack after the volatile clear has been published.
-    SLOT_VH.setVolatile(slotStates, ticket.slotIndex, 0L);
+    // CAS from the exact registered state: only the caller that actually owns this registration
+    // (active bit set, matching generation) wins the release; stale or duplicate tickets fail
+    // the compare and return without touching the free stack or another transaction's state.
+    final long expectedActiveState = (long) SLOT_VH.getVolatile(slotStates, ticket.slotIndex);
+    if ((expectedActiveState & ACTIVE_BIT) == 0L
+        || (int) ((expectedActiveState >>> GENERATION_SHIFT) & GENERATION_MASK) != ticket.generation) {
+      return;
+    }
+    // Release keeps the generation (inactive), so the next register of this slot still bumps
+    // past every ticket ever issued for it.
+    final long releasedState = expectedActiveState & ~ACTIVE_BIT & ~0xFFFF_FFFFL;
+    if (!SLOT_VH.compareAndSet(slotStates, ticket.slotIndex, expectedActiveState, releasedState)) {
+      return;
+    }
     synchronized (lock) {
+      // Defense in depth: never mutate freeTop past capacity even if an invariant breaks —
+      // a full stack here means a bug elsewhere, and corrupting the tracker would turn one
+      // bad close into a process-wide inability to open transactions.
+      if (freeTop == slotCount) {
+        throw new IllegalStateException(
+            "RevisionEpochTracker free stack overflow: slot " + ticket.slotIndex
+                + " released while all " + slotCount + " slots are already free");
+      }
       freeStack[freeTop++] = ticket.slotIndex;
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -53,6 +53,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.UncheckedIOException;
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
@@ -105,6 +107,27 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
    * Tracks whether the transaction is closed.
    */
   private volatile boolean isClosed;
+
+  /**
+   * One-shot latch making {@link #close()} run exactly once. {@link #isClosed} is only set at
+   * the END of the close body (so {@code assertNotClosed} stays quiet during cleanup), which
+   * used to let a concurrent or reentrant second close pass the {@code !isClosed} check and
+   * close the underlying {@code StorageEngineReader} twice — double-deregistering its
+   * epoch-tracker ticket (issue #1102). CASed 0 → 1 on entry; losers return immediately.
+   */
+  @SuppressWarnings("unused")
+  private volatile int closeInitiated;
+
+  private static final VarHandle CLOSE_INITIATED_VH;
+
+  static {
+    try {
+      CLOSE_INITIATED_VH =
+          MethodHandles.lookup().findVarHandle(AbstractNodeReadOnlyTrx.class, "closeInitiated", int.class);
+    } catch (final ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
 
   /**
    * Read-transaction-exclusive item list.
@@ -1482,6 +1505,9 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
 
   @Override
   public void close() {
+    if (!CLOSE_INITIATED_VH.compareAndSet(this, 0, 1)) {
+      return;
+    }
     if (!isClosed) {
       // Release page guard first to allow page eviction.
       releaseCurrentPageGuard();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -79,6 +79,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -131,6 +133,27 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * Determines if page reading transaction is closed or not.
    */
   private volatile boolean isClosed;
+
+  /**
+   * One-shot latch making {@link #close()} run exactly once. {@link #isClosed} is only set at
+   * the END of the close body (so {@code assertNotClosed} guards stay quiet during cleanup),
+   * which used to let a concurrent or reentrant second close pass the {@code !isClosed} check
+   * and deregister the epoch-tracker ticket twice — poisoning the process-wide tracker
+   * (issue #1102). CASed 0 → 1 on entry; losers return immediately.
+   */
+  @SuppressWarnings("unused")
+  private volatile int closeInitiated;
+
+  private static final VarHandle CLOSE_INITIATED_VH;
+
+  static {
+    try {
+      CLOSE_INITIATED_VH =
+          MethodHandles.lookup().findVarHandle(NodeStorageEngineReader.class, "closeInitiated", int.class);
+    } catch (final ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
 
   /**
    * {@link ResourceConfiguration} instance.
@@ -1670,6 +1693,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
   @Override
   public void close() {
+    if (!CLOSE_INITIATED_VH.compareAndSet(this, 0, 1)) {
+      return;
+    }
     if (!isClosed) {
       // Close current page guard
       closeCurrentPageGuard();

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/RevisionEpochTrackerTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/RevisionEpochTrackerTest.java
@@ -94,6 +94,54 @@ final class RevisionEpochTrackerTest {
     tracker.register(2);
   }
 
+  /**
+   * Issue #1102: a double-deregister with a full free stack incremented {@code freeTop} past
+   * capacity (the failed array store evaluates the index expression first), permanently
+   * poisoning the tracker — every later register threw ArrayIndexOutOfBoundsException.
+   * Deregistration must be idempotent instead.
+   */
+  @Test
+  void deregister_sameTicketTwice_isIdempotentAndPreservesCapacity() {
+    final RevisionEpochTracker tracker = new RevisionEpochTracker(4);
+    final RevisionEpochTracker.Ticket ticket = tracker.register(7);
+    tracker.deregister(ticket);
+    tracker.deregister(ticket); // pre-fix: poisoned the free stack when it was full
+    // Full capacity must still be available and register must not throw AIOOBE.
+    final List<RevisionEpochTracker.Ticket> tickets = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      tickets.add(tracker.register(i));
+    }
+    assertThrows(IllegalStateException.class, () -> tracker.register(0));
+    tickets.forEach(tracker::deregister);
+  }
+
+  /**
+   * Issue #1102 (ABA variant): a stale ticket whose slot was released and re-registered by
+   * another transaction must not clear the new registration's active state or re-push the
+   * slot index.
+   */
+  @Test
+  void deregister_staleTicketAfterSlotReuse_doesNotAffectNewRegistration() {
+    final RevisionEpochTracker tracker = new RevisionEpochTracker(1);
+    tracker.setLastCommittedRevision(99);
+
+    final RevisionEpochTracker.Ticket stale = tracker.register(5);
+    tracker.deregister(stale);
+
+    final RevisionEpochTracker.Ticket current = tracker.register(42);
+    // The single slot is reused; the stale ticket must be rejected.
+    tracker.deregister(stale);
+    assertEquals(42, tracker.minActiveRevision(),
+        "stale deregister must not clear the current registration");
+    // The slot must NOT have been pushed back: capacity 1 is in use, register must throw.
+    assertThrows(IllegalStateException.class, () -> tracker.register(0));
+
+    tracker.deregister(current);
+    assertEquals(99, tracker.minActiveRevision());
+    // And now the slot is usable again.
+    tracker.deregister(tracker.register(1));
+  }
+
   @Test
   void defaultSlotCount_returnsSensibleHeadroom() {
     // Sanity: the default needs to be much larger than the previous 4096 cap so a normal soak


### PR DESCRIPTION
Fixes #1102.

## The failure

On the macOS lane of PR #1100, a double-close in the prefetcher lifecycle teardown deregistered the same epoch-tracker ticket twice. `deregister` pushes with `freeStack[freeTop++] = slot` — when the free stack is already full, the store throws `ArrayIndexOutOfBoundsException`, **but the index expression has already incremented `freeTop` past capacity**, permanently poisoning the process-wide tracker: every later `register` throws AIOOBE at `freeStack[--freeTop]` and no transaction can be opened. In the CI JVM this cascaded through arbitrary later tests.

## Fixes (three layers)

1. **`RevisionEpochTracker` — ABA-safe, idempotent deregistration.** Tickets now carry a per-slot generation, packed into the spare bits 32–62 of the existing slot-state `long` (no extra memory; `minActiveRevision`'s sweep still does one volatile read per slot). `deregister` CASes the exact registered state (active bit + generation) to inactive — a stale or duplicate ticket fails the compare and returns without touching the free stack or another transaction's slot. The stack push also check-then-throws instead of mutating `freeTop` on an impossible overflow.

2. **`NodeStorageEngineReader.close()` — close-once.** The `!isClosed` guard only flips at the *end* of the close body (deliberately, so `assertNotClosed` stays quiet during cleanup), which let a concurrent or reentrant second close run the entire cleanup — including the ticket deregistration — twice. A CAS one-shot latch at entry makes close run exactly once, leaving the `isClosed` semantics untouched.

3. **`AbstractNodeReadOnlyTrx.close()`** — same pattern, same fix; this is the path `Holder.close()` → session close → rtx close takes.

## Tests

- `deregister_sameTicketTwice_isIdempotentAndPreservesCapacity` — the exact poisoning scenario.
- `deregister_staleTicketAfterSlotReuse_doesNotAffectNewRegistration` — the ABA variant: a stale ticket must not clear another transaction's registration or double-free the slot.
- Both verified to FAIL against the previous implementation and pass now; the existing tracker suite (including the concurrent-load and watermark-safety tests) stays green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_