### PR TITLE
Release 1.0.0-beta7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to SirixDB are documented in this file.
 
+## [1.0.0-beta7] — 2026-07-15
+
+### Fixed
+
+- **Every write transaction leaked its three writer file descriptors** (#1109) —
+  `NodeStorageEngineWriter.close()` never closed the underlying storage writer, and the
+  storage-engine reader deliberately skips its page reader for write transactions, so nobody
+  closed the `FileChannelWriter`: the buffered-data, SYNC-revisions and DSYNC-beacon channels
+  leaked per commit until the GC's channel cleaner happened to reclaim them. Long-running,
+  auto-committing workloads leaked 3 descriptors per commit and hit sporadic
+  `Too many open files` failures. The writer is now closed when the page write transaction
+  closes.
+- **Optimizer walkers closed the shared database on every compile** (#1109) — the CAS/path
+  index walker and the valid-time index walker closed the store's *cached* collection (which
+  closes the whole database and evicts it from the store) and potentially the cached shared
+  resource session after every compiled query. Besides the churn, a transient I/O failure
+  during the forced reopen was silently swallowed and disabled the VALIDTIME index rewrite for
+  that compile — the source of the flaky `windows-latest`
+  `ValidTimeIndexOptimizerRewriteTest` failures. The walkers now borrow the store-owned
+  objects, close only the transactions they open, and log resolution failures.
+- **Unbounded reader file-descriptor growth** (#1109) — `FileChannelStorage.createReader()`
+  opened two fresh `FileChannel`s per reader while read-only transactions stay cached in their
+  session, so descriptor usage grew with every query evaluated against a long-lived session.
+  Readers now share a striped, lazily-opened, reference-counted channel pool (up to
+  `min(availableProcessors, 8)` pairs per storage, closed when the last borrowing reader
+  closes): serial workloads keep the previous footprint, concurrent readers are capped at the
+  stripe count, idle sessions hold zero descriptors, and striping keeps positional reads
+  uncontended on Windows. As a side effect the valid-time optimizer gate test dropped from
+  ~8 minutes to ~30 seconds.
+
 ## [1.0.0-beta6] — 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ Add `--read-write` to the `args` to allow mutations (read-only is the default). 
 <dependency>
   <groupId>io.sirix</groupId>
   <artifactId>sirix-core</artifactId>
-  <version>1.0.0-beta6</version>
+  <version>1.0.0-beta7</version>
 </dependency>
 ```
 
 ```gradle
 // Gradle (Kotlin DSL)
-implementation("io.sirix:sirix-core:1.0.0-beta6")
+implementation("io.sirix:sirix-core:1.0.0-beta7")
 ```
 
 ```java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-beta6
+version=1.0.0-beta7
 vertxVersion=5.1.1
 org.gradle.jvmargs=-Xmx15000m


### PR DESCRIPTION
## What does this PR do?

Version bump to **1.0.0-beta7** (`gradle.properties`), CHANGELOG entry, and README dependency-snippet update — same shape as the beta6 release PR (#1106).

The beta7 changelog covers the three fixes that landed in #1109:
- the per-commit writer file-descriptor leak (`NodeStorageEngineWriter` never closed its storage writer),
- the optimizer walkers closing the shared database/session on every compile (root cause of the flaky `windows-latest` valid-time rewrite gate),
- unbounded reader descriptor growth, replaced by a striped, reference-counted shared channel pool.

After merge, the `Release to Maven Central` workflow will be dispatched with `tag_name=sirix-1.0.0-beta7` to create the tag at the release commit and publish.

## Related issue

Follow-up to #1109; release process per #1106.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [x] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — version/docs-only change; CI validates
- [ ] Added or updated tests covering the change — n/a, release metadata only
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — n/a, no engine change
- [x] Updated documentation (README / docs) where relevant — CHANGELOG + README snippets
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

Version references changed: `gradle.properties` (`1.0.0-beta6` → `1.0.0-beta7`), the two README dependency snippets, and the new CHANGELOG section dated 2026-07-15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM)_