### PR TITLE
Design plan: tamper-evident ledger mode

### DIFF
--- a/docs/TAMPER_EVIDENCE_PLAN.md
+++ b/docs/TAMPER_EVIDENCE_PLAN.md
@@ -1,6 +1,9 @@
 # Tamper-Evident Ledger Mode — Design Plan
 
-Status: **proposal** (no implementation yet)
+Status: **proposal** (no implementation yet). Reviewed twice against the
+codebase (storage-layer fact check, adversarial protocol review); all factual
+claims below carry the reviewed semantics.
+
 Scope: per-resource opt-in "ledger mode" that upgrades SirixDB's append-only,
 immutable-revision storage into a cryptographically tamper-evident system with
 externally anchorable, independently verifiable history.
@@ -13,170 +16,270 @@ and they are the hard ones to retrofit:
 - append-only single-log storage (FineLine-style: the data file *is* the log,
   no WAL, no in-place updates);
 - every commit produces an immutable, permanently addressable revision;
-- an optional per-node subtree hash tree (`HashType.ROLLING`/`POSTORDER`),
-  i.e. a Merkle-tree *shape* over every document;
-- page checksums, superblock checksums, checksummed 32-byte commit records.
+- parent pages embed a hash of every referenced child page fragment
+  (`PageReference.hashInBytes`, serialized with the reference in
+  `SerializationType.writeHash`, verified on read — `verifyChecksumsOnRead`
+  already defaults to `true`);
+- a per-commit record in the revisions file (32 bytes: offset, timestamp,
+  record checksum over the leading 16/24 bytes, and the `RevisionRootPage`'s
+  own 64-bit page hash);
+- optional per-node subtree hashes (`HashType.ROLLING`/`POSTORDER`).
 
-What it does **not** have is adversarial integrity. Every hash in the system
-is XXH3 (64-bit, non-cryptographic — `ResourceConfiguration.nodeHashFunction`,
-`io.sirix.io.HashAlgorithm.XXH3`), nothing chains commits together
-cryptographically, commit authorship (`CommitCredentials`) is unauthenticated
-metadata, and no state ever leaves the machine. Anyone with file access can
-rewrite a revision, recompute the hashes, and leave no trace. The README's
-"tamper detection" claim currently covers corruption and bugs, not adversaries.
+What it does **not** have is adversarial integrity:
 
-Threat model targeted by this plan:
+- every hash is **XXH3-64** (`HashAlgorithm.XXH3` is the only enum constant;
+  `nodeHashFunction` is XXH3; superblock and record checksums are XXH3) —
+  recomputable by anyone, collision-findable, not a security control;
+- the page-Merkle coverage has a hole: **older page fragments** are referenced
+  by `(revision, key)` *without* hashes (`PageFragmentKeyImpl`), and the
+  reconstruction path builds hash-less references, so under the default
+  `SLIDING_SNAPSHOT` versioning only the *newest* fragment of each page is
+  verified (the code itself carries a TODO for this in
+  `NodeStorageEngineReader`);
+- nothing chains commits; commit authorship (`CommitCredentials`) is
+  unauthenticated metadata; no state ever leaves the machine.
 
-| Adversary | Capability | Goal of this plan |
+### Threat model and what each phase actually buys
+
+| Adversary | Capability | Detected by |
 |---|---|---|
-| A. External client | API access only | already handled (authz) + verifiable query proofs |
-| B. Insider with file access | read/write the database files | every modification of committed history is detectable |
-| C. Insider with file + server + key access | full control of one machine | detectable once the head has been anchored externally |
+| A. External client | API access only | existing authz; Phase 5 gives verifiable proofs |
+| B. Insider, file access, **no keys** | read/write database files | Phase 3 (cannot re-sign) **or** Phases 1–2 + an externally trusted head (Phase 4) |
+| C. Insider, files + server + keys | full control of one machine | Phase 4 only, and only for the **anchored prefix** |
 
-"Tamper-**proof**" in the strict sense is impossible for C without external
-state; the design goal is tamper-**evidence** with a minimal trusted base: one
-externally witnessed hash.
+Stated plainly: Phases 1–2 alone (hashes + chain, no signatures, no anchor) do
+**not** stop adversary B — with no secret in the construction, B rewrites
+history and recomputes every hash and chain link forward. Chaining is
+tamper-evidence *relative to a trusted head held outside the attacker's
+reach*. Phases 1–2 provide: corruption detection, and O(1)-trusted-input
+verification once such a head exists. Everything after the last external
+anchor is malleable to adversary C (drop, reorder, rewrite, re-sign, or fork
+from the anchored prefix); only anchored prefixes are protected against C.
+Tamper *prevention* against C is impossible and out of scope.
 
 ## 2. Phase 1 — Cryptographic page-Merkle foundation
 
-**Goal:** turn the page trie's *existing* parent-embedded child hashes into a
-cryptographic Merkle DAG covering everything reachable from the revision root.
+**Goal:** make the page trie's existing parent-embedded hash structure a
+cryptographic Merkle DAG that covers **every byte reachable at every
+revision** — including reconstruction inputs and all secondary-index pages.
 
-SirixDB already stores a hash of every referenced page fragment in the parent
-page (`PageReference.hashInBytes`, set from the payload hash on write in
-`FileChannelWriter`, verified on read under `verifyChecksumsOnRead`, with the
-`RevisionRootPage`'s own hash stored in the commit record). This is a Merkle
-tree in shape — uber page → revision root → indirect pages → fragments —
-covering document data, the path summary, **and every secondary-index page
-subtree**. It is merely built from XXH3-64.
+Two gaps must close, not one:
 
-- Add `SHA_256` (JDK built-in, SHA-NI/ARMv8 intrinsics) and optionally
-  `BLAKE3_256` to `io.sirix.io.HashAlgorithm`; the enum already dispatches by
-  hash length, so on-disk auto-detection composes.
-- Ledger mode switches the **page-reference hash** to the cryptographic
-  algorithm and makes `verifyChecksumsOnRead` mandatory. `revHash(N)` becomes
-  the RevisionRootPage's page hash — the commit record already carries a
-  64-bit slot for exactly this value; the extended layout widens it.
-- **Secondary indexes are covered by construction.** This is required, not
-  optional: an unprotected index page lets an adversary silently omit or
-  redirect index-served query results while all document data verifies clean.
-  Rebuildability is no defense unless every query rebuilds and compares.
-- Cost: a streaming hash over already-serialized page payloads at commit —
-  O(bytes written), no node-layout change, zero cost for non-ledger resources.
-- **Optional add-on (may ship with Phase 5 instead):** 256-bit per-node
-  hashes computed once per commit over dirty paths (the
-  `TransactionIntentLog` knows every modified node), for *compact* semantic
-  inclusion proofs of a single node. Page-granular proofs (the page path from
-  root to fragment) work without it and are the default.
-- Deliverable gate: differential test `stored hashes == recomputed-from-
-  scratch` across randomized update sequences; commit-overhead benchmark
-  (target: ≤ 15 % commit throughput cost at 4 KB documents, measured like
-  `COMPARISON_POSTGRES.md`).
+1. **Hash strength.** Add `SHA_256` (JDK, SHA-NI/ARMv8 intrinsics) and
+   optionally `BLAKE3_256` (length-extension-resistant by design, needs a
+   dependency) to `HashAlgorithm`. The enum dispatches by hash length, but the
+   wire format does **not** compose automatically: `SerializationType`
+   hardcodes `PAGE_HASH_BYTES = 8` (write throws on other lengths), and the
+   uber-beacon trailer and revisions-record hash field are hardcoded
+   `Long.BYTES`. Widening to 32 bytes touches all of these sites and is gated
+   per resource by ledger mode plus a superblock layout-version bump — noting
+   that `Superblock.validate` currently hard-rejects any version ≠ 0, so the
+   migration needs an explicit compatibility branch, not just a new constant.
+2. **Fragment coverage.** Extend `PageFragmentKey` from `(revision, key)` to
+   `(revision, key, hash)` in ledger mode, so the parent's fragment list is
+   itself a Merkle commitment. Without this, a page reconstructed from older
+   fragments reads unverified bytes and the transitivity claim below is false
+   for every versioning type except `FULL`. Cost: 32 bytes per fragment key
+   (bounded by the snapshot window, ≤ N fragments per page).
+
+With both in place: `revHash(N) := pageHash(RevisionRootPage(N))`
+transitively commits to the document tree, the path summary, the DeweyID and
+valid-time index pages, and **all secondary-index page subtrees**
+(CAS/Path/Name pages and the HOT trees hanging off them are written through
+the same reference-hash path). Index coverage is a requirement, not an
+optimization: an unprotected index page lets an adversary silently omit or
+redirect index-served query results while document data verifies clean.
+(Whether a committed index correctly reflected the data *at build time* is a
+correctness concern for tests, not an integrity concern — the Merkle tree
+guarantees the index is exactly the committed bytes.)
+
+**What the hash commits to — plaintext vs. pipeline output.** Today page
+hashes cover the serialized payload *after* the byte-handler pipeline
+(compression, optionally encryption). That is sound for storage integrity of
+as-stored bytes, but it makes proofs non-verifiable for auditors without
+decryption keys and couples integrity to pipeline determinism. Decision for
+ledger mode: commit to a **canonical deterministic pre-pipeline encoding**
+(specified byte order, stable field ordering) for unencrypted resources;
+for encrypted resources, hash the ciphertext (plaintext hashes stored beside
+ciphertext would enable content-confirmation attacks) and accept that
+third-party proof verification then requires key access. Serialization
+determinism becomes a hard design requirement, enforced by a differential
+test (`stored hashes == recomputed-from-scratch` across randomized update
+sequences).
+
+**Write-path cost:** streaming hash over serialized page payloads at commit —
+O(bytes written), no node-layout change, zero cost for non-ledger resources.
+Budget gate: ≤ 15 % commit-throughput cost at 4 KB documents, measured like
+`COMPARISON_POSTGRES.md`. The optional 256-bit *per-node* hash profile
+(commit-time, dirty-paths-only via the `TransactionIntentLog`) is deferred to
+Phase 5 — it only makes single-node inclusion proofs compact; page-granular
+proofs work without it.
 
 ## 3. Phase 2 — Chained commit records
 
-**Goal:** the head commits to the entire history, in order.
+**Goal:** the head commits to the entire history, in order, with an exact,
+independently reproducible byte specification.
 
-Per committed revision *N* define:
+### Protocol specification (normative for implementation)
+
+All hashes below are the resource's ledger hash algorithm; every hash use is
+**domain-separated** by a tag that also pins the algorithm and version, and
+every variable-length field is length-prefixed (canonical encoding — two
+different field splits can never produce the same byte stream):
 
 ```
-revHash(N)   = pageHash( RevisionRootPage(N) )   // Phase 1: transitively
-               // commits to document data, path summary, and ALL
-               // secondary-index page subtrees via parent-embedded hashes
-chainHash(N) = H( chainHash(N-1) ‖ revHash(N) ‖ commitTimestamp(N)
-                  ‖ authorId(N) ‖ H(commitMessage(N)) )
+resourceIdentity = databaseId ‖ resourceId ‖ resourceUUID
+                   // resourceUUID: generated at resource creation, stored in
+                   // the superblock's reserved slot — binds chains to THIS
+                   // resource; defeats file-swap/transplant/replay of another
+                   // resource's valid chain
+
+chainHash(0)     = H( "SIRIX-LEDGER-GENESIS-v1-SHA256" ‖ resourceIdentity
+                      ‖ creationNonce )
+
+revHash(N)       = pageHash( RevisionRootPage(N) )
+                   // the RevisionRootPage body already serializes revision
+                   // number, commit timestamp, commit message, and author —
+                   // revHash therefore commits to all of them
+
+chainHash(N)     = H( "SIRIX-LEDGER-CHAIN-v1-SHA256" ‖ resourceIdentity
+                      ‖ revisionNumber(N) ‖ revHash(N) ‖ chainHash(N-1) )
 ```
 
-- Storage: extend the per-commit record in the revisions file
-  (`FileChannelWriter`, today 32 bytes: offset + timestamp + checksum) to a
-  versioned 96–128-byte layout carrying `revHash`, `chainHash`, and later the
-  signature. The revisions channel is already SYNC write-through, so the chain
-  link becomes durable atomically with the commit — the single-log design
-  (FineLine) makes the commit record the natural chaining unit, and
-  per-resource logs keep chains independent (aligned with autonomous-commit
-  decentralization; no cross-resource coordination on the commit path).
-- Also embed `chainHash(N-1)` in `RevisionRootPage` for self-containment (it
-  must be the *parent's* chain hash there, since `revHash(N)` is the hash of
-  the RevisionRootPage itself — a page cannot contain its own hash).
-- Secondary indexes (HOT/RBTree/path/CAS) are covered **by construction**
-  through the page-Merkle tree (Phase 1) — their page subtrees hang off the
-  revision root like all other pages.
-- Open behavior: `verifyChainOnOpen = none | heads | full` (default `heads`).
-- Deliverable gate: adversarial tests — bit-flip in an old revision, replayed
-  commit, swapped revisions, truncated tail — every one must fail verification.
+- `chainHash(N-1)` is embedded **in the `RevisionRootPage(N)` body** (a page
+  cannot contain its own hash, so each root page carries its *parent's* chain
+  state — thereby covered by `revHash(N)` and, in Phase 3, by the signature).
+- The extended commit record stores full-width (256-bit, never truncated)
+  `revHash(N)` and `chainHash(N)` plus, later, the signature. **The record is
+  a non-authoritative lookup cache**: its XXH3 checksum is a corruption check
+  with no security role, and verifiers MUST recompute `chainHash(N)` from
+  page-derived inputs and the parent link — never trust stored copies.
+  Verifiers also assert `record slot index == RevisionRootPage.revision ==
+  chained revisionNumber` (no slot relocation) and that commit timestamps are
+  non-decreasing along the chain.
+- The revisions channel is already SYNC write-through, so the chain link
+  becomes durable atomically with the commit; per-resource logs keep chains
+  independent (aligned with autonomous-commit decentralization — nothing new
+  on the commit path's critical section).
+- **Async intermediate commits (`KEEP_OPEN_ASYNC`) produce no commit record**
+  (they only pre-flush leaf pages; no uber page is written), hence no chain
+  link — correct, since those pages become reachable only through the next
+  real commit. Sync auto-commits produce full revisions and therefore full
+  chain links.
+- Open behavior `verifyChainOnOpen = full | anchored | head`. Honest
+  semantics: `head` checks only that the head record is internally consistent
+  (and signed) — it detects **no** historical tampering; `anchored` walks and
+  recomputes the chain back to the newest externally witnessed link;
+  `full` recomputes from genesis. Ledger-mode default: `anchored` once
+  Phase 4 exists, `full` in the Phases-1+2-only release (there is no anchor
+  to stop at yet).
+- Deliverable gate: adversarial tests — bit-flip in an old revision **and in
+  an old page fragment**, replayed commit, swapped revisions, swapped
+  resource files, transplanted chain, truncated tail — every one must fail
+  verification against a trusted head.
 
 ## 4. Phase 3 — Authenticated commits
 
-**Goal:** bind *who* to each chain link.
+**Goal:** bind *who* to each chain link with a secret adversary B lacks.
 
-- Ed25519 (JDK `java.security` since 15, no dependency) signature over
-  `chainHash(N)`, stored in the extended commit record.
+- Ed25519 (JDK `java.security`, no dependency). The signature covers the
+  domain-separated tuple
+  `("SIRIX-LEDGER-SIG-v1" ‖ keyId ‖ resourceIdentity ‖ revisionNumber(N)
+  ‖ chainHash(N))` — since `chainHash(N)` already commits to `revHash(N)`,
+  the parent link, and (via the page) timestamp/author/message, signing it
+  transitively signs them all; `keyId` and identity prevent key- and
+  resource-confusion. Verification recomputes `chainHash(N)` first (record
+  fields are untrusted).
 - Key material via a `SignerProvider` SPI: file keystore → env/KMS/HSM
-  (enterprise module). Key-rotation events are written **in-band** as commits,
-  so the chain itself witnesses key changes.
+  (enterprise module).
+- **Key rotation is not purely in-band** (a compromised current key could
+  otherwise rewrite rotation history): rotation events are commits in which
+  the *new* key signs the old key's fingerprint and the current head
+  `chainHash`, **and** every external anchor (Phase 4) records the active key
+  fingerprint, making the key→revision-range binding externally immutable.
+  The trusted-key set is external trust state, not in-band data.
 - REST layer maps the authenticated principal (Keycloak) to the signing
   identity; embedded users supply a signer in `ResourceConfiguration`.
-- Ledger mode **rejects `customCommitTimestamps`** for transaction time
-  (valid time — the bitemporal axis — is user data and unaffected).
+- Ledger mode **rejects `customCommitTimestamps`** (transaction time only;
+  valid time — the bitemporal axis — is user data and unaffected). The
+  transaction timestamp remains the local clock and is *not* trusted time;
+  trusted time comes from TSA anchoring (Phase 4). Verifiers reject
+  non-monotonic timestamps.
 
 ## 5. Phase 4 — External anchoring
 
-**Goal:** make the head undeniable, bounding what adversary C can silently do
-to the window since the last anchor.
+**Goal:** make anchored prefixes undeniable; bound adversary C's silent
+window to the commits since the last anchor.
 
 - `AnchorProvider` SPI, policy per resource (`every N commits` / `every T
   seconds` / manual `sdb:anchor()`), publishing
-  `(databaseId, resource, revision, chainHash, signature)`.
-- Reference implementations, in order: (1) second SirixDB instance (dogfood),
-  (2) S3 object-lock/WORM bucket (enterprise S3 module exists), (3) RFC 3161
-  TSA (adds trusted time), (4) transparency log (Trillian/CT-style).
-- Anchor receipts are written back as in-band commits (the chain witnesses its
-  own anchoring). On open: if the durable head is *behind* the newest local
-  anchor receipt → tampering/truncation alarm; this also cleanly separates the
-  legitimate crash-recovery truncation path (never crosses an anchored
-  revision) from malicious truncation.
+  `(resourceIdentity, revisionNumber, chainHash, keyFingerprint, signature)`.
+- **The external witness is the authority.** On open (and in the verifier),
+  the newest anchor is fetched *from the provider*, not from local storage:
+  require durable head ≥ anchored revision, recomputed
+  `chainHash(anchoredRev)` == witnessed value, and the chain to be an
+  append-only extension of the anchored prefix. In-band anchor receipts are
+  written back as commits for provenance, but they are a convenience cache —
+  an adversary who can tamper storage can delete them, so they must never be
+  the source of truth. (This also preserves the clean separation between
+  crash-recovery truncation — which never crosses an anchored revision — and
+  malicious truncation.)
+- Provider trust classes, documented per implementation: an RFC 3161 TSA
+  (adds trusted time), a public transparency log (Trillian/CT-style), or
+  WORM/object-lock storage **under an independent principal** resist
+  adversary C; a second SirixDB instance or an S3 bucket whose credentials C
+  controls is a dev/availability tier only and explicitly *not* a trust
+  anchor against C. There is always an un-anchored tail (at minimum the
+  anchor receipt itself); the anchoring interval is the honesty window.
 
 ## 6. Phase 5 — Proofs and independent verification
 
 **Goal:** auditors and clients verify without trusting the server.
 
-- **Inclusion proofs:** Merkle audit path from any node to `revHash(N)` —
-  `sdb:proof($node)` (query function) + REST endpoint; verified client-side
-  against an anchored `chainHash`.
+- **Inclusion proofs:** page path from `revHash(N)` down to the fragment
+  containing the target (page-granular; per-fragment hashes from Phase 1 make
+  these sound without whole-chain walks) — `sdb:proof($node)` + REST
+  endpoint, verified client-side against an anchored `chainHash`. The
+  optional per-node hash profile shrinks proofs to node granularity.
 - **Consistency proofs:** chain segment export proving revision M..N is an
-  append-only extension (auditors keep the last head they saw).
-- **Offline verifier:** `sirix verify` subcommand in `sirix-kotlin-cli`
-  (native-image friendly): full or incremental re-hash, chain walk, signature
-  checks, anchor comparison. Wire into the existing `verification.yml` deep
-  workflow as a CI gate.
-- Client libraries (python/ts) get proof-verification helpers (pure crypto, no
-  engine code).
+  append-only extension (auditors retain the highest anchored
+  `(revision, chainHash)` they have seen and reject non-extensions).
+- **Offline verifier:** `sirix verify` in `sirix-kotlin-cli` (native-image
+  friendly): full or anchored-prefix re-hash including fragment chains, chain
+  recomputation from genesis or anchor, signature checks against the external
+  key-fingerprint record, anchor comparison. Wired into `verification.yml`
+  as a CI gate.
+- Client libraries (python/ts) get proof-verification helpers (pure crypto,
+  no engine code).
 
 ## 7. Phase 6 — Ops hardening
 
 - Backup/restore (`docs/BACKUP.md`): a backup is valid iff its chain verifies
-  and its head is ≤ the anchored head — verification becomes O(1) per backup.
+  and its head chains into an externally anchored prefix.
 - Multi-resource databases: an optional database-level checkpoint chain over
-  a Merkle map of per-resource heads, so one anchor covers all resources.
-- Documentation: threat model + invariants added to
-  `docs/formal-verification.md`; README claim upgraded honestly only when
-  Phases 1–4 ship.
+  a Merkle map of per-resource heads (each entry bound to its
+  `resourceIdentity`), so one anchor covers all resources.
+- Documentation: threat model + invariants into `docs/formal-verification.md`;
+  the README's "tamper detection" claim upgraded honestly only when Phases
+  1–4 ship.
 
 ## 8. Sequencing, risk, and effort
 
 | Phase | Blast radius | Risk | Depends on |
 |---|---|---|---|
-| 1 Crypto page-Merkle | page-reference hash width, write/verify path | perf regressions (mitigated: O(bytes written), opt-in) | — |
-| 2 Chain | commit record format, commit path | format migration (mitigated: superblock versioning) | 1 |
-| 3 Signatures | commit record, config | key management UX | 2 |
-| 4 Anchoring | new SPI, background task | none on engine | 2 (3 recommended) |
+| 1 Crypto page-Merkle + fragment hashes | reference/fragment wire format, write/verify path, superblock compat branch | perf regressions (mitigated: O(bytes written), opt-in); format migration | — |
+| 2 Chain | commit-record format, commit path | spec discipline (canonical encoding) | 1 |
+| 3 Signatures | commit record, config, key mgmt | key-management UX | 2 |
+| 4 Anchoring | new SPI, open-path check | provider trust classes must be respected by operators | 2 (3 strongly recommended — see threat table) |
 | 5 Proofs/verifier | additive APIs + CLI | none | 1–2 |
 | 6 Ops | docs/tooling | none | 4 |
 
-Phases 1–2 are the engine work and carry the value: after them the system is
-tamper-evident *given a trusted head*. Phases 3–5 make it auditable by third
-parties. Recommended cut: ship 1+2 behind `ledgerMode=true` in one release,
-3+4+5 in the next.
+Phases 1–2 are the engine work. Honest framing of the cut line: after 1–2 the
+system detects corruption and is verifiable against a trusted head; **a
+key-less insider (B) is resisted only once signatures (3) or an external
+anchor (4) exist, and a key-holding one (C) only by anchoring (4), for
+anchored prefixes**. Recommended cut: 1+2 behind `ledgerMode=true` in one
+release; 3+4+5 in the next.
 
 ## 9. Non-goals
 
@@ -184,9 +287,9 @@ parties. Recommended cut: ship 1+2 behind `ledgerMode=true` in one release,
   witness access (impossible; out of scope).
 - Semantic re-verification of index *contents* against document data (the
   page-Merkle tree guarantees index pages are exactly the committed bytes;
-  whether the committed index correctly reflected the data at build time is a
-  correctness concern covered by tests, not an integrity concern).
+  build-time correctness is covered by tests).
 - Confidentiality (already served by the existing encryption pipeline;
-  orthogonal).
+  orthogonal — but see the Phase 1 ciphertext-vs-plaintext commitment
+  decision for where they touch).
 - Distributed consensus / BFT replication (anchoring covers the integrity
   need without it).

--- a/docs/TAMPER_EVIDENCE_PLAN.md
+++ b/docs/TAMPER_EVIDENCE_PLAN.md
@@ -37,28 +37,40 @@ Threat model targeted by this plan:
 state; the design goal is tamper-**evidence** with a minimal trusted base: one
 externally witnessed hash.
 
-## 2. Phase 1 — Cryptographic hash foundation
+## 2. Phase 1 — Cryptographic page-Merkle foundation
 
-**Goal:** a per-resource hash profile where node hashes and page checksums are
-collision-resistant.
+**Goal:** turn the page trie's *existing* parent-embedded child hashes into a
+cryptographic Merkle DAG covering everything reachable from the revision root.
 
-- Add `SHA_256` (JDK built-in, hardware intrinsics via SHA-NI/ARMv8) and
-  optionally `BLAKE3_256` (faster, needs a dependency) to
-  `io.sirix.io.HashAlgorithm`. The enum already dispatches by hash length, so
-  on-disk auto-detection composes.
-- Extend node hashing: today nodes store a 64-bit `long` hash computed via
-  `LongHashFunction` (see `NodeKind`, `AbstractNodeHashing`). Ledger mode
-  stores 256-bit hashes → node layout change, gated by resource
-  configuration and a layout-version bump validated by the superblock.
-- **Write-path cost control:** `ROLLING` recomputes ancestor hashes on every
-  modification — unacceptable with a cryptographic function. Ledger mode
-  computes hashes **once per commit** over the dirty paths (the
-  `TransactionIntentLog` already knows every modified node): O(changed nodes ×
-  depth) SHA-256 invocations per commit, zero cost for read-heavy workloads,
-  zero cost for resources not in ledger mode.
-- Deliverable gate: differential test `ledgerHash == recomputed-from-scratch`
-  across randomized update sequences; commit-overhead benchmark (target:
-  ≤ 15 % commit throughput cost at 4 KB documents, measured like
+SirixDB already stores a hash of every referenced page fragment in the parent
+page (`PageReference.hashInBytes`, set from the payload hash on write in
+`FileChannelWriter`, verified on read under `verifyChecksumsOnRead`, with the
+`RevisionRootPage`'s own hash stored in the commit record). This is a Merkle
+tree in shape — uber page → revision root → indirect pages → fragments —
+covering document data, the path summary, **and every secondary-index page
+subtree**. It is merely built from XXH3-64.
+
+- Add `SHA_256` (JDK built-in, SHA-NI/ARMv8 intrinsics) and optionally
+  `BLAKE3_256` to `io.sirix.io.HashAlgorithm`; the enum already dispatches by
+  hash length, so on-disk auto-detection composes.
+- Ledger mode switches the **page-reference hash** to the cryptographic
+  algorithm and makes `verifyChecksumsOnRead` mandatory. `revHash(N)` becomes
+  the RevisionRootPage's page hash — the commit record already carries a
+  64-bit slot for exactly this value; the extended layout widens it.
+- **Secondary indexes are covered by construction.** This is required, not
+  optional: an unprotected index page lets an adversary silently omit or
+  redirect index-served query results while all document data verifies clean.
+  Rebuildability is no defense unless every query rebuilds and compares.
+- Cost: a streaming hash over already-serialized page payloads at commit —
+  O(bytes written), no node-layout change, zero cost for non-ledger resources.
+- **Optional add-on (may ship with Phase 5 instead):** 256-bit per-node
+  hashes computed once per commit over dirty paths (the
+  `TransactionIntentLog` knows every modified node), for *compact* semantic
+  inclusion proofs of a single node. Page-granular proofs (the page path from
+  root to fragment) work without it and are the default.
+- Deliverable gate: differential test `stored hashes == recomputed-from-
+  scratch` across randomized update sequences; commit-overhead benchmark
+  (target: ≤ 15 % commit throughput cost at 4 KB documents, measured like
   `COMPARISON_POSTGRES.md`).
 
 ## 3. Phase 2 — Chained commit records
@@ -68,8 +80,9 @@ collision-resistant.
 Per committed revision *N* define:
 
 ```
-revHash(N)   = H( documentRootHash(N) ‖ pathSummaryRootHash(N)
-                  ‖ maxNodeKey(N) ‖ revisionNumber(N) )
+revHash(N)   = pageHash( RevisionRootPage(N) )   // Phase 1: transitively
+               // commits to document data, path summary, and ALL
+               // secondary-index page subtrees via parent-embedded hashes
 chainHash(N) = H( chainHash(N-1) ‖ revHash(N) ‖ commitTimestamp(N)
                   ‖ authorId(N) ‖ H(commitMessage(N)) )
 ```
@@ -82,9 +95,12 @@ chainHash(N) = H( chainHash(N-1) ‖ revHash(N) ‖ commitTimestamp(N)
   (FineLine) makes the commit record the natural chaining unit, and
   per-resource logs keep chains independent (aligned with autonomous-commit
   decentralization; no cross-resource coordination on the commit path).
-- Also embed `chainHash(N)` in `RevisionRootPage` for self-containment.
-- Secondary indexes (HOT/RBTree/path/CAS) are derived data: **not** covered by
-  the chain; they are rebuildable and verified against chained content.
+- Also embed `chainHash(N-1)` in `RevisionRootPage` for self-containment (it
+  must be the *parent's* chain hash there, since `revHash(N)` is the hash of
+  the RevisionRootPage itself — a page cannot contain its own hash).
+- Secondary indexes (HOT/RBTree/path/CAS) are covered **by construction**
+  through the page-Merkle tree (Phase 1) — their page subtrees hang off the
+  revision root like all other pages.
 - Open behavior: `verifyChainOnOpen = none | heads | full` (default `heads`).
 - Deliverable gate: adversarial tests — bit-flip in an old revision, replayed
   commit, swapped revisions, truncated tail — every one must fail verification.
@@ -150,7 +166,7 @@ to the window since the last anchor.
 
 | Phase | Blast radius | Risk | Depends on |
 |---|---|---|---|
-| 1 Crypto hashes | node layout, hashing hot path | perf regressions (mitigated: commit-time hashing, opt-in) | — |
+| 1 Crypto page-Merkle | page-reference hash width, write/verify path | perf regressions (mitigated: O(bytes written), opt-in) | — |
 | 2 Chain | commit record format, commit path | format migration (mitigated: superblock versioning) | 1 |
 | 3 Signatures | commit record, config | key management UX | 2 |
 | 4 Anchoring | new SPI, background task | none on engine | 2 (3 recommended) |
@@ -166,7 +182,10 @@ parties. Recommended cut: ship 1+2 behind `ledgerMode=true` in one release,
 
 - Tamper *prevention* against an adversary with unrestricted machine + key +
   witness access (impossible; out of scope).
-- Chaining derived indexes (rebuildable, verified against chained content).
+- Semantic re-verification of index *contents* against document data (the
+  page-Merkle tree guarantees index pages are exactly the committed bytes;
+  whether the committed index correctly reflected the data at build time is a
+  correctness concern covered by tests, not an integrity concern).
 - Confidentiality (already served by the existing encryption pipeline;
   orthogonal).
 - Distributed consensus / BFT replication (anchoring covers the integrity

--- a/docs/TAMPER_EVIDENCE_PLAN.md
+++ b/docs/TAMPER_EVIDENCE_PLAN.md
@@ -1,0 +1,173 @@
+# Tamper-Evident Ledger Mode — Design Plan
+
+Status: **proposal** (no implementation yet)
+Scope: per-resource opt-in "ledger mode" that upgrades SirixDB's append-only,
+immutable-revision storage into a cryptographically tamper-evident system with
+externally anchorable, independently verifiable history.
+
+## 1. Motivation and honest starting point
+
+SirixDB already has the *structural* properties a tamper-evident store needs —
+and they are the hard ones to retrofit:
+
+- append-only single-log storage (FineLine-style: the data file *is* the log,
+  no WAL, no in-place updates);
+- every commit produces an immutable, permanently addressable revision;
+- an optional per-node subtree hash tree (`HashType.ROLLING`/`POSTORDER`),
+  i.e. a Merkle-tree *shape* over every document;
+- page checksums, superblock checksums, checksummed 32-byte commit records.
+
+What it does **not** have is adversarial integrity. Every hash in the system
+is XXH3 (64-bit, non-cryptographic — `ResourceConfiguration.nodeHashFunction`,
+`io.sirix.io.HashAlgorithm.XXH3`), nothing chains commits together
+cryptographically, commit authorship (`CommitCredentials`) is unauthenticated
+metadata, and no state ever leaves the machine. Anyone with file access can
+rewrite a revision, recompute the hashes, and leave no trace. The README's
+"tamper detection" claim currently covers corruption and bugs, not adversaries.
+
+Threat model targeted by this plan:
+
+| Adversary | Capability | Goal of this plan |
+|---|---|---|
+| A. External client | API access only | already handled (authz) + verifiable query proofs |
+| B. Insider with file access | read/write the database files | every modification of committed history is detectable |
+| C. Insider with file + server + key access | full control of one machine | detectable once the head has been anchored externally |
+
+"Tamper-**proof**" in the strict sense is impossible for C without external
+state; the design goal is tamper-**evidence** with a minimal trusted base: one
+externally witnessed hash.
+
+## 2. Phase 1 — Cryptographic hash foundation
+
+**Goal:** a per-resource hash profile where node hashes and page checksums are
+collision-resistant.
+
+- Add `SHA_256` (JDK built-in, hardware intrinsics via SHA-NI/ARMv8) and
+  optionally `BLAKE3_256` (faster, needs a dependency) to
+  `io.sirix.io.HashAlgorithm`. The enum already dispatches by hash length, so
+  on-disk auto-detection composes.
+- Extend node hashing: today nodes store a 64-bit `long` hash computed via
+  `LongHashFunction` (see `NodeKind`, `AbstractNodeHashing`). Ledger mode
+  stores 256-bit hashes → node layout change, gated by resource
+  configuration and a layout-version bump validated by the superblock.
+- **Write-path cost control:** `ROLLING` recomputes ancestor hashes on every
+  modification — unacceptable with a cryptographic function. Ledger mode
+  computes hashes **once per commit** over the dirty paths (the
+  `TransactionIntentLog` already knows every modified node): O(changed nodes ×
+  depth) SHA-256 invocations per commit, zero cost for read-heavy workloads,
+  zero cost for resources not in ledger mode.
+- Deliverable gate: differential test `ledgerHash == recomputed-from-scratch`
+  across randomized update sequences; commit-overhead benchmark (target:
+  ≤ 15 % commit throughput cost at 4 KB documents, measured like
+  `COMPARISON_POSTGRES.md`).
+
+## 3. Phase 2 — Chained commit records
+
+**Goal:** the head commits to the entire history, in order.
+
+Per committed revision *N* define:
+
+```
+revHash(N)   = H( documentRootHash(N) ‖ pathSummaryRootHash(N)
+                  ‖ maxNodeKey(N) ‖ revisionNumber(N) )
+chainHash(N) = H( chainHash(N-1) ‖ revHash(N) ‖ commitTimestamp(N)
+                  ‖ authorId(N) ‖ H(commitMessage(N)) )
+```
+
+- Storage: extend the per-commit record in the revisions file
+  (`FileChannelWriter`, today 32 bytes: offset + timestamp + checksum) to a
+  versioned 96–128-byte layout carrying `revHash`, `chainHash`, and later the
+  signature. The revisions channel is already SYNC write-through, so the chain
+  link becomes durable atomically with the commit — the single-log design
+  (FineLine) makes the commit record the natural chaining unit, and
+  per-resource logs keep chains independent (aligned with autonomous-commit
+  decentralization; no cross-resource coordination on the commit path).
+- Also embed `chainHash(N)` in `RevisionRootPage` for self-containment.
+- Secondary indexes (HOT/RBTree/path/CAS) are derived data: **not** covered by
+  the chain; they are rebuildable and verified against chained content.
+- Open behavior: `verifyChainOnOpen = none | heads | full` (default `heads`).
+- Deliverable gate: adversarial tests — bit-flip in an old revision, replayed
+  commit, swapped revisions, truncated tail — every one must fail verification.
+
+## 4. Phase 3 — Authenticated commits
+
+**Goal:** bind *who* to each chain link.
+
+- Ed25519 (JDK `java.security` since 15, no dependency) signature over
+  `chainHash(N)`, stored in the extended commit record.
+- Key material via a `SignerProvider` SPI: file keystore → env/KMS/HSM
+  (enterprise module). Key-rotation events are written **in-band** as commits,
+  so the chain itself witnesses key changes.
+- REST layer maps the authenticated principal (Keycloak) to the signing
+  identity; embedded users supply a signer in `ResourceConfiguration`.
+- Ledger mode **rejects `customCommitTimestamps`** for transaction time
+  (valid time — the bitemporal axis — is user data and unaffected).
+
+## 5. Phase 4 — External anchoring
+
+**Goal:** make the head undeniable, bounding what adversary C can silently do
+to the window since the last anchor.
+
+- `AnchorProvider` SPI, policy per resource (`every N commits` / `every T
+  seconds` / manual `sdb:anchor()`), publishing
+  `(databaseId, resource, revision, chainHash, signature)`.
+- Reference implementations, in order: (1) second SirixDB instance (dogfood),
+  (2) S3 object-lock/WORM bucket (enterprise S3 module exists), (3) RFC 3161
+  TSA (adds trusted time), (4) transparency log (Trillian/CT-style).
+- Anchor receipts are written back as in-band commits (the chain witnesses its
+  own anchoring). On open: if the durable head is *behind* the newest local
+  anchor receipt → tampering/truncation alarm; this also cleanly separates the
+  legitimate crash-recovery truncation path (never crosses an anchored
+  revision) from malicious truncation.
+
+## 6. Phase 5 — Proofs and independent verification
+
+**Goal:** auditors and clients verify without trusting the server.
+
+- **Inclusion proofs:** Merkle audit path from any node to `revHash(N)` —
+  `sdb:proof($node)` (query function) + REST endpoint; verified client-side
+  against an anchored `chainHash`.
+- **Consistency proofs:** chain segment export proving revision M..N is an
+  append-only extension (auditors keep the last head they saw).
+- **Offline verifier:** `sirix verify` subcommand in `sirix-kotlin-cli`
+  (native-image friendly): full or incremental re-hash, chain walk, signature
+  checks, anchor comparison. Wire into the existing `verification.yml` deep
+  workflow as a CI gate.
+- Client libraries (python/ts) get proof-verification helpers (pure crypto, no
+  engine code).
+
+## 7. Phase 6 — Ops hardening
+
+- Backup/restore (`docs/BACKUP.md`): a backup is valid iff its chain verifies
+  and its head is ≤ the anchored head — verification becomes O(1) per backup.
+- Multi-resource databases: an optional database-level checkpoint chain over
+  a Merkle map of per-resource heads, so one anchor covers all resources.
+- Documentation: threat model + invariants added to
+  `docs/formal-verification.md`; README claim upgraded honestly only when
+  Phases 1–4 ship.
+
+## 8. Sequencing, risk, and effort
+
+| Phase | Blast radius | Risk | Depends on |
+|---|---|---|---|
+| 1 Crypto hashes | node layout, hashing hot path | perf regressions (mitigated: commit-time hashing, opt-in) | — |
+| 2 Chain | commit record format, commit path | format migration (mitigated: superblock versioning) | 1 |
+| 3 Signatures | commit record, config | key management UX | 2 |
+| 4 Anchoring | new SPI, background task | none on engine | 2 (3 recommended) |
+| 5 Proofs/verifier | additive APIs + CLI | none | 1–2 |
+| 6 Ops | docs/tooling | none | 4 |
+
+Phases 1–2 are the engine work and carry the value: after them the system is
+tamper-evident *given a trusted head*. Phases 3–5 make it auditable by third
+parties. Recommended cut: ship 1+2 behind `ledgerMode=true` in one release,
+3+4+5 in the next.
+
+## 9. Non-goals
+
+- Tamper *prevention* against an adversary with unrestricted machine + key +
+  witness access (impossible; out of scope).
+- Chaining derived indexes (rebuildable, verified against chained content).
+- Confidentiality (already served by the existing encryption pipeline;
+  orthogonal).
+- Distributed consensus / BFT replication (anchoring covers the integrity
+  need without it).


### PR DESCRIPTION
## What does this PR do?

Adds `docs/TAMPER_EVIDENCE_PLAN.md` — a six-phase design proposal for a per-resource opt-in **ledger mode**: cryptographic page-Merkle foundation, chained commit records, Ed25519-signed commits, external anchoring, verifiable proofs plus an offline verifier, and ops hardening. No implementation in this PR.

The plan is grounded in the existing storage architecture and was reviewed in three passes before this PR (a storage-layer fact check of every code claim with file:line evidence, an adversarial protocol review — 18 findings, all integrated — and a consistency pass). Highlights of what the reviews shaped:

- **Builds on the existing page-Merkle structure**: parent pages already embed child page-fragment hashes (`PageReference.hashInBytes`, verified under `verifyChecksumsOnRead`, default on) — ledger mode upgrades this from XXH3-64 to a cryptographic hash rather than introducing a parallel mechanism, so `revHash(N) = pageHash(RevisionRootPage(N))` covers document data, path summary, **and all secondary-index page subtrees** (unprotected index pages would let an adversary silently redirect index-served query results).
- **Closes the fragment hole**: `PageFragmentKey` gains a per-fragment hash — today only the newest fragment of each page is verified, and reconstruction under the default `SLIDING_SNAPSHOT` versioning reads older fragments unverified (the code carries a TODO for exactly this).
- **Normative chain spec**: domain-separated, canonically encoded, resource-identity-bound chain with a defined genesis; the extended commit record stores full-width hashes but is a *non-authoritative cache* — verifiers recompute from page-derived inputs.
- **Honest threat model**: hash-chaining alone does not stop a key-less insider (nothing in the construction is secret) — signatures or an external anchor do; anchors are fetched from the external witness, never from local receipts; per-provider anchor trust classes are stated (a co-located second instance is not a trust anchor against a key-holding insider); key rotation is cross-signed and externally witnessed.

## Related issue

Follow-up to the tamper-evidence discussion; complements the FineLine-style single-log architecture (the commit record is the natural chaining unit; per-resource logs keep chains off the commit path's critical section).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [x] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — n/a, docs only
- [ ] Added or updated tests covering the change — n/a (the plan itself specifies adversarial test gates per phase)
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — n/a, no engine change; the plan schedules invariant additions for Phase 6
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

The plan deliberately does not overclaim: the phase table states exactly which adversary each phase defeats, `verifyChainOnOpen=head` is documented as detecting no historical tampering, and tamper *prevention* against a key-holding insider with witness access is an explicit non-goal. The two engine-facing format changes (32-byte reference hashes — `SerializationType.PAGE_HASH_BYTES` and the beacon/record fields are currently hardcoded to 8 bytes — and fragment-key hashes) are gated per resource and by a superblock layout-version compatibility branch, which today hard-rejects unknown versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM)_