### PR TITLE
Promote the cross-platform CI lanes to gating; drop the README experimental label

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -92,13 +92,12 @@ jobs:
     name: Cross-platform tests (${{ matrix.os }})
     needs: Build
     runs-on: ${{ matrix.os }}
-    # ADVISORY lanes: first-class, gating Linux coverage lives in the jobs above. These runs
-    # back the README's macOS/Windows claims with CI instead of hope, but stay non-blocking
-    # (continue-on-error) until they prove stable — a platform-specific failure must not block
-    # unrelated PRs. Once consistently green, drop continue-on-error and the README's
-    # "experimental" label together. The REST API module is excluded (needs Docker/Keycloak,
-    # unavailable on these runners), as are native-image builds.
-    continue-on-error: true
+    # GATING lanes since two consecutive fully-green matrices on main (runs 29148084844 and
+    # 29148832520, 2026-07-11) — the earlier flakiness was pre-existing engine races, fixed in
+    # #1101/#1103/#1104/#1105. These runs back the README's macOS/Windows claims. The REST API
+    # module is excluded (needs Docker/Keycloak, unavailable on these runners), as are
+    # native-image builds. If a lane turns flaky again, diagnose the race — don't quietly
+    # restore continue-on-error.
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -206,14 +206,14 @@ When you modify data:
 
 ## Quick Start
 
-> **Platform support:** Linux is the fully supported, CI-tested platform (native JVM,
-> native binaries, Docker). On **macOS and Windows** the supported path is **Docker**
-> (via Docker Desktop) — the REST server, CLI images, and the demo stack all work there.
-> Running the JVM natively on macOS or Windows is **experimental**: all platforms run
-> the same Umbra-style frame-slot allocator (platform-specific reserve/commit plumbing:
-> POSIX `mmap`, Windows `VirtualAlloc`), and advisory CI lanes run the core, query, and
-> Kotlin test suites on `macos-latest` and `windows-latest`. The experimental label
-> drops once those lanes are consistently green — reports from real hardware welcome.
+> **Platform support:** Linux, macOS, and Windows are CI-tested: gating lanes run the
+> core, query, and Kotlin test suites on `ubuntu-latest`, `macos-latest`, and
+> `windows-latest` on every pull request. All platforms run the same Umbra-style
+> frame-slot allocator (platform-specific reserve/commit plumbing: POSIX `mmap`,
+> Windows `VirtualAlloc`). Linux additionally gets native binaries and the Docker
+> images; on macOS and Windows both the native JVM and Docker (via Docker Desktop)
+> work. One known limitation: crash-recovery re-initialization with `MEMORY_MAPPED`
+> storage is unsupported on Windows (see `docs/KNOWN_LIMITATIONS.md`).
 
 ### Using the CLI (Native Binaries)
 


### PR DESCRIPTION
When the macOS/Windows lanes landed in #1098 they were explicitly advisory (`continue-on-error`), with the stated bar: *"Once consistently green, drop continue-on-error and the README's 'experimental' label together."*

That bar is now met: the last two main runs ([29148084844](https://github.com/sirixdb/sirix/actions/runs/29148084844), [29148832520](https://github.com/sirixdb/sirix/actions/runs/29148832520)) have **fully green macOS and Windows lanes** — the first consecutive both-green matrices. Every earlier lane failure traced to pre-existing engine races that are now fixed (#1099→#1101, #1102→#1103, plus #1104/#1105), not to platform-specific problems.

Changes:
- `gradle.yml`: remove `continue-on-error` from `TestPlatforms` — macOS/Windows failures now block PRs like Linux failures do, with a comment warning against quietly restoring advisory mode if flakiness returns.
- `README.md`: the platform note now states CI-backed support on all three platforms (native JVM + Docker on macOS/Windows), keeping the one documented Windows limitation (`MEMORY_MAPPED` crash-recovery re-initialization).

This PR gates itself: its own macOS and Windows lanes must pass for the checks to go green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5ozZZAjsF5qM6cbogLZp6)_