### PR TITLE
Release the LZ4 decompression buffer on every failure path

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
@@ -573,19 +573,22 @@ public final class FFILz4Compressor implements ByteHandler {
       MemorySegment.copy(compressed, 0, nativeCompressed, 0, compressed.byteSize());
     }
 
+    // Ownership of the allocator-owned buffer transfers to the returned DecompressionResult
+    // only on success; EVERY failure path — including the native MethodHandle invocation itself
+    // throwing — must release it exactly once, or repeated corrupt reads drain the frame-slot
+    // budget into an OutOfMemoryError (issue #1074).
+    boolean ownershipTransferred = false;
     try {
       int actualSize;
       if (USE_FAST_DECOMPRESS) {
         int bytesRead = decompressSegmentFast(nativeCompressed.asSlice(4), buffer, decompressedSize);
         if (bytesRead < 0) {
-          ALLOCATOR.release(buffer);
           throw new RuntimeException("LZ4 fast decompression failed: " + bytesRead);
         }
         actualSize = decompressedSize;
       } else {
         actualSize = decompressSegment(nativeCompressed.asSlice(4), buffer, (int) nativeCompressed.byteSize() - 4);
         if (actualSize < 0) {
-          ALLOCATOR.release(buffer);
           throw new RuntimeException("LZ4 decompression failed: " + actualSize);
         }
       }
@@ -593,16 +596,20 @@ public final class FFILz4Compressor implements ByteHandler {
       if (actualSize != decompressedSize) {
         // A size mismatch IS corruption — returning a truncated slice with only a WARN let the
         // wrong-size page proceed into deserialization.
-        ALLOCATOR.release(buffer);
         throw new io.sirix.exception.SirixIOException(
             "Corrupt compressed page: declared decompressed size " + decompressedSize + " but got " + actualSize);
       }
 
       final MemorySegment backingBuffer = buffer;
-      return new DecompressionResult(buffer.asSlice(0, actualSize), backingBuffer,
+      final DecompressionResult result = new DecompressionResult(buffer.asSlice(0, actualSize), backingBuffer,
           () -> ALLOCATOR.release(backingBuffer),
           new java.util.concurrent.atomic.AtomicBoolean(false));
+      ownershipTransferred = true;
+      return result;
     } finally {
+      if (!ownershipTransferred) {
+        ALLOCATOR.release(buffer);
+      }
       if (tempArena != null) {
         tempArena.close();
       }


### PR DESCRIPTION
Fixes #1074.

## Status of the five audit items

Four of the five findings are already fixed on current `main` (verified at each cited location):

1. **ByteHandlerPipeline release-on-throw** — the multi-handler loop already releases the previous handler's buffer in a `catch` before rethrowing. The `FFILz4Compressor` half of this item was still open — fixed here (see below).
2. **ConcurrentAxis interrupt swallow** — `nextKey()` already restores the interrupt flag and throws `SirixThreadedException` instead of silently truncating.
3. **EditScript** — `hasNext()` already uses `mIndex < mChanges.size()`.
4. **FMSE cursor restore** — both the attribute and namespace inner loops already restore `wtx` to the element after matching.
5. **JSON moveSubtree diff tuples** — both move paths already call `adaptUpdateOperationsForMove`.

## The remaining gap, fixed here

`FFILz4Compressor.decompressScoped` released its allocator-owned output buffer on the explicit error returns (negative return code, size mismatch) but **leaked it when the native `MethodHandle` invocation itself threw** — the `finally` block only closed the temp arena. Repeated corrupt reads on that path drain the frame-slot budget into an `OutOfMemoryError`.

Restructured to an ownership-transfer pattern: the buffer is released exactly once in `finally` unless ownership passed to the returned `DecompressionResult` — covering every failure path (explicit throws, native invocation errors) with no double-release.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_