### PR TITLE
Async durable commits (KEEP_OPEN_ASYNC_COMMIT), asyncFlush rename, async-flush imports by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to SirixDB are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Asynchronous durable commits** (`AfterCommitState.KEEP_OPEN_ASYNC_COMMIT`) — the middle
+  ground between synchronous auto-commits and the async pre-flush: every threshold crossing
+  creates a real, durable, queryable revision, but the durability barriers (index-catalogue
+  fsync, buffered-tail flush, data force, uber-beacon writes) run on a background thread while
+  the transaction keeps inserting into the next epoch. Depth-1 pipeline with backpressure;
+  readers see a revision exactly when it hardens (durable-before-visible); a hardening failure
+  poisons the transaction. FILE_CHANNEL backend, count-based auto-commit only. See
+  `docs/ASYNC_COMMIT_DESIGN.md`.
+- `BasicJsonDBStore.Builder#useAsyncFlushForImports` — bulk imports (e.g. `jn:store`) now use
+  the asynchronous background pre-flush by **default** on the FILE_CHANNEL backend: one
+  semantically meaningful revision per import instead of parser-progress checkpoint revisions,
+  with leaf I/O overlapped with parsing and memory still bounded by
+  `numberOfNodesBeforeAutoCommit`. Pass `false` (or `-Dsirix.import.asyncFlush=false`) to
+  restore synchronous intermediate auto-commits.
+
+### Changed
+
+- **Breaking rename:** the async intermediate "commit" is now called what it is — an async
+  flush. `AfterCommitState.KEEP_OPEN_ASYNC` → `KEEP_OPEN_ASYNC_FLUSH`,
+  `StorageEngineWriter.asyncIntermediateCommit()` → `asyncFlush()`,
+  `awaitPendingAsyncCommit()` → `awaitPendingAsyncFlush()`. The mechanism creates no revision
+  and no commit record; the old names asserted otherwise.
+
 ## [1.0.0-beta7] — 2026-07-15
 
 ### Fixed

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -42,7 +42,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -331,10 +333,155 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
    *        redundant I/O (e.g. unchanged index definitions) may be skipped
    * @return this transaction for chaining
    */
+  // ==================== ASYNC COMMIT PIPELINE (KEEP_OPEN_ASYNC_COMMIT) ====================
+  // Depth-1 pipeline state. Lives on the NODE transaction (not the page writer) because every
+  // async-commit epoch creates a NEW page writer; the pipeline outlives each of them.
+
+  /** One background hardening in flight at most; acquired by phase 1, released after phase 2. */
+  private final Semaphore asyncCommitPermit = new Semaphore(1);
+
+  /** First background hardening failure; latches the transaction terminally. */
+  private volatile Throwable asyncCommitFailure;
+
+  /** Permanent failure latch — a lost hardening invalidates every successor epoch. */
+  private volatile boolean asyncCommitTerminalFailure;
+
+  /**
+   * Drain the async-commit pipeline: wait for a pending background hardening and surface its
+   * failure. Called before any synchronous commit, rollback, or close.
+   */
+  private void awaitPendingAsyncCommit() {
+    asyncCommitPermit.acquireUninterruptibly();
+    asyncCommitPermit.release();
+    final Throwable failure = asyncCommitFailure;
+    if (failure != null) {
+      asyncCommitFailure = null;
+      asyncCommitTerminalFailure = true;
+      throw new SirixIOException("Async commit hardening failed", failure);
+    }
+    if (asyncCommitTerminalFailure) {
+      throw new SirixIOException("Transaction in terminal failure state from prior async commit error");
+    }
+  }
+
+  /**
+   * Pipelined intermediate commit: phase 1 (page writes) inline, phase 2 (durability barriers)
+   * in the background; the transaction immediately continues on a successor epoch based on the
+   * pending uber page. Readers see the revision when the background hardening publishes it.
+   */
+  private void asyncCommitInternal(final String commitMessage) {
+    runLocked(() -> {
+      final var preCommitRevision = getRevisionNumber();
+
+      state = State.COMMITTING;
+
+      try {
+        if (pathSummaryWriter != null) {
+          pathSummaryWriter.flushPendingStats();
+        }
+        for (final PreCommitHook hook : preCommitHooks) {
+          hook.preCommit(this);
+        }
+
+        // Depth-1: wait for the previous epoch's hardening (and surface its failure), and drain
+        // any pending async flush of THIS writer before serializing.
+        awaitPendingAsyncCommit();
+        storageEngineWriter.awaitPendingAsyncFlush();
+      } catch (final RuntimeException | Error e) {
+        state = State.RUNNING;
+        throw e;
+      }
+
+      asyncCommitPermit.acquireUninterruptibly();
+
+      final StorageEngineWriter committingWriter = storageEngineWriter;
+      final UberPage pendingUberPage;
+      try {
+        pendingUberPage = committingWriter.commitWritePages(commitMessage, null, true);
+      } catch (final RuntimeException | Error e) {
+        asyncCommitPermit.release();
+        // Nothing is durable yet — keep the transaction usable, mirroring commitInternal.
+        state = State.RUNNING;
+        throw e;
+      }
+
+      // Phase 1 succeeded: the epoch will become durable (or the pipeline poisons the trx).
+      // Expose the pending revision root so the successor epoch (the only reader that can reach
+      // the unpublished revision) resolves it from memory.
+      resourceSession.putPendingRevisionRoot(pendingUberPage.getRevisionNumber(),
+          committingWriter.getActualRevisionRootPage());
+      modificationCount = 0L;
+
+      if (resourceSession.getResourceConfig().storeDiffs()) {
+        try {
+          serializeUpdateDiffs(preCommitRevision);
+        } catch (final RuntimeException | Error e) {
+          LOGGER.error("Update-diff serialization failed for pipelined revision {} — the diff file "
+              + "for this revision is missing.", preCommitRevision, e);
+        }
+      }
+
+      try {
+        reInstantiate(getId(), pendingUberPage.getRevisionNumber(), pendingUberPage);
+        state = State.RUNNING;
+      } catch (final RuntimeException | Error e) {
+        // Successor epoch could not be created — harden inline so the committed data survives,
+        // then surface the failure with a truthful terminal state (mirrors commitInternal).
+        hardenAndPublish(committingWriter, pendingUberPage);
+        asyncCommitPermit.release();
+        state = State.COMMITTED;
+        throw e;
+      }
+
+      try {
+        CompletableFuture.runAsync(() -> {
+          try {
+            hardenAndPublish(committingWriter, pendingUberPage);
+          } catch (final Throwable t) {
+            asyncCommitFailure = t;
+            asyncCommitTerminalFailure = true;
+          } finally {
+            asyncCommitPermit.release();
+          }
+        });
+      } catch (final Throwable t) {
+        // Submission failed (e.g. RejectedExecutionException): harden inline — correctness over
+        // pipelining.
+        try {
+          hardenAndPublish(committingWriter, pendingUberPage);
+        } finally {
+          asyncCommitPermit.release();
+        }
+      }
+    });
+
+    // Execute post-commit hooks (parity with sync intermediate commits).
+    for (final PostCommitHook hook : postCommitHooks) {
+      hook.postCommit(this);
+    }
+  }
+
+  /**
+   * Phase 2 + publication: harden the pending revision, make it visible to readers, and close the
+   * superseded page transaction (releasing its writer channels).
+   */
+  private void hardenAndPublish(final StorageEngineWriter committingWriter, final UberPage pendingUberPage) {
+    committingWriter.hardenCommit(pendingUberPage, true);
+    resourceSession.setLastCommittedUberPage(pendingUberPage);
+    // Publish-then-clear: there is no window in which the revision resolves through neither path.
+    resourceSession.clearPendingRevisionRoot(pendingUberPage.getRevisionNumber());
+    committingWriter.close();
+  }
+
   private W commitInternal(@Nullable final String commitMessage, @Nullable final Instant commitTimestamp,
       final boolean isIntermediateCommit) {
     runLocked(() -> {
       final var preCommitRevision = getRevisionNumber();
+
+      // Drain the async-commit pipeline first: the synchronous commit below must build on a
+      // hardened predecessor (and a poisoned pipeline must fail loudly, not commit on top of a
+      // lost revision).
+      awaitPendingAsyncCommit();
 
       state = State.COMMITTING;
 
@@ -392,7 +539,8 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
       try {
         // Reinstantiate everything.
         if (afterCommitState == AfterCommitState.KEEP_OPEN
-            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH
+            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
           // Use the newly committed revision number, not the pre-commit revision.
           // After commit, uberPage represents the new revision, and we need to
           // create a page transaction that will prepare the NEXT revision.
@@ -464,7 +612,9 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   protected final void checkAccessAndCommitBulk() {
     modificationCount++;
     if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
-      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
+        asyncCommitInternal("autoCommit");
+      } else if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
         storageEngineWriter.asyncFlush();
         modificationCount = 0;
         // Match sync reInstantiate() behavior: new nodeHashing has autoCommit=false.
@@ -498,7 +648,9 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   private void intermediateCommitIfRequired() {
     nodeReadOnlyTrx.assertNotClosed();
     if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
-      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
+        asyncCommitInternal("autoCommit");
+      } else if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
         storageEngineWriter.asyncFlush();
         modificationCount = 0;
         nodeHashing.setAutoCommit(false);
@@ -519,6 +671,16 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
    * @param revNumber revision number
    */
   private void reInstantiate(final int trxID, final int revNumber) {
+    reInstantiate(trxID, revNumber, null);
+  }
+
+  /**
+   * @param pendingBaseUberPage non-null for pipelined async commits: the phase-1-complete uber
+   *        page of the still-hardening revision. The superseded page transaction is DETACHED
+   *        (closed later by the background hardening thread), and the successor is based on the
+   *        pending uber page instead of {@code lastCommittedUberPage}.
+   */
+  private void reInstantiate(final int trxID, final int revNumber, final UberPage pendingBaseUberPage) {
     final boolean timing = LOGGER.isDebugEnabled();
     final long r0 = timing ? System.nanoTime() : 0;
 
@@ -526,12 +688,17 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
     final long currentNodeKey = nodeReadOnlyTrx.getNodeKey();
 
     // Reset page transaction to new uber page.
-    resourceSession.closeNodePageWriteTransaction(getId());
+    if (pendingBaseUberPage == null) {
+      resourceSession.closeNodePageWriteTransaction(getId());
+    } else {
+      resourceSession.detachNodePageWriteTransaction(getId());
+    }
 
     final long r1 = timing ? System.nanoTime() : 0;
 
     storageEngineWriter =
-        resourceSession.createPageTransaction(trxID, revNumber, revNumber, InternalResourceSession.Abort.NO, true);
+        resourceSession.createPageTransaction(trxID, revNumber, revNumber, InternalResourceSession.Abort.NO, true,
+            pendingBaseUberPage);
     nodeReadOnlyTrx.setPageReadTransaction(null);
     nodeReadOnlyTrx.setPageReadTransaction(storageEngineWriter);
     resourceSession.setNodePageWriteTransaction(getId(), storageEngineWriter);
@@ -591,6 +758,10 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
     }
     try {
       nodeReadOnlyTrx.assertNotClosed();
+
+      // Drain the async-commit pipeline: rolling back on top of an un-hardened (or failed)
+      // predecessor epoch is unsound.
+      awaitPendingAsyncCommit();
 
       // Save the current cursor position before closing the old page transaction.
       final long rollbackNodeKey = nodeReadOnlyTrx.getNodeKey();
@@ -788,6 +959,16 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   public void close() {
     runLocked(() -> {
       if (!isClosed()) {
+        // Drain the async-commit pipeline so every hardening finished (or its failure is known)
+        // before resources are torn down. A failure is logged, not thrown: close() must still
+        // release resources — the data loss already happened and was latched.
+        try {
+          awaitPendingAsyncCommit();
+        } catch (final RuntimeException e) {
+          LOGGER.error("Async commit pipeline failed before close — the last pipelined revision(s) "
+              + "did not become durable.", e);
+        }
+
         // Make sure to commit all dirty data.
         if (modificationCount > 0) {
           throw new SirixUsageException("Must commit/rollback transaction first!");

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -25,7 +25,6 @@ import io.sirix.node.interfaces.FlyweightNode;
 import io.sirix.node.interfaces.Node;
 import io.sirix.node.interfaces.StructNode;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
-import io.sirix.page.KeyValueLeafPage;
 import io.sirix.page.UberPage;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -356,7 +356,7 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
         }
 
         // Await any pending async background flush before sync commit
-        storageEngineWriter.awaitPendingAsyncCommit();
+        storageEngineWriter.awaitPendingAsyncFlush();
 
         uberPage = storageEngineWriter.commit(commitMessage, commitTimestamp, isAutoCommitting, isIntermediateCommit);
       } catch (final RuntimeException | Error e) {
@@ -392,7 +392,7 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
       try {
         // Reinstantiate everything.
         if (afterCommitState == AfterCommitState.KEEP_OPEN
-            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
+            || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
           // Use the newly committed revision number, not the pre-commit revision.
           // After commit, uberPage represents the new revision, and we need to
           // create a page transaction that will prepare the NEXT revision.
@@ -464,8 +464,8 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   protected final void checkAccessAndCommitBulk() {
     modificationCount++;
     if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
-      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
-        storageEngineWriter.asyncIntermediateCommit();
+      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+        storageEngineWriter.asyncFlush();
         modificationCount = 0;
         // Match sync reInstantiate() behavior: new nodeHashing has autoCommit=false.
         // Without this, rollingAdd() walks the full ancestor chain on every insert,
@@ -498,8 +498,8 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   private void intermediateCommitIfRequired() {
     nodeReadOnlyTrx.assertNotClosed();
     if (maxNodeCount > 0 && modificationCount > maxNodeCount && compoundOperationDepth == 0) {
-      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
-        storageEngineWriter.asyncIntermediateCommit();
+      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+        storageEngineWriter.asyncFlush();
         modificationCount = 0;
         nodeHashing.setAutoCommit(false);
       } else {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -43,6 +43,7 @@ import io.sirix.metrics.TransactionMetrics;
 import io.sirix.node.RevisionReferencesNode;
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.interfaces.Node;
+import io.sirix.page.RevisionRootPage;
 import io.sirix.page.UberPage;
 import io.sirix.settings.Fixed;
 import org.jspecify.annotations.Nullable;
@@ -363,13 +364,24 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   @Override
   public StorageEngineWriter createPageTransaction(final int id, final int representRevision,
       final int storedRevision, final Abort abort, boolean isBoundToNodeTrx) {
+    return createPageTransaction(id, representRevision, storedRevision, abort, isBoundToNodeTrx, null);
+  }
+
+  @Override
+  public StorageEngineWriter createPageTransaction(final int id, final int representRevision,
+      final int storedRevision, final Abort abort, boolean isBoundToNodeTrx,
+      final @Nullable UberPage pendingBaseUberPage) {
     checkArgument(id >= 0, "id must be >= 0!");
     checkArgument(representRevision >= 0, "representRevision must be >= 0!");
     checkArgument(storedRevision >= 0, "storedRevision must be >= 0!");
 
     final Writer writer = storage.createWriter();
 
-    final UberPage lastCommittedUberPage = this.lastCommittedUberPage.get();
+    // Pipelined async commits pass the pending (phase-1-complete, canonical in-memory) uber page
+    // of the still-hardening revision as the base for the successor epoch; readers keep resolving
+    // "latest" through lastCommittedUberPage until the background hardening publishes it.
+    final UberPage lastCommittedUberPage =
+        pendingBaseUberPage != null ? pendingBaseUberPage : this.lastCommittedUberPage.get();
     final int lastCommittedRev = lastCommittedUberPage.getRevisionNumber();
     final var storageEngineWriter = this.storageEngineWriterFactory.createStorageEngineWriter(this,
         abort == Abort.YES && lastCommittedUberPage.isBootstrap()
@@ -377,9 +389,46 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
             : new UberPage(lastCommittedUberPage),
         writer, id, representRevision, storedRevision, lastCommittedRev, isBoundToNodeTrx, bufferManager);
 
-    truncateToLastSuccessfullyCommittedRevisionIfCommitLockFileExists(writer, lastCommittedRev, storageEngineWriter);
+    // The commit marker legitimately exists while an in-process async commit hardens — the
+    // truncate check exists for CRASH recovery and must not fire for pipelined successor epochs.
+    if (pendingBaseUberPage == null) {
+      truncateToLastSuccessfullyCommittedRevisionIfCommitLockFileExists(writer, lastCommittedRev, storageEngineWriter);
+    }
 
     return storageEngineWriter;
+  }
+
+  /** Depth-1 pipelined async commit: the pending (phase-1-complete, unhardened) revision root. */
+  private volatile PendingRevisionRoot pendingRevisionRoot;
+
+  private record PendingRevisionRoot(int revision, RevisionRootPage rootPage) {
+  }
+
+  @Override
+  public void putPendingRevisionRoot(final int revision, final RevisionRootPage rootPage) {
+    pendingRevisionRoot = new PendingRevisionRoot(revision, rootPage);
+  }
+
+  @Override
+  public RevisionRootPage getPendingRevisionRoot(final int revision) {
+    final PendingRevisionRoot pending = pendingRevisionRoot;
+    return pending != null && pending.revision() == revision ? pending.rootPage() : null;
+  }
+
+  @Override
+  public void clearPendingRevisionRoot(final int revision) {
+    final PendingRevisionRoot pending = pendingRevisionRoot;
+    if (pending != null && pending.revision() == revision) {
+      pendingRevisionRoot = null;
+    }
+  }
+
+  @Override
+  public void detachNodePageWriteTransaction(final int transactionID) {
+    // Pipelined async commit: the superseded page transaction is handed to the background
+    // hardening thread, which closes it after the beacon write — remove it from the map WITHOUT
+    // closing so the successor can register itself.
+    storageEngineWriterMap.remove(transactionID);
   }
 
   private void truncateToLastSuccessfullyCommittedRevisionIfCommitLockFileExists(Writer writer, int lastCommittedRev,
@@ -773,16 +822,17 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     }
     requireNonNull(timeUnit);
 
-    // KEEP_OPEN_ASYNC_FLUSH runtime guards
-    if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+    // KEEP_OPEN_ASYNC_FLUSH / KEEP_OPEN_ASYNC_COMMIT runtime guards
+    if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH
+        || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
       if (getResourceConfig().getStorageType() != StorageType.FILE_CHANNEL) {
         throw new IllegalArgumentException(
-            "KEEP_OPEN_ASYNC_FLUSH requires FILE_CHANNEL storage backend; got "
+            afterCommitState + " requires FILE_CHANNEL storage backend; got "
                 + getResourceConfig().getStorageType());
       }
       if (maxTime > 0) {
         throw new IllegalArgumentException(
-            "KEEP_OPEN_ASYNC_FLUSH does not support timed auto-commit; use count-based only");
+            afterCommitState + " does not support timed auto-commit; use count-based only");
       }
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -773,16 +773,16 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     }
     requireNonNull(timeUnit);
 
-    // KEEP_OPEN_ASYNC runtime guards
-    if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC) {
+    // KEEP_OPEN_ASYNC_FLUSH runtime guards
+    if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
       if (getResourceConfig().getStorageType() != StorageType.FILE_CHANNEL) {
         throw new IllegalArgumentException(
-            "KEEP_OPEN_ASYNC requires FILE_CHANNEL storage backend; got "
+            "KEEP_OPEN_ASYNC_FLUSH requires FILE_CHANNEL storage backend; got "
                 + getResourceConfig().getStorageType());
       }
       if (maxTime > 0) {
         throw new IllegalArgumentException(
-            "KEEP_OPEN_ASYNC does not support timed auto-commit; use count-based only");
+            "KEEP_OPEN_ASYNC_FLUSH does not support timed auto-commit; use count-based only");
       }
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
@@ -15,7 +15,7 @@ public enum AfterCommitState {
    *   <li>Only threshold-based auto-commit supported (timed auto-commit not allowed)</li>
    * </ul>
    */
-  KEEP_OPEN_ASYNC,
+  KEEP_OPEN_ASYNC_FLUSH,
 
   CLOSE
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
@@ -17,5 +17,19 @@ public enum AfterCommitState {
    */
   KEEP_OPEN_ASYNC_FLUSH,
 
+  /**
+   * Asynchronous durable commits. Each threshold crossing creates a REAL revision (durable,
+   * queryable, with its own commit record), but the durability barriers — index-catalogue fsync,
+   * buffered-tail flush, data force, uber-beacon writes — run on a background thread while the
+   * transaction continues inserting into the next epoch. The writer thread pays only page
+   * serialization (phase 1); readers see a new revision exactly when it hardens
+   * (durable-before-visible). Depth-1 pipeline: the next epoch's phase 1 waits for the previous
+   * epoch's hardening. A hardening failure poisons the transaction terminally.
+   *
+   * <p>See {@code docs/ASYNC_COMMIT_DESIGN.md}. Requirements (as for
+   * {@link #KEEP_OPEN_ASYNC_FLUSH}): FILE_CHANNEL backend, count-based auto-commit only.</p>
+   */
+  KEEP_OPEN_ASYNC_COMMIT,
+
   CLOSE
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
@@ -7,6 +7,7 @@ import io.sirix.api.NodeTrx;
 import io.sirix.api.ResourceSession;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.io.Reader;
+import io.sirix.page.RevisionRootPage;
 import io.sirix.page.UberPage;
 
 import java.nio.file.Path;
@@ -36,6 +37,35 @@ public interface InternalResourceSession<R extends NodeReadOnlyTrx & NodeCursor,
   void assertAccess(int revision);
 
   StorageEngineWriter createPageTransaction(int trxID, int revision, int i, Abort no, boolean isBoundToNodeTrx);
+
+  /**
+   * Variant for pipelined async commits: bases the new page transaction on the given PENDING
+   * (phase-1-complete, not yet hardened) uber page instead of {@code lastCommittedUberPage}, and
+   * skips the crash-recovery truncate check (the commit marker legitimately exists while the
+   * previous epoch hardens in the background). Pass {@code null} for the default behavior.
+   */
+  StorageEngineWriter createPageTransaction(int trxID, int revision, int i, Abort no, boolean isBoundToNodeTrx,
+      UberPage pendingBaseUberPage);
+
+  /**
+   * Remove a node-bound page write transaction from the session's map WITHOUT closing it — used
+   * by pipelined async commits, where the superseded page transaction is closed by the background
+   * hardening thread after the beacon write.
+   */
+  void detachNodePageWriteTransaction(int transactionID);
+
+  /**
+   * Pipelined async commits: register / resolve / clear the PENDING revision root — the
+   * phase-1-complete, canonical in-memory root of a revision whose hardening is still running in
+   * the background. Readers of the pending revision (only the successor epoch can reach it)
+   * resolve it from here, since neither the revisions-file record nor
+   * {@code lastCommittedUberPage} exist for it yet. Depth-1 pipeline ⇒ at most one pending entry.
+   */
+  void putPendingRevisionRoot(int revision, RevisionRootPage rootPage);
+
+  RevisionRootPage getPendingRevisionRoot(int revision);
+
+  void clearPendingRevisionRoot(int revision);
 
   Lock getCommitLock();
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/AbstractForwardingStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/AbstractForwardingStorageEngineWriter.java
@@ -1,5 +1,6 @@
 package io.sirix.access.trx.page;
 
+import java.time.Instant;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.index.IndexType;
 import io.sirix.node.NodeKind;
@@ -66,6 +67,27 @@ public abstract class AbstractForwardingStorageEngineWriter extends AbstractForw
   @Override
   public void commit(PageReference reference) {
     delegate().commit(reference);
+  }
+
+  @Override
+  public UberPage commitWritePages(String commitMessage, Instant commitTimeStamp,
+      boolean isIntermediateCommit) {
+    return delegate().commitWritePages(commitMessage, commitTimeStamp, isIntermediateCommit);
+  }
+
+  @Override
+  public void hardenCommit(UberPage uberPage, boolean isIntermediateCommit) {
+    delegate().hardenCommit(uberPage, isIntermediateCommit);
+  }
+
+  @Override
+  public void asyncFlush() {
+    delegate().asyncFlush();
+  }
+
+  @Override
+  public void awaitPendingAsyncFlush() {
+    delegate().awaitPendingAsyncFlush();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -800,6 +800,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    */
   @Override
   public RevisionRootPage loadRevRoot(final int revisionKey) {
+    // Pipelined async commit: revision N's root exists canonically in memory after phase 1 but
+    // is neither published (lastCommittedUberPage) nor recorded in the revisions file until the
+    // background hardening completes. Serve it from the session's pending slot.
+    final RevisionRootPage pendingRevisionRoot = resourceSession.getPendingRevisionRoot(revisionKey);
+    if (pendingRevisionRoot != null) {
+      return pendingRevisionRoot;
+    }
     assert revisionKey <= resourceSession.getMostRecentRevisionNumber();
     if (trxIntentLog == null) {
       final Cache<RevisionRootPageCacheKey, RevisionRootPage> cache = resourceBufferManager.getRevisionRootPageCache();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -962,6 +962,20 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     storageEngineReader.resourceSession.getCommitLock().lock();
 
     try {
+      final UberPage uberPage = commitWritePages(commitMessage, commitTimestamp, isIntermediateCommit);
+      hardenCommit(uberPage, isIntermediateCommit);
+      return uberPage;
+    } finally {
+      storageEngineReader.resourceSession.getCommitLock().unlock();
+    }
+  }
+
+  @Override
+  public UberPage commitWritePages(@Nullable final String commitMessage, @Nullable final Instant commitTimestamp,
+      final boolean isIntermediateCommit) {
+    storageEngineReader.assertNotClosed();
+
+    {
       final boolean timing = LOGGER.isDebugEnabled();
 
       final Path commitFile = storageEngineReader.resourceSession.getCommitFile();
@@ -969,10 +983,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       // Issues with windows that it's not created in the first time?
       createIfAbsent(commitFile);
 
-      final PageReference uberPageReference =
-          new PageReference().setDatabaseId(storageEngineReader.getDatabaseId()).setResourceId(storageEngineReader.getResourceId());
       final UberPage uberPage = storageEngineReader.getUberPage();
-      uberPageReference.setPage(uberPage);
 
       setUserIfPresent();
       setCommitMessageAndTimestampIfRequired(commitMessage, commitTimestamp);
@@ -986,6 +997,31 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       LOGGER.debug("TIL size before recursive commit: {}", log.getList().size());
       uberPage.commit(this);
       LOGGER.debug("TIL size after recursive commit: {} (closed entries not cleaned)", log.getList().size());
+
+      // Flush the buffered page tail WITHOUT any barrier: after phase 1 every revision-N page
+      // must be readable by offset through any reader channel (the pipelined successor epoch
+      // reads the pending revision's pages before phase 2 hardens). Plain write(2), no fsync —
+      // the durability barriers remain phase 2's job.
+      storagePageReaderWriter.flushBufferedWrites(bufferBytes);
+
+      if (timing) {
+        LOGGER.debug("Commit phase 1 r{}: serialize={}ms recursive={}ms", uberPage.getRevisionNumber(),
+            ms(t1 - t0), ms(System.nanoTime() - t1));
+      }
+      return uberPage;
+    }
+  }
+
+  @Override
+  public void hardenCommit(final UberPage uberPage, final boolean isIntermediateCommit) {
+    {
+      final boolean timing = LOGGER.isDebugEnabled();
+
+      final Path commitFile = storageEngineReader.resourceSession.getCommitFile();
+
+      final PageReference uberPageReference =
+          new PageReference().setDatabaseId(storageEngineReader.getDatabaseId()).setResourceId(storageEngineReader.getResourceId());
+      uberPageReference.setPage(uberPage);
 
       final long t2 = timing ? System.nanoTime() : 0;
 
@@ -1047,16 +1083,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       }
 
       if (timing) {
-        LOGGER.debug("Commit r{}: serialize={}ms recursive={}ms indexDefs={}ms uberWrite={}ms "
-            + "tilClear={}ms total={}ms",
-            revision, ms(t1 - t0), ms(t2 - t1), ms(t3 - t2), ms(t4 - t3), ms(t5 - t4), ms(t5 - t0));
+        LOGGER.debug("Commit phase 2 r{}: indexDefs={}ms uberWrite={}ms tilClear={}ms total={}ms",
+            revision, ms(t3 - t2), ms(t4 - t3), ms(t5 - t4), ms(t5 - t2));
       }
-
-      // Return the in-memory UberPage directly — it was modified in-place by uberPage.commit(this)
-      // and then written to disk. Its in-memory state is already current and canonical.
-      return uberPage;
-    } finally {
-      storageEngineReader.resourceSession.getCommitLock().unlock();
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -270,13 +270,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   // ==================== ASYNC AUTO-COMMIT STATE ====================
 
   /** Backpressure: at most one background snapshot flush in-flight. */
-  private final Semaphore commitPermit = new Semaphore(1);
+  private final Semaphore flushPermit = new Semaphore(1);
 
   /** True while a background snapshot flush is running. */
-  private volatile boolean asyncCommitInFlight;
+  private volatile boolean asyncFlushInFlight;
 
   /** Error from background thread — checked and cleared by insert thread. */
-  private volatile Throwable asyncCommitError;
+  private volatile Throwable asyncFlushError;
 
   /** Terminal failure latch — once true, NEVER reset. Transaction is permanently failed. */
   private volatile boolean asyncTerminalFailure;
@@ -683,7 +683,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   // ==================== ASYNC AUTO-COMMIT ====================
 
   @Override
-  public void asyncIntermediateCommit() {
+  public void asyncFlush() {
     // Fail-fast: terminal failure is a permanent latch — transaction is unusable.
     if (asyncTerminalFailure) {
       throw new SirixIOException(
@@ -691,27 +691,27 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     // Backpressure: block if previous background flush still running
-    commitPermit.acquireUninterruptibly();
+    flushPermit.acquireUninterruptibly();
 
     // CRITICAL double-check: error may have been set by background thread
     // between our latch check above and the acquire completing.
-    final Throwable priorError = asyncCommitError;
+    final Throwable priorError = asyncFlushError;
     if (priorError != null) {
-      asyncCommitError = null;
+      asyncFlushError = null;
       asyncTerminalFailure = true;
-      commitPermit.release();
+      flushPermit.release();
       throw new SirixIOException("Prior async commit failed", priorError);
     }
 
     // If previous snapshot completed, clean it up first
-    if (log.getSnapshotSize() > 0 && log.isSnapshotCommitComplete()) {
+    if (log.getSnapshotSize() > 0 && log.isSnapshotFlushComplete()) {
       log.cleanupSnapshot();
     }
 
     // O(1) snapshot — array swap + generation increment
     final int snapshotSize = log.snapshot();
     if (snapshotSize == 0) {
-      commitPermit.release();
+      flushPermit.release();
       return;
     }
 
@@ -722,7 +722,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // Re-add structural pages to fresh TIL for continued operation
     reAddStructuralPagesToTil();
 
-    asyncCommitInFlight = true;
+    asyncFlushInFlight = true;
 
     // Background thread: write KVL pages to disk.
     // CRITICAL: If submission throws (RejectedExecutionException), release permit
@@ -730,28 +730,28 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     try {
       CompletableFuture.runAsync(this::executeSnapshotWrite);
     } catch (final Throwable t) {
-      asyncCommitInFlight = false;
+      asyncFlushInFlight = false;
       asyncTerminalFailure = true;
-      commitPermit.release();
+      flushPermit.release();
       throw new SirixIOException("Failed to submit async commit", t);
     }
   }
 
   @Override
-  public void awaitPendingAsyncCommit() {
-    if (!asyncCommitInFlight) {
+  public void awaitPendingAsyncFlush() {
+    if (!asyncFlushInFlight) {
       return;
     }
 
     // Block until background thread releases permit
-    commitPermit.acquireUninterruptibly();
-    commitPermit.release();
-    asyncCommitInFlight = false;
+    flushPermit.acquireUninterruptibly();
+    flushPermit.release();
+    asyncFlushInFlight = false;
 
     // Check for background thread errors — latch terminal failure
-    final Throwable error = asyncCommitError;
+    final Throwable error = asyncFlushError;
     if (error != null) {
-      asyncCommitError = null;
+      asyncFlushError = null;
       asyncTerminalFailure = true;
       throw new SirixIOException("Async commit failed", error);
     }
@@ -799,12 +799,12 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       } finally {
         bgBuffer.close();
       }
-      log.markSnapshotCommitComplete();
+      log.markSnapshotFlushComplete();
     } catch (final Throwable t) {
-      asyncCommitError = t;
+      asyncFlushError = t;
       asyncTerminalFailure = true;
     } finally {
-      commitPermit.release();
+      flushPermit.release();
     }
   }
 
@@ -1177,7 +1177,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // Best-effort: await + cleanup even if async errored.
     // We still need to drain the snapshot and clear TIL regardless.
     try {
-      awaitPendingAsyncCommit();
+      awaitPendingAsyncFlush();
     } catch (final SirixIOException e) {
       LOGGER.error("Async commit failed during rollback — cleaning up anyway", e);
     }
@@ -1207,7 +1207,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
       // Best-effort: await + cleanup async commit even if errored
       try {
-        awaitPendingAsyncCommit();
+        awaitPendingAsyncFlush();
       } catch (final SirixIOException e) {
         LOGGER.error("Async commit failed during close — cleaning up anyway", e);
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
@@ -271,6 +271,34 @@ public interface StorageEngineWriter extends StorageEngineReader {
   default void asyncFlush() {}
 
   /**
+   * Phase 1 of a pipelined commit: create the commit marker, serialize and write every modified
+   * page from the TIL (assigning all disk keys) through the buffered data channel. After this
+   * returns, the revision's page trie is fully addressed and nothing references TIL-only state —
+   * but NOTHING is durable yet. Must run on the writer thread (serialization mutates TIL pages).
+   *
+   * <p>Pair with {@link #hardenCommit(UberPage, boolean)}; {@code commit(...)} is exactly the two
+   * phases run back-to-back.</p>
+   *
+   * @return the canonical in-memory uber page of the pending revision
+   */
+  default UberPage commitWritePages(@Nullable String commitMessage, @Nullable Instant commitTimeStamp,
+      boolean isIntermediateCommit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Phase 2 of a pipelined commit: make the revision durable — index catalogue, buffered-tail
+   * flush, data force, uber-page beacons — then clear the TIL and delete the commit marker.
+   * Safe to run off the writer thread; performs no page mutation. Does NOT publish
+   * {@code lastCommittedUberPage} — the orchestrator decides when the revision becomes visible.
+   *
+   * @param uberPage the uber page returned by {@link #commitWritePages}
+   */
+  default void hardenCommit(UberPage uberPage, boolean isIntermediateCommit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Block until any pending async intermediate commit completes, then clean up the snapshot
    * (apply disk offsets, close written KVL pages, promote IndirectPages to current TIL).
    *

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
@@ -266,9 +266,9 @@ public interface StorageEngineWriter extends StorageEngineReader {
    * Perform an async intermediate commit: snapshot the current TIL via O(1) array swap
    * and flush KVL pages to disk in a background thread. The insert thread continues immediately.
    *
-   * <p>Only supported with {@code AfterCommitState.KEEP_OPEN_ASYNC} and FILE_CHANNEL backend.</p>
+   * <p>Only supported with {@code AfterCommitState.KEEP_OPEN_ASYNC_FLUSH} and FILE_CHANNEL backend.</p>
    */
-  default void asyncIntermediateCommit() {}
+  default void asyncFlush() {}
 
   /**
    * Block until any pending async intermediate commit completes, then clean up the snapshot
@@ -278,7 +278,7 @@ public interface StorageEngineWriter extends StorageEngineReader {
    *
    * @throws io.sirix.exception.SirixIOException if the background async commit failed
    */
-  default void awaitPendingAsyncCommit() {}
+  default void awaitPendingAsyncFlush() {}
 
   /**
    * Get the underlying {@link StorageEngineReader}.

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -267,7 +267,7 @@ public final class TransactionIntentLog implements AutoCloseable {
     // Cross-generation guard: a reference whose activeTilGeneration belongs to a
     // PRIOR (snapshot) generation must NOT reuse its old logKey in the new TIL.
     // Without this check, a CoW of a frozen IndirectPage after
-    // asyncIntermediateCommit() can collide with a structural-page slot in the
+    // asyncFlush() can collide with a structural-page slot in the
     // new generation (NamePage / CASPage / ProjectionIndexPage etc. that
     // reAddStructuralPagesToTil packed into low logKeys), silently swapping
     // the container at that index. The visible symptom is a ClassCastException
@@ -432,7 +432,7 @@ public final class TransactionIntentLog implements AutoCloseable {
    * Mark the snapshot flush as complete. Called by the background thread after all KVL pages
    * have been written to disk and their offsets stored in the side-channel arrays.
    */
-  public void markSnapshotCommitComplete() {
+  public void markSnapshotFlushComplete() {
     snapshotCommitComplete = true;
   }
 
@@ -441,7 +441,7 @@ public final class TransactionIntentLog implements AutoCloseable {
    *
    * @return true if the background thread has finished writing all snapshot pages
    */
-  public boolean isSnapshotCommitComplete() {
+  public boolean isSnapshotFlushComplete() {
     return snapshotCommitComplete;
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/access/AsyncAutoCommitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/AsyncAutoCommitTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for the {@link AfterCommitState#KEEP_OPEN_ASYNC} commit path.
+ * Tests for the {@link AfterCommitState#KEEP_OPEN_ASYNC_FLUSH} commit path.
  *
  * <p>The doc currently advises operators to use synchronous commits and avoid this
  * path. These tests verify the path actually works under its documented constraints
@@ -49,7 +49,7 @@ final class AsyncAutoCommitTest {
   }
 
   @Test
-  @DisplayName("KEEP_OPEN_ASYNC + FILE_CHANNEL + count-based auto-commit: data round-trips through one revision")
+  @DisplayName("KEEP_OPEN_ASYNC_FLUSH + FILE_CHANNEL + count-based auto-commit: data round-trips through one revision")
   void asyncAutoCommit_underDocumentedConstraints_works() {
     Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
     try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
@@ -65,7 +65,7 @@ final class AsyncAutoCommitTest {
            // maxNodes = 1024 → after every 1024 modifications the async path
            // rotates the TIL (background flush) but does NOT mint a new revision.
            // Only the final explicit commit creates a revision.
-           final JsonNodeTrx wtx = session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC)) {
+           final JsonNodeTrx wtx = session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
         final long arrayNodeKey = wtx.insertArrayAsFirstChild().getNodeKey();
         // Insert enough records to cross the maxNodes threshold a few times.
         // Move back to the array on every iteration so we're inserting AS a
@@ -97,7 +97,7 @@ final class AsyncAutoCommitTest {
   }
 
   @Test
-  @DisplayName("KEEP_OPEN_ASYNC + MEMORY_MAPPED fails fast at session.beginNodeTrx (runtime guard)")
+  @DisplayName("KEEP_OPEN_ASYNC_FLUSH + MEMORY_MAPPED fails fast at session.beginNodeTrx (runtime guard)")
   void asyncAutoCommit_withMemoryMapped_throwsClearly() {
     Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
     try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
@@ -111,8 +111,8 @@ final class AsyncAutoCommitTest {
 
       try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
         final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-            () -> session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC).close(),
-            "MEMORY_MAPPED + KEEP_OPEN_ASYNC must throw at trx creation, not fail later");
+            () -> session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH).close(),
+            "MEMORY_MAPPED + KEEP_OPEN_ASYNC_FLUSH must throw at trx creation, not fail later");
         assertTrue(thrown.getMessage().contains("FILE_CHANNEL"),
             "error must name the required backend; got: " + thrown.getMessage());
       }
@@ -120,7 +120,7 @@ final class AsyncAutoCommitTest {
   }
 
   @Test
-  @DisplayName("KEEP_OPEN_ASYNC + timed auto-commit fails fast (runtime guard)")
+  @DisplayName("KEEP_OPEN_ASYNC_FLUSH + timed auto-commit fails fast (runtime guard)")
   void asyncAutoCommit_withTimedAutoCommit_throwsClearly() {
     Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
     try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
@@ -134,8 +134,8 @@ final class AsyncAutoCommitTest {
 
       try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
         final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
-            () -> session.beginNodeTrx(1024, 5, TimeUnit.SECONDS, AfterCommitState.KEEP_OPEN_ASYNC).close(),
-            "timed auto-commit + KEEP_OPEN_ASYNC must throw at trx creation");
+            () -> session.beginNodeTrx(1024, 5, TimeUnit.SECONDS, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH).close(),
+            "timed auto-commit + KEEP_OPEN_ASYNC_FLUSH must throw at trx creation");
         assertTrue(thrown.getMessage().contains("timed"),
             "error must mention timed auto-commit; got: " + thrown.getMessage());
       }

--- a/bundles/sirix-core/src/test/java/io/sirix/access/AsyncCommitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/AsyncCommitTest.java
@@ -12,7 +12,6 @@ import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.io.StorageType;
-import io.sirix.service.json.shredder.JsonShredder;
 import io.sirix.settings.VersioningType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/bundles/sirix-core/src/test/java/io/sirix/access/AsyncCommitTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/AsyncCommitTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link AfterCommitState#KEEP_OPEN_ASYNC_COMMIT}: pipelined durable commits — every
+ * threshold crossing creates a REAL revision, hardened in the background while the transaction
+ * keeps inserting. See {@code docs/ASYNC_COMMIT_DESIGN.md}.
+ */
+final class AsyncCommitTest {
+
+  private static final String RESOURCE = "async-commit-resource";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  @DisplayName("KEEP_OPEN_ASYNC_COMMIT: every epoch creates a durable, queryable revision")
+  void asyncCommit_createsQueryableRevisions() {
+    Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+          .storeDiffs(false)
+          .hashKind(HashType.NONE)
+          .buildPathSummary(false)
+          .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
+          .storageType(StorageType.FILE_CHANNEL)
+          .build());
+
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+           // maxNodes = 1024 → each threshold crossing runs phase 1 inline and hardens revision
+           // N in the background while inserts continue into epoch N+1.
+           final JsonNodeTrx wtx = session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_COMMIT)) {
+        final long arrayNodeKey = wtx.insertArrayAsFirstChild().getNodeKey();
+        for (int i = 0; i < 5000; i++) {
+          wtx.moveTo(arrayNodeKey);
+          wtx.insertStringValueAsFirstChild("item-" + i);
+        }
+        // Final explicit commit drains the pipeline first, then commits the tail epoch.
+        wtx.commit();
+      }
+    }
+
+    // Reopen: multiple revisions must exist (≈ 5000/1024 intermediate + the final commit), and
+    // every revision must open cleanly with a consistent page tree.
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile());
+         final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+      final int mostRecent = session.getMostRecentRevisionNumber();
+      assertTrue(mostRecent >= 4,
+          "expected several pipelined revisions plus the final commit, got " + mostRecent);
+
+      long previousCount = -1;
+      for (int rev = 1; rev <= mostRecent; rev++) {
+        try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(rev)) {
+          rtx.moveToDocumentRoot();
+          assertTrue(rtx.moveToFirstChild(), "array must be reachable in revision " + rev);
+          final long count = rtx.getChildCount();
+          assertTrue(count >= previousCount,
+              "child count must be non-decreasing across revisions; rev " + rev + " has " + count
+                  + " after " + previousCount);
+          previousCount = count;
+        }
+      }
+      assertEquals(5000, previousCount, "the newest revision must contain every inserted item");
+    }
+  }
+
+  @Test
+  @DisplayName("KEEP_OPEN_ASYNC_COMMIT + MEMORY_MAPPED: fails fast")
+  void asyncCommit_withMemoryMapped_throwsClearly() {
+    Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+          .storageType(StorageType.MEMORY_MAPPED)
+          .build());
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+            () -> session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_COMMIT));
+        assertTrue(thrown.getMessage().contains("FILE_CHANNEL"));
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("KEEP_OPEN_ASYNC_COMMIT + timed auto-commit: fails fast")
+  void asyncCommit_withTimedAutoCommit_throwsClearly() {
+    Databases.createJsonDatabase(new DatabaseConfiguration(PATHS.PATH1.getFile()));
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(PATHS.PATH1.getFile())) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+          .storageType(StorageType.FILE_CHANNEL)
+          .build());
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+            () -> session.beginNodeTrx(1024, 30, TimeUnit.SECONDS, AfterCommitState.KEEP_OPEN_ASYNC_COMMIT));
+        assertTrue(thrown.getMessage().contains("timed"));
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/AsyncIntermediateCommitStaleRefTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/AsyncIntermediateCommitStaleRefTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Regression tests for #1077: silent record loss under {@code KEEP_OPEN_ASYNC} intermediate
+ * Regression tests for #1077: silent record loss under {@code KEEP_OPEN_ASYNC_FLUSH} intermediate
  * commits (and the stale-reference resolution the final commit depends on).
  *
  * <p>Monotonic inserts at the head of an array make every epoch (a) freeze the TIL, (b) flush the
@@ -123,19 +123,19 @@ final class AsyncIntermediateCommitStaleRefTest {
   @Test
   @DisplayName("Records survive many async epochs (page-aligned rotation threshold)")
   void asyncAligned512() {
-    insertManyEpochsAndVerify(512, AfterCommitState.KEEP_OPEN_ASYNC, "async-512");
+    insertManyEpochsAndVerify(512, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH, "async-512");
   }
 
   @Test
   @DisplayName("Records survive many async epochs (unaligned rotation threshold)")
   void asyncUnaligned300() {
-    insertManyEpochsAndVerify(300, AfterCommitState.KEEP_OPEN_ASYNC, "async-300");
+    insertManyEpochsAndVerify(300, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH, "async-300");
   }
 
   @Test
   @DisplayName("Records survive fewer, larger async epochs")
   void asyncLarge2048() {
-    insertManyEpochsAndVerify(2048, AfterCommitState.KEEP_OPEN_ASYNC, "async-2048");
+    insertManyEpochsAndVerify(2048, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH, "async-2048");
   }
 
   @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/JacksonJsonShredderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/service/json/shredder/JacksonJsonShredderTest.java
@@ -632,7 +632,7 @@ public final class JacksonJsonShredderTest {
                                                  .byteHandlerPipeline(new ByteHandlerPipeline(new FFILz4Compressor()))
                                                  .build());
     try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-        final var trx = manager.beginNodeTrx((262_144 << 4) + 262_144, AfterCommitState.KEEP_OPEN_ASYNC);
+        final var trx = manager.beginNodeTrx((262_144 << 4) + 262_144, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH);
         final var parser = JacksonJsonShredder.createFileParser(jsonPath)) {
       trx.insertSubtreeAsFirstChild(parser, JsonNodeTrx.Commit.NO);
       trx.commit();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -11,6 +11,7 @@ import io.brackit.query.jsonitem.object.ArrayObject;
 import io.sirix.access.DatabaseConfiguration;
 import io.sirix.access.Databases;
 import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.api.Database;
 import io.sirix.api.json.JsonNodeTrx;
@@ -81,6 +82,16 @@ public final class BasicJsonDBStore implements JsonDBStore {
    * {@link StorageType} instance.
    */
   private final StorageType storageType;
+
+  /**
+   * Use the asynchronous background pre-flush ({@link AfterCommitState#KEEP_OPEN_ASYNC_FLUSH})
+   * for bulk imports instead of synchronous intermediate auto-commits. Default {@code true}:
+   * imports produce ONE semantically meaningful revision ("dataset imported") instead of
+   * parser-progress checkpoint revisions, with the leaf I/O overlapped with parsing and memory
+   * still bounded by the flush threshold. Applies only with the FILE_CHANNEL backend; other
+   * backends fall back to synchronous auto-commits.
+   */
+  private final boolean useAsyncFlushForImports;
 
   /**
    * The location to store created collections/databases.
@@ -197,6 +208,10 @@ public final class BasicJsonDBStore implements JsonDBStore {
         ? Integer.parseInt(System.getProperty("numberOfNodesBeforeAutoCommit"))
         : 262_144 << 2;
 
+    /** See {@link BasicJsonDBStore#useAsyncFlushForImports}. */
+    private boolean useAsyncFlushForImports = System.getProperty("sirix.import.asyncFlush") == null
+        || Boolean.parseBoolean(System.getProperty("sirix.import.asyncFlush"));
+
     /**
      * Whether the record-to-revisions index is maintained on insert. Default
      * matches ResourceConfiguration's default ({@code true}) but is overridable
@@ -312,6 +327,20 @@ public final class BasicJsonDBStore implements JsonDBStore {
     }
 
     /**
+     * Whether bulk imports use the asynchronous background pre-flush (default) or synchronous
+     * intermediate auto-commits (one revision per threshold crossing). Synchronous auto-commits
+     * give durable checkpoints during the import at the cost of commit barriers on the import
+     * path and parser-progress revisions in the history.
+     *
+     * @param useAsyncFlushForImports {@code false} to restore synchronous intermediate commits
+     * @return this builder instance
+     */
+    public Builder useAsyncFlushForImports(final boolean useAsyncFlushForImports) {
+      this.useAsyncFlushForImports = useAsyncFlushForImports;
+      return this;
+    }
+
+    /**
      * Create a new {@link BasicJsonDBStore} instance
      *
      * @return new {@link BasicJsonDBStore} instance
@@ -339,6 +368,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
     versioningType = builder.versioningType;
     numberOfNodesBeforeAutoCommit = builder.numberOfNodesBeforeAutoCommit;
     storeNodeHistory = builder.storeNodeHistory;
+    useAsyncFlushForImports = builder.useAsyncFlushForImports;
   }
 
   /**
@@ -346,6 +376,20 @@ public final class BasicJsonDBStore implements JsonDBStore {
    */
   public Path getLocation() {
     return location;
+  }
+
+  /**
+   * Begin the write transaction for a bulk import: the asynchronous background pre-flush when
+   * enabled and supported (FILE_CHANNEL only — see the guard in {@code beginNodeTrx}), otherwise
+   * classic synchronous intermediate auto-commits. Both bound memory by
+   * {@code numberOfNodesBeforeAutoCommit}; the async variant overlaps leaf I/O with parsing and
+   * produces a single import revision instead of parser-progress checkpoints.
+   */
+  private JsonNodeTrx beginImportTrx(final JsonResourceSession resourceSession) {
+    if (useAsyncFlushForImports && storageType == StorageType.FILE_CHANNEL) {
+      return resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH);
+    }
+    return resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit);
   }
 
   @Override
@@ -502,7 +546,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       // via page release), and a multi-GB shred exhausts the budget long
       // before the single final commit fires.
       try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
-          final JsonNodeTrx wtx = resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit)) {
+          final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       }
@@ -626,7 +670,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       final String resourceName, final Object options) {
     createResource(options, database, resourceName);
     try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
-        final JsonNodeTrx wtx = resourceSession.beginNodeTrx(numberOfNodesBeforeAutoCommit)) {
+        final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
       final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       wtx.insertSubtreeAsFirstChild(reader);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2093,6 +2093,7 @@ real commit, and one of which deliberately is **not**:
 | Explicit `commit()` | yes | yes | full commit protocol |
 | Sync auto-commit (`maxNodeCount`/timer, `KEEP_OPEN`) | yes | yes | full commit protocol, transaction stays open |
 | Async pre-flush (`KEEP_OPEN_ASYNC_FLUSH`) | **no** | **no** | shadow-writes leaf pages ahead of the next real commit |
+| Async durable commit (`KEEP_OPEN_ASYNC_COMMIT`) | yes | yes | page writes on the writer thread, durability barriers in the background (`docs/ASYNC_COMMIT_DESIGN.md`) |
 
 **The async pre-flush is a durability optimization, not a transactional
 event.** When triggered, the TIL takes an O(1) snapshot (an array swap that

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2082,7 +2082,7 @@ The TIL holds uncommitted modifications during a write transaction:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Auto-Commit and the Async Pre-Flush (`KEEP_OPEN_ASYNC`)
+### Auto-Commit and the Async Pre-Flush (`KEEP_OPEN_ASYNC_FLUSH`)
 
 Long-running write transactions (bulk loads, streaming ingest) can bound their
 memory and commit latency with two distinct mechanisms — one of which is a
@@ -2092,7 +2092,7 @@ real commit, and one of which deliberately is **not**:
 |---|---|---|---|
 | Explicit `commit()` | yes | yes | full commit protocol |
 | Sync auto-commit (`maxNodeCount`/timer, `KEEP_OPEN`) | yes | yes | full commit protocol, transaction stays open |
-| Async pre-flush (`KEEP_OPEN_ASYNC`) | **no** | **no** | shadow-writes leaf pages ahead of the next real commit |
+| Async pre-flush (`KEEP_OPEN_ASYNC_FLUSH`) | **no** | **no** | shadow-writes leaf pages ahead of the next real commit |
 
 **The async pre-flush is a durability optimization, not a transactional
 event.** When triggered, the TIL takes an O(1) snapshot (an array swap that

--- a/docs/ASYNC_COMMIT_DESIGN.md
+++ b/docs/ASYNC_COMMIT_DESIGN.md
@@ -1,0 +1,114 @@
+# Asynchronous Durable Commits (`KEEP_OPEN_ASYNC_COMMIT`) — Design
+
+Status: **phase 1 implemented** (pipelined hardening); phase 2 (fully
+backgrounded serialization) is future work.
+
+## Motivation — the missing middle ground
+
+| Mode | Revisions | Writer blocks on | Crash loses |
+|---|---|---|---|
+| `KEEP_OPEN` (sync auto-commit) | one per threshold, durable+queryable | full commit protocol per epoch | ≤ 1 epoch |
+| `KEEP_OPEN_ASYNC_FLUSH` | none until final `commit()` | ~nothing (leaf I/O backgrounded) | everything since last real commit |
+| **`KEEP_OPEN_ASYNC_COMMIT`** | **one per threshold, durable+queryable** | **serialization only — never the flush barriers** | ≤ 1 in-flight epoch + working set |
+
+Micro-benchmark context (100k inserts, threshold 8k, this repo's bench
+environment): sync auto-commit 556 ms, async flush 141 ms, single commit
+106 ms. The sync-commit overhead is dominated by per-epoch durability
+barriers (index-catalogue fsync, buffered-tail flush, data force, two DSYNC
+beacon writes) — exactly the part this mode moves off the writer thread.
+
+## Design: split the commit at the durability barrier
+
+`NodeStorageEngineWriter.commit()` decomposes into two phases:
+
+**Phase 1 — write pages (synchronous, writer thread).**
+Create the commit marker file, set user/message/timestamp,
+`parallelSerializationOfKeyValuePages()`, `uberPage.commit(this)` (walks the
+TIL-backed reference tree, writes every modified page through the buffered
+data channel and assigns every reference its disk key). After phase 1 the
+revision's page trie is fully addressed in memory and fully written into OS
+buffers — nothing references TIL-only state anymore. This phase mutates TIL
+pages during serialization and therefore MUST run on the writer thread (the
+async-flush path solves the same race with deep copies; doing that for the
+whole trie is the phase-2 roadmap item below).
+
+**Phase 2 — harden (background thread).**
+`serializeIndexDefinitions(revision)` (must be durable before the beacon —
+existing crash invariant), `writeUberPageReference(...)` (flushes the
+buffered tail, forces the data file, writes both uber beacons write-through;
+its return is the commit acknowledge), clear the TIL and local caches,
+delete the commit marker, **then** publish
+`session.setLastCommittedUberPage(...)` and close the superseded page
+transaction (releasing its writer channels).
+
+The public synchronous `commit()` is unchanged: phase 1 + phase 2 inline.
+
+`asyncCommit()` = acquire the single commit permit (depth-1 pipeline), run
+phase 1 inline, submit phase 2 to a background thread, return. The node
+transaction immediately re-instantiates onto a **new page transaction based
+on the pending uber page** and keeps inserting while phase 2's barriers run.
+
+## Why this is safe
+
+- **No concurrent file appends.** Only phase 1 writes data pages, and a new
+  epoch's phase 1 cannot start before acquiring the permit that the previous
+  epoch's phase 2 releases. Inserts (pure in-memory) are the only thing that
+  overlaps hardening.
+- **Reads of the pending revision are ordinary reads.** Phase 1 assigned
+  disk keys everywhere, so the successor page transaction reads revision N
+  through the normal buffer-manager/disk path (OS page cache serves
+  not-yet-forced bytes). No frozen-TIL indirection, no forwarding links —
+  the stale-reference machinery of the async *flush* path is not involved.
+- **Durable-before-visible.** Readers resolve "latest" through
+  `lastCommittedUberPage`, which phase 2 publishes only after the beacon
+  write returns. A revision can never be opened and then lost to a crash.
+- **Crash semantics unchanged.** A crash during/after phase 1 but before the
+  beacon leaves the commit marker file present and no beacon for revision N:
+  the existing truncate-to-last-committed recovery discards the partial
+  epoch, exactly as for a crashed synchronous commit.
+- **Commit-marker gating.** While an async commit is in flight the marker
+  file legitimately exists; the successor page transaction's
+  truncate-on-open check is skipped for pipelined creation (the check exists
+  for *crash* recovery; in-process the in-flight state is known).
+- **Failure poisoning.** A phase-2 failure latches the transaction
+  terminally (same pattern as the async-flush path): the next operation
+  throws, close/rollback drain the pipeline first. The already-reinstantiated
+  epoch N+1 is based on a revision that never became durable, so poisoning —
+  not retrying — is the only sound response.
+- **Lineage.** Epoch N+1's page transaction is created from the pending
+  (phase-1-complete, canonical in memory) uber page of revision N, not from
+  `lastCommittedUberPage`. The depth-1 pipeline makes the pending chain at
+  most one deep.
+
+## Constraints (mirroring the async-flush guards)
+
+- `FILE_CHANNEL` storage backend only.
+- Count-based auto-commit only (no timed trigger).
+- One in-flight hardening per transaction (permit); an explicit `commit()`
+  or `close()` first drains the pipeline.
+
+## What phase 2 (future) adds
+
+Backgrounding phase 1 as well — deep-copying the frozen generation's pages
+(leaf *and* structural) so serialization runs off-thread, the way
+`asyncFlush` already does for leaves. That removes the last synchronous cost
+(CPU serialization) from the writer thread at the price of copying the trie
+spine, and requires the successor transaction to read revision N through the
+frozen generation until keys are assigned (the TIL generation/forwarding
+machinery is the intended vehicle). The interface (`asyncCommit()`) is
+unchanged by that evolution, which is why the mode ships now with pipelined
+hardening only.
+
+## Interaction with ledger mode (`TAMPER_EVIDENCE_PLAN.md`)
+
+Each async commit is a full revision with a commit record, so the chain
+gains one link per epoch, in pipeline order (depth-1 ⇒ order preserved).
+Chain-hash computation and (later) signing belong to phase 2 — off the
+writer thread by construction.
+
+## Store/import guidance
+
+Bulk imports that want one semantically meaningful revision should keep
+using `KEEP_OPEN_ASYNC_FLUSH` (see the shredding discussion in
+`ARCHITECTURE.md`); `KEEP_OPEN_ASYNC_COMMIT` is for ingest that needs
+periodic *queryable* checkpoints without paying synchronous barriers.

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -37,7 +37,7 @@ Categories used:
 | `index/hot/HOTIndexIntegrationTest.java:685` | (not actually disabled) | The `@Disabled` here is in a comment, not on a test. False positive in `grep`. |
 | `page/SirixLZ77DumpEncodedTest.java:22` | manual-utility | Utility that dumps a canonical encoded frame for the standalone C bench. Not a test. |
 | ~~`io/ChecksumVerificationTest.java:295`~~ | re-enabled | 4 `SirixCorruptionException` constructor tests — re-enabled this session; all pass. |
-| ~~`access/AsyncAutoCommitTest.java:asyncAutoCommit_underDocumentedConstraints_works`~~ | re-enabled | Surfaced the `KeyedTrieWriter.prepareIndirectPage:176` ClassCastException under `KEEP_OPEN_ASYNC` — root cause was a cross-generation `logKey` collision in `TransactionIntentLog.put`. Fixed this session by adding an `activeTilGeneration == currentGeneration` guard before reusing `existingKey`. Test now passes. |
+| ~~`access/AsyncAutoCommitTest.java:asyncAutoCommit_underDocumentedConstraints_works`~~ | re-enabled | Surfaced the `KeyedTrieWriter.prepareIndirectPage:176` ClassCastException under `KEEP_OPEN_ASYNC_FLUSH` — root cause was a cross-generation `logKey` collision in `TransactionIntentLog.put`. Fixed this session by adding an `activeTilGeneration == currentGeneration` guard before reusing `existingKey`. Test now passes. |
 
 ## Platform
 

--- a/docs/TAMPER_EVIDENCE_PLAN.md
+++ b/docs/TAMPER_EVIDENCE_PLAN.md
@@ -161,7 +161,7 @@ chainHash(N)     = H( "SIRIX-LEDGER-CHAIN-v1-SHA256" ‖ resourceIdentity
   becomes durable atomically with the commit; per-resource logs keep chains
   independent (aligned with autonomous-commit decentralization — nothing new
   on the commit path's critical section).
-- **Async intermediate commits (`KEEP_OPEN_ASYNC`) produce no commit record**
+- **Async intermediate commits (`KEEP_OPEN_ASYNC_FLUSH`) produce no commit record**
   (they only pre-flush leaf pages; no uber page is written), hence no chain
   link — correct, since those pages become reachable only through the next
   real commit. Sync auto-commits produce full revisions and therefore full

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -319,10 +319,10 @@ resource at the desired revision number or timestamp via
 
 4. **Auto-commit features are in flight on multiple branches**
    (`feature/warm-auto-commit-v1`, `feature/async-auto-commit`,
-   `feature/eager-serialize-gc-fix`). The `AfterCommitState.KEEP_OPEN_ASYNC`
+   `feature/eager-serialize-gc-fix`). The `AfterCommitState.KEEP_OPEN_ASYNC_FLUSH`
    path on `main` now passes a basic round-trip test (3000 inserts crossing
    the auto-commit threshold, final commit + read-back). Runtime guards in
-   `AbstractResourceSession.beginNodeTrx` reject misuse: `KEEP_OPEN_ASYNC`
+   `AbstractResourceSession.beginNodeTrx` reject misuse: `KEEP_OPEN_ASYNC_FLUSH`
    requires `FILE_CHANNEL` + count-based auto-commit; the `AsyncAutoCommitTest`
    suite covers both the happy path and the two fail-fast guards. The branch
    consolidation (merging the three feature branches' design improvements


### PR DESCRIPTION
## What does this PR do?

Three related changes around commit/flush semantics (design in the new `docs/ASYNC_COMMIT_DESIGN.md`):

1. **Rename (breaking, 1.0.0-beta API):** the async intermediate "commit" is now called what it is — an **async flush**. `AfterCommitState.KEEP_OPEN_ASYNC` → `KEEP_OPEN_ASYNC_FLUSH`, `StorageEngineWriter.asyncIntermediateCommit()` → `asyncFlush()`, `awaitPendingAsyncCommit()` → `awaitPendingAsyncFlush()`, plus internal fields and `TransactionIntentLog` snapshot-state methods. The mechanism creates no revision and no commit record; the old names asserted otherwise and required disclaimers wherever they appeared.

2. **New: `AfterCommitState.KEEP_OPEN_ASYNC_COMMIT` — pipelined durable commits.** The middle ground between sync auto-commits (durable + queryable, but blocking on every epoch's barriers) and the async flush (non-blocking, but nothing durable until the final commit). The commit protocol splits at the durability barrier:
   - *Phase 1 (writer thread):* commit marker, page serialization, `uberPage.commit()` assigning all disk keys, and a **barrier-free buffered-tail flush** so every page of the pending revision is readable by offset through any reader channel.
   - *Phase 2 (background):* index-catalogue fsync, data force, DSYNC uber-beacon writes, TIL clear, marker delete — and only then publication of `lastCommittedUberPage` (**durable-before-visible**) and closing of the superseded page transaction.
   - Pipeline state lives on the **node transaction** (each epoch mints a new page writer): depth-1 permit for ordering/backpressure, terminal-failure latch that poisons the transaction, drains before sync commits, rollback, and close.
   - The successor epoch is based on the **pending uber page** (new `createPageTransaction` overload) which also skips the crash-recovery truncate check — the commit marker legitimately exists while hardening runs; the pending revision root is served from a session-level slot since neither the revisions-file record nor `lastCommittedUberPage` exist for it yet.
   - Crash semantics unchanged: a crash before the beacon leaves the marker and no beacon — existing truncate recovery discards the partial epoch, exactly as for a crashed synchronous commit. Guards mirror the flush mode: FILE_CHANNEL, count-based auto-commit only.

3. **Bulk imports default to the async flush** (`BasicJsonDBStore`): one semantically meaningful revision per import ("dataset imported") instead of parser-progress checkpoint revisions polluting a *temporal* database's history, with leaf I/O overlapped with parsing and memory still bounded. Escape hatches: `useAsyncFlushForImports(false)` or `-Dsirix.import.asyncFlush=false`; non-FILE_CHANNEL backends fall back to sync automatically.

Benchmark context (100k inserts, threshold 8k, sandbox disk): sync auto-commit 556 ms / async flush 141 ms / single commit 106 ms — the barriers moved to the background in (2) are exactly the 4× gap.

## Related issue

Follow-up to the asyncFlush discussion and the docs merged in #1113; design reviewed against `NodeStorageEngineWriter`/`TransactionIntentLog` semantics (incl. the #1077 supersession machinery).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [x] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — full sirix-core + sirix-query suites running with system Gradle (results posted before merge)
- [x] Added or updated tests covering the change — new `AsyncCommitTest` (multiple durable, queryable revisions with monotonically growing content across epochs; fail-fast guards for MEMORY_MAPPED and timed auto-commit); existing `AsyncAutoCommitTest`/`AsyncIntermediateCommitStaleRefTest` renamed and green
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — the durability protocol itself is unchanged (same barriers, same order, same beacon semantics); what moved is *which thread* runs phase 2, with visibility strictly after durability
- [x] Updated documentation (README / docs) where relevant — `docs/ASYNC_COMMIT_DESIGN.md` (new), `docs/ARCHITECTURE.md` mode table, CHANGELOG (Unreleased: Added + breaking rename)
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- The two subtle bits phase-splitting surfaced (both caught by the new test, both fixed): the successor epoch must read the pending revision root from memory (no revisions-file record exists until phase 2), and phase 1 must flush the writer's buffered tail (plain write, no barrier) so pending-revision pages are readable through reader channels.
- `hardenCommit` intentionally does not publish visibility; the orchestrator does, so readers can never open a revision that a crash could lose.
- Website docs for the rename (`KEEP_OPEN_ASYNC` → `KEEP_OPEN_ASYNC_FLUSH` on sirix.io) will follow in a separate sirixdb.github.io PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf5SK538LuX3ZeNCRr1haM)_