### PR TITLE
Divert oversized flyweight values to overflow pages instead of crashing the commit

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
@@ -131,6 +131,13 @@ public final class ObjectNamedStringNode
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_STRING_FIELD_COUNT;
 
+  /**
+   * Upper bound on the serialized size of everything except the string payload: kind byte +
+   * {@link #FIELD_COUNT}-byte offset table + seven delta varints (≤ 9 bytes each) + 8-byte hash
+   * + compressed flag + payload-length varint. Used by {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 80;
+
   public ObjectNamedStringNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
@@ -377,6 +384,18 @@ public final class ObjectNamedStringNode
 
   public int[] getHeapOffsets() {
     return heapOffsets;
+  }
+
+  @Override
+  public int estimateSerializedSize() {
+    // Without this override the FlyweightNode default of 256 bytes let a large string value
+    // sail past KeyValueLeafPage#serializeToHeap's capacity check and blow the slotted-page
+    // segment mid-write (issue #1076).
+    if (!valueParsed) {
+      parseValueField();
+    }
+    final int payloadLen = value != null ? value.length : 0;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
@@ -129,6 +129,13 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
   private static final int FIELD_COUNT = NodeFieldLayout.STRING_VALUE_FIELD_COUNT;
 
   /**
+   * Upper bound on the serialized size of everything except the value payload (kind byte +
+   * offset table + delta varints + hash + flags + payload-length varint). Used by
+   * {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 55;
+
+  /**
    * Constructor for flyweight binding.
    * All fields except nodeKey and hashFunction will be read from page memory after bind().
    *
@@ -267,7 +274,7 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
   @Override
   public int estimateSerializedSize() {
     final int payloadLen = value != null ? value.length : 0;
-    return 55 + payloadLen;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   // ==================== FLYWEIGHT FIELD READ HELPERS ====================

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
@@ -100,6 +100,13 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
   private static final int FIELD_COUNT = NodeFieldLayout.ATTRIBUTE_FIELD_COUNT;
 
   /**
+   * Upper bound on the serialized size of everything except the value payload (kind byte +
+   * offset table + delta varints + hash + flags + payload-length varint). Used by
+   * {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 55;
+
+  /**
    * Constructor for flyweight binding.
    * All fields except nodeKey and hashFunction will be read from page memory after bind().
    *
@@ -598,7 +605,7 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
   @Override
   public int estimateSerializedSize() {
     final int payloadLen = value != null ? value.length : 0;
-    return 55 + payloadLen;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   // ==================== FLYWEIGHT FIELD READ HELPERS ====================

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
@@ -107,6 +107,13 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   private static final int FIELD_COUNT = NodeFieldLayout.COMMENT_FIELD_COUNT;
 
   /**
+   * Upper bound on the serialized size of everything except the value payload (kind byte +
+   * offset table + delta varints + hash + flags + payload-length varint). Used by
+   * {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 55;
+
+  /**
    * Constructor for flyweight binding.
    * All fields except nodeKey and hashFunction will be read from page memory after bind().
    *
@@ -219,7 +226,7 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   @Override
   public int estimateSerializedSize() {
     final int payloadLen = value != null ? value.length : 0;
-    return 55 + payloadLen;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   // ==================== FLYWEIGHT FIELD READ HELPERS ====================

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
@@ -94,6 +94,13 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
   private long descendantCount;
   private long hash;
 
+  /**
+   * Upper bound on the serialized size of everything except the value payload (kind byte +
+   * offset table + delta varints + hash + flags + payload-length varint). Used by
+   * {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 119;
+
   // === VALUE FIELD ===
   private byte[] value;
   private boolean isCompressed;
@@ -297,7 +304,7 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
   @Override
   public int estimateSerializedSize() {
     final int payloadLen = value != null ? value.length : 0;
-    return 119 + payloadLen;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   // ==================== FLYWEIGHT FIELD READ HELPERS ====================

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
@@ -112,6 +112,13 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   private static final int FIELD_COUNT = NodeFieldLayout.TEXT_FIELD_COUNT;
 
   /**
+   * Upper bound on the serialized size of everything except the value payload (kind byte +
+   * offset table + delta varints + hash + flags + payload-length varint). Used by
+   * {@link #estimateSerializedSize()}.
+   */
+  private static final int SERIALIZED_METADATA_UPPER_BOUND = 55;
+
+  /**
    * Constructor for flyweight binding.
    * All fields except nodeKey and hashFunction will be read from page memory after bind().
    *
@@ -231,7 +238,7 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   @Override
   public int estimateSerializedSize() {
     final int payloadLen = value != null ? value.length : 0;
-    return 55 + payloadLen;
+    return SERIALIZED_METADATA_UPPER_BOUND + payloadLen;
   }
 
   // ==================== FLYWEIGHT FIELD READ HELPERS ====================

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -766,7 +766,16 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
 
     // Write directly to heap at current end
     final long absOffset = PageLayout.heapAbsoluteOffset(heapEnd);
-    final int recordBytes = fn.serializeToHeap(slottedPage, absOffset);
+    final int recordBytes;
+    try {
+      recordBytes = fn.serializeToHeap(slottedPage, absOffset);
+    } catch (final IndexOutOfBoundsException e) {
+      // A node type with an inaccurate estimateSerializedSize() outgrew the segment mid-write.
+      // Nothing past this point ran, so heapEnd/directory/bitmap are untouched and the partial
+      // bytes sit in unclaimed heap space — safe to divert the record to an OverflowPage
+      // instead of failing the commit (issue #1076).
+      return false;
+    }
 
     // When DeweyIDs are stored, append DeweyID data + 2-byte trailer
     final int totalBytes;

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/LargeRecordRoundTripTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/LargeRecordRoundTripTest.java
@@ -1,0 +1,78 @@
+package io.sirix.access.node.json;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.Databases;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for issue #1076: values whose serialized size exceeds
+ * {@code PageConstants.MAX_RECORD_SIZE} (150,000 bytes) must round-trip through commit —
+ * originally they were silently lost (the in-memory OverflowPage was never written); after the
+ * overflow write path landed, values beyond the ~512 KB slot cap still failed in
+ * {@code growSlottedPage} instead of diverting to an OverflowPage.
+ */
+final class LargeRecordRoundTripTest {
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    // Multi-megabyte values leave outsized pages in the global buffer caches; drop them so
+    // later test classes in the same JVM start from a clean slate (same pattern as the HOT
+    // stress suites).
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  private static String repeat(final char c, final int count) {
+    return String.valueOf(c).repeat(count);
+  }
+
+  private void roundTrip(final int valueLength) {
+    final String bigValue = repeat('x', valueLength);
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE)) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"big\":\"" + bigValue + "\",\"marker\":42}"));
+        wtx.commit();
+      }
+      try (final var rtx = session.beginNodeReadOnlyTrx()) {
+        rtx.moveToDocumentRoot();
+        assertTrue(rtx.moveToFirstChild(), "document must have a root object");
+        assertTrue(rtx.moveToFirstChild(), "object must have the 'big' field");
+        assertEquals("big", rtx.getName().getLocalName());
+        final String stored = rtx.getValue();
+        assertEquals(valueLength, stored.length(), "stored value truncated or lost");
+        assertEquals(bigValue, stored, "stored value corrupted");
+      }
+    }
+  }
+
+  @Test
+  void roundTrip200KbValue_overMaxRecordSize() {
+    roundTrip(200_000);
+  }
+
+  @Test
+  void roundTrip600KbValue_overSlotCap() {
+    roundTrip(600_000);
+  }
+
+  @Test
+  void roundTrip2MbValue() {
+    roundTrip(2_000_000);
+  }
+}


### PR DESCRIPTION
Fixes #1076.

## Where the issue stood

The original silent-loss defect (in-memory `OverflowPage` never written, reference key frozen at `-1`) is already fixed on `main` — a 200 KB value round-trips fine. What remained is the retitled residual: **values beyond the largest slotted-page size class (~512 KB heap) crashed the commit** instead of diverting to an overflow page:

```
java.lang.IndexOutOfBoundsException: Out of bound access on segment ...; byteSize: 262144; new length = 600000
	at io.sirix.node.json.ObjectNamedStringNode.writeNewRecord(...)
	at io.sirix.page.KeyValueLeafPage.serializeToHeap(...)
	at io.sirix.page.KeyValueLeafPage.processEntries(...)
```

## Root cause

`KeyValueLeafPage#serializeToHeap` sizes its capacity/grow/divert decision on `FlyweightNode.estimateSerializedSize()` — whose **interface default is 256 bytes**. Five of the six value-carrying flyweights override it; `ObjectNamedStringNode` (the fused object-field string — the most common way a large string enters a JSON resource) does not. The bogus 256-byte estimate passed the capacity check, `growSlottedPage` never ran (or stopped at the size-class cap without diverting), and the real multi-hundred-KB write blew the segment mid-commit.

## Fix

- `ObjectNamedStringNode.estimateSerializedSize()` override: metadata upper bound + payload length, matching the sibling value nodes. The previously inline metadata bounds (`55`, `119`) in those siblings are extracted into named `SERIALIZED_METADATA_UPPER_BOUND` constants across all six classes.
- Defense in depth in `serializeToHeap`: if a node type with an inaccurate estimate still outgrows the segment, the out-of-bounds write is caught and the record diverts to an `OverflowPage` instead of failing the commit. At that point `heapEnd`, the directory, and the bitmap are untouched and the partial bytes sit in unclaimed heap space, so the page stays consistent.

## Tests

`LargeRecordRoundTripTest`: 200 KB (over `MAX_RECORD_SIZE`, passed before — guards the original loss bug), 600 KB (over the slot cap — crashed before), 2 MB (crashed before). All three round-trip through commit and read back byte-identical. Serialization-heavy suites (`access.node.json`, `page`, `property` oracles, `service.json`) green across three consecutive runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_