### PR TITLE
chore: add justfile for common dev and benchmark tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,24 @@ Thank you for your interest in contributing to SirixDB! This guide will help you
 - Gradle 9.1+ (or use the included wrapper)
 - GraalVM (optional, for native image builds)
 
+### Common tasks
+
+A `justfile` in the repo root wraps the commands below for convenience. It is
+optional — every task is a plain `./gradlew` invocation you can run directly.
+With [`just`](https://github.com/casey/just) installed, `just --list` shows them:
+
+| Recipe | Underlying command |
+| --- | --- |
+| `just toolchains` | `./gradlew -q javaToolchains` — confirm a JDK 25 is detected |
+| `just build` | `./gradlew build -x test` |
+| `just test` | `./gradlew test` |
+| `just format` | `./gradlew spotlessApply` |
+| `just bench <Class>` | `./gradlew :sirix-benchmarks:jmh -Pjmh.includes=<Class>` |
+| `just scale "<args>"` | `./gradlew :sirix-benchmarks:runScale -Pscale.args="<args>"` |
+
+Benchmarks live in `sirix-benchmarks` (JMH). Override JMH `@Param` values with a
+second argument, e.g. `just bench JsonWritePathBenchmark compressionPipeline=NONE`.
+
 ## Development Workflow
 
 1. Create a branch from `main`:

--- a/justfile
+++ b/justfile
@@ -1,0 +1,40 @@
+# SirixDB developer tasks. Run `just` (or `just --list`) to see them.
+#
+# Requires JDK 25. Gradle's toolchain auto-detects it, so the Gradle daemon
+# itself can keep running on whatever JDK your JAVA_HOME points at — you do
+# not need to switch your default JDK. Verify detection with `just toolchains`.
+
+# List available recipes.
+default:
+    @just --list
+
+# Show every JDK Gradle detected (confirm a "Language Version: 25" entry exists).
+toolchains:
+    ./gradlew -q javaToolchains
+
+# Compile all modules without running tests.
+build:
+    ./gradlew build -x test
+
+# Run the full test suite.
+test:
+    ./gradlew test
+
+# Apply Spotless formatting; run before committing.
+format:
+    ./gradlew spotlessApply
+
+# Run one JMH benchmark; `just bench JsonWritePathBenchmark compressionPipeline=NONE`.
+bench name params="":
+    # `name` is a class-name pattern; `params` overrides JMH @Param values
+    # (pipe-separated for multiple, e.g. storageType=FILE_CHANNEL|MEMORY_MAPPED).
+    ./gradlew :sirix-benchmarks:jmh -Pjmh.includes={{name}} -Pjmh.benchmarkParameters="{{params}}"
+
+# Run the entire JMH benchmark suite (slow).
+bench-all:
+    ./gradlew :sirix-benchmarks:jmh
+
+# Run the large-dataset scale benchmark; `just scale "1000000 true 3"`.
+scale args="1000000 true 3":
+    # args = "records shred? iterations". Task uses -Xms8g -Xmx24g; shrink on a laptop.
+    ./gradlew :sirix-benchmarks:runScale -Pscale.args="{{args}}"


### PR DESCRIPTION
Hey @JohannesLichtenberger, it's been too long!  I got some free time, so I'd revisit the project. I was re-explloring the codebase, and I found the gradlew commands rather cumbersome, hence this **optional** justfile:

Wrap the routine gradle invocations (build, test, spotless, JMH benchmarks, scale bench) behind a justfile so contributors have a single discoverable entry point via `just --list`. The benchmark flags in particular (`-Pjmh.includes`, `-Pjmh.benchmarkParameters`, `-Pscale.args`) were only documented in a build.gradle comment; they now have a named recipe.

The justfile is an optional convenience wrapper — every recipe is a plain `./gradlew` command that still works directly. CONTRIBUTING.md gains a 'Common tasks' table documenting both forms.

<!--
Thanks for contributing to SirixDB! Please fill in the sections below.
Keep the PR focused — smaller PRs get reviewed faster.
-->

## What does this PR do?
Wrap the routine gradle invocations (build, test, spotless, JMH benchmarks, scale bench) behind a justfile so contributors have a single discoverable entry point via `just --list`.

| Recipe | Underlying command |
| --- | --- |
| `just toolchains` | `./gradlew -q javaToolchains` — confirm a JDK 25 is detected |
| `just build` | `./gradlew build -x test` |
| `just test` | `./gradlew test` |
| `just format` | `./gradlew spotlessApply` |
| `just bench <Class>` | `./gradlew :sirix-benchmarks:jmh -Pjmh.includes=<Class>` |
| `just scale "<args>"` | `./gradlew :sirix-benchmarks:runScale -Pscale.args="<args>"` |

## Related issue
N/A

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [x] Documentation only

## Checklist

- [x] `./gradlew build` passes locally (JDK 25)
- [x] Added or updated tests covering the change
- [ ] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed)
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

<!-- Anything that needs special attention: trade-offs, follow-ups, areas of uncertainty. -->
