### PR TITLE
Document auto-commit vs KEEP_OPEN_ASYNC pre-flush in the architecture spec

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2082,6 +2082,60 @@ The TIL holds uncommitted modifications during a write transaction:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
+### Auto-Commit and the Async Pre-Flush (`KEEP_OPEN_ASYNC`)
+
+Long-running write transactions (bulk loads, streaming ingest) can bound their
+memory and commit latency with two distinct mechanisms — one of which is a
+real commit, and one of which deliberately is **not**:
+
+| Mechanism | Creates a revision? | Writes a commit record? | What it does |
+|---|---|---|---|
+| Explicit `commit()` | yes | yes | full commit protocol |
+| Sync auto-commit (`maxNodeCount`/timer, `KEEP_OPEN`) | yes | yes | full commit protocol, transaction stays open |
+| Async pre-flush (`KEEP_OPEN_ASYNC`) | **no** | **no** | shadow-writes leaf pages ahead of the next real commit |
+
+**The async pre-flush is a durability optimization, not a transactional
+event.** When triggered, the TIL takes an O(1) snapshot (an array swap that
+freezes the current entries — the "frozen zone") and the insert thread
+immediately continues on a fresh TIL generation. A background thread then
+writes every `KeyValueLeafPage` in the frozen snapshot to the data file
+through a *shadow* `PageReference` — never touching the live references — and
+records each page's disk offset and content hash in the snapshot. No indirect
+pages, no `RevisionRootPage`, no `UberPage`, and no revisions-file record are
+written: nothing becomes visible, and if the process crashes before the next
+real commit, the pre-flushed bytes are unreachable dead space (equivalent to
+rolled-back bytes in the append-only file).
+
+At the next real commit, each pre-flushed page falls into one of two cases:
+
+- **Unmodified since the snapshot** — the commit reuses the recorded offset
+  and hash instead of rewriting the page. This is the payoff: the leaf I/O
+  (typically the bulk of a commit) already happened off the commit path.
+- **Modified since the snapshot** — the insert thread's modification
+  triggered a copy-on-write of the frozen page into the current TIL
+  generation, and that copy is the authoritative version. The earlier flush
+  is now **superseded (stale)**: its offset describes an outdated page. The
+  TIL records a forwarding link for the superseded `(generation, logKey)`
+  identity so that any stale reference copies — e.g. inside CoW'd
+  `IndirectPage`s that are never re-walked — resolve to the new entry rather
+  than to the stale disk offset. Without this forwarding chain the final
+  commit would durably serialize the outdated page and silently lose every
+  record added after the snapshot boundary (issue #1077, hit in practice by
+  leaf pages straddling a snapshot epoch during monotonic bulk inserts). The
+  stale flushed bytes remain as unreachable dead space — write amplification
+  on write-hot pages is the price of moving leaf I/O off the commit path.
+
+Two invariants follow that other subsystems rely on:
+
+1. **Every revision has a commit record.** There is no code path that creates
+   a revision without writing the per-commit record in the revisions file —
+   sync auto-commits included. The async pre-flush creates no revision, so
+   the equivalence "revision ⇔ commit record" holds unconditionally (this is
+   what makes the commit record a sound per-revision chaining point, see
+   `TAMPER_EVIDENCE_PLAN.md`).
+2. **Only reachable bytes carry authority.** Superseded flushes are never
+   referenced by any revision; page hashes embedded in parent pages cover
+   exactly the pages a revision can read, never dead space.
 
 ## Memory Management
 


### PR DESCRIPTION
## What does this PR do?

Adds a Transaction Model subsection to `docs/ARCHITECTURE.md` documenting the distinction between synchronous auto-commits and the `KEEP_OPEN_ASYNC` asynchronous pre-flush:

- sync auto-commits run the **full commit protocol** — one real revision + commit record each;
- the async pre-flush is **not a commit**: O(1) TIL snapshot, background shadow-writes of leaf pages, no revision, no commit record, crash-discards as unreachable dead space;
- stale pre-flushed pages (modified again after the snapshot) are superseded via copy-on-write plus the TIL forwarding chain (#1077 — without it the final commit would serialize the outdated page and silently lose records added after the snapshot boundary), while unmodified pages' offsets and hashes are reused at the real commit;
- the two invariants downstream designs rely on (notably `TAMPER_EVIDENCE_PLAN.md`): **revision ⇔ commit record**, and **only reachable bytes carry authority**.

Companion website PR: sirixdb/sirixdb.github.io#claude/document-async-preflush (architecture page + transactional-cursor-api page).

## Related issue

Documents the semantics fixed by #1077; requested follow-up to the ledger-mode design discussion (#1112).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [x] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — n/a, docs only
- [ ] Added or updated tests covering the change — n/a
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — n/a, documentation of existing behavior
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

The behavior documented was verified directly against `NodeStorageEngineWriter.asyncIntermediateCommit`/`executeSnapshotWrite` and `TransactionIntentLog`'s snapshot/forwarding machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM)_