### PR TITLE
Fix optimizer walkers closing shared state, a per-commit writer FD leak, and per-reader channel growth

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -1251,6 +1251,14 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       secondMostRecentPageContainer = null;
       mostRecentPathSummaryPageContainer = null;
 
+      // Close the storage writer and its three file channels (data, SYNC revisions, DSYNC
+      // beacon). NOTHING else does: storageEngineReader.close() deliberately skips its
+      // pageReader for write transactions (trxIntentLog != null — the pageReader IS this
+      // writer), so omitting this leaked three descriptors per write transaction — every
+      // commit with KEEP_OPEN swaps in a fresh writer via createPageTransaction, growing FD
+      // usage without bound until the GC's channel cleaner happened to run.
+      storagePageReaderWriter.close();
+
       isClosed = true;
       // Tell the Cleaner-registered leak detector this writer closed cleanly so the
       // post-GC callback skips its warn-log.

--- a/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/StorageType.java
@@ -82,8 +82,15 @@ public enum StorageType {
       final AsyncCache<Integer, RevisionFileData> cache = getIntegerRevisionFileDataAsyncCache(resourceConf);
       final RevisionIndexHolder revisionIndexHolder = getRevisionIndexHolder(resourceConf);
       final var storage = new FileChannelStorage(resourceConf, cache, revisionIndexHolder);
-      storage.loadRevisionFileDataIntoMemory(cache);
-      storage.loadRevisionIndex(revisionIndexHolder);
+      try {
+        storage.loadRevisionFileDataIntoMemory(cache);
+        storage.loadRevisionIndex(revisionIndexHolder);
+      } catch (final RuntimeException e) {
+        // The pre-load readers borrow the storage's shared channels — release them before the
+        // half-initialized storage is abandoned, or the descriptors leak.
+        storage.close();
+        throw e;
+      }
       return storage;
     }
   },

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -47,6 +47,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * File Reader. Used for {@link StorageEngineReader} to provide read only access on a
@@ -73,11 +74,18 @@ public final class FileChannelReader extends AbstractReader {
   private final Cache<Integer, RevisionFileData> cache;
 
   /**
-   * Whether this reader owns its channels and must close them in {@link #close()}. Readers handed
-   * one of the storage's SHARED channel stripes (a small fixed pool per {@link FileChannelStorage},
-   * positional reads only) must NOT close it — the storage does on its own {@link IOStorage#close()}.
+   * Release action for a reader borrowing one of the storage's SHARED channel stripes (a small
+   * reference-counted pool per {@link FileChannelStorage}, positional reads only): instead of
+   * closing the channels, {@link #close()} runs this callback so the storage can close the pool
+   * once the LAST borrowing reader is gone. {@code null} means this reader owns its channels and
+   * closes them directly (writer delegate, {@code MMStorage}, recovery, test harnesses).
    */
-  private final boolean ownsChannels;
+  private final @Nullable Runnable releaseAction;
+
+  /**
+   * Guards against double-release: a reader must decrement the storage's borrow count exactly once.
+   */
+  private final AtomicBoolean closed = new AtomicBoolean();
 
   /**
    * Direct-ByteBuffer pool for page reads. Owning a buffer via
@@ -154,7 +162,7 @@ public final class FileChannelReader extends AbstractReader {
   public FileChannelReader(final FileChannel dataFileChannel, final FileChannel revisionsOffsetFileChannel,
       final ByteHandler handler, final SerializationType type, final PagePersister pagePersistenter,
       final Cache<Integer, RevisionFileData> cache) {
-    this(dataFileChannel, revisionsOffsetFileChannel, handler, type, pagePersistenter, cache, true);
+    this(dataFileChannel, revisionsOffsetFileChannel, handler, type, pagePersistenter, cache, null);
   }
 
   /**
@@ -163,17 +171,18 @@ public final class FileChannelReader extends AbstractReader {
    * @param dataFileChannel the data file channel
    * @param revisionsOffsetFileChannel the file, which holds pointers to the revision root pages
    * @param handler {@link ByteHandler} instance
-   * @param ownsChannels whether {@link #close()} closes the channels; pass {@code false} for
-   *        readers borrowing the storage's shared channels
+   * @param releaseAction run on {@link #close()} INSTEAD of closing the channels, for readers
+   *        borrowing the storage's shared channel stripes; {@code null} makes this reader own and
+   *        close its channels
    */
   public FileChannelReader(final FileChannel dataFileChannel, final FileChannel revisionsOffsetFileChannel,
       final ByteHandler handler, final SerializationType type, final PagePersister pagePersistenter,
-      final Cache<Integer, RevisionFileData> cache, final boolean ownsChannels) {
+      final Cache<Integer, RevisionFileData> cache, final @Nullable Runnable releaseAction) {
     super(handler, pagePersistenter, type);
     this.dataFileChannel = dataFileChannel;
     this.revisionsOffsetFileChannel = revisionsOffsetFileChannel;
     this.cache = cache;
-    this.ownsChannels = ownsChannels;
+    this.releaseAction = releaseAction;
   }
 
   /**
@@ -389,8 +398,13 @@ public final class FileChannelReader extends AbstractReader {
 
   @Override
   public void close() {
-    if (!ownsChannels) {
-      // Borrowed shared channels — the owning storage closes them.
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    if (releaseAction != null) {
+      // Borrowed shared channels — hand the borrow back; the storage closes the pool when the
+      // last borrower is gone.
+      releaseAction.run();
       return;
     }
     try {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -74,8 +74,8 @@ public final class FileChannelReader extends AbstractReader {
 
   /**
    * Whether this reader owns its channels and must close them in {@link #close()}. Readers handed
-   * the storage's SHARED channels (one pair per {@link FileChannelStorage}, positional reads only)
-   * must NOT close them — the storage does on its own {@link IOStorage#close()}.
+   * one of the storage's SHARED channel stripes (a small fixed pool per {@link FileChannelStorage},
+   * positional reads only) must NOT close it — the storage does on its own {@link IOStorage#close()}.
    */
   private final boolean ownsChannels;
 

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -73,6 +73,13 @@ public final class FileChannelReader extends AbstractReader {
   private final Cache<Integer, RevisionFileData> cache;
 
   /**
+   * Whether this reader owns its channels and must close them in {@link #close()}. Readers handed
+   * the storage's SHARED channels (one pair per {@link FileChannelStorage}, positional reads only)
+   * must NOT close them — the storage does on its own {@link IOStorage#close()}.
+   */
+  private final boolean ownsChannels;
+
+  /**
    * Direct-ByteBuffer pool for page reads. Owning a buffer via
    * {@link java.util.concurrent.ArrayBlockingQueue#poll} gives a thread exclusive use
    * without holding any shared monitor during the expensive decompress + deserialize
@@ -147,10 +154,26 @@ public final class FileChannelReader extends AbstractReader {
   public FileChannelReader(final FileChannel dataFileChannel, final FileChannel revisionsOffsetFileChannel,
       final ByteHandler handler, final SerializationType type, final PagePersister pagePersistenter,
       final Cache<Integer, RevisionFileData> cache) {
+    this(dataFileChannel, revisionsOffsetFileChannel, handler, type, pagePersistenter, cache, true);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param dataFileChannel the data file channel
+   * @param revisionsOffsetFileChannel the file, which holds pointers to the revision root pages
+   * @param handler {@link ByteHandler} instance
+   * @param ownsChannels whether {@link #close()} closes the channels; pass {@code false} for
+   *        readers borrowing the storage's shared channels
+   */
+  public FileChannelReader(final FileChannel dataFileChannel, final FileChannel revisionsOffsetFileChannel,
+      final ByteHandler handler, final SerializationType type, final PagePersister pagePersistenter,
+      final Cache<Integer, RevisionFileData> cache, final boolean ownsChannels) {
     super(handler, pagePersistenter, type);
     this.dataFileChannel = dataFileChannel;
     this.revisionsOffsetFileChannel = revisionsOffsetFileChannel;
     this.cache = cache;
+    this.ownsChannels = ownsChannels;
   }
 
   /**
@@ -366,6 +389,10 @@ public final class FileChannelReader extends AbstractReader {
 
   @Override
   public void close() {
+    if (!ownsChannels) {
+      // Borrowed shared channels — the owning storage closes them.
+      return;
+    }
     try {
       dataFileChannel.close();
       revisionsOffsetFileChannel.close();

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
@@ -19,6 +19,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Factory to provide file channel access as a backend.
@@ -58,24 +59,37 @@ public final class FileChannelStorage implements IOStorage {
   private final RevisionIndexHolder revisionIndexHolder;
 
   /**
-   * Lock guarding lazy open/close of the shared reader channels.
+   * Number of shared reader channel stripes per storage. {@link FileChannelReader} uses positional
+   * reads exclusively, which are lock-free in the JDK on POSIX (straight {@code pread(2)}), but on
+   * Windows {@code FileDispatcherImpl.needsPositionLock()} is {@code true} and every positional
+   * read on a channel serializes on that channel's position lock. A single shared channel would
+   * therefore serialize concurrent readers of the same resource on Windows. A small stripe pool
+   * keeps FD usage O(stripes) per storage (instead of O(open transactions) with per-reader
+   * channels, which exhausted the process FD limit under query-heavy workloads) while restoring
+   * uncontended reads for up to {@code stripes} concurrent readers.
+   */
+  private static final int READER_CHANNEL_STRIPES =
+      Math.max(1, Math.min(8, Runtime.getRuntime().availableProcessors()));
+
+  /**
+   * Lock guarding lazy open/close of the shared reader channel stripes.
    */
   private final Object readerChannelLock = new Object();
 
   /**
-   * Shared data file channel handed to every reader. {@link FileChannelReader} uses positional
-   * reads exclusively, so a single channel is safe under arbitrary reader concurrency. One pair of
-   * file descriptors per storage instead of one pair per reader: read-only transactions stay
-   * cached in their session until it closes, so per-reader channels grow FD usage linearly with
-   * the number of transactions ever opened and exhaust the process FD limit under query-heavy
-   * workloads.
+   * Round-robin stripe assignment for readers; each reader keeps its stripe for life.
    */
-  private volatile FileChannel sharedDataFileChannel;
+  private final AtomicInteger readerStripeCounter = new AtomicInteger();
 
   /**
-   * Shared revisions-offset file channel handed to every reader (see {@link #sharedDataFileChannel}).
+   * Shared data file channels handed to readers, one stripe picked per reader at creation.
    */
-  private volatile FileChannel sharedRevisionsOffsetFileChannel;
+  private volatile FileChannel[] sharedDataFileChannels;
+
+  /**
+   * Shared revisions-offset file channels (same striping as {@link #sharedDataFileChannels}).
+   */
+  private volatile FileChannel[] sharedRevisionsOffsetFileChannels;
 
   /**
    * Constructor.
@@ -118,16 +132,17 @@ public final class FileChannelStorage implements IOStorage {
   public Reader createReader() {
     try {
       validateSuperblocksOnce();
-      FileChannel dataFileChannel;
-      FileChannel revisionsOffsetFileChannel;
+      FileChannel[] dataFileChannels;
+      FileChannel[] revisionsOffsetFileChannels;
       do {
         ensureSharedReaderChannelsOpen();
-        dataFileChannel = sharedDataFileChannel;
-        revisionsOffsetFileChannel = sharedRevisionsOffsetFileChannel;
+        dataFileChannels = sharedDataFileChannels;
+        revisionsOffsetFileChannels = sharedRevisionsOffsetFileChannels;
         // A racing close() may null the fields between ensure and read — re-open in that case.
-      } while (dataFileChannel == null || revisionsOffsetFileChannel == null);
+      } while (dataFileChannels == null || revisionsOffsetFileChannels == null);
 
-      return new FileChannelReader(dataFileChannel, revisionsOffsetFileChannel,
+      final int stripe = Math.floorMod(readerStripeCounter.getAndIncrement(), READER_CHANNEL_STRIPES);
+      return new FileChannelReader(dataFileChannels[stripe], revisionsOffsetFileChannels[stripe],
           new ByteHandlerPipeline(byteHandlerPipeline), SerializationType.DATA, new PagePersister(),
           cache.synchronous(), false);
     } catch (final IOException e) {
@@ -136,25 +151,54 @@ public final class FileChannelStorage implements IOStorage {
   }
 
   /**
-   * Lazily open the one shared channel pair all readers of this storage use. Double-checked on the
-   * volatile fields so the steady-state cost per reader is two volatile reads, no lock, no open(2)
-   * syscalls.
+   * Lazily open the shared reader channel stripes. Double-checked on the volatile fields so the
+   * steady-state cost per reader is two volatile reads and one atomic increment — no lock, no
+   * open(2) syscalls.
    */
   private void ensureSharedReaderChannelsOpen() throws IOException {
-    if (sharedDataFileChannel != null) {
+    if (sharedDataFileChannels != null) {
       return;
     }
     synchronized (readerChannelLock) {
-      if (sharedDataFileChannel != null) {
+      if (sharedDataFileChannels != null) {
         return;
       }
       final Path dataFilePath = createDirectoriesAndFile();
       final Path revisionsOffsetFilePath = getRevisionFilePath();
       createRevisionsOffsetFileIfNotExists(revisionsOffsetFilePath);
-      // Order matters for the null-check fast path above: publish the data channel LAST so a
-      // non-null sharedDataFileChannel guarantees both channels are open.
-      sharedRevisionsOffsetFileChannel = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
-      sharedDataFileChannel = createDataFileChannel(dataFilePath);
+      final FileChannel[] revisions = new FileChannel[READER_CHANNEL_STRIPES];
+      final FileChannel[] data = new FileChannel[READER_CHANNEL_STRIPES];
+      try {
+        for (int i = 0; i < READER_CHANNEL_STRIPES; i++) {
+          revisions[i] = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
+          data[i] = createDataFileChannel(dataFilePath);
+        }
+      } catch (final IOException e) {
+        closeAll(data);
+        closeAll(revisions);
+        throw e;
+      }
+      // Order matters for the null-check fast path above: publish the data array LAST so a
+      // non-null sharedDataFileChannels guarantees both arrays are fully open.
+      sharedRevisionsOffsetFileChannels = revisions;
+      sharedDataFileChannels = data;
+    }
+  }
+
+  /**
+   * Best-effort close of every non-null channel. Used both for cleanup after a partially failed
+   * stripe open (the original failure is rethrown by the caller) and on storage close, where a
+   * close failure on a read-only channel must not mask or abort the remaining closes.
+   */
+  private static void closeAll(final FileChannel[] channels) {
+    for (final FileChannel channel : channels) {
+      if (channel != null) {
+        try {
+          channel.close();
+        } catch (final IOException ignored) {
+          // Intentionally swallowed — see javadoc.
+        }
+      }
     }
   }
 
@@ -248,21 +292,17 @@ public final class FileChannelStorage implements IOStorage {
   @Override
   public void close() {
     synchronized (readerChannelLock) {
-      final FileChannel data = sharedDataFileChannel;
-      final FileChannel revisions = sharedRevisionsOffsetFileChannel;
-      // Null out first so a racing createReader() after close re-opens instead of handing out a
-      // closed channel.
-      sharedDataFileChannel = null;
-      sharedRevisionsOffsetFileChannel = null;
-      try {
-        if (data != null) {
-          data.close();
-        }
-        if (revisions != null) {
-          revisions.close();
-        }
-      } catch (final IOException e) {
-        throw new SirixIOException(e);
+      final FileChannel[] data = sharedDataFileChannels;
+      final FileChannel[] revisions = sharedRevisionsOffsetFileChannels;
+      // Null out first so a racing createReader() after close re-opens instead of handing out
+      // closed channels.
+      sharedDataFileChannels = null;
+      sharedRevisionsOffsetFileChannels = null;
+      if (data != null) {
+        closeAll(data);
+      }
+      if (revisions != null) {
+        closeAll(revisions);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
@@ -58,6 +58,26 @@ public final class FileChannelStorage implements IOStorage {
   private final RevisionIndexHolder revisionIndexHolder;
 
   /**
+   * Lock guarding lazy open/close of the shared reader channels.
+   */
+  private final Object readerChannelLock = new Object();
+
+  /**
+   * Shared data file channel handed to every reader. {@link FileChannelReader} uses positional
+   * reads exclusively, so a single channel is safe under arbitrary reader concurrency. One pair of
+   * file descriptors per storage instead of one pair per reader: read-only transactions stay
+   * cached in their session until it closes, so per-reader channels grow FD usage linearly with
+   * the number of transactions ever opened and exhaust the process FD limit under query-heavy
+   * workloads.
+   */
+  private volatile FileChannel sharedDataFileChannel;
+
+  /**
+   * Shared revisions-offset file channel handed to every reader (see {@link #sharedDataFileChannel}).
+   */
+  private volatile FileChannel sharedRevisionsOffsetFileChannel;
+
+  /**
    * Constructor.
    *
    * @param resourceConfig the resource configuration
@@ -98,18 +118,43 @@ public final class FileChannelStorage implements IOStorage {
   public Reader createReader() {
     try {
       validateSuperblocksOnce();
-      final Path dataFilePath = createDirectoriesAndFile();
-      final Path revisionsOffsetFilePath = getRevisionFilePath();
-
-      createRevisionsOffsetFileIfNotExists(revisionsOffsetFilePath);
-      final FileChannel revisionsOffsetFileChannel = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
-      final FileChannel dataFileChannel = createDataFileChannel(dataFilePath);
+      FileChannel dataFileChannel;
+      FileChannel revisionsOffsetFileChannel;
+      do {
+        ensureSharedReaderChannelsOpen();
+        dataFileChannel = sharedDataFileChannel;
+        revisionsOffsetFileChannel = sharedRevisionsOffsetFileChannel;
+        // A racing close() may null the fields between ensure and read — re-open in that case.
+      } while (dataFileChannel == null || revisionsOffsetFileChannel == null);
 
       return new FileChannelReader(dataFileChannel, revisionsOffsetFileChannel,
           new ByteHandlerPipeline(byteHandlerPipeline), SerializationType.DATA, new PagePersister(),
-          cache.synchronous());
+          cache.synchronous(), false);
     } catch (final IOException e) {
       throw new SirixIOException(e);
+    }
+  }
+
+  /**
+   * Lazily open the one shared channel pair all readers of this storage use. Double-checked on the
+   * volatile fields so the steady-state cost per reader is two volatile reads, no lock, no open(2)
+   * syscalls.
+   */
+  private void ensureSharedReaderChannelsOpen() throws IOException {
+    if (sharedDataFileChannel != null) {
+      return;
+    }
+    synchronized (readerChannelLock) {
+      if (sharedDataFileChannel != null) {
+        return;
+      }
+      final Path dataFilePath = createDirectoriesAndFile();
+      final Path revisionsOffsetFilePath = getRevisionFilePath();
+      createRevisionsOffsetFileIfNotExists(revisionsOffsetFilePath);
+      // Order matters for the null-check fast path above: publish the data channel LAST so a
+      // non-null sharedDataFileChannel guarantees both channels are open.
+      sharedRevisionsOffsetFileChannel = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
+      sharedDataFileChannel = createDataFileChannel(dataFilePath);
     }
   }
 
@@ -202,7 +247,24 @@ public final class FileChannelStorage implements IOStorage {
 
   @Override
   public void close() {
-    // Do nothing.
+    synchronized (readerChannelLock) {
+      final FileChannel data = sharedDataFileChannel;
+      final FileChannel revisions = sharedRevisionsOffsetFileChannel;
+      // Null out first so a racing createReader() after close re-opens instead of handing out a
+      // closed channel.
+      sharedDataFileChannel = null;
+      sharedRevisionsOffsetFileChannel = null;
+      try {
+        if (data != null) {
+          data.close();
+        }
+        if (revisions != null) {
+          revisions.close();
+        }
+      } catch (final IOException e) {
+        throw new SirixIOException(e);
+      }
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
@@ -63,16 +63,21 @@ public final class FileChannelStorage implements IOStorage {
    * reads exclusively, which are lock-free in the JDK on POSIX (straight {@code pread(2)}), but on
    * Windows {@code FileDispatcherImpl.needsPositionLock()} is {@code true} and every positional
    * read on a channel serializes on that channel's position lock. A single shared channel would
-   * therefore serialize concurrent readers of the same resource on Windows. A small stripe pool
-   * keeps FD usage O(stripes) per storage (instead of O(open transactions) with per-reader
-   * channels, which exhausted the process FD limit under query-heavy workloads) while restoring
+   * therefore serialize concurrent readers of the same resource on Windows; striping restores
    * uncontended reads for up to {@code stripes} concurrent readers.
+   *
+   * <p>The pool is REFERENCE-COUNTED and closes when the last borrowing reader closes: workloads
+   * holding many concurrent read transactions (query evaluation against a long-lived session)
+   * share O(stripes) descriptors instead of the per-reader channels that exhausted the process FD
+   * limit, while workloads with many short-lived sessions/resources drop back to zero descriptors
+   * as soon as their transactions close — holding stripes open for a session's whole lifetime
+   * exhausted the FD limit from the other direction (many idle sessions × stripes).
    */
   private static final int READER_CHANNEL_STRIPES =
       Math.max(1, Math.min(8, Runtime.getRuntime().availableProcessors()));
 
   /**
-   * Lock guarding lazy open/close of the shared reader channel stripes.
+   * Lock guarding the borrow count and lazy open/close of the shared reader channel stripes.
    */
   private final Object readerChannelLock = new Object();
 
@@ -82,14 +87,22 @@ public final class FileChannelStorage implements IOStorage {
   private final AtomicInteger readerStripeCounter = new AtomicInteger();
 
   /**
-   * Shared data file channels handed to readers, one stripe picked per reader at creation.
+   * Number of live readers borrowing the stripes. Guarded by {@link #readerChannelLock}; the pool
+   * closes when this drops to zero.
    */
-  private volatile FileChannel[] sharedDataFileChannels;
+  private int borrowingReaders;
+
+  /**
+   * Shared data file channels handed to readers, one stripe picked per reader at creation.
+   * Guarded by {@link #readerChannelLock}.
+   */
+  private FileChannel[] sharedDataFileChannels;
 
   /**
    * Shared revisions-offset file channels (same striping as {@link #sharedDataFileChannels}).
+   * Guarded by {@link #readerChannelLock}.
    */
-  private volatile FileChannel[] sharedRevisionsOffsetFileChannels;
+  private FileChannel[] sharedRevisionsOffsetFileChannels;
 
   /**
    * Constructor.
@@ -132,56 +145,57 @@ public final class FileChannelStorage implements IOStorage {
   public Reader createReader() {
     try {
       validateSuperblocksOnce();
-      FileChannel[] dataFileChannels;
-      FileChannel[] revisionsOffsetFileChannels;
-      do {
-        ensureSharedReaderChannelsOpen();
-        dataFileChannels = sharedDataFileChannels;
-        revisionsOffsetFileChannels = sharedRevisionsOffsetFileChannels;
-        // A racing close() may null the fields between ensure and read — re-open in that case.
-      } while (dataFileChannels == null || revisionsOffsetFileChannels == null);
-
       final int stripe = Math.floorMod(readerStripeCounter.getAndIncrement(), READER_CHANNEL_STRIPES);
-      return new FileChannelReader(dataFileChannels[stripe], revisionsOffsetFileChannels[stripe],
+      final FileChannel dataFileChannel;
+      final FileChannel revisionsOffsetFileChannel;
+      synchronized (readerChannelLock) {
+        // Lazily open only the borrowed stripe: a storage whose readers never overlap holds at
+        // most one channel pair, matching the old per-reader footprint.
+        if (sharedDataFileChannels == null) {
+          sharedDataFileChannels = new FileChannel[READER_CHANNEL_STRIPES];
+          sharedRevisionsOffsetFileChannels = new FileChannel[READER_CHANNEL_STRIPES];
+        }
+        if (sharedDataFileChannels[stripe] == null) {
+          final Path dataFilePath = createDirectoriesAndFile();
+          final Path revisionsOffsetFilePath = getRevisionFilePath();
+          createRevisionsOffsetFileIfNotExists(revisionsOffsetFilePath);
+          sharedRevisionsOffsetFileChannels[stripe] = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
+          sharedDataFileChannels[stripe] = createDataFileChannel(dataFilePath);
+        }
+        dataFileChannel = sharedDataFileChannels[stripe];
+        revisionsOffsetFileChannel = sharedRevisionsOffsetFileChannels[stripe];
+        borrowingReaders++;
+      }
+
+      return new FileChannelReader(dataFileChannel, revisionsOffsetFileChannel,
           new ByteHandlerPipeline(byteHandlerPipeline), SerializationType.DATA, new PagePersister(),
-          cache.synchronous(), false);
+          cache.synchronous(), this::releaseReaderChannels);
     } catch (final IOException e) {
       throw new SirixIOException(e);
     }
   }
 
   /**
-   * Lazily open the shared reader channel stripes. Double-checked on the volatile fields so the
-   * steady-state cost per reader is two volatile reads and one atomic increment — no lock, no
-   * open(2) syscalls.
+   * Hand back one reader's borrow of the shared stripes; the pool closes when the last borrower is
+   * gone, so descriptors are held only while at least one read transaction is actually open.
    */
-  private void ensureSharedReaderChannelsOpen() throws IOException {
-    if (sharedDataFileChannels != null) {
-      return;
-    }
+  private void releaseReaderChannels() {
     synchronized (readerChannelLock) {
-      if (sharedDataFileChannels != null) {
-        return;
+      if (borrowingReaders > 0 && --borrowingReaders == 0) {
+        closeSharedReaderChannels();
       }
-      final Path dataFilePath = createDirectoriesAndFile();
-      final Path revisionsOffsetFilePath = getRevisionFilePath();
-      createRevisionsOffsetFileIfNotExists(revisionsOffsetFilePath);
-      final FileChannel[] revisions = new FileChannel[READER_CHANNEL_STRIPES];
-      final FileChannel[] data = new FileChannel[READER_CHANNEL_STRIPES];
-      try {
-        for (int i = 0; i < READER_CHANNEL_STRIPES; i++) {
-          revisions[i] = createRevisionsOffsetFileChannel(revisionsOffsetFilePath);
-          data[i] = createDataFileChannel(dataFilePath);
-        }
-      } catch (final IOException e) {
-        closeAll(data);
-        closeAll(revisions);
-        throw e;
-      }
-      // Order matters for the null-check fast path above: publish the data array LAST so a
-      // non-null sharedDataFileChannels guarantees both arrays are fully open.
-      sharedRevisionsOffsetFileChannels = revisions;
-      sharedDataFileChannels = data;
+    }
+  }
+
+  /** Close and clear the stripe arrays. Must be called under {@link #readerChannelLock}. */
+  private void closeSharedReaderChannels() {
+    if (sharedDataFileChannels != null) {
+      closeAll(sharedDataFileChannels);
+      sharedDataFileChannels = null;
+    }
+    if (sharedRevisionsOffsetFileChannels != null) {
+      closeAll(sharedRevisionsOffsetFileChannels);
+      sharedRevisionsOffsetFileChannels = null;
     }
   }
 
@@ -292,18 +306,11 @@ public final class FileChannelStorage implements IOStorage {
   @Override
   public void close() {
     synchronized (readerChannelLock) {
-      final FileChannel[] data = sharedDataFileChannels;
-      final FileChannel[] revisions = sharedRevisionsOffsetFileChannels;
-      // Null out first so a racing createReader() after close re-opens instead of handing out
-      // closed channels.
-      sharedDataFileChannels = null;
-      sharedRevisionsOffsetFileChannels = null;
-      if (data != null) {
-        closeAll(data);
-      }
-      if (revisions != null) {
-        closeAll(revisions);
-      }
+      // Defensive: sessions close all their transactions (and thus every borrowing reader) before
+      // closing the storage, but force-release anything still outstanding so descriptors never
+      // outlive the storage.
+      borrowingReaders = 0;
+      closeSharedReaderChannels();
     }
   }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/optimizer/walker/json/AbstractJsonPathWalker.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/optimizer/walker/json/AbstractJsonPathWalker.java
@@ -105,9 +105,17 @@ abstract class AbstractJsonPathWalker extends ScopeWalker {
 
     final RevisionData revisionData = getRevisionData(node);
 
-    try (final var jsonCollection = jsonDBStore.lookup(revisionData.databaseName());
-        final var resourceSession = jsonCollection.getDatabase().beginResourceSession(revisionData.resourceName());
-        final var rtx = revisionData.revision() == -1
+    // BORROW the collection and session, never close them: lookup() returns the store's CACHED
+    // collection (whose close() closes the WHOLE database) and beginResourceSession() may return
+    // the cached open session shared with concurrent evaluations. Only the transactions opened
+    // below are owned by this compile step; the store/database close their own objects.
+    final var jsonCollection = jsonDBStore.lookup(revisionData.databaseName());
+    if (jsonCollection == null) {
+      return astNode;
+    }
+    final var resourceSession = jsonCollection.getDatabase().beginResourceSession(revisionData.resourceName());
+
+    try (final var rtx = revisionData.revision() == -1
             ? resourceSession.beginNodeReadOnlyTrx()
             : resourceSession.beginNodeReadOnlyTrx(revisionData.revision());
         final var pathSummary = revisionData.revision() == -1

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/optimizer/walker/json/JsonValidTimeStep.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/optimizer/walker/json/JsonValidTimeStep.java
@@ -10,8 +10,11 @@ import io.sirix.access.trx.node.json.JsonIndexController;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.index.IndexDef;
 import io.sirix.index.IndexType;
+import io.sirix.query.json.JsonDBCollection;
 import io.sirix.query.json.JsonDBStore;
+import io.sirix.utils.LogWrapper;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.LoggerFactory;
 
 /**
  * Optimizer step that auto-selects the persistent VALIDTIME interval index for a plain FLWOR
@@ -42,6 +45,9 @@ import org.jspecify.annotations.Nullable;
  * @author Johannes Lichtenberger
  */
 public final class JsonValidTimeStep extends Walker {
+
+  private static final LogWrapper LOG_WRAPPER =
+      new LogWrapper(LoggerFactory.getLogger(JsonValidTimeStep.class));
 
   private static final QNm DOC = new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "doc");
   private static final QNm OPEN = new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "open");
@@ -355,31 +361,39 @@ public final class JsonValidTimeStep extends Walker {
    * revision-aware index-existence check the CAS walker performs.
    */
   private @Nullable ValidTimeConfig resolveValidTimeConfigWithIndex(final RevisionData revisionData) {
-    try (final var collection = jsonDBStore.lookup(revisionData.databaseName())) {
+    try {
+      // BORROW, never close: lookup() returns the store's CACHED collection and
+      // beginResourceSession() the database's cached open session. Closing either from a compile
+      // step (JsonDBCollection.close() closes the WHOLE database) tears shared state out from
+      // under concurrent evaluations and forces a close/reopen cycle per compiled query. The
+      // store/database own these objects and close them on their own shutdown.
+      final JsonDBCollection collection = jsonDBStore.lookup(revisionData.databaseName());
       if (collection == null) {
         return null;
       }
-      try (final var resourceSession = collection.getDatabase().beginResourceSession(revisionData.resourceName())) {
-        final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
-        if (validTimeConfig == null) {
-          return null;
-        }
-        final int revision = revisionData.revision() == -1
-            ? resourceSession.getMostRecentRevisionNumber()
-            : revisionData.revision();
-        final JsonIndexController controller = resourceSession.getRtxIndexController(revision);
-        if (controller == null) {
-          return null;
-        }
-        for (final IndexDef indexDef : controller.getIndexes().getIndexDefs()) {
-          if (indexDef.getType() == IndexType.VALIDTIME) {
-            return validTimeConfig;
-          }
-        }
+      final var resourceSession = collection.getDatabase().beginResourceSession(revisionData.resourceName());
+      final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
+      if (validTimeConfig == null) {
         return null;
       }
+      final int revision = revisionData.revision() == -1
+          ? resourceSession.getMostRecentRevisionNumber()
+          : revisionData.revision();
+      final JsonIndexController controller = resourceSession.getRtxIndexController(revision);
+      if (controller == null) {
+        return null;
+      }
+      for (final IndexDef indexDef : controller.getIndexes().getIndexDefs()) {
+        if (indexDef.getType() == IndexType.VALIDTIME) {
+          return validTimeConfig;
+        }
+      }
+      return null;
     } catch (final RuntimeException e) {
-      // Any resolution failure simply means "don't rewrite" — normal evaluation still runs.
+      // Any resolution failure means "don't rewrite" — normal evaluation still runs — but it must
+      // not be silent: an invisible transient failure here disables the index without a trace.
+      LOG_WRAPPER.warn("VALIDTIME index resolution failed during optimization; skipping rewrite for {}/{}",
+          revisionData.databaseName(), revisionData.resourceName(), e);
       return null;
     }
   }


### PR DESCRIPTION
## What does this PR do?

Started as the flaky `windows-latest` failure of `ValidTimeIndexOptimizerRewriteTest` (seen on the merge of #1108) and root-caused into **three real production bugs**:

1. **Optimizer walkers tore down shared state on every compile** (`af35f3b`). `JsonValidTimeStep.resolveValidTimeConfigWithIndex` and `AbstractJsonPathWalker.replaceAstIfIndexApplicableImpl` used try-with-resources on objects they don't own: `JsonDBStore.lookup()` returns the store's *cached* `JsonDBCollection` — whose `close()` closes the **whole database** and evicts it from the store — and `Database.beginResourceSession()` returns the *cached open session* when one exists, whose `close()` rolls back any open transactions. Every compiled query closed the database under the runtime and forced a close/reopen cycle; on Windows a transient I/O failure in one of thousands of reopen cycles was swallowed by the walker's catch-all and silently reported as "no VALIDTIME index → don't rewrite", tripping the gate. The walkers now borrow those objects and close only the transactions they open; a null lookup falls through to "no rewrite"; resolution failures are logged.

2. **Every write transaction leaked its three writer FileChannels** (`0fcd2f3`) — the big one. `NodeStorageEngineWriter.close()` never closed `storagePageReaderWriter`, and `NodeStorageEngineReader.close()` deliberately skips its `pageReader` for write transactions (`trxIntentLog != null` — the pageReader IS the writer). Nobody closed the `FileChannelWriter`, so every write transaction leaked its buffered-data, SYNC-revisions, and DSYNC-beacon channels until the GC's cleaner happened to reclaim them; auto-committing workloads swap in a fresh writer per commit via `createPageTransaction`, i.e. a long-running server leaked **3 descriptors per commit**. Measured live: hundreds of channels (the writer's 2:1 data:revisions signature) pinned on a single resource during `MixedReadWriteUafStressTest`, half pointing at already-deleted files. The writer is now closed at the end of `NodeStorageEngineWriter.close()`; its channels are clean at that point (durability is established at `writeUberPageReference` return), so the close-time force is a fast no-dirty-data flush.

3. **Per-reader FileChannel growth for read transactions** (`e805a09`, `4b51245`, `24b0bb8`). `FileChannelStorage.createReader()` opened two fresh channels per reader while read-only transactions stay cached in their session — long-lived query sessions (the rewrite-gate test holds thousands of live readers) exhausted the FD limit. The storage now keeps a **striped, lazily-opened, reference-counted channel pool**: up to `min(availableProcessors, 8)` pairs shared by all readers, each stripe opened on first borrow, the pool closed when the last borrowing reader closes. Serial churn matches the old footprint exactly (one pair open at a time, same `open(2)` count); overlapping readers are capped at `stripes` pairs; idle sessions hold zero; striping keeps Windows positional reads uncontended (`FileDispatcherImpl.needsPositionLock()` is `true` there, so a single shared channel would serialize concurrent readers — on POSIX preads are lock-free either way). Readers borrowing a stripe release via a close callback guarded by an `AtomicBoolean`; the writer path, `MMStorage`, recovery, and the power-loss harness keep the old owning semantics via the delegating constructor.

Side benefit: `ValidTimeIndexOptimizerRewriteTest` runs in ~32s instead of ~8+ minutes — the per-compile database teardown/reopen and two `open(2)` syscalls per read transaction were a large hidden cost.

## Related issue

No issue — root-caused from the `Cross-platform tests (windows-latest)` failure on merge commit `5d64d35` (CI run 29431003470).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — full build not run in this environment (the 9.4.1 wrapper distribution is blocked by the sandbox egress policy); verified with system Gradle 8.14.3 instead, see below
- [x] Added or updated tests covering the change — the **entire sirix-core suite (9350 tests) passes with 0 failures inside a deliberately FD-constrained sandbox (`ulimit -n` 4096)** where both the old code (550 failures, incl. classloading collapse from descriptor starvation) and intermediate designs failed; peak descriptor usage across the whole 13-minute suite was **180**. Query-side gates green: `ValidTimeIndexOptimizerRewriteTest` (the originally flaky test, ~32s), `ValidTimeIndexDropTest`, `ValidTimeIndexEndToEndTest`, `OptimizerBehavioralE2ETest`, `ExplainIntegrationTest`, `PredicateOverUnwrappedArrayTest`, `IndexVersioningIntegrationTest`
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — no commit-protocol or durability change: writer channel flags (SYNC/DSYNC) and the beacon protocol are untouched; the writer is now *actually closed* after commit/rollback, and reader channel ownership moved to a reference-counted per-storage pool
- [ ] Updated documentation (README / docs) where relevant — n/a, internal fix
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- Bug 2 is the important one for production: 3 leaked descriptors per commit on any auto-committing / keep-open workload, previously masked because (a) the optimizer walkers' destructive database-close (bug 1) kept resetting state in query workloads, and (b) the GC's FileChannel cleaner reclaims some channels under heap pressure — which is why it presented as *sporadic* exhaustion rather than a deterministic failure.
- Safety of the shared reader stripes: `FileChannelReader` performs only positional reads (`channel.read(buf, offset)`, pread semantics), documented thread-safe under arbitrary concurrency. Writers still open their own channels with the same SYNC/DSYNC flags.
- The Windows lanes (gating since #1107) are the definitive check for the original flake; this PR's CI run is the proof.
- Local verification used system Gradle 8.14.3 on Linux because the sandbox cannot download the 9.4.1 wrapper distribution; no build-script changes are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM