### PR TITLE
Projection indexes: persistence-safe aggregates, dense composite kernels, compact storage codec, path features, JSONiq creation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,72 @@ Two interchangeable storage backends sit behind every index type, selected per r
 
 Like the rest of the engine, indexes are **fully versioned**: opening an index at revision *N* returns the index state as of *N* — never a later commit's. RBTree indexes inherit this from the standard page-versioning trie (the same copy-on-write pages as the document tree); for the HOT backend it is verified directly across point and range reads, session close/reopen, and a concurrent pinned-reader-vs-writer (see `HOTMultiVersionInvariantsTest`).
 
+### Projection indexes (experimental, analytical)
+
+A fourth, columnar index type accelerates analytical queries — aggregates, filtered counts, group-bys,
+count-distinct — over homogeneous record sets. A **projection index** extracts the declared fields of every
+record under a root path into compact column-oriented leaf pages (1024 rows per leaf: frame-of-reference
+numerics, per-leaf string dictionaries, presence bitmaps), which the vectorized executor scans with SIMD
+kernels instead of walking the document tree. Persisted leaves are bit-packed to roughly **5% of their
+in-memory size**, so the on-disk tax over the versioned document store is ~10%.
+
+Create one with JSONiq — the resource must be created with a path summary (`buildPathSummary(true)`):
+
+```xquery
+(: store a record set :)
+jn:store('mydb', 'sales.jn', '[
+  {"age": 30, "active": true,  "dept": "Eng",   "city": "NYC"},
+  {"age": 45, "active": false, "dept": "Sales", "city": "LA"},
+  {"age": 52, "active": true,  "dept": "Eng",   "city": "NYC"}
+]')
+```
+
+```xquery
+(: project (age, active, dept, city) over the top-level array :)
+let $doc := jn:doc('mydb', 'sales.jn')
+let $stats := jn:create-projection-index($doc, '/[]',
+    ('/[]/age', '/[]/active', '/[]/dept', '/[]/city'),
+    ('long', 'boolean', 'string', 'string'))
+return {"revision": sdb:commit($doc)}
+```
+
+Nested roots and nested columns are paths too — e.g. a record set under `'/wrapper/records/[]'` with a
+column `'/wrapper/records/[]/address/city'`, or a descendant pattern `'//records/[]'` spanning sibling
+subtrees. Missing fields are tracked per row in presence bitmaps, so sparse data stays correct.
+
+There is no separate scan function — eligible queries route through the projection automatically once it
+is installed (compile through `SirixCompileChain.createWithJsonStore(store, session)` to get the
+analytical executor). Plain JSONiq does it:
+
+```xquery
+(: full-column aggregates — served from the numeric column, no tree walk :)
+let $doc := jn:doc('mydb', 'sales.jn')
+return {"sum": sum(for $r in $doc[] return $r.age),
+        "min": min(for $r in $doc[] return $r.age),
+        "max": max(for $r in $doc[] return $r.age)}
+
+(: filtered count — conjunctive predicate over the age + active columns :)
+let $doc := jn:doc('mydb', 'sales.jn')
+return count(for $r in $doc[] where $r.age > 40 and $r.active return $r)
+
+(: single- and multi-key group-by — dictionary-encoded group columns :)
+let $doc := jn:doc('mydb', 'sales.jn')
+for $r in $doc[]
+let $d := $r.dept, $c := $r.city
+group by $d, $c
+return {"dept": $d, "city": $c, "count": count($r)}
+
+(: count-distinct — answered from the union of per-leaf dictionaries :)
+let $doc := jn:doc('mydb', 'sales.jn')
+return count(for $r in $doc[] let $d := $r.dept group by $d return $d)
+```
+
+Re-running `jn:create-projection-index` on a re-opened database **hydrates** the persisted projection
+(sub-second per ~10M rows) instead of rebuilding it. Current limits: one projection per resource; the
+projection is a static snapshot of the indexed revision (update transactions do not maintain it yet);
+queries that the projection cannot serve exactly (unrepresentable values, non-covered predicates) fall
+back to the regular pipeline automatically, so results are always identical with or without the index.
+
 ## Correctness & Formal Verification
 
 A versioned storage engine is only useful if old revisions are *exactly* what was written. We take

--- a/README.md
+++ b/README.md
@@ -737,8 +737,12 @@ let $doc := jn:doc('mydb', 'sales.jn')
 return count(for $r in $doc[] let $d := $r.dept group by $d return $d)
 ```
 
-Re-running `jn:create-projection-index` on a re-opened database **hydrates** the persisted projection
-(sub-second per ~10M rows) instead of rebuilding it. Current limits: one projection per resource; the
+The index is written into the session's transaction — `sdb:commit($doc)` persists it, like the other
+index-creation functions. Re-running `jn:create-projection-index` on a re-opened database **hydrates**
+the persisted projection (sub-second per ~10M rows) instead of rebuilding it, validating the requested
+shape against persisted metadata. Current limits: one projection per resource; column types are `long`,
+`boolean`, and `string` (floating-point columns are rejected rather than silently degraded); columns are
+resolved by trailing field name, which must be unique and unambiguous under the record set; the
 projection is a static snapshot of the indexed revision (update transactions do not maintain it yet);
 queries that the projection cannot serve exactly (unrepresentable values, non-covered predicates) fall
 back to the regular pipeline automatically, so results are always identical with or without the index.

--- a/bundles/sirix-benchmarks/build.gradle
+++ b/bundles/sirix-benchmarks/build.gradle
@@ -100,6 +100,31 @@ tasks.register('exportScaleCsv', JavaExec) {
     ]
 }
 
+// Convenience task: run the pure-Brackit in-memory baseline (no Sirix storage)
+// over the same synthetic dataset / query set as runScale, for an
+// apples-to-apples engine comparison.
+// Usage:
+//   ./gradlew :sirix-benchmarks:runBrackitScale -Pscale.args="1000000 5"
+tasks.register('runBrackitScale', JavaExec) {
+    group = 'benchmark'
+    description = 'Run BrackitInMemoryScaleBenchMain (pure Brackit baseline, no Sirix).'
+    classpath = sourceSets.jmh.runtimeClasspath
+    mainClass = 'io.sirix.benchmark.BrackitInMemoryScaleBenchMain'
+    def argsStr = (findProperty('scale.args') ?: '1000000 5').toString()
+    args = argsStr.split(/\s+/).findAll { !it.isEmpty() }
+    def baseJvmArgs = [
+        '--enable-preview',
+        '-Xms1g',
+        '-Xmx12g'
+    ]
+    def extraJvmArgs = (findProperty('scale.jvmArgs') ?: '').toString().trim()
+    if (!extraJvmArgs.isEmpty()) {
+        jvmArgs = baseJvmArgs + extraJvmArgs.split(/\s+/).findAll { !it.isEmpty() }
+    } else {
+        jvmArgs = baseJvmArgs
+    }
+}
+
 // Convenience task: run BrackitQueryOnSirixScaleMain directly (not via JMH).
 // Usage:
 //   ./gradlew :sirix-benchmarks:runScale -Pscale.args="1000000 true 3"

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/BrackitInMemoryScaleBenchMain.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/BrackitInMemoryScaleBenchMain.java
@@ -1,0 +1,191 @@
+package io.sirix.benchmark;
+
+import ch.qos.logback.classic.Logger;
+import io.brackit.query.BrackitQueryContext;
+import io.brackit.query.Query;
+import io.brackit.query.QueryContext;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.compiler.CompileChain;
+import io.brackit.query.function.json.FastJSONParser;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.util.io.IOUtils;
+import io.brackit.query.util.serialize.StringSerializer;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Pure-Brackit (in-memory, no Sirix storage) baseline for the aggregate
+ * scale-bench query set.
+ * <p>
+ * Generates the exact same synthetic dataset as
+ * {@link BrackitQueryOnSirixScaleMain} — {@code Random(42)}, ages
+ * {@code 18 + nextInt(48)}, identical DEPTS/CITIES pools — parses it with
+ * Brackit's {@link FastJSONParser} into Brackit's own in-memory JSON items and
+ * runs the identical query set through a plain {@link CompileChain} with no
+ * vectorized executor installed. This measures Brackit's stock interpreted
+ * aggregate/group-by pipeline, giving an apples-to-apples baseline against:
+ * <ul>
+ *   <li>Sirix + vectorized executor (generic columnar scan), and</li>
+ *   <li>Sirix + vectorized executor + covering projection index.</li>
+ * </ul>
+ *
+ * <p>Usage:
+ * <pre>
+ *   java io.sirix.benchmark.BrackitInMemoryScaleBenchMain &lt;recordCount&gt; [iters=N]
+ * </pre>
+ */
+public final class BrackitInMemoryScaleBenchMain {
+
+  private static final String[] DEPTS = { "Eng", "Sales", "Mkt", "Ops", "HR", "Finance", "Legal", "Supp" };
+  private static final String[] CITIES = { "NYC", "LA", "SF", "ATL", "BOS", "CHI", "DEN", "DAL" };
+  private static final QNm DOC_VAR = new QNm("doc");
+
+  private static final Map<String, String> QUERIES = new LinkedHashMap<>();
+  static {
+    QUERIES.put("filterCount",            "count(for $u in $doc[] where $u.age > 40 and $u.active return $u)");
+    QUERIES.put("groupByDept",            "for $u in $doc[] let $d := $u.dept group by $d return {\"dept\": $d, \"count\": count($u)}");
+    QUERIES.put("sumAge",                 "sum(for $u in $doc[] return $u.age)");
+    QUERIES.put("avgAge",                 "avg(for $u in $doc[] return $u.age)");
+    QUERIES.put("minMaxAge",              "{\"min\": min(for $u in $doc[] return $u.age), \"max\": max(for $u in $doc[] return $u.age)}");
+    QUERIES.put("groupBy2Keys",           "for $u in $doc[] let $d := $u.dept, $c := $u.city group by $d, $c return {\"d\": $d, \"c\": $c, \"n\": count($u)}");
+    QUERIES.put("filterGroupBy",          "for $u in $doc[] where $u.active let $d := $u.dept group by $d return {\"dept\": $d, \"count\": count($u)}");
+    QUERIES.put("countDistinct",          "count(for $u in $doc[] let $d := $u.dept group by $d return $d)");
+    QUERIES.put("compoundAndFilterCount", "count(for $u in $doc[] where $u.age > 30 and $u.age < 50 and $u.active return $u)");
+    QUERIES.put("filterGroupByAge",       "for $u in $doc[] where $u.age > 40 let $d := $u.dept group by $d return {\"dept\": $d, \"count\": count($u)}");
+  }
+
+  private BrackitInMemoryScaleBenchMain() {
+  }
+
+  public static void main(final String[] args) throws Exception {
+    if (args.length < 1) {
+      System.err.println("Usage: BrackitInMemoryScaleBenchMain <recordCount> [iters=N]");
+      System.exit(1);
+    }
+    final long recordCount = Long.parseLong(args[0]);
+    final int iters = args.length < 2 ? 3 : Integer.parseInt(args[1]);
+
+    final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    root.setLevel(ch.qos.logback.classic.Level.WARN);
+
+    System.out.printf("# Engine: pure Brackit (in-memory items, no Sirix)   Records: %,d   Iters: %d%n",
+                      recordCount, iters);
+
+    // Generate the dataset as UTF-8 bytes and hand it to FastJSONParser.
+    // ASCII-only payload, so bytes == chars; pre-sized to avoid growth copies.
+    final long tGen = System.nanoTime();
+    final byte[] json = generateJson(recordCount);
+    System.out.printf("# Generated JSON: %,d bytes in %,d ms%n",
+                      json.length, (System.nanoTime() - tGen) / 1_000_000L);
+
+    final long tParse = System.nanoTime();
+    final Item doc = new FastJSONParser(json, 0, json.length).parse();
+    System.out.printf("# Parsed to in-memory Brackit items in %,d ms%n",
+                      (System.nanoTime() - tParse) / 1_000_000L);
+
+    final CompileChain chain = new CompileChain();
+    final QueryContext ctx = new BrackitQueryContext();
+    ctx.bind(DOC_VAR, (Sequence) doc);
+
+    System.out.printf("%-26s | %10s | %10s | %10s | %10s%n", "query", "min(ms)", "avg(ms)", "max(ms)", "result_bytes");
+    System.out.printf("%-26s + %10s + %10s + %10s + %10s%n", "--------------------------",
+                      "----------", "----------", "----------", "------------");
+
+    for (final Map.Entry<String, String> e : QUERIES.entrySet()) {
+      runQueryRepeated(chain, ctx, e.getKey(), e.getValue(), iters);
+    }
+  }
+
+  private static byte[] generateJson(final long recordCount) throws Exception {
+    if (recordCount > 20_000_000L) {
+      // ~90 bytes/record: beyond ~20 M the byte[] would push past 1.8 GB and
+      // the parsed item tree past typical heap sizes for this baseline.
+      throw new IllegalArgumentException("recordCount too large for the in-memory baseline: " + recordCount);
+    }
+    final Random rng = new Random(42);
+    final int sizeHint = (int) Math.min(Integer.MAX_VALUE - 16L, recordCount * 92L + 16L);
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream(sizeHint);
+    try (Writer w = new OutputStreamWriter(bos, StandardCharsets.US_ASCII)) {
+      w.write('[');
+      final StringBuilder line = new StringBuilder(96);
+      for (long i = 0; i < recordCount; i++) {
+        line.setLength(0);
+        if (i > 0) {
+          line.append(',');
+        }
+        line.append("{\"id\":").append(i)
+            .append(",\"age\":").append(18 + rng.nextInt(48))
+            .append(",\"dept\":\"").append(DEPTS[rng.nextInt(DEPTS.length)])
+            .append("\",\"city\":\"").append(CITIES[rng.nextInt(CITIES.length)])
+            .append("\",\"active\":").append(rng.nextBoolean() ? "true" : "false")
+            .append('}');
+        w.write(line.toString());
+      }
+      w.write(']');
+    }
+    return bos.toByteArray();
+  }
+
+  private static void runQueryRepeated(final CompileChain chain, final QueryContext ctx,
+                                       final String name, final String body, final int iters) {
+    final String wrapped = "declare variable $doc external; " + body;
+
+    // Warm up enough for HotSpot to tier-up the interpreted pipeline; capped
+    // by a 5 s budget so very slow query shapes don't stall the run.
+    // Brackit has no result caches, so warm iterations only remove JIT noise.
+    final boolean noWarmup = Boolean.getBoolean("sirix.noWarmup");
+    final int warmupCount = noWarmup ? 0 : Math.max(3, Math.min(20, iters));
+    final long warmDeadline = System.nanoTime() + 5_000_000_000L;
+    try {
+      for (int i = 0; i < warmupCount && System.nanoTime() < warmDeadline; i++) {
+        runOnce(chain, ctx, wrapped);
+      }
+    } catch (final RuntimeException re) {
+      System.out.printf("%-26s | (skipped: %s)%n", name, re.getMessage());
+      return;
+    }
+
+    long min = Long.MAX_VALUE;
+    long max = 0;
+    long sum = 0;
+    int bytes = 0;
+    try {
+      for (int i = 0; i < iters; i++) {
+        final long t0 = System.nanoTime();
+        bytes = runOnce(chain, ctx, wrapped);
+        final long elapsed = System.nanoTime() - t0;
+        sum += elapsed;
+        if (elapsed < min) {
+          min = elapsed;
+        }
+        if (elapsed > max) {
+          max = elapsed;
+        }
+      }
+    } catch (final RuntimeException re) {
+      System.out.printf("%-26s | (aborted iter: %s)%n", name, re.getMessage());
+      return;
+    }
+    final double minMs = min / 1e6;
+    final double maxMs = max / 1e6;
+    final double avgMs = (sum / (double) iters) / 1e6;
+    System.out.printf("%-26s | %10.3f | %10.3f | %10.3f | %,10d%n",
+                      name, minMs, avgMs, maxMs, bytes);
+  }
+
+  private static int runOnce(final CompileChain chain, final QueryContext ctx, final String wrapped) {
+    final var buf = IOUtils.createBuffer();
+    try (var ser = new StringSerializer(buf)) {
+      ser.serialize(new Query(chain, wrapped).execute(ctx));
+    }
+    return buf.toString().length();
+  }
+}

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/BrackitInMemoryScaleBenchMain.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/BrackitInMemoryScaleBenchMain.java
@@ -1,5 +1,6 @@
 package io.sirix.benchmark;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import io.brackit.query.BrackitQueryContext;
 import io.brackit.query.Query;
@@ -13,10 +14,14 @@ import io.brackit.query.util.io.IOUtils;
 import io.brackit.query.util.serialize.StringSerializer;
 import org.slf4j.LoggerFactory;
 
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
@@ -39,8 +44,17 @@ import java.util.Random;
  *
  * <p>Usage:
  * <pre>
- *   java io.sirix.benchmark.BrackitInMemoryScaleBenchMain &lt;recordCount&gt; [iters=N]
+ *   java io.sirix.benchmark.BrackitInMemoryScaleBenchMain &lt;recordCount&gt; [iters=N] [jsonFile]
  * </pre>
+ *
+ * <p>When {@code jsonFile} is given and the file exists, the dataset is read
+ * from disk instead of generated in memory — the read is timed separately so
+ * a disk-cold "time to first answer" (read + parse + first query) can be
+ * compared against Sirix's DB-open + projection-hydrate + first query. When
+ * the file does not exist it is generated and written, and with
+ * {@code iters == 0} the process exits right after writing — use that to
+ * prepare the file in one process, drop the OS page cache, and measure the
+ * cold read in a fresh one.
  */
 public final class BrackitInMemoryScaleBenchMain {
 
@@ -67,24 +81,52 @@ public final class BrackitInMemoryScaleBenchMain {
 
   public static void main(final String[] args) throws Exception {
     if (args.length < 1) {
-      System.err.println("Usage: BrackitInMemoryScaleBenchMain <recordCount> [iters=N]");
+      System.err.println("Usage: BrackitInMemoryScaleBenchMain <recordCount> [iters=N] [jsonFile]");
       System.exit(1);
     }
     final long recordCount = Long.parseLong(args[0]);
     final int iters = args.length < 2 ? 3 : Integer.parseInt(args[1]);
+    final Path jsonFile = args.length < 3 ? null : Path.of(args[2]);
 
-    final Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
-    root.setLevel(ch.qos.logback.classic.Level.WARN);
+    final Logger root = (Logger) LoggerFactory.getLogger(ROOT_LOGGER_NAME);
+    root.setLevel(Level.WARN);
 
-    System.out.printf("# Engine: pure Brackit (in-memory items, no Sirix)   Records: %,d   Iters: %d%n",
-                      recordCount, iters);
+    System.out.printf("# Engine: pure Brackit (in-memory items, no Sirix)   Records: %,d   Iters: %d   File: %s%n",
+                      recordCount, iters, jsonFile == null ? "-" : jsonFile);
 
-    // Generate the dataset as UTF-8 bytes and hand it to FastJSONParser.
-    // ASCII-only payload, so bytes == chars; pre-sized to avoid growth copies.
-    final long tGen = System.nanoTime();
-    final byte[] json = generateJson(recordCount);
-    System.out.printf("# Generated JSON: %,d bytes in %,d ms%n",
-                      json.length, (System.nanoTime() - tGen) / 1_000_000L);
+    // Obtain the dataset as UTF-8 bytes for FastJSONParser: read from disk
+    // when a file is given (timed — the disk-cold comparison point), else
+    // generate in memory. ASCII-only payload, so bytes == chars.
+    final byte[] json;
+    if (jsonFile != null && Files.exists(jsonFile)) {
+      if (iters <= 0) {
+        System.out.println("# iters == 0 and file already prepared: nothing to do");
+        return;
+      }
+      final long tRead = System.nanoTime();
+      json = Files.readAllBytes(jsonFile);
+      System.out.printf("# Read JSON file: %,d bytes in %,d ms%n",
+                        json.length, (System.nanoTime() - tRead) / 1_000_000L);
+    } else {
+      if (iters <= 0 && jsonFile == null) {
+        System.out.println("# iters == 0 without a jsonFile: nothing to do");
+        return;
+      }
+      final long tGen = System.nanoTime();
+      json = generateJson(recordCount);
+      System.out.printf("# Generated JSON: %,d bytes in %,d ms%n",
+                        json.length, (System.nanoTime() - tGen) / 1_000_000L);
+      if (jsonFile != null) {
+        final long tWrite = System.nanoTime();
+        Files.write(jsonFile, json);
+        System.out.printf("# Wrote JSON file: %s in %,d ms%n",
+                          jsonFile, (System.nanoTime() - tWrite) / 1_000_000L);
+        if (iters <= 0) {
+          System.out.println("# iters == 0: file prepared, exiting before parse/queries");
+          return;
+        }
+      }
+    }
 
     final long tParse = System.nanoTime();
     final Item doc = new FastJSONParser(json, 0, json.length).parse();
@@ -95,9 +137,9 @@ public final class BrackitInMemoryScaleBenchMain {
     final QueryContext ctx = new BrackitQueryContext();
     ctx.bind(DOC_VAR, (Sequence) doc);
 
-    System.out.printf("%-26s | %10s | %10s | %10s | %10s%n", "query", "min(ms)", "avg(ms)", "max(ms)", "result_bytes");
-    System.out.printf("%-26s + %10s + %10s + %10s + %10s%n", "--------------------------",
-                      "----------", "----------", "----------", "------------");
+    System.out.printf("%-26s | %10s | %10s | %10s | %10s | %10s%n", "query", "first(ms)", "min(ms)", "avg(ms)", "max(ms)", "result_bytes");
+    System.out.printf("%-26s + %10s + %10s + %10s + %10s + %10s%n", "--------------------------",
+                      "----------", "----------", "----------", "----------", "------------");
 
     for (final Map.Entry<String, String> e : QUERIES.entrySet()) {
       runQueryRepeated(chain, ctx, e.getKey(), e.getValue(), iters);
@@ -153,6 +195,7 @@ public final class BrackitInMemoryScaleBenchMain {
       return;
     }
 
+    long first = 0;
     long min = Long.MAX_VALUE;
     long max = 0;
     long sum = 0;
@@ -162,6 +205,9 @@ public final class BrackitInMemoryScaleBenchMain {
         final long t0 = System.nanoTime();
         bytes = runOnce(chain, ctx, wrapped);
         final long elapsed = System.nanoTime() - t0;
+        if (i == 0) {
+          first = elapsed;
+        }
         sum += elapsed;
         if (elapsed < min) {
           min = elapsed;
@@ -174,11 +220,12 @@ public final class BrackitInMemoryScaleBenchMain {
       System.out.printf("%-26s | (aborted iter: %s)%n", name, re.getMessage());
       return;
     }
+    final double firstMs = first / 1e6;
     final double minMs = min / 1e6;
     final double maxMs = max / 1e6;
     final double avgMs = (sum / (double) iters) / 1e6;
-    System.out.printf("%-26s | %10.3f | %10.3f | %10.3f | %,10d%n",
-                      name, minMs, avgMs, maxMs, bytes);
+    System.out.printf("%-26s | %10.3f | %10.3f | %10.3f | %10.3f | %,10d%n",
+                      name, firstMs, minMs, avgMs, maxMs, bytes);
   }
 
   private static int runOnce(final CompileChain chain, final QueryContext ctx, final String wrapped) {

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/ProjectionIndexBenchSetup.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/ProjectionIndexBenchSetup.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Bench helper: build a (age, active, dept) projection index over the
+ * Bench helper: build a (age, active, dept, city) projection index over the
  * current revision of {@code session}'s resource and publish it wildcard
  * in {@link ProjectionIndexRegistry}.
  *
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public final class ProjectionIndexBenchSetup {
 
-  private static final String[] FIELD_NAMES = {"age", "active", "dept"};
+  private static final String[] FIELD_NAMES = {"age", "active", "dept", "city"};
 
   private ProjectionIndexBenchSetup() {
   }
@@ -50,18 +50,21 @@ public final class ProjectionIndexBenchSetup {
     final Path<QNm> agePath = Path.parse("/[]/age", PathParser.Type.JSON);
     final Path<QNm> activePath = Path.parse("/[]/active", PathParser.Type.JSON);
     final Path<QNm> deptPath = Path.parse("/[]/dept", PathParser.Type.JSON);
+    final Path<QNm> cityPath = Path.parse("/[]/city", PathParser.Type.JSON);
     final IndexDef def = IndexDefs.createProjectionIdxDef(
         rootPath,
-        List.of(agePath, activePath, deptPath),
-        List.of(Type.LON, Type.BOOL, Type.STR),
+        List.of(agePath, activePath, deptPath, cityPath),
+        List.of(Type.LON, Type.BOOL, Type.STR, Type.STR),
         0,
         IndexDef.DbType.JSON);
 
     final List<byte[]> leaves = new ArrayList<>();
+    final ProjectionIndexBuilder builder;
     final int revision = session.getMostRecentRevisionNumber();
     try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision);
          PathSummaryReader pathSummary = session.openPathSummary(revision)) {
-      new ProjectionIndexBuilder(def, pathSummary, leaves::add).build(rtx);
+      builder = new ProjectionIndexBuilder(def, pathSummary, leaves::add);
+      builder.build(rtx);
     }
 
     long totalRows = 0L;
@@ -69,8 +72,14 @@ public final class ProjectionIndexBenchSetup {
       totalRows += ByteBuffer.wrap(payload, 0, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
     }
 
+    // Install with the builder's integrality flags — without them the
+    // registry treats every numeric column as "unknown provenance" and
+    // SirixVectorizedExecutor#tryProjectionAggregate declines to serve
+    // sum/avg/min/max from the projection, silently falling back to the
+    // full storage scan.
     final String resourceKey = session.getResourceConfig().getResource().toString();
-    ProjectionIndexRegistry.installWildcard(resourceKey, FIELD_NAMES, leaves);
+    ProjectionIndexRegistry.installWildcard(resourceKey, FIELD_NAMES, leaves,
+        builder.numericColumnNonIntegralFlags());
     return new BuildResult(leaves.size(), totalRows);
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -12,6 +12,12 @@ import io.sirix.index.IndexDef;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.node.NodeKind;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -49,19 +55,28 @@ public final class ProjectionIndexBuilder {
   private final PathSummaryReader pathSummary;
   private final Consumer<byte[]> leafSink;
 
-  /** Resolved pathNodeKey of the projection root (e.g. {@code $doc[]}). */
-  private final long rootPathNodeKey;
+  /**
+   * Resolved pathNodeKeys of the projection root (e.g. {@code $doc[]}).
+   * Multi-PCR roots — the same path shape under sibling subtrees — are
+   * supported: every node whose pathNodeKey is in this set is a record
+   * (set) root.
+   */
+  private final LongSet rootPathNodeKeys;
 
-  /** Strict ancestor pathNodeKeys of {@link #rootPathNodeKey} — guides pruned descent. */
-  private final it.unimi.dsi.fastutil.longs.LongSet rootAncestorPathNodeKeys;
+  /** Strict ancestor pathNodeKeys of every root PCR — guides pruned descent. */
+  private final LongSet rootAncestorPathNodeKeys;
 
   /**
-   * Resolved pathNodeKey per declared field, index-aligned with
-   * {@code indexDef.getProjectionFields()}. {@code -1L} when the path is
-   * unresolvable in the current PathSummary — such records contribute
-   * only {@code presentKind == 0} to that column.
+   * Flattened (pathNodeKey → column) pairs for the declared fields. A field
+   * path resolving to MULTIPLE pathNodeKeys (same shape under different
+   * roots) contributes one pair per PCR — {@link #findField} matches any of
+   * them. A field whose path resolves to nothing contributes no pair: such
+   * records carry only {@code present == false} for that column. Kept as two
+   * parallel flat arrays (not a map) — total PCR count is tiny and the
+   * linear scan JIT-inlines cleanly.
    */
-  private final long[] fieldPathNodeKeys;
+  private final long[] fieldPcrKeys;
+  private final int[] fieldPcrColumns;
 
   /** Per-field column kind, index-aligned with projection fields. */
   private final byte[] columnKinds;
@@ -74,6 +89,8 @@ public final class ProjectionIndexBuilder {
   private final boolean[] rowPresent;
   /** Per-row poison: present field whose value the column kind cannot hold (null / object / array / mismatch). */
   private final boolean[] rowUnrepresentable;
+  /** Per-row provenance: NUMERIC_LONG cell truncated from a non-integral number. */
+  private final boolean[] rowNonIntegral;
 
   private ProjectionIndexLeafPage currentLeaf;
   private long rowsEmitted;
@@ -97,53 +114,92 @@ public final class ProjectionIndexBuilder {
           "Projection root path '" + rootPath + "' did not resolve to any pathNodeKey — "
               + "declare the index after the resource has records matching the root");
     }
-    // For the initial cut we require the root path to resolve to exactly
-    // one pathNodeKey. Multi-path roots (e.g. identical paths under sibling
-    // arrays) land in a follow-up once the multi-pathNodeKey scan is wired.
-    if (rootPcrs.size() > 1) {
-      throw new IllegalStateException(
-          "Projection root path '" + rootPath + "' resolves to " + rootPcrs.size()
-              + " pathNodeKeys; only single-path roots are supported in this version");
+    // Multi-PCR roots (identical path shapes under sibling subtrees) are
+    // supported: every PCR is a record(-set) root and the pruned descent
+    // follows the union of their ancestor chains.
+    this.rootPathNodeKeys = new LongOpenHashSet(rootPcrs.size());
+    for (final Long pcr : rootPcrs) {
+      rootPathNodeKeys.add(pcr.longValue());
     }
-    this.rootPathNodeKey = rootPcrs.iterator().next();
+    // Fail fast on NESTED root PCRs (one record set living inside another
+    // matched record's subtree, e.g. //records/[] over self-nested
+    // "records" arrays): the pruned descent stops at the outer match, and
+    // the per-record field DFS would let the inner record's fields
+    // overwrite the outer row's columns — silently wrong results. Sibling
+    // multi-PCR roots (the supported case) have no ancestor relation.
+    assertNoNestedRootPcrs(pathSummary, rootPathNodeKeys, rootPath);
     // Pre-compute the set of pathNodeKeys along every path from docRoot
-    // to rootPathNodeKey — used to PRUNE the walk to only descend into
+    // to each root PCR — used to PRUNE the walk to only descend into
     // subtrees that can structurally contain records. For deep nested
     // projections (e.g. /wrapper/records/[]) this turns O(total-nodes)
     // into O(ancestor-depth + records). Reference to a HashSet of longs
     // via fastutil to avoid boxing.
-    this.rootAncestorPathNodeKeys = computeAncestorPathNodeKeys(pathSummary, rootPathNodeKey);
+    this.rootAncestorPathNodeKeys = computeAncestorPathNodeKeys(pathSummary, rootPathNodeKeys);
 
     final List<Path<QNm>> fieldPaths = indexDef.getProjectionFields();
     final List<Type> fieldTypes = indexDef.getProjectionFieldTypes();
-    this.fieldPathNodeKeys = new long[fieldPaths.size()];
     this.columnKinds = new byte[fieldPaths.size()];
     this.numericColumnSawNonIntegral = new boolean[fieldPaths.size()];
+    final LongArrayList pcrKeys = new LongArrayList();
+    final IntArrayList pcrCols = new IntArrayList();
     for (int i = 0; i < fieldPaths.size(); i++) {
       final Set<Path<QNm>> one = new HashSet<>();
       one.add(fieldPaths.get(i));
-      final Set<Long> pcrs = pathSummary.getPCRsForPaths(one);
-      fieldPathNodeKeys[i] = pcrs.isEmpty() ? -1L : pcrs.iterator().next();
+      for (final Long pcr : pathSummary.getPCRsForPaths(one)) {
+        pcrKeys.add(pcr.longValue());
+        pcrCols.add(i);
+      }
       columnKinds[i] = mapTypeToColumnKind(fieldTypes.get(i));
     }
+    this.fieldPcrKeys = pcrKeys.toLongArray();
+    this.fieldPcrColumns = pcrCols.toIntArray();
     this.rowLongs = new long[fieldPaths.size()];
     this.rowBools = new boolean[fieldPaths.size()];
     this.rowStrings = new String[fieldPaths.size()];
     this.rowPresent = new boolean[fieldPaths.size()];
     this.rowUnrepresentable = new boolean[fieldPaths.size()];
+    this.rowNonIntegral = new boolean[fieldPaths.size()];
     this.currentLeaf = new ProjectionIndexLeafPage(columnKinds);
   }
 
-  private static it.unimi.dsi.fastutil.longs.LongSet computeAncestorPathNodeKeys(
-      final PathSummaryReader pathSummary, final long rootPathNodeKey) {
-    final it.unimi.dsi.fastutil.longs.LongSet ancestors = new it.unimi.dsi.fastutil.longs.LongOpenHashSet();
+  private static void assertNoNestedRootPcrs(final PathSummaryReader pathSummary,
+      final LongSet rootPathNodeKeys, final Path<QNm> rootPath) {
     final long saved = pathSummary.getNodeKey();
     try {
-      if (!pathSummary.moveTo(rootPathNodeKey)) return ancestors;
-      while (pathSummary.moveToParent()) {
-        final long pk = pathSummary.getNodeKey();
-        if (pk <= 0) break; // document root / no more
-        ancestors.add(pk);
+      final LongIterator roots = rootPathNodeKeys.iterator();
+      while (roots.hasNext()) {
+        final long root = roots.nextLong();
+        if (!pathSummary.moveTo(root)) continue;
+        while (pathSummary.moveToParent()) {
+          final long pk = pathSummary.getNodeKey();
+          if (pk <= 0) break;
+          if (rootPathNodeKeys.contains(pk)) {
+            throw new IllegalStateException(
+                "Projection root path '" + rootPath + "' resolves to NESTED record sets "
+                    + "(pathNodeKey " + root + " lies inside record set " + pk + ") — "
+                    + "self-nested roots are not supported; declare a more specific root path");
+          }
+        }
+      }
+    } finally {
+      pathSummary.moveTo(saved);
+    }
+  }
+
+  private static LongSet computeAncestorPathNodeKeys(
+      final PathSummaryReader pathSummary, final LongSet rootPathNodeKeys) {
+    final LongSet ancestors = new LongOpenHashSet();
+    final long saved = pathSummary.getNodeKey();
+    try {
+      final LongIterator roots = rootPathNodeKeys.iterator();
+      while (roots.hasNext()) {
+        final long root = roots.nextLong();
+        if (!pathSummary.moveTo(root)) continue;
+        while (pathSummary.moveToParent()) {
+          final long pk = pathSummary.getNodeKey();
+          if (pk <= 0) break; // document root / no more
+          ancestors.add(pk);
+        }
       }
     } finally {
       pathSummary.moveTo(saved);
@@ -162,7 +218,7 @@ public final class ProjectionIndexBuilder {
 
   /**
    * Walk the resource from the document root, materialising one projection
-   * row per node whose pathNodeKey equals {@code rootPathNodeKey}. Flushes
+   * row per node whose pathNodeKey is a projection-root PCR. Flushes
    * any partially-filled trailing leaf on completion.
    */
   public void build(final JsonNodeReadOnlyTrx rtx) {
@@ -189,8 +245,8 @@ public final class ProjectionIndexBuilder {
 
   /**
    * Generic pruned descent: walk from docRoot, descending only into
-   * subtrees whose pathNodeKey is an ancestor of {@code rootPathNodeKey}
-   * (pre-computed from PathSummary). When a descendant matches the root
+   * subtrees whose pathNodeKey is an ancestor of any root PCR
+   * (pre-computed from PathSummary). When a descendant matches a root
    * pathNodeKey, process it as a record — either as an array whose
    * children are rows, or as a single-record itself.
    *
@@ -201,7 +257,7 @@ public final class ProjectionIndexBuilder {
    */
   private boolean tryFastArrayIteration(final JsonNodeReadOnlyTrx rtx) {
     final long docRoot = rtx.getNodeKey();
-    if (rootAncestorPathNodeKeys.isEmpty() && rootPathNodeKey <= 0) return false;
+    if (rootPathNodeKeys.isEmpty()) return false;
     boolean processedAny = descendToRoots(rtx, docRoot);
     rtx.moveTo(docRoot);
     return processedAny;
@@ -218,7 +274,7 @@ public final class ProjectionIndexBuilder {
     boolean any = false;
     do {
       final long pk = getPathNodeKeyAtCursor(rtx);
-      if (pk == rootPathNodeKey) {
+      if (pk >= 0 && rootPathNodeKeys.contains(pk)) {
         // Match — process as record(s).
         final long matchKey = rtx.getNodeKey();
         final NodeKind matchKind = rtx.getKind();
@@ -294,7 +350,8 @@ public final class ProjectionIndexBuilder {
    */
   private boolean isRecordRoot(final JsonNodeReadOnlyTrx rtx) {
     if (rtx.isDocumentRoot()) return false;
-    return getPathNodeKeyAtCursor(rtx) == rootPathNodeKey;
+    final long pk = getPathNodeKeyAtCursor(rtx);
+    return pk >= 0 && rootPathNodeKeys.contains(pk);
   }
 
   private static long getPathNodeKeyAtCursor(final JsonNodeReadOnlyTrx rtx) {
@@ -321,12 +378,13 @@ public final class ProjectionIndexBuilder {
   private void extractRow(final JsonNodeReadOnlyTrx rtx, final long recordKey) {
     // Reset per-row slots — fields we fail to resolve stay "missing"
     // (presence bit clear) and serialise as defaults on the leaf page.
-    for (int i = 0; i < fieldPathNodeKeys.length; i++) {
+    for (int i = 0; i < columnKinds.length; i++) {
       rowLongs[i] = 0L;
       rowBools[i] = false;
       rowStrings[i] = "";
       rowPresent[i] = false;
       rowUnrepresentable[i] = false;
+      rowNonIntegral[i] = false;
     }
     // Generic DFS: walk every descendant of recordKey via an explicit
     // work-list of unvisited first-children. For each node we visit:
@@ -381,10 +439,12 @@ public final class ProjectionIndexBuilder {
       } while (true);
     }
     rtx.moveTo(recordKey);
-    if (!currentLeaf.appendRow(recordKey, rowLongs, rowBools, rowStrings, rowPresent, rowUnrepresentable)) {
+    if (!currentLeaf.appendRow(recordKey, rowLongs, rowBools, rowStrings, rowPresent, rowUnrepresentable,
+        rowNonIntegral)) {
       flushCurrentLeaf();
       currentLeaf = new ProjectionIndexLeafPage(columnKinds);
-      currentLeaf.appendRow(recordKey, rowLongs, rowBools, rowStrings, rowPresent, rowUnrepresentable);
+      currentLeaf.appendRow(recordKey, rowLongs, rowBools, rowStrings, rowPresent, rowUnrepresentable,
+          rowNonIntegral);
     }
     rowsEmitted++;
   }
@@ -402,11 +462,11 @@ public final class ProjectionIndexBuilder {
   }
 
   private int findField(final long pathNodeKey) {
-    // Linear scan is cheaper than a HashMap lookup at typical projection
-    // width (~5 fields) — fits in a single cache line and JIT-inlines
-    // cleanly.
-    for (int i = 0; i < fieldPathNodeKeys.length; i++) {
-      if (fieldPathNodeKeys[i] == pathNodeKey) return i;
+    // Linear scan over the flattened (pcr -> column) pairs is cheaper than
+    // a HashMap lookup at typical projection width (~5 fields, one or a few
+    // PCRs each) — fits in a cache line and JIT-inlines cleanly.
+    for (int i = 0; i < fieldPcrKeys.length; i++) {
+      if (fieldPcrKeys[i] == pathNodeKey) return fieldPcrColumns[i];
     }
     return -1;
   }
@@ -441,7 +501,10 @@ public final class ProjectionIndexBuilder {
       case ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG -> {
         final Number n = rtx.isNumberValue() ? rtx.getNumberValue() : null;
         if (n != null) {
-          if (isNonIntegral(n)) numericColumnSawNonIntegral[col] = true;
+          if (isNonIntegral(n)) {
+            numericColumnSawNonIntegral[col] = true;
+            rowNonIntegral[col] = true;
+          }
           rowLongs[col] = n.longValue();
         } else {
           rowUnrepresentable[col] = true;
@@ -487,7 +550,10 @@ public final class ProjectionIndexBuilder {
             ? rtx.getNumberValue()
             : null;
         if (n != null) {
-          if (isNonIntegral(n)) numericColumnSawNonIntegral[col] = true;
+          if (isNonIntegral(n)) {
+            numericColumnSawNonIntegral[col] = true;
+            rowNonIntegral[col] = true;
+          }
           rowLongs[col] = n.longValue();
         } else {
           // Kind mismatch (number where the column expects bool/string) or a

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexByteScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexByteScan.java
@@ -7,7 +7,9 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import jdk.incubator.vector.LongVector;
@@ -118,8 +120,8 @@ public final class ProjectionIndexByteScan {
     int[] columnDataOff = new int[16];
     int[] columnMinMaxOff = new int[16];
     /**
-     * End offset of the legacy (v1) data stream of the leaf most recently
-     * processed by {@link #evaluateLeafMask} — i.e. where a v2 presence tail
+     * End offset of the column data stream of the leaf most recently
+     * processed by {@link #evaluateLeafMask} — i.e. where the presence tail
      * would start. Lets the group/aggregate kernels locate presence bitmaps
      * with an EXACT boundary check instead of trusting the footer alone.
      */
@@ -217,7 +219,7 @@ public final class ProjectionIndexByteScan {
    * @return immutable canonical dict (caller must not mutate), or
    *         {@code null} if ineligible.
    */
-  public static byte[][] probeCanonicalDict(final java.util.List<byte[]> leafPayloads,
+  public static byte[][] probeCanonicalDict(final List<byte[]> leafPayloads,
       final int groupColumn, final int probeLeaves, final int cardLimit) {
     if (leafPayloads == null || leafPayloads.isEmpty()) return null;
     if (probeLeaves <= 0 || cardLimit <= 0) return null;
@@ -228,7 +230,7 @@ public final class ProjectionIndexByteScan {
     if (firstLeaf[24 + groupColumn] != ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT) return null;
 
     // Seed the canonical dict from the first leaf's dict.
-    final java.util.ArrayList<byte[]> canon = new java.util.ArrayList<>(Math.min(cardLimit, 64));
+    final ArrayList<byte[]> canon = new ArrayList<>(Math.min(cardLimit, 64));
     final int scanUpTo = Math.min(probeLeaves, leafPayloads.size());
     for (int li = 0; li < scanUpTo; li++) {
       final byte[] payload = leafPayloads.get(li);
@@ -335,9 +337,9 @@ public final class ProjectionIndexByteScan {
   }
 
   /**
-   * Sparse-aware variant — matching rows missing the group field (v2
+   * Sparse-aware variant — matching rows missing the group field (
    * presence bit clear) count into {@code missingOut[0]}; {@code null}
-   * keeps the legacy dense behavior. See
+   * keeps the dense behavior. See
    * {@link #conjunctiveCountByGroup(Iterable, ProjectionIndexScan.ColumnPredicate[], int, Object2LongOpenHashMap, long[])}.
    */
   public static void conjunctiveCountByGroupDense(final Iterable<byte[]> leafPayloads,
@@ -595,9 +597,9 @@ public final class ProjectionIndexByteScan {
    * callers can decode group records with the same machinery as the typed
    * slot-walk kernel.
    *
-   * <p>Sparse semantics: when the leaf carries a v2 presence tail, rows on
+   * <p>Sparse semantics: when the leaf carries a presence tail, rows on
    * which a group field is missing contribute the {@code 'm'} segment instead
-   * of the stored default. Leaves without presence keep the legacy dense
+   * of the stored default. Leaves without a readable presence tail keep the dense
    * behavior — callers must gate via {@link #probeSparseEvidence} when the
    * data may be sparse.
    *
@@ -711,6 +713,226 @@ public final class ProjectionIndexByteScan {
   }
 
   /**
+   * Dense multi-key conjunctive group-by-count: the composite-key analog of
+   * {@link #conjunctiveCountByGroupDense}. Instead of materialising a
+   * composite {@code String} key per cell and paying two hash probes per
+   * matching row ({@link #conjunctiveCountByGroupMulti}), each group column
+   * gets a per-leaf {@code dictId → canonicalId} remap, and every matching
+   * row does exactly one mixed-radix array increment:
+   * {@code counts[((idA) * (lenB+1) + idB) ...]++} where index
+   * {@code canonLen_g} encodes MISSING for column {@code g}.
+   *
+   * <p>Leaves whose dictionary carries a value absent from the canonical
+   * dict fall back to the composite hashmap path
+   * ({@link #conjunctiveCountByGroupMulti}) for that leaf only, into
+   * {@code fallbackOut} — the caller merges both accumulators (decode the
+   * counts array with the same mixed radix, then {@code addTo}).
+   *
+   * <p>HFT-grade: zero hashmap ops, zero String materialisation and zero
+   * hashing on the per-row path; per-leaf remap cost is
+   * {@code dictSize × canonLen} tiny byte-compares per column.
+   *
+   * @param counts caller-zeroed accumulator of length
+   *               {@code prod(canonicalDicts[g].length + 1)}, mixed-radix
+   *               ordered with column 0 as the most significant digit.
+   */
+  public static void conjunctiveCountByGroupMultiDense(final Iterable<byte[]> leafPayloads,
+      final ProjectionIndexScan.ColumnPredicate[] predicates,
+      final int[] groupColumns,
+      final byte[][][] canonicalDicts,
+      final long[] counts,
+      final Object2LongOpenHashMap<String> fallbackOut) {
+    if (predicates == null) {
+      throw new IllegalArgumentException("predicates must not be null");
+    }
+    final int m = groupColumns.length;
+    if (canonicalDicts == null || canonicalDicts.length != m) {
+      throw new IllegalArgumentException("canonicalDicts must be per-group-column");
+    }
+    long expectedSize = 1L;
+    for (int g = 0; g < m; g++) {
+      expectedSize *= canonicalDicts[g].length + 1L;
+    }
+    if (counts == null || counts.length < expectedSize) {
+      throw new IllegalArgumentException("counts[] too small for canonical dict product");
+    }
+    final ScanScratch s = SCRATCH.get();
+    final int[][] remaps = new int[m][];
+    final int[] dictSizes = new int[m];
+    final int[] idsOffs = new int[m];
+    final int[] presOffs = new int[m];
+    for (final byte[] payload : leafPayloads) {
+      final int columnCount = columnCountOf(payload);
+      if (s.columnDataOff.length < columnCount) {
+        s.columnDataOff = new int[columnCount];
+        s.columnMinMaxOff = new int[columnCount];
+      }
+      final int rowCount = evaluateLeafMask(payload, predicates, s);
+      if (rowCount <= 0) continue;
+      final int tailStart = presenceTailStart(payload, s.leafDataEnd);
+      boolean needsFallback = false;
+      for (int g = 0; g < m; g++) {
+        final int col = groupColumns[g];
+        final byte kind = payload[24 + col];
+        if (kind != ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT) {
+          throw new IllegalStateException("groupColumn " + col + " is not STRING_DICT (kind=" + kind + ")");
+        }
+        final int base = s.columnDataOff[col];
+        final int dictSize = getIntLE(payload, base);
+        dictSizes[g] = dictSize;
+        final int lenHeaderOff = base + 4;
+        final int concatOff = lenHeaderOff + dictSize * 4;
+        int[] remap = remaps[g];
+        if (remap == null || remap.length < dictSize) {
+          remap = new int[Math.max(64, dictSize)];
+          remaps[g] = remap;
+        }
+        final byte[][] canon = canonicalDicts[g];
+        final int canonLen = canon.length;
+        int running = concatOff;
+        for (int i = 0; i < dictSize; i++) {
+          final int len = getIntLE(payload, lenHeaderOff + i * 4);
+          int hit = -1;
+          for (int c = 0; c < canonLen; c++) {
+            if (bytesEqualAt(payload, running, len, canon[c])) { hit = c; break; }
+          }
+          remap[i] = hit;
+          if (hit < 0) needsFallback = true;
+          running += len;
+        }
+        idsOffs[g] = running;
+        presOffs[g] = tailStart >= 0 ? presenceWordsOff(payload, tailStart, col) : -1;
+      }
+      if (needsFallback) {
+        // A dict value outside the canonical dict — run the composite
+        // hashmap kernel on this single leaf; caller merges fallbackOut.
+        if (fallbackOut == null) {
+          throw new IllegalStateException("canonical dict missing value and no fallback provided");
+        }
+        conjunctiveCountByGroupMulti(List.of(payload), predicates, groupColumns, fallbackOut);
+        continue;
+      }
+      final int stride = (rowCount + 63) >>> 6;
+      final long[] scanMask = s.mask;
+      for (int w = 0; w < stride; w++) {
+        long word = scanMask[w];
+        while (word != 0L) {
+          final int bit = Long.numberOfTrailingZeros(word);
+          word &= word - 1L;
+          final int rowIdx = (w << 6) + bit;
+          if (rowIdx >= rowCount) break;
+          int idx = 0;
+          for (int g = 0; g < m; g++) {
+            final boolean missing = presOffs[g] >= 0
+                && (getLongLE(payload, presOffs[g] + (rowIdx >>> 6) * 8) & (1L << (rowIdx & 63))) == 0L;
+            final int id = missing ? canonicalDicts[g].length : remaps[g][getIntLE(payload, idsOffs[g] + rowIdx * 4)];
+            idx = idx * (canonicalDicts[g].length + 1) + id;
+          }
+          counts[idx]++;
+        }
+      }
+    }
+  }
+
+  /**
+   * Exact distinct PRESENT string values of {@code groupColumn} across all
+   * leaves — the count-distinct fast path. Exploits a structural invariant
+   * of the leaf format: every non-empty dictionary entry was interned by an
+   * actual row of that leaf (missing/unrepresentable rows intern only the
+   * {@code ""} default), so with the column gated sparse-clean the distinct
+   * set is simply the UNION of the per-leaf dictionaries — no per-row work
+   * at all, except to disambiguate a {@code ""} dictionary entry, which may
+   * be a phantom from missing rows: on a fully-present leaf it is real; on a
+   * leaf with missing rows the packed ids are scanned for a present row
+   * referencing it (early exit on first hit).
+   *
+   * <p>Valid ONLY for the unpredicated case (every row counts) and for
+   * sparse-clean columns — callers gate on both.
+   *
+   * @param cardLimit bail-out bound: exceeding it returns {@code null}
+   *                  (caller falls back to the group-counting path, which
+   *                  handles any cardinality).
+   * @return distinct present values as UTF-8 byte arrays (a {@code ""}
+   *         value is included as a zero-length entry when real), or
+   *         {@code null} when the kernel cannot serve (kind mismatch,
+   *         malformed leaf, missing presence tail, cardinality exceeded).
+   */
+  public static ArrayList<byte[]> distinctPresentStrings(
+      final List<byte[]> leafPayloads, final int groupColumn, final int cardLimit) {
+    if (leafPayloads == null) return null;
+    final ArrayList<byte[]> distinct = new ArrayList<>(16);
+    boolean emptyReal = false;
+    for (final byte[] payload : leafPayloads) {
+      if (payload == null) return null;
+      final int rowCount = getIntLE(payload, 0);
+      if (rowCount == 0) continue;
+      final int columnCount = getIntLE(payload, 4);
+      if (groupColumn < 0 || groupColumn >= columnCount) return null;
+      if (payload[24 + groupColumn] != ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT) return null;
+      final int groupBase = columnDataOffFor(payload, groupColumn);
+      if (groupBase < 0) return null;
+      final int dictSize = getIntLE(payload, groupBase);
+      final int lenHeaderOff = groupBase + 4;
+      final int concatOff = lenHeaderOff + dictSize * 4;
+      final int dataEnd = leafDataEnd(payload);
+      final int tailStart = dataEnd < 0 ? -1 : presenceTailStart(payload, dataEnd);
+      if (tailStart < 0) return null;
+      final int presOff = presenceWordsOff(payload, tailStart, groupColumn);
+      int emptyId = -1;
+      int running = concatOff;
+      for (int i = 0; i < dictSize; i++) {
+        final int len = getIntLE(payload, lenHeaderOff + i * 4);
+        if (len == 0) {
+          emptyId = i;
+        } else {
+          boolean present = false;
+          final int n = distinct.size();
+          for (int c = 0; c < n; c++) {
+            if (bytesEqualAt(payload, running, len, distinct.get(c))) { present = true; break; }
+          }
+          if (!present) {
+            if (distinct.size() >= cardLimit) return null;
+            final byte[] copy = new byte[len];
+            System.arraycopy(payload, running, copy, 0, len);
+            distinct.add(copy);
+          }
+        }
+        running += len;
+      }
+      if (emptyId >= 0 && !emptyReal) {
+        final int idsOff = running;
+        final int presWords = (rowCount + 63) >>> 6;
+        boolean allPresent = true;
+        for (int w = 0; w < presWords; w++) {
+          final long expect = w == presWords - 1 && (rowCount & 63) != 0
+              ? (1L << (rowCount & 63)) - 1
+              : -1L;
+          if ((getLongLE(payload, presOff + w * 8) & expect) != expect) {
+            allPresent = false;
+            break;
+          }
+        }
+        if (allPresent) {
+          // Every row is present, so the "" entry was interned by a present row.
+          emptyReal = true;
+        } else {
+          for (int r = 0; r < rowCount; r++) {
+            if ((getLongLE(payload, presOff + (r >>> 6) * 8) & (1L << (r & 63))) == 0L) continue;
+            if (getIntLE(payload, idsOff + r * 4) == emptyId) {
+              emptyReal = true;
+              break;
+            }
+          }
+        }
+      }
+    }
+    if (emptyReal) {
+      distinct.add(new byte[0]);
+    }
+    return distinct;
+  }
+
+  /**
    * Conjunctive filter + group-by-count: walks {@code leafPayloads} with the
    * supplied {@code predicates}, then for every matching row reads the
    * {@code groupColumn}'s UTF-8 string value and increments the matching
@@ -732,10 +954,10 @@ public final class ProjectionIndexByteScan {
   /**
    * Sparse-aware variant of {@link #conjunctiveCountByGroup(Iterable,
    * ProjectionIndexScan.ColumnPredicate[], int, Object2LongOpenHashMap)}:
-   * matching rows on which the group field is MISSING (v2 presence bit clear)
+   * matching rows on which the group field is MISSING (presence bit clear)
    * are counted into {@code missingOut[0]} instead of polluting the string
    * groups with the stored default. {@code missingOut == null} keeps the
-   * legacy dense behavior; leaves without a presence tail always use it.
+   * dense behavior; leaves without a readable presence tail always use it.
    */
   public static void conjunctiveCountByGroup(final Iterable<byte[]> leafPayloads,
       final ProjectionIndexScan.ColumnPredicate[] predicates,
@@ -842,18 +1064,19 @@ public final class ProjectionIndexByteScan {
   }
 
   // ------------------------------------------------------------------
-  // v2 presence tail (sparse-field correctness). Layout appended AFTER the
-  // legacy stream — see ProjectionIndexLeafPage's class javadoc:
-  //   byte[columnCount] columnFlags        (bit0 = unrepresentable seen)
+  // Presence tail (sparse-field correctness). Layout appended AFTER the
+  // column stream — see ProjectionIndexLeafPage's class javadoc:
+  //   byte[columnCount] columnFlags        (bit0 = unrepresentable seen,
+  //                                         bit1 = non-integral seen)
   //   long[presWords] presence per column  (only when rowCount > 0)
   //   int tailLen; int magic = "PIX2"
   // ------------------------------------------------------------------
 
   /**
-   * Start offset of the v2 presence tail given the EXACT end of the legacy
-   * data stream, or {@code -1} when the leaf carries no presence information
-   * (legacy v1 payload). The boundary equality check makes false positives
-   * impossible — a v1 payload can never be misread as v2.
+   * Start offset of the presence tail given the EXACT end of the column
+   * data stream, or {@code -1} when the trailing bytes don't form a valid
+   * tail (malformed payload). The boundary equality check makes false
+   * positives impossible — a truncated payload can never be misread.
    */
   static int presenceTailStart(final byte[] payload, final int dataEnd) {
     final int rowCount = getIntLE(payload, 0);
@@ -875,7 +1098,7 @@ public final class ProjectionIndexByteScan {
   }
 
   /**
-   * End offset of the legacy (v1) data stream — header + recordKeys + all
+   * End offset of the column data stream — header + recordKeys + all
    * column bodies. Walks the column directory; used by the one-shot evidence
    * probe (the hot kernels get the boundary from {@link #evaluateLeafMask}).
    * Returns {@code -1} on structural inconsistency.
@@ -908,15 +1131,15 @@ public final class ProjectionIndexByteScan {
 
   /** Sparse-evidence status: not yet probed. */
   public static final byte SPARSE_STATUS_UNKNOWN = 0;
-  /** Every leaf carries v2 presence data and the column never saw an unrepresentable value. */
+  /** Every leaf carries presence data and the column never saw an unrepresentable value. */
   public static final byte SPARSE_STATUS_CLEAN = 1;
-  /** Some leaf lacks presence data (legacy v1) or saw an unrepresentable value — fail closed. */
+  /** Some leaf lacks a valid presence tail (malformed) or saw an unrepresentable value — fail closed. */
   public static final byte SPARSE_STATUS_DIRTY = 2;
 
   /**
    * One-shot probe over ALL leaves: per column, decide whether sparse-correct
    * semantics can be served from the projection. A column is CLEAN iff every
-   * leaf carries the v2 presence tail AND never flags the column as
+   * leaf carries a valid presence tail AND never flags the column as
    * unrepresentable (JSON null / object / array / kind-mismatch values poison
    * the column — a present row's stored default is not the real value).
    * Anything else is DIRTY — consumers must fall back (typed scan kernels /
@@ -926,7 +1149,7 @@ public final class ProjectionIndexByteScan {
    *         {@link #SPARSE_STATUS_DIRTY}, sized {@code columnCount};
    *         zero-length when the leaf list is empty.
    */
-  public static byte[] probeSparseEvidence(final java.util.List<byte[]> leafPayloads) {
+  public static byte[] probeSparseEvidence(final List<byte[]> leafPayloads) {
     if (leafPayloads == null || leafPayloads.isEmpty()) return new byte[0];
     final byte[] first = leafPayloads.get(0);
     if (first == null) return new byte[0];
@@ -941,7 +1164,7 @@ public final class ProjectionIndexByteScan {
       final int dataEnd = leafDataEnd(payload);
       final int tailStart = dataEnd < 0 ? -1 : presenceTailStart(payload, dataEnd);
       if (tailStart < 0) {
-        // Legacy v1 leaf — no presence info anywhere; every column is dirty.
+        // Malformed leaf — no trustworthy presence info; every column is dirty.
         Arrays.fill(status, SPARSE_STATUS_DIRTY);
         return status;
       }
@@ -952,6 +1175,51 @@ public final class ProjectionIndexByteScan {
       }
     }
     return status;
+  }
+
+  /**
+   * One-shot probe over ALL leaves: recover per-column NUMERIC_LONG
+   * integrality provenance from the persisted bytes. A column's flag is the
+   * OR of {@link ProjectionIndexLeafPage#COLUMN_FLAG_NON_INTEGRAL} across
+   * every leaf — {@code true} means some cell was truncated from a
+   * non-integral number and value-exact consumers must decline the column.
+   *
+   * <p>Returns {@code null} — integrality UNKNOWN, consumers must fail
+   * closed — when any leaf lacks a valid presence tail (malformed payload):
+   * fabricating "integral" for such leaves would let aggregates return
+   * truncated sums. This is the persistence-safe
+   * counterpart of {@code ProjectionIndexBuilder#numericColumnNonIntegralFlags()}:
+   * it lets a re-opened resource re-derive the flags that previously lived
+   * only in builder memory.
+   *
+   * @return per-column non-integral flags sized {@code columnCount}, or
+   *         {@code null} when any leaf lacks the presence tail; zero-length
+   *         when the leaf list is empty.
+   */
+  public static boolean[] probeNumericNonIntegral(final List<byte[]> leafPayloads) {
+    if (leafPayloads == null || leafPayloads.isEmpty()) return new boolean[0];
+    final byte[] first = leafPayloads.get(0);
+    if (first == null || first.length < 8) return null;
+    final int columnCount = columnCountOf(first);
+    if (columnCount < 0) return null;
+    final boolean[] nonIntegral = new boolean[columnCount];
+    try {
+      for (final byte[] payload : leafPayloads) {
+        if (payload == null || payload.length < 8 || columnCountOf(payload) != columnCount) return null;
+        final int dataEnd = leafDataEnd(payload);
+        final int tailStart = dataEnd < 0 ? -1 : presenceTailStart(payload, dataEnd);
+        if (tailStart < 0) return null;
+        for (int c = 0; c < columnCount; c++) {
+          if ((payload[tailStart + c] & ProjectionIndexLeafPage.COLUMN_FLAG_NON_INTEGRAL) != 0) {
+            nonIntegral[c] = true;
+          }
+        }
+      }
+    } catch (final IndexOutOfBoundsException truncated) {
+      // Malformed / truncated payload — fail closed per the contract.
+      return null;
+    }
+    return nonIntegral;
   }
 
   private static long countLeaf(final byte[] payload,
@@ -972,17 +1240,17 @@ public final class ProjectionIndexByteScan {
    * rules out the page), or {@code 0} for empty leaves / zone-map
    * skips — callers should treat {@code 0} as "nothing to do".
    *
-   * <p>Sparse-field semantics: when the leaf carries a v2 presence tail,
+   * <p>Sparse-field semantics: when the leaf carries a presence tail,
    * every predicate's match bits are AND-ed with the predicate column's
    * presence bitmap — a comparison/EBV over a MISSING field evaluates over
    * the empty sequence and is FALSE in XQuery, never "matches the stored
-   * default". Legacy v1 leaves (no tail) keep the historical all-present
+   * default". Leaves without a readable tail keep the all-present
    * behavior; sparse-correct callers must gate on
    * {@link #probeSparseEvidence} before trusting them.
    *
    * <p>The mask is sized to {@code ceil(MAX_ROWS/64)}; only the first
    * {@code ceil(rowCount/64)} words are populated. As a side effect
-   * {@code s.leafDataEnd} records where the legacy stream ends.
+   * {@code s.leafDataEnd} records where the column stream ends.
    */
   private static int evaluateLeafMask(final byte[] payload,
       final ProjectionIndexScan.ColumnPredicate[] predicates, final ScanScratch s) {
@@ -1025,7 +1293,7 @@ public final class ProjectionIndexByteScan {
     s.leafDataEnd = cursor;
 
     // Zone-map prune — numeric columns only (same policy as the
-    // materialising variant). v2 zone maps fold in only PRESENT,
+    // materialising variant). Zone maps fold in only PRESENT,
     // representable values, so an all-missing leaf prunes outright.
     for (final var p : predicates) {
       final byte kind = payload[kindsOff + p.column];

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafCodec.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+/**
+ * Storage codec for projection leaves: converts between the flat
+ * scan-friendly byte layout the {@link ProjectionIndexByteScan} kernels
+ * operate on (the "raw" form — see {@link ProjectionIndexLeafPage}'s class
+ * javadoc) and a compact persisted form. The raw form trades space for
+ * branch-free fixed-stride access (raw 8-byte numerics, 4-byte dict-ids,
+ * full presence words); persisting it verbatim roughly doubles the store.
+ * The compact form applies:
+ *
+ * <ul>
+ *   <li><b>record keys</b> — delta + frame-of-reference bit-packing when
+ *       ascending (the builder's document-order walk), absolute FOR
+ *       otherwise;</li>
+ *   <li><b>NUMERIC_LONG columns</b> — frame-of-reference base + minimal
+ *       bit-width packing ({@code width == 0} collapses a constant column,
+ *       including the all-default body of an all-missing column, to 9
+ *       bytes);</li>
+ *   <li><b>STRING_DICT columns</b> — dictionary verbatim (tiny), dict-ids
+ *       bit-packed to {@code ceil(log2(dictSize))} bits;</li>
+ *   <li><b>BOOLEAN columns</b> — packed words verbatim (already 1 bit/row);</li>
+ *   <li><b>presence bitmaps</b> — one marker byte for the all-present /
+ *       all-missing cases, literal words otherwise.</li>
+ * </ul>
+ *
+ * <p>{@link #decode} reconstructs the raw payload <b>byte-identically</b>
+ * (it re-assembles a {@link ProjectionIndexLeafPage} and re-serialises it),
+ * so hydrated leaves are indistinguishable from freshly built ones —
+ * presence, unrepresentable and integrality provenance included. Encode →
+ * decode is a strict identity on any valid raw leaf.
+ *
+ * <p>Compact payloads are recognised by a leading {@link #COMPACT_MAGIC};
+ * {@link #decode} passes non-compact payloads through unchanged (a raw
+ * leaf's first int is its row count {@code <= 1024}, which can never
+ * collide with the magic).
+ */
+public final class ProjectionIndexLeafCodec {
+
+  /** Leading magic of a compact payload ("PIXC" little-endian). */
+  public static final int COMPACT_MAGIC = 0x43585049;
+
+  private ProjectionIndexLeafCodec() {
+  }
+
+  // ==================== encode ====================
+
+  /**
+   * Encode a raw leaf payload into the compact persisted form.
+   *
+   * @throws IllegalStateException when {@code rawPayload} is not a valid raw
+   *         leaf (propagated from {@link ProjectionIndexLeafPage#deserialize}).
+   */
+  public static byte[] encode(final byte[] rawPayload) {
+    if (rawPayload == null) {
+      return null;
+    }
+    final ProjectionIndexLeafPage page = ProjectionIndexLeafPage.deserialize(rawPayload);
+    final int rowCount = page.getRowCount();
+    final int columnCount = page.getColumnCount();
+    final ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
+    putIntLE(out, COMPACT_MAGIC);
+    putIntLE(out, rowCount);
+    putIntLE(out, columnCount);
+    putLongLE(out, page.firstRecordKey());
+    putLongLE(out, page.lastRecordKey());
+    for (int c = 0; c < columnCount; c++) {
+      out.write(page.columnKind(c));
+    }
+    if (rowCount > 0) {
+      encodeRecordKeys(out, page.recordKeys(), rowCount);
+      for (int c = 0; c < columnCount; c++) {
+        putLongLE(out, page.columnMin(c));
+        putLongLE(out, page.columnMax(c));
+        switch (page.columnKind(c)) {
+          case ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG ->
+              encodeForBitPacked(out, page.numericColumn(c), rowCount);
+          case ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN -> {
+            final long[] bits = page.booleanColumnBits(c);
+            final int words = (rowCount + 63) >>> 6;
+            for (int w = 0; w < words; w++) {
+              putLongLE(out, bits[w]);
+            }
+          }
+          case ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT ->
+              encodeStringDict(out, page.stringDictionary(c), page.stringDictIdColumn(c), rowCount);
+          default -> throw new IllegalStateException("Unknown column kind " + page.columnKind(c));
+        }
+      }
+    }
+    // Tail: flags verbatim, presence per column as marker byte or literal words.
+    for (int c = 0; c < columnCount; c++) {
+      byte flags = page.columnUnrepresentable(c) ? ProjectionIndexLeafPage.COLUMN_FLAG_UNREPRESENTABLE : 0;
+      if (page.columnNumericNonIntegral(c)) {
+        flags |= ProjectionIndexLeafPage.COLUMN_FLAG_NON_INTEGRAL;
+      }
+      out.write(flags);
+    }
+    if (rowCount > 0) {
+      for (int c = 0; c < columnCount; c++) {
+        encodePresence(out, page.presenceColumnBits(c), rowCount);
+      }
+    }
+    return out.toByteArray();
+  }
+
+  private static void encodeRecordKeys(final ByteArrayOutputStream out, final long[] keys, final int rowCount) {
+    boolean ascending = true;
+    for (int i = 1; i < rowCount; i++) {
+      if (keys[i] < keys[i - 1]) {
+        ascending = false;
+        break;
+      }
+    }
+    if (ascending) {
+      long maxDelta = 0;
+      for (int i = 1; i < rowCount; i++) {
+        final long d = keys[i] - keys[i - 1];
+        if (d > maxDelta) maxDelta = d;
+      }
+      final int width = widthOf(maxDelta);
+      out.write(0);                       // key mode 0 = delta-FOR
+      putLongLE(out, keys[0]);
+      out.write(width);
+      final BitWriter bw = new BitWriter(out);
+      for (int i = 1; i < rowCount; i++) {
+        bw.write(keys[i] - keys[i - 1], width);
+      }
+      bw.flush();
+    } else {
+      long min = Long.MAX_VALUE;
+      long max = Long.MIN_VALUE;
+      for (int i = 0; i < rowCount; i++) {
+        if (keys[i] < min) min = keys[i];
+        if (keys[i] > max) max = keys[i];
+      }
+      final int width = rangeWidth(min, max);
+      out.write(1);                       // key mode 1 = absolute-FOR
+      putLongLE(out, min);
+      out.write(width);
+      final BitWriter bw = new BitWriter(out);
+      for (int i = 0; i < rowCount; i++) {
+        bw.write(keys[i] - min, width);
+      }
+      bw.flush();
+    }
+  }
+
+  private static void encodeForBitPacked(final ByteArrayOutputStream out, final long[] values, final int rowCount) {
+    long min = Long.MAX_VALUE;
+    long max = Long.MIN_VALUE;
+    for (int i = 0; i < rowCount; i++) {
+      if (values[i] < min) min = values[i];
+      if (values[i] > max) max = values[i];
+    }
+    final int width = rangeWidth(min, max);
+    putLongLE(out, min);
+    out.write(width);
+    if (width > 0) {
+      final BitWriter bw = new BitWriter(out);
+      for (int i = 0; i < rowCount; i++) {
+        bw.write(values[i] - min, width);
+      }
+      bw.flush();
+    }
+  }
+
+  private static void encodeStringDict(final ByteArrayOutputStream out, final byte[][] dict,
+      final int[] ids, final int rowCount) {
+    int dictSize = 0;
+    while (dictSize < dict.length && dict[dictSize] != null) {
+      dictSize++;
+    }
+    putIntLE(out, dictSize);
+    for (int i = 0; i < dictSize; i++) {
+      putIntLE(out, dict[i].length);
+    }
+    for (int i = 0; i < dictSize; i++) {
+      out.write(dict[i], 0, dict[i].length);
+    }
+    final int width = dictSize <= 1 ? 0 : widthOf(dictSize - 1L);
+    out.write(width);
+    if (width > 0) {
+      final BitWriter bw = new BitWriter(out);
+      for (int i = 0; i < rowCount; i++) {
+        bw.write(ids[i], width);
+      }
+      bw.flush();
+    }
+  }
+
+  private static void encodePresence(final ByteArrayOutputStream out, final long[] bits, final int rowCount) {
+    final int words = (rowCount + 63) >>> 6;
+    boolean allPresent = true;
+    boolean allMissing = true;
+    for (int w = 0; w < words; w++) {
+      final long expect = expectedFullWord(w, words, rowCount);
+      if (bits[w] != expect) allPresent = false;
+      if (bits[w] != 0L) allMissing = false;
+    }
+    if (allPresent) {
+      out.write(0);
+    } else if (allMissing) {
+      out.write(1);
+    } else {
+      out.write(2);
+      for (int w = 0; w < words; w++) {
+        putLongLE(out, bits[w]);
+      }
+    }
+  }
+
+  // ==================== decode ====================
+
+  /**
+   * Decode a compact payload back to the raw scan form; non-compact
+   * payloads (no leading {@link #COMPACT_MAGIC}) pass through unchanged.
+   */
+  public static byte[] decode(final byte[] payload) {
+    if (payload == null || payload.length < 4 || getIntLE(payload, 0) != COMPACT_MAGIC) {
+      return payload;
+    }
+    final Cursor in = new Cursor(payload, 4);
+    final int rowCount = in.readInt();
+    final int columnCount = in.readInt();
+    final long firstRecordKey = in.readLong();
+    final long lastRecordKey = in.readLong();
+    final byte[] kinds = new byte[columnCount];
+    for (int c = 0; c < columnCount; c++) {
+      kinds[c] = in.readByte();
+    }
+    final long[] recordKeys = rowCount > 0 ? decodeRecordKeys(in, rowCount) : new long[0];
+    final long[] columnMin = new long[columnCount];
+    final long[] columnMax = new long[columnCount];
+    final long[][] numericCols = new long[columnCount][];
+    final long[][] booleanCols = new long[columnCount][];
+    final int[][] dictIdCols = new int[columnCount][];
+    final byte[][][] dicts = new byte[columnCount][][];
+    final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
+    if (rowCount > 0) {
+      for (int c = 0; c < columnCount; c++) {
+        columnMin[c] = in.readLong();
+        columnMax[c] = in.readLong();
+        switch (kinds[c]) {
+          case ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG -> {
+            final long base = in.readLong();
+            final int width = in.readByte() & 0xFF;
+            final long[] values = new long[rowCount];
+            if (width == 0) {
+              Arrays.fill(values, base);
+            } else {
+              final BitReader br = new BitReader(in);
+              for (int i = 0; i < rowCount; i++) {
+                values[i] = base + br.read(width);
+              }
+              br.align();
+            }
+            numericCols[c] = values;
+          }
+          case ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN -> {
+            final long[] bits = new long[presWords];
+            for (int w = 0; w < presWords; w++) {
+              bits[w] = in.readLong();
+            }
+            booleanCols[c] = bits;
+          }
+          case ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT -> {
+            final int dictSize = in.readInt();
+            final int[] lens = new int[dictSize];
+            for (int i = 0; i < dictSize; i++) {
+              lens[i] = in.readInt();
+            }
+            final byte[][] dict = new byte[Math.max(16, dictSize)][];
+            for (int i = 0; i < dictSize; i++) {
+              dict[i] = in.readBytes(lens[i]);
+            }
+            dicts[c] = dict;
+            final int width = in.readByte() & 0xFF;
+            final int[] ids = new int[rowCount];
+            if (width > 0) {
+              final BitReader br = new BitReader(in);
+              for (int i = 0; i < rowCount; i++) {
+                ids[i] = (int) br.read(width);
+              }
+              br.align();
+            }
+            dictIdCols[c] = ids;
+          }
+          default -> throw new IllegalStateException("Unknown column kind " + kinds[c]);
+        }
+      }
+    }
+    final boolean[] unrep = new boolean[columnCount];
+    final boolean[] nonIntegral = new boolean[columnCount];
+    for (int c = 0; c < columnCount; c++) {
+      final byte flags = in.readByte();
+      unrep[c] = (flags & ProjectionIndexLeafPage.COLUMN_FLAG_UNREPRESENTABLE) != 0;
+      nonIntegral[c] = (flags & ProjectionIndexLeafPage.COLUMN_FLAG_NON_INTEGRAL) != 0;
+    }
+    final long[][] presence = new long[columnCount][];
+    for (int c = 0; c < columnCount; c++) {
+      final long[] bits = new long[Math.max(presWords, (ProjectionIndexLeafPage.MAX_ROWS + 63) >>> 6)];
+      presence[c] = bits;
+      if (rowCount == 0) continue;
+      final int mode = in.readByte() & 0xFF;
+      switch (mode) {
+        case 0 -> {
+          for (int w = 0; w < presWords; w++) {
+            bits[w] = expectedFullWord(w, presWords, rowCount);
+          }
+        }
+        case 1 -> { /* all-missing — words stay zero */ }
+        case 2 -> {
+          for (int w = 0; w < presWords; w++) {
+            bits[w] = in.readLong();
+          }
+        }
+        default -> throw new IllegalStateException("Bad presence marker " + mode);
+      }
+    }
+    final ProjectionIndexLeafPage page = ProjectionIndexLeafPage.reconstruct(kinds, rowCount,
+        firstRecordKey, lastRecordKey, recordKeys, columnMin, columnMax,
+        numericCols, booleanCols, dictIdCols, dicts, presence, unrep, nonIntegral);
+    return page.serialize();
+  }
+
+  private static long[] decodeRecordKeys(final Cursor in, final int rowCount) {
+    final int mode = in.readByte() & 0xFF;
+    final long base = in.readLong();
+    final int width = in.readByte() & 0xFF;
+    final long[] keys = new long[rowCount];
+    if (mode == 0) {
+      keys[0] = base;
+      final BitReader br = new BitReader(in);
+      for (int i = 1; i < rowCount; i++) {
+        keys[i] = keys[i - 1] + (width == 0 ? 0 : br.read(width));
+      }
+      br.align();
+    } else if (mode == 1) {
+      final BitReader br = new BitReader(in);
+      for (int i = 0; i < rowCount; i++) {
+        keys[i] = base + (width == 0 ? 0 : br.read(width));
+      }
+      br.align();
+    } else {
+      throw new IllegalStateException("Bad record-key mode " + mode);
+    }
+    return keys;
+  }
+
+  // ==================== helpers ====================
+
+  /** Bits needed to represent {@code maxValue >= 0}; 0 for 0. */
+  private static int widthOf(final long maxValue) {
+    return clampPackWidth(64 - Long.numberOfLeadingZeros(maxValue));
+  }
+
+  /** FOR width for [min, max]; 64 when the range overflows a signed long. */
+  private static int rangeWidth(final long min, final long max) {
+    try {
+      return widthOf(Math.subtractExact(max, min));
+    } catch (final ArithmeticException overflow) {
+      return 64;
+    }
+  }
+
+  /**
+   * The byte-at-a-time {@link BitReader} accumulates at most 63 usable bits
+   * (a byte shifted by {@code avail > 56} loses its top bits past bit 63),
+   * so packed runs are capped at 56 bits; anything wider uses the aligned
+   * raw 64-bit path. Wider-than-56-bit ranges are pathological for FOR
+   * packing anyway — the raw path costs at most 1 byte/value more.
+   */
+  private static int clampPackWidth(final int width) {
+    return width > 56 ? 64 : width;
+  }
+
+  /** The presence word value of a fully-present leaf at word {@code w}. */
+  private static long expectedFullWord(final int w, final int words, final int rowCount) {
+    return w == words - 1 && (rowCount & 63) != 0 ? (1L << (rowCount & 63)) - 1 : -1L;
+  }
+
+  private static void putIntLE(final ByteArrayOutputStream out, final int v) {
+    out.write(v);
+    out.write(v >>> 8);
+    out.write(v >>> 16);
+    out.write(v >>> 24);
+  }
+
+  private static void putLongLE(final ByteArrayOutputStream out, final long v) {
+    putIntLE(out, (int) v);
+    putIntLE(out, (int) (v >>> 32));
+  }
+
+  private static int getIntLE(final byte[] b, final int off) {
+    return (b[off] & 0xFF) | ((b[off + 1] & 0xFF) << 8) | ((b[off + 2] & 0xFF) << 16) | ((b[off + 3] & 0xFF) << 24);
+  }
+
+  /** Little-endian byte cursor over a compact payload. */
+  private static final class Cursor {
+    private final byte[] buf;
+    private int pos;
+
+    Cursor(final byte[] buf, final int pos) {
+      this.buf = buf;
+      this.pos = pos;
+    }
+
+    byte readByte() {
+      return buf[pos++];
+    }
+
+    int readInt() {
+      final int v = getIntLE(buf, pos);
+      pos += 4;
+      return v;
+    }
+
+    long readLong() {
+      final long lo = readInt() & 0xFFFFFFFFL;
+      final long hi = readInt() & 0xFFFFFFFFL;
+      return lo | (hi << 32);
+    }
+
+    byte[] readBytes(final int n) {
+      final byte[] out = new byte[n];
+      System.arraycopy(buf, pos, out, 0, n);
+      pos += n;
+      return out;
+    }
+  }
+
+  /** LSB-first bit packer emitting whole bytes into the output stream. */
+  private static final class BitWriter {
+    private final ByteArrayOutputStream out;
+    private long acc;
+    private int used;
+
+    BitWriter(final ByteArrayOutputStream out) {
+      this.out = out;
+    }
+
+    void write(final long value, final int width) {
+      if (width == 0) return;
+      if (width == 64) {
+        flush();
+        putLongLE(out, value);
+        return;
+      }
+      final long masked = value & ((1L << width) - 1);
+      acc |= masked << used;
+      used += width;
+      if (used >= 64) {
+        putLongLE(out, acc);
+        used -= 64;
+        acc = used == 0 ? 0L : masked >>> (width - used);
+      }
+      // Note: when used < 64 the accumulator still holds the partial bits.
+    }
+
+    void flush() {
+      int remaining = used;
+      long rest = acc;
+      while (remaining > 0) {
+        out.write((int) rest);
+        rest >>>= 8;
+        remaining -= 8;
+      }
+      acc = 0L;
+      used = 0;
+    }
+  }
+
+  /** LSB-first bit reader mirroring {@link BitWriter}. */
+  private static final class BitReader {
+    private final Cursor in;
+    private long acc;
+    private int avail;
+
+    BitReader(final Cursor in) {
+      this.in = in;
+    }
+
+    long read(final int width) {
+      if (width == 0) return 0L;
+      if (width == 64) {
+        if (avail != 0) {
+          throw new IllegalStateException("64-bit read on unaligned stream");
+        }
+        return in.readLong();
+      }
+      while (avail < width) {
+        acc |= (long) (in.readByte() & 0xFF) << avail;
+        avail += 8;
+      }
+      final long v = acc & ((1L << width) - 1);
+      acc >>>= width;
+      avail -= width;
+      return v;
+    }
+
+    /** Drop any partial-byte state at the end of a packed run. */
+    void align() {
+      acc = 0L;
+      avail = 0;
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
@@ -16,48 +16,59 @@ import java.nio.charset.StandardCharsets;
  * maps onto column slot {@code i} in this page, and the column's primitive
  * shape is determined by {@code IndexDef#getProjectionFieldTypes().get(i)}.
  *
- * <h2>On-disk shape</h2>
+ * <h2>Serialized scan shape (in-memory form)</h2>
  *
  * The page materialises to a sequence of primitive arrays — no boxed
  * collections, no {@code Object[]}, no per-row allocation on the scan hot
- * path:
+ * path. This flat layout deliberately favors fixed-stride, branch-free
+ * kernel access (raw 8-byte numerics, raw 4-byte dict-ids) over density: it
+ * is what {@link ProjectionIndexByteScan} scans and what the registry holds
+ * in memory. <b>Persistence uses {@link ProjectionIndexLeafCodec}</b>, which
+ * bit-packs this form (frame-of-reference numerics, delta record keys,
+ * packed dict-ids, marker-byte presence) to a fraction of its size and
+ * decodes back byte-identically on hydrate.
  *
  * <pre>
  *   int    rowCount              // number of active rows (0..MAX_ROWS)
  *   int    columnCount           // index-aligned with the owning IndexDef
- *   long[rowCount] recordKeys    // nodeKey of each record projected here
  *   long   firstRecordKey        // zone-map lower bound across recordKeys
  *   long   lastRecordKey         //   upper bound — enables HOT range skip
+ *   byte[columnCount] kinds      // 0=NUMERIC_LONG, 1=BOOLEAN, 2=STRING_DICT
+ *   long[rowCount] recordKeys    // nodeKey of each record projected here
  *
  *   for each column c in [0, columnCount):
- *     byte kind                  // 0=NUMERIC_LONG, 1=BOOLEAN, 2=STRING_DICT
+ *     long min, max              // per-column zone map
  *
  *     // NUMERIC_LONG:
- *       long min, max            // per-column zone map
- *       byte valueBitWidth       // 1..64 (64 = no bit-packing)
- *       long valueBase           // frame-of-reference base for bit-packing
- *       byte[]  packedValues     // ceil(rowCount*valueBitWidth/8) bytes
+ *       long[rowCount] values    // raw 8-byte values (fixed stride)
  *
  *     // BOOLEAN:
- *       byte[ceil(rowCount/8)] packedBits
+ *       long[ceil(rowCount/64)] packedBits
  *
  *     // STRING_DICT:
  *       int       localDictSize
  *       int[localDictSize] stringLengths
  *       byte[]    concatenatedUtf8
- *       byte      dictIdBitWidth // fits log2(localDictSize)
- *       byte[]    packedDictIds  // ceil(rowCount*dictIdBitWidth/8) bytes
+ *       int[rowCount] dictIds    // raw 4-byte ids (fixed stride)
  *
- *   // ---- v2 presence tail (appended AFTER the legacy stream; legacy
- *   // readers ignore trailing bytes, so v1 readers parse v2 leaves and
- *   // v2 readers detect v1 leaves by the absent footer — never misread):
+ *   // ---- presence tail (v1, mandatory — appended after the column stream):
  *   byte[columnCount] columnFlags     // bit0 = present-but-unrepresentable value seen
  *                                     //        (JSON null, object/array, kind mismatch)
+ *                                     // bit1 = non-integral value truncated into a
+ *                                     //        NUMERIC_LONG cell
  *   for each column c (only when rowCount &gt; 0):
  *     long[ceil(rowCount/64)] presenceBits  // bit i = field exists on row i
  *   int  tailLength                   // bytes from tail start to before this field
- *   int  magic = 0x50495832 ("PIX2")
+ *   int  magic = 0x50495831 ("PIX1")
  * </pre>
+ *
+ * <p><b>Integrality semantics.</b> Flag bit1 records, per NUMERIC_LONG
+ * column, whether any cell was fed from a non-integral number (double /
+ * decimal with a fraction) and hence TRUNCATED by
+ * {@code Number#longValue()}. Value-exact consumers (aggregates) may serve
+ * a numeric column iff the tail is present AND bit1 is clear. Because the
+ * evidence lives in the persisted bytes — not in builder memory — the
+ * aggregate fast path survives a close/re-open.
  *
  * <p><b>Presence semantics.</b> The presence bit is set iff the projected
  * field EXISTS on the record — including present-but-unrepresentable values
@@ -66,9 +77,8 @@ import java.nio.charset.StandardCharsets;
  * ({@code 0} / {@code false} / {@code ""}); consumers MUST consult the
  * presence bitmap before trusting a value, and MUST decline columns whose
  * unrepresentable flag is set (a present row's stored default is not the
- * real value). Leaves without the v2 tail carry NO presence information —
- * sparse-correct consumers must fail closed on them (rebuild via
- * {@code -Dsirix.projection.forceRebuild=true} migrates persisted indexes).
+ * real value). The tail is a mandatory part of the format —
+ * {@link #deserialize} rejects payloads without it as corrupt.
  *
  * <h2>Scan hot-path contract</h2>
  *
@@ -167,11 +177,18 @@ public final class ProjectionIndexLeafPage {
   public static final byte COLUMN_KIND_BOOLEAN = 1;
   public static final byte COLUMN_KIND_STRING_DICT = 2;
 
-  /** Footer magic of the v2 presence tail ("PIX2" little-endian). */
-  public static final int PRESENCE_TAIL_MAGIC = 0x50495832;
+  /** Footer magic of the presence tail ("PIX1" little-endian). */
+  public static final int PRESENCE_TAIL_MAGIC = 0x50495831;
 
   /** Column flag bit: a present-but-unrepresentable value (null / object / array / kind mismatch) was seen. */
   public static final byte COLUMN_FLAG_UNREPRESENTABLE = 0x01;
+
+  /**
+   * Column flag bit: a NUMERIC_LONG cell was fed from a non-integral number
+   * and truncated by {@code Number#longValue()} — value-exact consumers must
+   * decline the column.
+   */
+  public static final byte COLUMN_FLAG_NON_INTEGRAL = 0x02;
 
   /** Number of populated rows on this page, {@code 0..MAX_ROWS}. */
   private int rowCount;
@@ -246,13 +263,12 @@ public final class ProjectionIndexLeafPage {
   private final boolean[] columnUnrepresentable;
 
   /**
-   * Whether this page carries trustworthy presence information. {@code true}
-   * for builder-constructed pages and pages deserialized from the v2 wire
-   * format; {@code false} for pages deserialized from legacy v1 payloads —
-   * those re-serialize WITHOUT a presence tail so downstream consumers keep
-   * failing closed instead of trusting fabricated all-present bits.
+   * Per-column flag: a NUMERIC_LONG cell on THIS leaf was fed from a
+   * non-integral number and truncated. Persisted in the presence tail
+   * (flag bit1) so value-exact consumers can keep serving the column after
+   * a close/re-open.
    */
-  private boolean presenceTracked = true;
+  private final boolean[] columnNonIntegral;
 
   /**
    * Initialise an empty page for the declared column shape. The actual
@@ -268,6 +284,7 @@ public final class ProjectionIndexLeafPage {
     this.stringDicts = new byte[columnCount][][];
     this.presenceCols = new long[columnCount][];
     this.columnUnrepresentable = new boolean[columnCount];
+    this.columnNonIntegral = new boolean[columnCount];
     this.columnMin = new long[columnCount];
     this.columnMax = new long[columnCount];
     for (int c = 0; c < columnCount; c++) {
@@ -326,12 +343,7 @@ public final class ProjectionIndexLeafPage {
     return stringDicts[column];
   }
 
-  /** Whether this page carries trustworthy per-row presence information. */
-  public boolean hasPresence() {
-    return presenceTracked;
-  }
-
-  /** 64-way packed presence bits of {@code column} — meaningful only when {@link #hasPresence()}. */
+  /** 64-way packed presence bits of {@code column}. */
   public long[] presenceColumnBits(final int column) {
     return presenceCols[column];
   }
@@ -339,6 +351,46 @@ public final class ProjectionIndexLeafPage {
   /** Whether {@code column} saw a present-but-unrepresentable value (null / object / array / mismatch). */
   public boolean columnUnrepresentable(final int column) {
     return columnUnrepresentable[column];
+  }
+
+  /**
+   * Whether a NUMERIC_LONG cell of {@code column} on this leaf was truncated
+   * from a non-integral number.
+   */
+  public boolean columnNumericNonIntegral(final int column) {
+    return columnNonIntegral[column];
+  }
+
+  /**
+   * Reassemble a page from decoded components — the inverse half of
+   * {@link ProjectionIndexLeafCodec}. Arrays are adopted (not copied): the
+   * codec hands over freshly built arrays sized for {@code rowCount}, which
+   * is all {@link #serialize()} ever reads. Package-private on purpose —
+   * the only legitimate caller is the codec.
+   */
+  static ProjectionIndexLeafPage reconstruct(final byte[] kinds, final int rowCount,
+      final long firstRecordKey, final long lastRecordKey, final long[] recordKeys,
+      final long[] columnMin, final long[] columnMax,
+      final long[][] numericCols, final long[][] booleanCols,
+      final int[][] stringDictIdCols, final byte[][][] stringDicts,
+      final long[][] presenceCols, final boolean[] unrepresentable, final boolean[] nonIntegral) {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(kinds);
+    page.rowCount = rowCount;
+    page.firstRecordKey = firstRecordKey;
+    page.lastRecordKey = lastRecordKey;
+    page.recordKeys = recordKeys;
+    for (int c = 0; c < page.columnCount; c++) {
+      page.columnMin[c] = columnMin[c];
+      page.columnMax[c] = columnMax[c];
+      page.numericCols[c] = numericCols[c];
+      page.booleanCols[c] = booleanCols[c];
+      page.stringDictIdCols[c] = stringDictIdCols[c];
+      page.stringDicts[c] = stringDicts[c];
+      page.presenceCols[c] = presenceCols[c];
+      page.columnUnrepresentable[c] = unrepresentable[c];
+      page.columnNonIntegral[c] = nonIntegral[c];
+    }
+    return page;
   }
 
   /** Ensure the per-column primitive arrays are materialised. Idempotent. */
@@ -371,7 +423,7 @@ public final class ProjectionIndexLeafPage {
    */
   public boolean appendRow(final long recordKey,
       final long[] longValues, final boolean[] boolValues, final String[] stringValues) {
-    return appendRow(recordKey, longValues, boolValues, stringValues, null, null);
+    return appendRow(recordKey, longValues, boolValues, stringValues, null, null, null);
   }
 
   /**
@@ -396,6 +448,20 @@ public final class ProjectionIndexLeafPage {
   public boolean appendRow(final long recordKey,
       final long[] longValues, final boolean[] boolValues, final String[] stringValues,
       final boolean[] present, final boolean[] unrepresentable) {
+    return appendRow(recordKey, longValues, boolValues, stringValues, present, unrepresentable, null);
+  }
+
+  /**
+   * Variant additionally carrying per-column integrality provenance:
+   * {@code nonIntegral[c]} marks that this row's NUMERIC_LONG cell {@code c}
+   * was truncated from a non-integral number ({@code null} = every numeric
+   * cell exact). The flag is sticky per column for the lifetime of the leaf
+   * and is persisted in the presence tail so value-exact consumers can keep
+   * serving the column after a close/re-open.
+   */
+  public boolean appendRow(final long recordKey,
+      final long[] longValues, final boolean[] boolValues, final String[] stringValues,
+      final boolean[] present, final boolean[] unrepresentable, final boolean[] nonIntegral) {
     if (rowCount == MAX_ROWS) return false;
     ensureCapacity();
     final int row = rowCount;
@@ -410,6 +476,9 @@ public final class ProjectionIndexLeafPage {
       }
       if (isUnrepresentable) {
         columnUnrepresentable[c] = true;
+      }
+      if (nonIntegral != null && nonIntegral[c]) {
+        columnNonIntegral[c] = true;
       }
       final boolean clean = isPresent && !isUnrepresentable;
       switch (columnKinds[c]) {
@@ -470,10 +539,12 @@ public final class ProjectionIndexLeafPage {
 
   /**
    * Parse a serialised leaf byte[] back into a live
-   * {@link ProjectionIndexLeafPage}. Inverse of {@link #serialize}. Handles
-   * both wire formats: legacy v1 payloads (no presence tail) deserialize with
-   * {@link #hasPresence()} {@code == false} — presence information is NEVER
-   * fabricated for them.
+   * {@link ProjectionIndexLeafPage}. Inverse of {@link #serialize}. The
+   * presence tail is mandatory — a payload whose trailing bytes don't form a
+   * valid tail (length, footer length field, and magic must all agree) is
+   * rejected as corrupt rather than misread.
+   *
+   * @throws IllegalStateException when the payload carries no valid presence tail
    */
   public static ProjectionIndexLeafPage deserialize(final byte[] payload) {
     final ByteBuffer bb = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
@@ -520,31 +591,32 @@ public final class ProjectionIndexLeafPage {
         }
       }
     }
-    // v2 presence tail. The legacy stream ends exactly at bb.position(); a valid
+    // Presence tail. The column stream ends exactly at bb.position(); a valid
     // tail must account for every remaining byte (flags + presence words +
-    // 8-byte footer with the magic). Anything else is treated as v1 — fail
-    // closed, never misread.
+    // 8-byte footer with the magic). Anything else is corrupt — never misread.
     final int tailStart = bb.position();
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     final int expectedTailLen = columnCount + columnCount * presWords * 8;
-    if (payload.length == tailStart + expectedTailLen + 8
-        && getIntLE(payload, payload.length - 4) == PRESENCE_TAIL_MAGIC
-        && getIntLE(payload, payload.length - 8) == expectedTailLen) {
-      page.presenceTracked = true;
+    if (payload.length != tailStart + expectedTailLen + 8
+        || getIntLE(payload, payload.length - 4) != PRESENCE_TAIL_MAGIC
+        || getIntLE(payload, payload.length - 8) != expectedTailLen) {
+      throw new IllegalStateException(
+          "Corrupt projection leaf: no valid presence tail (payload " + payload.length
+              + " bytes, column stream ends at " + tailStart + ", expected tail "
+              + (expectedTailLen + 8) + " bytes)");
+    }
+    for (int c = 0; c < columnCount; c++) {
+      page.columnUnrepresentable[c] = (payload[tailStart + c] & COLUMN_FLAG_UNREPRESENTABLE) != 0;
+      page.columnNonIntegral[c] = (payload[tailStart + c] & COLUMN_FLAG_NON_INTEGRAL) != 0;
+    }
+    if (rowCount > 0) {
       for (int c = 0; c < columnCount; c++) {
-        page.columnUnrepresentable[c] = (payload[tailStart + c] & COLUMN_FLAG_UNREPRESENTABLE) != 0;
-      }
-      if (rowCount > 0) {
-        for (int c = 0; c < columnCount; c++) {
-          final long[] bits = page.presenceCols[c];
-          final int base = tailStart + columnCount + c * presWords * 8;
-          for (int w = 0; w < presWords; w++) {
-            bits[w] = getLongLE(payload, base + w * 8);
-          }
+        final long[] bits = page.presenceCols[c];
+        final int base = tailStart + columnCount + c * presWords * 8;
+        for (int w = 0; w < presWords; w++) {
+          bits[w] = getLongLE(payload, base + w * 8);
         }
       }
-    } else {
-      page.presenceTracked = false;
     }
     return page;
   }
@@ -643,22 +715,19 @@ public final class ProjectionIndexLeafPage {
   }
 
   /**
-   * Append the v2 presence tail (flags + presence words + footer) at
-   * {@code off}; no-op for pages without trustworthy presence (legacy
-   * v1-deserialized pages re-serialize as v1).
+   * Append the presence tail (flags + presence words + footer) at
+   * {@code off}.
    *
    * @return the offset after the tail
    */
   private long writePresenceTailIntoSegment(final java.lang.foreign.MemorySegment dst, final long start) {
-    if (!presenceTracked) return start;
     final java.lang.foreign.ValueLayout.OfInt I =
         java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
     final java.lang.foreign.ValueLayout.OfLong L =
         java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
     long off = start;
     for (int c = 0; c < columnCount; c++) {
-      dst.set(java.lang.foreign.ValueLayout.JAVA_BYTE, off++,
-          columnUnrepresentable[c] ? COLUMN_FLAG_UNREPRESENTABLE : 0);
+      dst.set(java.lang.foreign.ValueLayout.JAVA_BYTE, off++, columnFlagsByte(c));
     }
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     if (presWords > 0) {
@@ -701,9 +770,8 @@ public final class ProjectionIndexLeafPage {
     return size + presenceTailSize();
   }
 
-  /** Byte size of the v2 presence tail incl. the 8-byte footer; 0 when untracked. */
+  /** Byte size of the presence tail incl. the 8-byte footer. */
   private int presenceTailSize() {
-    if (!presenceTracked) return 0;
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     return columnCount + columnCount * presWords * 8 + 8;
   }
@@ -775,14 +843,13 @@ public final class ProjectionIndexLeafPage {
     return baos.toByteArray();
   }
 
-  /** Append the v2 presence tail; no-op for pages without trustworthy presence. */
+  /** Append the presence tail. */
   private void writePresenceTail(final ByteArrayOutputStream baos) {
-    if (!presenceTracked) return;
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     final int tailLen = columnCount + columnCount * presWords * 8;
     final ByteBuffer tail = ByteBuffer.allocate(tailLen + 8).order(ByteOrder.LITTLE_ENDIAN);
     for (int c = 0; c < columnCount; c++) {
-      tail.put(columnUnrepresentable[c] ? COLUMN_FLAG_UNREPRESENTABLE : 0);
+      tail.put(columnFlagsByte(c));
     }
     if (presWords > 0) {
       for (int c = 0; c < columnCount; c++) {
@@ -793,6 +860,15 @@ public final class ProjectionIndexLeafPage {
     tail.putInt(tailLen);
     tail.putInt(PRESENCE_TAIL_MAGIC);
     baos.write(tail.array(), 0, tail.position());
+  }
+
+  /** Per-column flags byte of the tail: bit0 = unrepresentable seen, bit1 = non-integral seen. */
+  private byte columnFlagsByte(final int c) {
+    byte flags = columnUnrepresentable[c] ? COLUMN_FLAG_UNREPRESENTABLE : 0;
+    if (columnNonIntegral[c]) {
+      flags |= COLUMN_FLAG_NON_INTEGRAL;
+    }
+    return flags;
   }
 
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
@@ -4,6 +4,8 @@
 package io.sirix.index.projection;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -299,6 +301,16 @@ public final class ProjectionIndexLeafPage {
     return rowCount;
   }
 
+  /**
+   * Column count of a serialised raw leaf payload — the single canonical
+   * reader of the header layout (bytes 4..7, little-endian). Callers must
+   * pass a payload of at least 8 bytes.
+   */
+  public static int columnCountOf(final byte[] rawPayload) {
+    return (rawPayload[4] & 0xFF) | ((rawPayload[5] & 0xFF) << 8)
+        | ((rawPayload[6] & 0xFF) << 16) | ((rawPayload[7] & 0xFF) << 24);
+  }
+
   public int getColumnCount() {
     return columnCount;
   }
@@ -495,7 +507,13 @@ public final class ProjectionIndexLeafPage {
             booleanCols[c][row >>> 6] |= 1L << (row & 63);
           }
         }
-        case COLUMN_KIND_STRING_DICT -> stringDictIdCols[c][row] = appendString(c, stringValues[c]);
+        // Absent / unrepresentable cells intern the "" DEFAULT regardless of
+        // what the caller left in the scratch slot — this makes "every
+        // non-empty dictionary entry was interned by a clean present row" a
+        // STRUCTURAL invariant of the leaf (the dictionary-union
+        // count-distinct kernel depends on it), not a builder convention.
+        case COLUMN_KIND_STRING_DICT ->
+            stringDictIdCols[c][row] = appendString(c, clean ? stringValues[c] : "");
         default -> throw new IllegalStateException("Unknown column kind " + columnKinds[c]);
       }
     }
@@ -651,11 +669,11 @@ public final class ProjectionIndexLeafPage {
    * @param dstOff  starting byte offset within {@code dst}
    * @return bytes written
    */
-  public int serializeIntoSegment(final java.lang.foreign.MemorySegment dst, final long dstOff) {
-    final java.lang.foreign.ValueLayout.OfInt I =
-        java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
-    final java.lang.foreign.ValueLayout.OfLong L =
-        java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
+  public int serializeIntoSegment(final MemorySegment dst, final long dstOff) {
+    final ValueLayout.OfInt I =
+        ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    final ValueLayout.OfLong L =
+        ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
     long off = dstOff;
     dst.set(I, off, rowCount);                          off += 4;
     dst.set(I, off, columnCount);                       off += 4;
@@ -663,8 +681,8 @@ public final class ProjectionIndexLeafPage {
     dst.set(L, off, lastRecordKey);                     off += 8;
     // columnKinds — bulk-copy on-heap bytes to segment.
     if (columnCount > 0) {
-      java.lang.foreign.MemorySegment.copy(
-          columnKinds, 0, dst, java.lang.foreign.ValueLayout.JAVA_BYTE, off, columnCount);
+      MemorySegment.copy(
+          columnKinds, 0, dst, ValueLayout.JAVA_BYTE, off, columnCount);
       off += columnCount;
     }
     if (rowCount == 0) {
@@ -672,7 +690,7 @@ public final class ProjectionIndexLeafPage {
       return (int) (off - dstOff);
     }
     // recordKeys: bulk copy long[]
-    java.lang.foreign.MemorySegment.copy(recordKeys, 0, dst, L, off, rowCount);
+    MemorySegment.copy(recordKeys, 0, dst, L, off, rowCount);
     off += rowCount * 8L;
     // per-column
     for (int c = 0; c < columnCount; c++) {
@@ -680,12 +698,12 @@ public final class ProjectionIndexLeafPage {
       dst.set(L, off, columnMax[c]); off += 8;
       switch (columnKinds[c]) {
         case COLUMN_KIND_NUMERIC_LONG -> {
-          java.lang.foreign.MemorySegment.copy(numericCols[c], 0, dst, L, off, rowCount);
+          MemorySegment.copy(numericCols[c], 0, dst, L, off, rowCount);
           off += rowCount * 8L;
         }
         case COLUMN_KIND_BOOLEAN -> {
           final int wordCount = (rowCount + 63) >>> 6;
-          java.lang.foreign.MemorySegment.copy(booleanCols[c], 0, dst, L, off, wordCount);
+          MemorySegment.copy(booleanCols[c], 0, dst, L, off, wordCount);
           off += wordCount * 8L;
         }
         case COLUMN_KIND_STRING_DICT -> {
@@ -699,12 +717,12 @@ public final class ProjectionIndexLeafPage {
           for (int i = 0; i < dictSize; i++) {
             final int n = dict[i].length;
             if (n > 0) {
-              java.lang.foreign.MemorySegment.copy(
-                  dict[i], 0, dst, java.lang.foreign.ValueLayout.JAVA_BYTE, off, n);
+              MemorySegment.copy(
+                  dict[i], 0, dst, ValueLayout.JAVA_BYTE, off, n);
               off += n;
             }
           }
-          java.lang.foreign.MemorySegment.copy(stringDictIdCols[c], 0, dst, I, off, rowCount);
+          MemorySegment.copy(stringDictIdCols[c], 0, dst, I, off, rowCount);
           off += rowCount * 4L;
         }
         default -> throw new IllegalStateException("Unknown column kind " + columnKinds[c]);
@@ -720,19 +738,19 @@ public final class ProjectionIndexLeafPage {
    *
    * @return the offset after the tail
    */
-  private long writePresenceTailIntoSegment(final java.lang.foreign.MemorySegment dst, final long start) {
-    final java.lang.foreign.ValueLayout.OfInt I =
-        java.lang.foreign.ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
-    final java.lang.foreign.ValueLayout.OfLong L =
-        java.lang.foreign.ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
+  private long writePresenceTailIntoSegment(final MemorySegment dst, final long start) {
+    final ValueLayout.OfInt I =
+        ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+    final ValueLayout.OfLong L =
+        ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
     long off = start;
     for (int c = 0; c < columnCount; c++) {
-      dst.set(java.lang.foreign.ValueLayout.JAVA_BYTE, off++, columnFlagsByte(c));
+      dst.set(ValueLayout.JAVA_BYTE, off++, columnFlagsByte(c));
     }
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     if (presWords > 0) {
       for (int c = 0; c < columnCount; c++) {
-        java.lang.foreign.MemorySegment.copy(presenceCols[c], 0, dst, L, off, presWords);
+        MemorySegment.copy(presenceCols[c], 0, dst, L, off, presWords);
         off += presWords * 8L;
       }
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * Self-describing metadata payload persisted alongside projection leaves
+ * (slot 0 of the HOT sub-tree, leaves at slots 1..N): the projection's root
+ * path, per-column field paths, column names, and column kinds. Hydration
+ * reads the projection's shape from HERE instead of trusting the caller's
+ * argument list — without it, a re-create with a same-arity but different
+ * field list would silently install the persisted columns under the wrong
+ * names (the exact corruption the column-count guard alone cannot catch).
+ *
+ * <p>Wire form: {@link #MAGIC} ("PIXM" little-endian), a version byte, the
+ * root path as a length-prefixed UTF-8 string, an int column count, then per
+ * column: path (UTF-8, length-prefixed), name (UTF-8, length-prefixed), and
+ * one column-kind byte ({@link ProjectionIndexLeafPage#COLUMN_KIND_NUMERIC_LONG}
+ * / {@code BOOLEAN} / {@code STRING_DICT}).
+ *
+ * <p>{@link #parse} returns {@code null} for payloads without the magic, so
+ * hydrate paths can probe slot 0 and fall back to metadata-less handling for
+ * stores written by the bench setups (which persist leaves only).
+ */
+public final class ProjectionIndexMetadata {
+
+  /** Leading magic of a metadata payload ("PIXM" little-endian). */
+  public static final int MAGIC = 0x4D585049;
+
+  private static final byte VERSION = 1;
+
+  private final String rootPath;
+  private final String[] fieldPaths;
+  private final String[] fieldNames;
+  private final byte[] columnKinds;
+
+  public ProjectionIndexMetadata(final String rootPath, final String[] fieldPaths,
+      final String[] fieldNames, final byte[] columnKinds) {
+    if (fieldPaths.length != fieldNames.length || fieldPaths.length != columnKinds.length) {
+      throw new IllegalArgumentException("paths/names/kinds must be index-aligned");
+    }
+    this.rootPath = rootPath;
+    this.fieldPaths = fieldPaths.clone();
+    this.fieldNames = fieldNames.clone();
+    this.columnKinds = columnKinds.clone();
+  }
+
+  public String rootPath() {
+    return rootPath;
+  }
+
+  public String[] fieldPaths() {
+    return fieldPaths.clone();
+  }
+
+  public String[] fieldNames() {
+    return fieldNames.clone();
+  }
+
+  public byte[] columnKinds() {
+    return columnKinds.clone();
+  }
+
+  /** Whether this metadata describes exactly the given shape. */
+  public boolean matches(final String otherRootPath, final String[] otherFieldPaths,
+      final byte[] otherColumnKinds) {
+    return rootPath.equals(otherRootPath)
+        && Arrays.equals(fieldPaths, otherFieldPaths)
+        && Arrays.equals(columnKinds, otherColumnKinds);
+  }
+
+  public byte[] serialize() {
+    final ByteArrayOutputStream out = new ByteArrayOutputStream(256);
+    putIntLE(out, MAGIC);
+    out.write(VERSION);
+    putString(out, rootPath);
+    putIntLE(out, fieldPaths.length);
+    for (int i = 0; i < fieldPaths.length; i++) {
+      putString(out, fieldPaths[i]);
+      putString(out, fieldNames[i]);
+      out.write(columnKinds[i]);
+    }
+    return out.toByteArray();
+  }
+
+  /**
+   * Parse a metadata payload; {@code null} when {@code payload} does not
+   * carry the metadata magic (e.g. a leaf payload from a metadata-less
+   * store).
+   *
+   * @throws IllegalStateException on a structurally corrupt metadata payload
+   */
+  public static ProjectionIndexMetadata parse(final byte[] payload) {
+    if (payload == null || payload.length < 5 || getIntLE(payload, 0) != MAGIC) {
+      return null;
+    }
+    try {
+      final int[] pos = {4};
+      final byte version = payload[pos[0]++];
+      if (version != VERSION) {
+        throw new IllegalStateException("Unknown projection metadata version " + version);
+      }
+      final String rootPath = getString(payload, pos);
+      final int n = getIntLE(payload, pos[0]);
+      pos[0] += 4;
+      if (n < 0 || n > 4096) {
+        throw new IllegalStateException("Implausible projection column count " + n);
+      }
+      final String[] paths = new String[n];
+      final String[] names = new String[n];
+      final byte[] kinds = new byte[n];
+      for (int i = 0; i < n; i++) {
+        paths[i] = getString(payload, pos);
+        names[i] = getString(payload, pos);
+        kinds[i] = payload[pos[0]++];
+      }
+      return new ProjectionIndexMetadata(rootPath, paths, names, kinds);
+    } catch (final IndexOutOfBoundsException truncated) {
+      throw new IllegalStateException("Corrupt projection metadata payload", truncated);
+    }
+  }
+
+  private static void putString(final ByteArrayOutputStream out, final String value) {
+    final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+    putIntLE(out, bytes.length);
+    out.write(bytes, 0, bytes.length);
+  }
+
+  private static String getString(final byte[] payload, final int[] pos) {
+    final int len = getIntLE(payload, pos[0]);
+    pos[0] += 4;
+    if (len < 0 || pos[0] + len > payload.length) {
+      throw new IndexOutOfBoundsException("string length " + len);
+    }
+    final String value = new String(payload, pos[0], len, StandardCharsets.UTF_8);
+    pos[0] += len;
+    return value;
+  }
+
+  private static void putIntLE(final ByteArrayOutputStream out, final int v) {
+    out.write(v);
+    out.write(v >>> 8);
+    out.write(v >>> 16);
+    out.write(v >>> 24);
+  }
+
+  private static int getIntLE(final byte[] b, final int off) {
+    return (b[off] & 0xFF) | ((b[off + 1] & 0xFF) << 8) | ((b[off + 2] & 0xFF) << 16) | ((b[off + 3] & 0xFF) << 24);
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -62,21 +62,34 @@ public final class ProjectionIndexRegistry {
     private volatile byte[][][] canonicalDicts;
 
     /**
-     * Per-column integrality evidence for NUMERIC_LONG columns: {@code true}
-     * means the builder SAW a non-integral (truncated) value in that column.
-     * {@code null} = unknown provenance (e.g. re-encoded persisted leaves) —
-     * value-exact consumers must treat unknown as not-provably-integral.
+     * Sentinel for "integrality was probed and is UNKNOWN" — some leaf lacks
+     * a valid presence tail, so value-exact consumers must fail closed.
      */
-    private final boolean[] numericNonIntegral;
+    private static final boolean[] INTEGRALITY_UNKNOWN = new boolean[0];
+
+    /**
+     * Per-column integrality evidence for NUMERIC_LONG columns: {@code true}
+     * means a non-integral (truncated) value was SEEN in that column.
+     * Populated eagerly from builder-tracked flags when the installer passes
+     * them, otherwise lazily re-derived from the leaf payloads' presence tails via
+     * {@link ProjectionIndexByteScan#probeNumericNonIntegral} — so the
+     * evidence survives persistence and close/re-open just like the sparse
+     * evidence. {@code null} = not yet resolved;
+     * {@link #INTEGRALITY_UNKNOWN} = probed, provenance unavailable
+     * (malformed leaves) — value-exact consumers must treat that as
+     * not-provably-integral.
+     */
+    private volatile boolean[] integralityEvidence;
 
     /**
      * Lazily-probed per-column sparse evidence — values are
      * {@link ProjectionIndexByteScan#SPARSE_STATUS_CLEAN} /
      * {@link ProjectionIndexByteScan#SPARSE_STATUS_DIRTY}. Computed once for
      * ALL columns by {@link ProjectionIndexByteScan#probeSparseEvidence} on
-     * first use; the evidence lives INSIDE the leaf payloads (v2 presence
+     * first use; the evidence lives INSIDE the leaf payloads (presence
      * tail + per-column unrepresentable flags) so it survives persistence
-     * and re-encoding, unlike the handle-carried integrality flags.
+     * and re-encoding — the integrality evidence follows the same pattern
+     * via flag bit1 of the same tail (see {@link #integralityEvidence}).
      */
     private volatile byte[] sparseStatus;
 
@@ -88,34 +101,56 @@ public final class ProjectionIndexRegistry {
         final boolean[] numericNonIntegral) {
       this.fieldNames = Objects.requireNonNull(fieldNames, "fieldNames").clone();
       this.leafPayloads = Objects.requireNonNull(leafPayloads, "leafPayloads");
-      this.numericNonIntegral = numericNonIntegral == null ? null : numericNonIntegral.clone();
+      this.integralityEvidence = numericNonIntegral == null ? null : numericNonIntegral.clone();
     }
 
     /**
-     * {@code true} iff the column is PROVABLY integral: builder-tracked flags
-     * exist and never saw a fractional value. Used to gate value-exact fast
-     * paths (aggregates); unknown provenance returns {@code false}.
+     * Resolve the per-column integrality evidence. Installer-provided flags
+     * win; otherwise probe the leaf payloads once (double-checked, same
+     * pattern as {@link #columnSparseClean}) — presence tails carry the
+     * flags; malformed payloads resolve to {@link #INTEGRALITY_UNKNOWN}.
      */
-    public boolean numericColumnIsIntegral(final int col) {
-      return numericNonIntegral != null && col >= 0 && col < numericNonIntegral.length
-          && !numericNonIntegral[col];
+    private boolean[] integralityEvidence() {
+      boolean[] evidence = integralityEvidence;
+      if (evidence == null) {
+        synchronized (this) {
+          evidence = integralityEvidence;
+          if (evidence == null) {
+            final boolean[] probed = ProjectionIndexByteScan.probeNumericNonIntegral(leafPayloads);
+            evidence = probed == null ? INTEGRALITY_UNKNOWN : probed;
+            integralityEvidence = evidence;
+          }
+        }
+      }
+      return evidence;
     }
 
-    /** {@code true} iff the builder POSITIVELY saw non-integral values in the column. */
+    /**
+     * {@code true} iff the column is PROVABLY integral: integrality evidence
+     * exists (builder-tracked flags or persisted tail flags) and never saw
+     * a fractional value. Used to gate value-exact fast paths (aggregates);
+     * unknown provenance returns {@code false}.
+     */
+    public boolean numericColumnIsIntegral(final int col) {
+      final boolean[] evidence = integralityEvidence();
+      return evidence != INTEGRALITY_UNKNOWN && col >= 0 && col < evidence.length
+          && !evidence[col];
+    }
+
+    /** {@code true} iff a non-integral value was POSITIVELY seen in the column. */
     public boolean numericColumnKnownNonIntegral(final int col) {
-      return numericNonIntegral != null && col >= 0 && col < numericNonIntegral.length
-          && numericNonIntegral[col];
+      final boolean[] evidence = integralityEvidence();
+      return evidence != INTEGRALITY_UNKNOWN && col >= 0 && col < evidence.length
+          && evidence[col];
     }
 
     /**
      * {@code true} iff column {@code col} can serve SPARSE-CORRECT answers:
-     * every leaf carries the v2 presence tail and the column never saw a
+     * every leaf carries a valid presence tail and the column never saw a
      * present-but-unrepresentable value (JSON null, object/array, kind
-     * mismatch). Anything else — including legacy v1 leaves, which have no
-     * presence information at all — returns {@code false} and consumers must
+     * mismatch). Anything else returns {@code false} and consumers must
      * fall back (typed scan kernels / generic pipeline). Probe runs once per
-     * handle and is cached; rebuilding the projection
-     * ({@code -Dsirix.projection.forceRebuild=true}) migrates v1 leaves.
+     * handle and is cached.
      */
     public boolean columnSparseClean(final int col) {
       if (col < 0) return false;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexScan.java
@@ -173,10 +173,10 @@ public final class ProjectionIndexScan {
     }
 
     // One 1024-bit mask initialised to "all rows pass" and AND'd with
-    // each column's predicate outcome in turn. When the leaf carries v2
-    // presence bitmaps, each predicate also ANDs its column's presence —
-    // a comparison over a MISSING field is false (the stored default must
-    // never match). Mirrors ProjectionIndexByteScan's sparse semantics.
+    // each column's predicate outcome in turn. Each predicate also ANDs
+    // its column's presence bitmap — a comparison over a MISSING field is
+    // false (the stored default must never match). Mirrors
+    // ProjectionIndexByteScan's sparse semantics.
     final int stride = (rowCount + 63) >>> 6;
     final long[] mask = new long[stride];
     fillAllTrue(mask, rowCount);
@@ -184,12 +184,8 @@ public final class ProjectionIndexScan {
     for (final ColumnPredicate p : predicates) {
       java.util.Arrays.fill(colMask, 0L);
       evalColumn(leaf, p, rowCount, colMask);
-      if (leaf.hasPresence()) {
-        final long[] presence = leaf.presenceColumnBits(p.column);
-        for (int i = 0; i < stride; i++) mask[i] &= colMask[i] & presence[i];
-      } else {
-        for (int i = 0; i < stride; i++) mask[i] &= colMask[i];
-      }
+      final long[] presence = leaf.presenceColumnBits(p.column);
+      for (int i = 0; i < stride; i++) mask[i] &= colMask[i] & presence[i];
     }
     long result = 0;
     for (int i = 0; i < stride; i++) result += Long.bitCount(mask[i]);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexDenseCompositeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexDenseCompositeTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Parity and fail-closed behavior of the dense composite group-by kernel
+ * ({@link ProjectionIndexByteScan#conjunctiveCountByGroupMultiDense}) and the
+ * dictionary-union count-distinct kernel
+ * ({@link ProjectionIndexByteScan#distinctPresentStrings}) against the
+ * composite hashmap kernel as ground truth — including missing fields
+ * (presence bits), per-leaf fallback on out-of-canon dictionary values, and
+ * the phantom-{@code ""} disambiguation that missing rows force on the
+ * distinct kernel.
+ */
+public final class ProjectionIndexDenseCompositeTest {
+
+  private static final byte[] KINDS = {
+      ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG,
+      ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT,
+      ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT
+  };
+
+  private static final String[] DEPTS = {"Eng", "Sales", "Mkt"};
+  private static final String[] CITIES = {"NYC", "LA"};
+
+  /**
+   * Build a leaf of {@code rows} rows over (age, dept, city): dept missing on
+   * every fifth row, city missing on every seventh, values round-robin from
+   * the pools (offset by {@code seed} so different leaves favor different
+   * dictionary orders).
+   */
+  private static ProjectionIndexLeafPage leaf(final int rows, final int seed, final String[] depts) {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final long[] longs = new long[3];
+    final boolean[] bools = new boolean[3];
+    final String[] strings = new String[3];
+    final boolean[] present = new boolean[3];
+    final boolean[] unrep = new boolean[3];
+    for (int i = 0; i < rows; i++) {
+      final boolean deptMissing = i % 5 == 0;
+      final boolean cityMissing = i % 7 == 0;
+      longs[0] = 18 + ((seed + i) % 48);
+      strings[1] = deptMissing ? "" : depts[(seed + i) % depts.length];
+      strings[2] = cityMissing ? "" : CITIES[(seed + i) % CITIES.length];
+      present[0] = true;
+      present[1] = !deptMissing;
+      present[2] = !cityMissing;
+      Arrays.fill(unrep, false);
+      assertTrue(page.appendRow(1000L * (seed + 1) + i, longs, bools, strings, present, unrep));
+    }
+    return page;
+  }
+
+  private static List<byte[]> leaves(final String[]... deptsPerLeaf) {
+    final List<byte[]> out = new ArrayList<>(deptsPerLeaf.length);
+    for (int i = 0; i < deptsPerLeaf.length; i++) {
+      out.add(leaf(100 + i * 30, i, deptsPerLeaf[i]).serialize());
+    }
+    return out;
+  }
+
+  /** Decode the dense counts array into composite keys exactly as the executor does. */
+  private static Object2LongOpenHashMap<String> decode(final long[] counts, final byte[][][] canon) {
+    final Object2LongOpenHashMap<String> out = new Object2LongOpenHashMap<>();
+    out.defaultReturnValue(0L);
+    final int m = canon.length;
+    final int[] ids = new int[m];
+    for (int cell = 0; cell < counts.length; cell++) {
+      if (counts[cell] == 0L) continue;
+      int rem = cell;
+      for (int g = m - 1; g >= 0; g--) {
+        final int radix = canon[g].length + 1;
+        ids[g] = rem % radix;
+        rem /= radix;
+      }
+      final StringBuilder kb = new StringBuilder();
+      for (int g = 0; g < m; g++) {
+        if (ids[g] == canon[g].length) {
+          kb.append('m');
+        } else {
+          final String v = new String(canon[g][ids[g]], StandardCharsets.UTF_8);
+          kb.append('s').append(v.length()).append(':').append(v);
+        }
+      }
+      out.addTo(kb.toString(), counts[cell]);
+    }
+    return out;
+  }
+
+  private static int cellCount(final byte[][][] canon) {
+    int n = 1;
+    for (final byte[][] dict : canon) {
+      n *= dict.length + 1;
+    }
+    return n;
+  }
+
+  // ==================== dense composite parity ====================
+
+  @Test
+  void denseCompositeMatchesHashmapKernel() {
+    final List<byte[]> payloads = leaves(DEPTS, DEPTS, DEPTS);
+    final int[] cols = {1, 2};
+    final ProjectionIndexScan.ColumnPredicate[] noPreds = new ProjectionIndexScan.ColumnPredicate[0];
+
+    final Object2LongOpenHashMap<String> reference = new Object2LongOpenHashMap<>();
+    reference.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMulti(payloads, noPreds, cols, reference);
+
+    final byte[][][] canon = {
+        ProjectionIndexByteScan.probeCanonicalDict(payloads, 1, payloads.size(), 256),
+        ProjectionIndexByteScan.probeCanonicalDict(payloads, 2, payloads.size(), 256)
+    };
+    final long[] counts = new long[cellCount(canon)];
+    final Object2LongOpenHashMap<String> fallback = new Object2LongOpenHashMap<>();
+    fallback.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMultiDense(payloads, noPreds, cols, canon, counts, fallback);
+    assertEquals(0, fallback.size(), "all dict values are canonical — no fallback expected");
+
+    assertEquals(reference, decode(counts, canon));
+  }
+
+  @Test
+  void denseCompositeMatchesHashmapKernelUnderPredicate() {
+    final List<byte[]> payloads = leaves(DEPTS, DEPTS);
+    final int[] cols = {1, 2};
+    final ProjectionIndexScan.ColumnPredicate[] preds = {
+        ProjectionIndexScan.ColumnPredicate.numeric(0, ProjectionIndexScan.Op.GT, 40L)
+    };
+
+    final Object2LongOpenHashMap<String> reference = new Object2LongOpenHashMap<>();
+    reference.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMulti(payloads, preds, cols, reference);
+
+    final byte[][][] canon = {
+        ProjectionIndexByteScan.probeCanonicalDict(payloads, 1, payloads.size(), 256),
+        ProjectionIndexByteScan.probeCanonicalDict(payloads, 2, payloads.size(), 256)
+    };
+    final long[] counts = new long[cellCount(canon)];
+    final Object2LongOpenHashMap<String> fallback = new Object2LongOpenHashMap<>();
+    fallback.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMultiDense(payloads, preds, cols, canon, counts, fallback);
+    assertEquals(0, fallback.size());
+
+    assertEquals(reference, decode(counts, canon));
+  }
+
+  @Test
+  void denseCompositeFallsBackPerLeafOnOutOfCanonValue() {
+    // Canonical dicts probed from the FIRST leaf only; the second leaf
+    // introduces "Legal", which is out-of-canon → that leaf must be counted
+    // through the fallback hashmap, and dense+fallback must equal reference.
+    final List<byte[]> payloads = leaves(DEPTS, new String[] {"Eng", "Sales", "Legal"});
+    final int[] cols = {1, 2};
+    final ProjectionIndexScan.ColumnPredicate[] noPreds = new ProjectionIndexScan.ColumnPredicate[0];
+
+    final Object2LongOpenHashMap<String> reference = new Object2LongOpenHashMap<>();
+    reference.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMulti(payloads, noPreds, cols, reference);
+
+    final byte[][][] canon = {
+        ProjectionIndexByteScan.probeCanonicalDict(payloads.subList(0, 1), 1, 1, 256),
+        ProjectionIndexByteScan.probeCanonicalDict(payloads.subList(0, 1), 2, 1, 256)
+    };
+    final long[] counts = new long[cellCount(canon)];
+    final Object2LongOpenHashMap<String> fallback = new Object2LongOpenHashMap<>();
+    fallback.defaultReturnValue(0L);
+    ProjectionIndexByteScan.conjunctiveCountByGroupMultiDense(payloads, noPreds, cols, canon, counts, fallback);
+    assertTrue(fallback.size() > 0, "second leaf must route through the fallback kernel");
+
+    final Object2LongOpenHashMap<String> combined = decode(counts, canon);
+    fallback.object2LongEntrySet().fastForEach(e -> combined.addTo(e.getKey(), e.getLongValue()));
+    assertEquals(reference, combined);
+  }
+
+  // ==================== dictionary-union count-distinct ====================
+
+  @Test
+  void distinctExcludesPhantomEmptyFromMissingRows() {
+    // Every leaf has missing dept rows (interning the "" default), but no
+    // PRESENT row carries "" — the phantom must not count.
+    final List<byte[]> payloads = leaves(DEPTS, DEPTS, new String[] {"Eng", "Legal", "HR"});
+    final ArrayList<byte[]> distinct = ProjectionIndexByteScan.distinctPresentStrings(payloads, 1, 1024);
+    // Union: Eng, Sales, Mkt, Legal, HR — and NOT "".
+    assertEquals(5, distinct.size());
+    for (final byte[] v : distinct) {
+      assertTrue(v.length > 0, "phantom empty value must be excluded");
+    }
+  }
+
+  @Test
+  void distinctIncludesRealEmptyValue() {
+    // A leaf where "" is a REAL present dept value on rows that are present.
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final boolean[] present = {true, true, true};
+    final boolean[] unrep = new boolean[3];
+    page.appendRow(1L, new long[] {30, 0, 0}, new boolean[3], new String[] {"", "", "NYC"}, present, unrep);
+    page.appendRow(2L, new long[] {31, 0, 0}, new boolean[3], new String[] {"", "Eng", "LA"}, present, unrep);
+    final List<byte[]> payloads = List.of(page.serialize());
+    final ArrayList<byte[]> distinct = ProjectionIndexByteScan.distinctPresentStrings(payloads, 1, 1024);
+    // "" (present on row 1) and "Eng".
+    assertEquals(2, distinct.size());
+  }
+
+  @Test
+  void distinctMatchesGroupCountingKernel() {
+    final List<byte[]> payloads = leaves(DEPTS, new String[] {"Legal", "HR", "Eng"});
+    final ArrayList<byte[]> distinct = ProjectionIndexByteScan.distinctPresentStrings(payloads, 1, 1024);
+
+    final Object2LongOpenHashMap<String> groups = new Object2LongOpenHashMap<>();
+    groups.defaultReturnValue(0L);
+    final long[] missing = new long[1];
+    ProjectionIndexByteScan.conjunctiveCountByGroup(payloads,
+        new ProjectionIndexScan.ColumnPredicate[0], 1, groups, missing);
+    assertEquals(groups.size(), distinct.size(), "dict union must equal the group-counting distinct set");
+  }
+
+  @Test
+  void distinctFailsClosedOnCardinalityAndMalformedLeaves() {
+    final List<byte[]> payloads = leaves(DEPTS);
+    assertNull(ProjectionIndexByteScan.distinctPresentStrings(payloads, 1, 2),
+        "cardinality above the limit must bail");
+    // Tail-less (malformed) leaf — no presence info, must fail closed.
+    final byte[] full = payloads.get(0);
+    final int tailLen = (full[full.length - 8] & 0xFF) | ((full[full.length - 7] & 0xFF) << 8)
+        | ((full[full.length - 6] & 0xFF) << 16) | ((full[full.length - 5] & 0xFF) << 24);
+    final byte[] truncated = Arrays.copyOf(full, full.length - 8 - tailLen);
+    assertNull(ProjectionIndexByteScan.distinctPresentStrings(List.of(truncated), 1, 1024));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Persistence of NUMERIC_LONG integrality provenance in the projection leaf
+ * presence tail (flag bit1). Historically the "did this column ever see a
+ * truncated non-integral value?" flags lived only in
+ * {@link ProjectionIndexBuilder} memory, so a close/re-open (hydrating
+ * leaves from HOT storage) lost them — {@code numericColumnIsIntegral}
+ * returned {@code false} and every sum/avg/min/max aggregate silently fell
+ * back from the projection to a full storage scan. The flags now persist in
+ * each leaf's tail; the registry handle re-derives them from the bytes when
+ * the installer cannot supply builder-tracked flags.
+ *
+ * <p>Fail-closed invariants under test:
+ * <ul>
+ * <li>leaves round-trip the per-column non-integral bit;</li>
+ * <li>tail-less payloads are rejected by {@code deserialize} as corrupt —
+ * provenance is never fabricated;</li>
+ * <li>a single malformed leaf poisons the whole probe (it might hide a
+ * truncated value).</li>
+ * </ul>
+ */
+public final class ProjectionIndexIntegralityPersistenceTest {
+
+  private static final byte[] KINDS = {
+      ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG,
+      ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN,
+      ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
+  };
+
+  private static final String[] FIELD_NAMES = {"age", "active", "amount"};
+
+  /**
+   * Build a leaf of {@code rows} dense rows; when {@code col2NonIntegral},
+   * every fifth row's second numeric column is marked as truncated from a
+   * non-integral number (the value slot itself always carries a long — the
+   * flag records provenance, not representation).
+   */
+  private static ProjectionIndexLeafPage leaf(final int rows, final boolean col2NonIntegral) {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final long[] longs = new long[3];
+    final boolean[] bools = new boolean[3];
+    final String[] strings = new String[3];
+    final boolean[] present = {true, true, true};
+    final boolean[] unrep = new boolean[3];
+    final boolean[] nonIntegral = new boolean[3];
+    for (int i = 0; i < rows; i++) {
+      longs[0] = 18 + (i % 48);
+      bools[1] = i % 2 == 0;
+      longs[2] = i * 10L;
+      nonIntegral[2] = col2NonIntegral && i % 5 == 0;
+      assertTrue(page.appendRow(1000 + i, longs, bools, strings, present, unrep, nonIntegral));
+    }
+    return page;
+  }
+
+  private static int intLE(final byte[] b, final int off) {
+    return (b[off] & 0xFF) | ((b[off + 1] & 0xFF) << 8) | ((b[off + 2] & 0xFF) << 16) | ((b[off + 3] & 0xFF) << 24);
+  }
+
+  /** Strip the mandatory presence tail — a corrupt/truncated payload. */
+  private static byte[] stripTail(final byte[] payload) {
+    final int tailLen = intLE(payload, payload.length - 8);
+    return Arrays.copyOf(payload, payload.length - 8 - tailLen);
+  }
+
+  // ==================== leaf round-trip ====================
+
+  @Test
+  void freshLeafRoundTripsIntegralColumns() {
+    final byte[] payload = leaf(100, false).serialize();
+    assertEquals(ProjectionIndexLeafPage.PRESENCE_TAIL_MAGIC, intLE(payload, payload.length - 4));
+
+    final ProjectionIndexLeafPage back = ProjectionIndexLeafPage.deserialize(payload);
+    for (int c = 0; c < KINDS.length; c++) {
+      assertFalse(back.columnNumericNonIntegral(c), "column " + c + " must stay provably integral");
+    }
+  }
+
+  @Test
+  void nonIntegralFlagSurvivesRoundTrip() {
+    final byte[] payload = leaf(100, true).serialize();
+    final ProjectionIndexLeafPage back = ProjectionIndexLeafPage.deserialize(payload);
+    assertFalse(back.columnNumericNonIntegral(0));
+    assertTrue(back.columnNumericNonIntegral(2));
+    // Re-serialization preserves the flag bytes exactly.
+    assertArrayEquals(payload, back.serialize());
+  }
+
+  @Test
+  void tailLessPayloadIsRejected() {
+    final byte[] truncated = stripTail(leaf(64, true).serialize());
+    assertThrows(IllegalStateException.class, () -> ProjectionIndexLeafPage.deserialize(truncated));
+  }
+
+  // ==================== byte-level probe ====================
+
+  @Test
+  void probeRecoversFlagsFromPersistedLeaves() {
+    final List<byte[]> leaves = List.of(leaf(100, false).serialize(), leaf(80, true).serialize());
+    final boolean[] nonIntegral = ProjectionIndexByteScan.probeNumericNonIntegral(leaves);
+    assertArrayEquals(new boolean[] {false, false, true}, nonIntegral,
+        "flags must OR across leaves");
+  }
+
+  @Test
+  void probeFailsClosedWhenAnyLeafIsMalformed() {
+    final byte[] tailed = leaf(100, false).serialize();
+    assertNull(ProjectionIndexByteScan.probeNumericNonIntegral(List.of(tailed, stripTail(tailed))));
+    assertNull(ProjectionIndexByteScan.probeNumericNonIntegral(List.of(stripTail(tailed))));
+  }
+
+  @Test
+  void probeOfEmptyLeafListIsZeroColumns() {
+    assertEquals(0, ProjectionIndexByteScan.probeNumericNonIntegral(List.of()).length);
+  }
+
+  // ==================== registry handle (close/re-open path) ====================
+
+  @Test
+  void handleWithoutInstallerFlagsRederivesIntegralityFromPersistedBytes() {
+    // Simulates the hydrate-after-reopen path: leaves come back from HOT
+    // storage, the builder (and its flags) are long gone.
+    final List<byte[]> leaves = List.of(leaf(100, false).serialize(), leaf(80, true).serialize());
+    final ProjectionIndexRegistry.Handle handle =
+        new ProjectionIndexRegistry.Handle(FIELD_NAMES, leaves);
+    assertTrue(handle.numericColumnIsIntegral(0), "age column must stay aggregate-servable after re-open");
+    assertFalse(handle.numericColumnIsIntegral(2), "amount column saw truncated values");
+    assertTrue(handle.numericColumnKnownNonIntegral(2));
+    assertFalse(handle.numericColumnKnownNonIntegral(0));
+  }
+
+  @Test
+  void handleFailsClosedOnMalformedLeaves() {
+    final byte[] tailed = leaf(100, false).serialize();
+    final ProjectionIndexRegistry.Handle handle =
+        new ProjectionIndexRegistry.Handle(FIELD_NAMES, List.of(tailed, stripTail(tailed)));
+    assertFalse(handle.numericColumnIsIntegral(0), "a malformed leaf must resolve the handle to UNKNOWN");
+    assertFalse(handle.numericColumnKnownNonIntegral(0));
+  }
+
+  @Test
+  void installerProvidedFlagsStillWin() {
+    // Builder-tracked flags say non-integral even though the (synthetic)
+    // leaves look clean — explicit evidence must not be overridden by probing.
+    final List<byte[]> leaves = List.of(leaf(100, false).serialize());
+    final ProjectionIndexRegistry.Handle handle =
+        new ProjectionIndexRegistry.Handle(FIELD_NAMES, leaves, new boolean[] {false, false, true});
+    assertTrue(handle.numericColumnIsIntegral(0));
+    assertFalse(handle.numericColumnIsIntegral(2));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexLeafCodecTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexLeafCodecTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Lossless-ness and compaction of {@link ProjectionIndexLeafCodec}: for every
+ * leaf shape, {@code decode(encode(raw))} must reproduce the raw payload
+ * BYTE-IDENTICALLY (presence, unrepresentable and integrality flags
+ * included), and the compact form must actually be smaller on
+ * representative analytical data.
+ */
+public final class ProjectionIndexLeafCodecTest {
+
+  private static final byte[] KINDS = {
+      ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG,
+      ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN,
+      ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT,
+      ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
+  };
+
+  private static final String[] DEPTS = {"Eng", "Sales", "Mkt", "Ops", "HR", "Finance", "Legal", "Supp"};
+
+  /**
+   * Representative bench-shaped leaf: ascending record keys with jittered
+   * spacing, small-range ages, 8-value dict, an all-missing numeric column
+   * (the "amount" pattern), sparse dept rows, non-integral marks.
+   */
+  private static ProjectionIndexLeafPage benchLeaf(final int rows, final long keyBase) {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final Random rng = new Random(7);
+    final long[] longs = new long[4];
+    final boolean[] bools = new boolean[4];
+    final String[] strings = new String[4];
+    final boolean[] present = new boolean[4];
+    final boolean[] unrep = new boolean[4];
+    final boolean[] nonIntegral = new boolean[4];
+    long key = keyBase;
+    for (int i = 0; i < rows; i++) {
+      key += 8 + rng.nextInt(9);
+      final boolean deptMissing = i % 5 == 0;
+      longs[0] = 18 + rng.nextInt(48);
+      bools[1] = rng.nextBoolean();
+      strings[2] = deptMissing ? "" : DEPTS[rng.nextInt(DEPTS.length)];
+      longs[3] = 0L;                       // all-missing "amount" column
+      present[0] = true;
+      present[1] = true;
+      present[2] = !deptMissing;
+      present[3] = false;
+      Arrays.fill(unrep, false);
+      nonIntegral[0] = i % 11 == 0;        // occasional truncated double
+      assertTrue(page.appendRow(key, longs, bools, strings, present, unrep, nonIntegral));
+    }
+    return page;
+  }
+
+  private static void assertRoundTrip(final ProjectionIndexLeafPage page) {
+    final byte[] raw = page.serialize();
+    final byte[] compact = ProjectionIndexLeafCodec.encode(raw);
+    assertArrayEquals(raw, ProjectionIndexLeafCodec.decode(compact),
+        "decode(encode(raw)) must be byte-identical");
+  }
+
+  // ==================== round trips ====================
+
+  @Test
+  void benchShapedLeafRoundTripsAndShrinks() {
+    final ProjectionIndexLeafPage page = benchLeaf(1024, 1_000_000L);
+    final byte[] raw = page.serialize();
+    final byte[] compact = ProjectionIndexLeafCodec.encode(raw);
+    assertArrayEquals(raw, ProjectionIndexLeafCodec.decode(compact));
+    assertTrue(compact.length * 5 < raw.length,
+        "expected >5x compaction on bench-shaped data, got " + raw.length + " -> " + compact.length);
+  }
+
+  @Test
+  void partialLeafAndSingleRowRoundTrip() {
+    assertRoundTrip(benchLeaf(100, 42L));
+    assertRoundTrip(benchLeaf(1, 42L));
+    assertRoundTrip(benchLeaf(64, 42L));  // exact word boundary
+    assertRoundTrip(benchLeaf(65, 42L));
+  }
+
+  @Test
+  void emptyLeafRoundTrips() {
+    assertRoundTrip(new ProjectionIndexLeafPage(KINDS));
+  }
+
+  @Test
+  void nonAscendingKeysAndExtremeValuesRoundTrip() {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final boolean[] present = {true, true, true, true};
+    final boolean[] unrep = new boolean[4];
+    final long[] keys = {900L, 5L, 12_345_678_901L, 3L};
+    final long[] extremes = {Long.MIN_VALUE, Long.MAX_VALUE, -1L, 0L};
+    for (int i = 0; i < keys.length; i++) {
+      page.appendRow(keys[i], new long[] {extremes[i], 0, 0, i}, new boolean[4],
+          new String[] {"", "", "x", ""}, present, unrep);
+    }
+    assertRoundTrip(page);
+  }
+
+  @Test
+  void realEmptyStringAndUnrepresentableRoundTrip() {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final boolean[] present = {true, true, true, true};
+    page.appendRow(1L, new long[] {7, 0, 0, 0}, new boolean[] {false, true, false, false},
+        new String[] {"", "", "", ""}, present, new boolean[] {false, false, false, true});
+    page.appendRow(2L, new long[] {8, 0, 0, 0}, new boolean[4],
+        new String[] {"", "", "Eng", ""}, present, new boolean[4]);
+    assertRoundTrip(page);
+  }
+
+  @Test
+  void singleValueDictCollapsesToZeroWidth() {
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final boolean[] present = {true, true, true, true};
+    final boolean[] unrep = new boolean[4];
+    for (int i = 0; i < 256; i++) {
+      page.appendRow(1000 + i, new long[] {5, 0, 0, 0}, new boolean[4],
+          new String[] {"", "", "OnlyValue", ""}, present, unrep);
+    }
+    final byte[] raw = page.serialize();
+    final byte[] compact = ProjectionIndexLeafCodec.encode(raw);
+    assertArrayEquals(raw, ProjectionIndexLeafCodec.decode(compact));
+    // Constant columns (age=5, single dict value, amount=0) all collapse:
+    // the compact form must be a small fraction of raw.
+    assertTrue(compact.length * 10 < raw.length,
+        "constant columns should collapse, got " + raw.length + " -> " + compact.length);
+  }
+
+  @Test
+  void wideBitWidthRangesRoundTripExactly() {
+    // Regression: pack widths 57-63 used to lose bits in the byte-at-a-time
+    // reader (a byte shifted past bit 63); such widths now take the raw
+    // 64-bit path. Cover every width from 48 to 64 with adversarial values.
+    for (int width = 48; width <= 64; width++) {
+      final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+      final boolean[] present = {true, true, true, true};
+      final boolean[] unrep = new boolean[4];
+      final Random rng = new Random(width);
+      final long span = width >= 64 ? Long.MAX_VALUE : (1L << (width - 1)) + 7;
+      for (int i = 0; i < 100; i++) {
+        final long v = i % 3 == 0 ? 0L : i % 3 == 1 ? span - i : Math.floorMod(rng.nextLong(), span);
+        page.appendRow(1_000_000L + i * 3L, new long[] {v, 0, 0, 0}, new boolean[4],
+            new String[] {"", "", "x", ""}, present, unrep);
+      }
+      final byte[] raw = page.serialize();
+      assertArrayEquals(raw, ProjectionIndexLeafCodec.decode(ProjectionIndexLeafCodec.encode(raw)),
+          "width " + width + " must round-trip byte-identically");
+    }
+  }
+
+  @Test
+  void hugeAscendingKeyDeltasRoundTrip() {
+    // Delta-FOR mode with deltas needing >56 bits must clamp to the raw path.
+    final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
+    final boolean[] present = {true, true, true, true};
+    final boolean[] unrep = new boolean[4];
+    long key = 10L;
+    for (int i = 0; i < 10; i++) {
+      page.appendRow(key, new long[] {i, 0, 0, 0}, new boolean[4],
+          new String[] {"", "", "x", ""}, present, unrep);
+      key += 1L << 58;
+    }
+    assertRoundTrip(page);
+  }
+
+  // ==================== passthrough & flags ====================
+
+  @Test
+  void decodePassesRawPayloadsThrough() {
+    final byte[] raw = benchLeaf(100, 42L).serialize();
+    assertSame(raw, ProjectionIndexLeafCodec.decode(raw), "raw payloads must pass through untouched");
+  }
+
+  @Test
+  void provenanceSurvivesTheCodec() {
+    final byte[] raw = benchLeaf(200, 42L).serialize();
+    final ProjectionIndexLeafPage back =
+        ProjectionIndexLeafPage.deserialize(ProjectionIndexLeafCodec.decode(ProjectionIndexLeafCodec.encode(raw)));
+    assertTrue(back.columnNumericNonIntegral(0), "integrality provenance must survive");
+    assertEquals(200, back.getRowCount());
+    // The all-missing amount column: presence bits all clear.
+    final long[] pres = back.presenceColumnBits(3);
+    for (final long w : pres) {
+      assertEquals(0L, w, "all-missing column must stay all-missing");
+    }
+    // Probes over the decoded payload behave exactly as over the original.
+    final byte[] decoded = ProjectionIndexLeafCodec.decode(ProjectionIndexLeafCodec.encode(raw));
+    assertArrayEquals(ProjectionIndexByteScan.probeSparseEvidence(List.of(raw)),
+        ProjectionIndexByteScan.probeSparseEvidence(List.of(decoded)));
+    assertArrayEquals(ProjectionIndexByteScan.probeNumericNonIntegral(List.of(raw)),
+        ProjectionIndexByteScan.probeNumericNonIntegral(List.of(decoded)));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexMetadataTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexMetadataTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Round-trip and robustness coverage for {@link ProjectionIndexMetadata} —
+ * the self-describing shape payload persisted at HOT slot 0 of a projection
+ * sub-tree.
+ */
+public final class ProjectionIndexMetadataTest {
+
+  private static final String ROOT = "/wrapper/records/[]";
+  private static final String[] PATHS = { "/wrapper/records/[]/age", "/wrapper/records/[]/active",
+      "/wrapper/records/[]/dept" };
+  private static final String[] NAMES = { "age", "active", "dept" };
+  private static final byte[] KINDS = { ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG,
+      ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN, ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT };
+
+  @Test
+  public void roundTripsThroughSerializeAndParse() {
+    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS);
+    final ProjectionIndexMetadata parsed = ProjectionIndexMetadata.parse(metadata.serialize());
+    assertEquals(ROOT, parsed.rootPath());
+    assertArrayEquals(PATHS, parsed.fieldPaths());
+    assertArrayEquals(NAMES, parsed.fieldNames());
+    assertArrayEquals(KINDS, parsed.columnKinds());
+  }
+
+  @Test
+  public void matchesComparesRootFieldPathsAndKinds() {
+    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS);
+    assertTrue(metadata.matches(ROOT, PATHS, KINDS));
+    assertFalse(metadata.matches("/[]", PATHS, KINDS));
+    assertFalse(metadata.matches(ROOT, new String[] { PATHS[0], PATHS[1] },
+        new byte[] { KINDS[0], KINDS[1] }));
+    final byte[] otherKinds = KINDS.clone();
+    otherKinds[0] = ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT;
+    assertFalse(metadata.matches(ROOT, PATHS, otherKinds));
+  }
+
+  @Test
+  public void parseReturnsNullWithoutTheMagic() {
+    assertNull(ProjectionIndexMetadata.parse(null));
+    assertNull(ProjectionIndexMetadata.parse(new byte[0]));
+    assertNull(ProjectionIndexMetadata.parse(new byte[] { 1, 2, 3, 4, 5, 6 }));
+    // A compact leaf payload starts with the PIXC magic — must not parse.
+    assertNull(ProjectionIndexMetadata.parse(new byte[] { 0x49, 0x50, 0x58, 0x43, 0, 0, 0, 0 }));
+  }
+
+  @Test
+  public void truncatedPayloadFailsLoudly() {
+    final byte[] serialized = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS).serialize();
+    for (final int cut : new int[] { 5, 9, serialized.length / 2, serialized.length - 1 }) {
+      final byte[] truncated = Arrays.copyOf(serialized, cut);
+      assertThrows(IllegalStateException.class, () -> ProjectionIndexMetadata.parse(truncated),
+          "cut at " + cut);
+    }
+  }
+
+  @Test
+  public void misalignedArraysAreRejected() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new ProjectionIndexMetadata(ROOT, PATHS, new String[] { "age" }, KINDS));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexNestedPathTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexNestedPathTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.brackit.query.util.path.Path.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Path coverage for projection indexes beyond the flat {@code /[]} bench
+ * shape:
+ * <ul>
+ * <li><b>nested roots</b> — the record set lives under object steps
+ * ({@code /east/records/[]});</li>
+ * <li><b>nested field columns</b> — a column path descends below the record
+ * root ({@code .../[]/nested/city});</li>
+ * <li><b>multi-PCR roots</b> — one descendant path pattern
+ * ({@code //records/[]}) resolving to record sets under SIBLING subtrees;
+ * historically this threw ("only single-path roots are supported"), now
+ * every matching PCR is a record root;</li>
+ * <li><b>multi-PCR field paths</b> — the same field pattern resolving under
+ * each root; historically only the first PCR was (silently) matched, which
+ * made every record under the second root report the field as missing.</li>
+ * </ul>
+ */
+final class ProjectionIndexNestedPathTest {
+
+  private static final String JSON = """
+      {
+        "east": {"records": [
+          {"age": 30, "name": "a"},
+          {"age": 45, "name": "b"}
+        ]},
+        "west": {"records": [
+          {"age": 50, "name": "c"},
+          {"age": 20, "nested": {"city": "NYC"}}
+        ]},
+        "other": [1, 2]
+      }""";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final var wtx = manager.beginNodeTrx()) {
+      new JsonShredder.Builder(wtx, JsonShredder.createStringReader(JSON),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  private static List<byte[]> buildLeaves(final String rootPath, final String agePath,
+      final String namePath, final String cityPath) {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final var rtx = manager.beginNodeReadOnlyTrx();
+         final var pathSummary = manager.openPathSummary()) {
+      final IndexDef def = IndexDefs.createProjectionIdxDef(
+          parse(rootPath, PathParser.Type.JSON),
+          List.of(parse(agePath, PathParser.Type.JSON),
+                  parse(namePath, PathParser.Type.JSON),
+                  parse(cityPath, PathParser.Type.JSON)),
+          List.of(Type.LON, Type.STR, Type.STR),
+          0,
+          IndexDef.DbType.JSON);
+      final List<byte[]> leaves = new ArrayList<>();
+      new ProjectionIndexBuilder(def, pathSummary, leaves::add).build(rtx);
+      return leaves;
+    }
+  }
+
+  private static String stringAt(final ProjectionIndexLeafPage leaf, final int column, final int row) {
+    final byte[][] dict = leaf.stringDictionary(column);
+    final int id = leaf.stringDictIdColumn(column)[row];
+    return new String(dict[id], StandardCharsets.UTF_8);
+  }
+
+  private static boolean presentAt(final ProjectionIndexLeafPage leaf, final int column, final int row) {
+    return (leaf.presenceColumnBits(column)[row >>> 6] & (1L << (row & 63))) != 0;
+  }
+
+  // ==================== nested single-PCR root ====================
+
+  @Test
+  void selfNestedRootPcrsFailFast() {
+    // A record set nested inside another matched record's subtree must be
+    // rejected loudly — the builder cannot emit correct rows for it (the
+    // inner record's fields would overwrite the outer row's columns).
+    JsonTestHelper.deleteEverything();
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final var wtx = manager.beginNodeTrx()) {
+      new JsonShredder.Builder(wtx, JsonShredder.createStringReader(
+          "{\"records\":[{\"age\":30,\"records\":[{\"age\":99}]}]}"),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+    }
+    try (final var manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final var rtx = manager.beginNodeReadOnlyTrx();
+         final var pathSummary = manager.openPathSummary()) {
+      final IndexDef def = IndexDefs.createProjectionIdxDef(
+          parse("//records/[]", PathParser.Type.JSON),
+          List.of(parse("//records/[]/age", PathParser.Type.JSON)),
+          List.of(Type.LON), 0, IndexDef.DbType.JSON);
+      assertThrows(IllegalStateException.class,
+          () -> new ProjectionIndexBuilder(def, pathSummary, payload -> { }));
+    }
+  }
+
+
+  @Test
+  void nestedRootAndNestedFieldColumn() {
+    final List<byte[]> leaves = buildLeaves(
+        "/east/records/[]",
+        "/east/records/[]/age",
+        "/east/records/[]/name",
+        "/east/records/[]/nested/city");
+    assertEquals(1, leaves.size());
+    final ProjectionIndexLeafPage leaf = ProjectionIndexLeafPage.deserialize(leaves.get(0));
+    assertEquals(2, leaf.getRowCount());
+    assertEquals(30, leaf.numericColumn(0)[0]);
+    assertEquals(45, leaf.numericColumn(0)[1]);
+    assertEquals("a", stringAt(leaf, 1, 0));
+    assertEquals("b", stringAt(leaf, 1, 1));
+    // No east record carries nested/city — column all-missing.
+    assertFalse(presentAt(leaf, 2, 0));
+    assertFalse(presentAt(leaf, 2, 1));
+  }
+
+  // ==================== multi-PCR root + multi-PCR fields ====================
+
+  @Test
+  void descendantPatternRootSpansSiblingSubtrees() {
+    final List<byte[]> leaves = buildLeaves(
+        "//records/[]",
+        "//records/[]/age",
+        "//records/[]/name",
+        "//records/[]/nested/city");
+    assertEquals(1, leaves.size());
+    final ProjectionIndexLeafPage leaf = ProjectionIndexLeafPage.deserialize(leaves.get(0));
+    // Both sibling record sets contribute rows, in document order.
+    assertEquals(4, leaf.getRowCount());
+    assertEquals(30, leaf.numericColumn(0)[0]);
+    assertEquals(45, leaf.numericColumn(0)[1]);
+    assertEquals(50, leaf.numericColumn(0)[2]);
+    assertEquals(20, leaf.numericColumn(0)[3]);
+    // Field PCRs resolve under BOTH roots — the west rows must not report
+    // age/name as missing (the historical first-PCR-only behavior).
+    assertTrue(presentAt(leaf, 0, 2), "west row must match the age field's second PCR");
+    assertEquals("c", stringAt(leaf, 1, 2));
+    assertFalse(presentAt(leaf, 1, 3), "row without name stays missing");
+    // Nested column below the record root, present on exactly one row.
+    assertFalse(presentAt(leaf, 2, 0));
+    assertTrue(presentAt(leaf, 2, 3));
+    assertEquals("NYC", stringAt(leaf, 2, 3));
+
+    // The scan stack agrees: age > 25 matches rows 0,1,2.
+    final long matches = ProjectionIndexByteScan.conjunctiveCount(leaves,
+        new ProjectionIndexScan.ColumnPredicate[] {
+            ProjectionIndexScan.ColumnPredicate.numeric(0, ProjectionIndexScan.Op.GT, 25L)
+        });
+    assertEquals(3, matches);
+  }
+
+  @Test
+  void unresolvableFieldPathYieldsAllMissingColumn() {
+    final List<byte[]> leaves = buildLeaves(
+        "/west/records/[]",
+        "/west/records/[]/age",
+        "/west/records/[]/no_such_field",
+        "/west/records/[]/nested/city");
+    final ProjectionIndexLeafPage leaf = ProjectionIndexLeafPage.deserialize(leaves.get(0));
+    assertEquals(2, leaf.getRowCount());
+    assertFalse(presentAt(leaf, 1, 0));
+    assertFalse(presentAt(leaf, 1, 1));
+    assertTrue(presentAt(leaf, 2, 1));
+    assertEquals("NYC", stringAt(leaf, 2, 1));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexPresenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexPresenceTest.java
@@ -14,10 +14,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Sparse-field correctness of the projection leaf format v2 (presence
+ * Sparse-field correctness of the projection leaf format (presence
  * bitmaps + per-column unrepresentable flags) and the presence-aware
  * {@link ProjectionIndexByteScan} kernels.
  *
@@ -30,8 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * of the {@code ""} default group;</li>
  * <li>aggregates skip missing rows (the historical sum counted phantom
  * zeros into count/min/max);</li>
- * <li>legacy v1 leaves carry NO presence info and must be detected as
- * such — never misread, and re-serialized WITHOUT a fabricated tail.</li>
+ * <li>the presence tail is mandatory — tail-less payloads are rejected
+ * as corrupt, never misread.</li>
  * </ul>
  */
 public final class ProjectionIndexPresenceTest {
@@ -75,7 +76,6 @@ public final class ProjectionIndexPresenceTest {
     final ProjectionIndexLeafPage page = sparseLeaf(100);
     final byte[] payload = page.serialize();
     final ProjectionIndexLeafPage back = ProjectionIndexLeafPage.deserialize(payload);
-    assertTrue(back.hasPresence());
     assertEquals(100, back.getRowCount());
     for (int i = 0; i < 100; i++) {
       final boolean numPresent = (back.presenceColumnBits(0)[i >>> 6] & (1L << (i & 63))) != 0;
@@ -118,20 +118,16 @@ public final class ProjectionIndexPresenceTest {
   }
 
   @Test
-  void legacyV1PayloadIsDetectedNotMisread() {
+  void tailLessPayloadIsRejectedNotMisread() {
     final ProjectionIndexLeafPage page = sparseLeaf(50);
-    final byte[] v2 = page.serialize();
-    // Strip the v2 tail to obtain the EXACT legacy byte stream.
+    final byte[] full = page.serialize();
+    // Strip the tail — the mandatory footer is gone, deserialize must reject.
     final int presWords = (50 + 63) >>> 6;
     final int tailSize = KINDS.length + KINDS.length * presWords * 8 + 8;
-    final byte[] v1 = Arrays.copyOf(v2, v2.length - tailSize);
-    final ProjectionIndexLeafPage back = ProjectionIndexLeafPage.deserialize(v1);
-    assertFalse(back.hasPresence(), "v1 payload must not fabricate presence");
-    assertEquals(50, back.getRowCount());
-    // Re-serializing a v1-deserialized page must NOT invent a presence tail.
-    assertEquals(v1.length, back.serialize().length);
-    // And the sparse-evidence probe must report DIRTY for every column.
-    final byte[] status = ProjectionIndexByteScan.probeSparseEvidence(List.of(v1));
+    final byte[] truncated = Arrays.copyOf(full, full.length - tailSize);
+    assertThrows(IllegalStateException.class, () -> ProjectionIndexLeafPage.deserialize(truncated));
+    // The byte-level sparse probe fails closed on the same payload.
+    final byte[] status = ProjectionIndexByteScan.probeSparseEvidence(List.of(truncated));
     for (final byte st : status) {
       assertEquals(ProjectionIndexByteScan.SPARSE_STATUS_DIRTY, st);
     }
@@ -155,7 +151,6 @@ public final class ProjectionIndexPresenceTest {
     final ProjectionIndexLeafPage page = new ProjectionIndexLeafPage(KINDS);
     final byte[] payload = page.serialize();
     final ProjectionIndexLeafPage back = ProjectionIndexLeafPage.deserialize(payload);
-    assertTrue(back.hasPresence());
     assertEquals(0, back.getRowCount());
     assertEquals(payload.length, back.serializedSize());
   }

--- a/bundles/sirix-query/bench/ch_bench.py
+++ b/bundles/sirix-query/bench/ch_bench.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""ClickHouse (chdb, embedded) side of the SirixDB cross-engine comparison —
+the ClickHouse analog of duck_bench.py (docs/COMPARISON_DUCKDB.md).
+
+Generates the benchmark table in-engine with the same shape and distributions
+as SirixDB's GeneratedRecordsReader ({id, age: 18..65, dept: 8 values,
+city: 8 values, active: bool}, uniform), then runs the nine analytical query
+shapes with one untimed warmup and N timed runs each, materializing results
+and reporting the minimum.
+
+Usage:
+    python3 ch_bench.py <rows> <iters> <db_path> [threads]
+
+Requires: pip install chdb
+"""
+
+import sys
+import time
+
+import chdb.session
+
+DEPTS = ["Eng", "Sales", "Mkt", "Ops", "HR", "Finance", "Legal", "Supp"]
+CITIES = ["NYC", "LA", "SF", "ATL", "BOS", "CHI", "DEN", "DAL"]
+
+QUERIES = [
+    ("filterCount", "SELECT count(*) FROM records WHERE age > 40 AND active"),
+    ("groupByDept", "SELECT dept, count(*) FROM records GROUP BY dept"),
+    ("sumAge", "SELECT sum(age) FROM records"),
+    ("avgAge", "SELECT avg(age) FROM records"),
+    ("minMaxAge", "SELECT min(age), max(age) FROM records"),
+    ("groupByDeptCity", "SELECT dept, city, count(*) FROM records GROUP BY dept, city"),
+    ("filterGroupBy", "SELECT dept, count(*) FROM records WHERE active GROUP BY dept"),
+    ("countDistinctDept", "SELECT count(DISTINCT dept) FROM records"),
+    ("compoundAnd", "SELECT count(*) FROM records WHERE age > 30 AND age < 50 AND active"),
+]
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        sys.exit(__doc__)
+    rows = int(sys.argv[1])
+    iters = int(sys.argv[2])
+    db_path = sys.argv[3]
+    threads = int(sys.argv[4]) if len(sys.argv) > 4 else 4
+
+    ses = chdb.session.Session(db_path)
+    settings = f"SETTINGS max_threads = {threads}"
+    print(f"# chdb {chdb.__version__} (ClickHouse {chdb.engine_version}), threads={threads}, "
+          f"rows={rows:,}, iters={iters}")
+
+    existing = ses.query(
+        "SELECT count(*) FROM system.tables WHERE database = currentDatabase() AND name = 'records'"
+    ).data().strip()
+    if existing != "0":
+        count = ses.query("SELECT count(*) FROM records").data().strip()
+        print(f"# reusing existing table records ({int(count):,} rows)")
+    else:
+        depts = ", ".join(f"'{d}'" for d in DEPTS)
+        cities = ", ".join(f"'{c}'" for c in CITIES)
+        t0 = time.perf_counter()
+        ses.query(
+            """
+            CREATE TABLE records (
+                id UInt64,
+                age Int64,
+                dept LowCardinality(String),
+                city LowCardinality(String),
+                active Bool
+            ) ENGINE = MergeTree ORDER BY id
+            """
+        )
+        ses.query(
+            f"""
+            INSERT INTO records
+            SELECT number AS id,
+                   18 + rand(1) % 48 AS age,
+                   [{depts}][1 + rand(2) % 8] AS dept,
+                   [{cities}][1 + rand(3) % 8] AS city,
+                   rand(4) % 2 = 1 AS active
+            FROM numbers({rows})
+            """
+        )
+        print(f"# generated {rows:,} rows in {time.perf_counter() - t0:.1f} s")
+
+    for name, sql in QUERIES:
+        full = f"{sql} {settings}"
+        ses.query(full).data()  # untimed warmup
+        best = min(timed_run(ses, full) for _ in range(iters))
+        print(f"{name}: {best * 1000:.1f} ms")
+
+
+def timed_run(ses: "chdb.session.Session", sql: str) -> float:
+    t0 = time.perf_counter()
+    ses.query(sql).data()
+    return time.perf_counter() - t0
+
+
+if __name__ == "__main__":
+    main()

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
@@ -17,9 +17,11 @@ import io.sirix.index.projection.ProjectionIndexBuilder;
 import io.sirix.index.projection.ProjectionIndexHOTStorage;
 import io.sirix.index.projection.ProjectionIndexLeafCodec;
 import io.sirix.index.projection.ProjectionIndexLeafPage;
+import io.sirix.index.projection.ProjectionIndexMetadata;
 import io.sirix.index.projection.ProjectionIndexRegistry;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -72,12 +74,31 @@ final class ScaleBenchProjectionSetup {
         final List<byte[]> compact =
             ProjectionIndexHOTStorage.readAll(probeRtx.getStorageEngineReader(), INDEX_NUMBER);
         if (!compact.isEmpty()) {
+          // A store persisted via jn:create-projection-index carries a
+          // self-describing metadata payload at slot 0 (leaves at 1..N) —
+          // skip it here (the bench wires its shape statically) but keep the
+          // slot offset so a repersist below doesn't clobber the metadata.
+          final ProjectionIndexMetadata metadata = ProjectionIndexMetadata.parse(compact.get(0));
+          final int leafSlotBase = metadata == null ? 0 : 1;
           // Persisted leaves are stored in the compact codec form — decode
           // to the flat scan form the kernels (and the registry probes)
           // operate on. Raw pre-codec payloads pass through unchanged.
-          final List<byte[]> persisted = new ArrayList<>(compact.size());
-          for (final byte[] payload : compact) {
-            persisted.add(ProjectionIndexLeafCodec.decode(payload));
+          final List<byte[]> persisted = new ArrayList<>(compact.size() - leafSlotBase);
+          for (int i = leafSlotBase; i < compact.size(); i++) {
+            persisted.add(ProjectionIndexLeafCodec.decode(compact.get(i)));
+          }
+          // Guard the shape: hydrating leaves with a different column count
+          // under the bench's static field list would mislabel every column.
+          if (!persisted.isEmpty()) {
+            final byte[] first = persisted.get(0);
+            final int persistedColumns =
+                first == null || first.length < 8 ? -1 : ProjectionIndexLeafPage.columnCountOf(first);
+            if (persistedColumns != FIELD_NAMES.length) {
+              throw new IllegalStateException("Persisted projection has " + persistedColumns
+                  + " columns but the bench expects " + FIELD_NAMES.length + " "
+                  + Arrays.toString(FIELD_NAMES)
+                  + " — rebuild it with -Dsirix.projection.forceRebuild=true.");
+            }
           }
           final List<byte[]> reencoded = (inMemoryReencode || repersistReencoded)
               ? reencodeLeaves(persisted)
@@ -91,7 +112,7 @@ final class ScaleBenchProjectionSetup {
               final ProjectionIndexHOTStorage storage =
                   new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
               for (int i = 0; i < reencoded.size(); i++) {
-                storage.put(i, ProjectionIndexLeafCodec.encode(reencoded.get(i)));
+                storage.put(leafSlotBase + i, ProjectionIndexLeafCodec.encode(reencoded.get(i)));
               }
               wtx.commit();
             }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
@@ -15,6 +15,7 @@ import io.sirix.index.IndexDefs;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.index.projection.ProjectionIndexBuilder;
 import io.sirix.index.projection.ProjectionIndexHOTStorage;
+import io.sirix.index.projection.ProjectionIndexLeafCodec;
 import io.sirix.index.projection.ProjectionIndexLeafPage;
 import io.sirix.index.projection.ProjectionIndexRegistry;
 
@@ -68,9 +69,16 @@ final class ScaleBenchProjectionSetup {
     final int revision = session.getMostRecentRevisionNumber();
     if (!forceRebuild) {
       try (JsonNodeReadOnlyTrx probeRtx = session.beginNodeReadOnlyTrx(revision)) {
-        final List<byte[]> persisted =
+        final List<byte[]> compact =
             ProjectionIndexHOTStorage.readAll(probeRtx.getStorageEngineReader(), INDEX_NUMBER);
-        if (!persisted.isEmpty()) {
+        if (!compact.isEmpty()) {
+          // Persisted leaves are stored in the compact codec form — decode
+          // to the flat scan form the kernels (and the registry probes)
+          // operate on. Raw pre-codec payloads pass through unchanged.
+          final List<byte[]> persisted = new ArrayList<>(compact.size());
+          for (final byte[] payload : compact) {
+            persisted.add(ProjectionIndexLeafCodec.decode(payload));
+          }
           final List<byte[]> reencoded = (inMemoryReencode || repersistReencoded)
               ? reencodeLeaves(persisted)
               : persisted;
@@ -83,13 +91,16 @@ final class ScaleBenchProjectionSetup {
               final ProjectionIndexHOTStorage storage =
                   new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
               for (int i = 0; i < reencoded.size(); i++) {
-                storage.put(i, reencoded.get(i));
+                storage.put(i, ProjectionIndexLeafCodec.encode(reencoded.get(i)));
               }
               wtx.commit();
             }
             System.out.printf("# Projection repersisted: %,d leaves in %,d ms%n",
                 reencoded.size(), (System.nanoTime() - t0) / 1_000_000L);
           }
+          // No builder flags on this path — the Handle lazily re-derives the
+          // NUMERIC_LONG integrality evidence from the leaves' persisted
+          // presence tails, so aggregate fast paths survive close/re-open.
           ProjectionIndexRegistry.installWildcard(resourceKey, FIELD_NAMES, reencoded);
           return reencoded.size();
         }
@@ -152,14 +163,25 @@ final class ScaleBenchProjectionSetup {
           builder.numericColumnNonIntegralFlags());
       return leaves.size();
     }
+    long rawBytes = 0;
+    long compactBytes = 0;
     try (JsonNodeTrx wtx = session.beginNodeTrx()) {
       final ProjectionIndexHOTStorage storage =
           new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
       for (int i = 0; i < leaves.size(); i++) {
-        storage.put(i, leaves.get(i));
+        // Persist in the compact codec form (FOR/bit-packed values, packed
+        // dict-ids, delta record keys, marker-byte presence) — the flat
+        // scan form stays in-memory only. Hydrate decodes back losslessly.
+        final byte[] raw = leaves.get(i);
+        final byte[] compact = ProjectionIndexLeafCodec.encode(raw);
+        rawBytes += raw.length;
+        compactBytes += compact.length;
+        storage.put(i, compact);
       }
       wtx.commit();
     }
+    System.out.printf("# Projection persisted: %,d leaves, raw %,d bytes -> compact %,d bytes (%.1f%%)%n",
+        leaves.size(), rawBytes, compactBytes, rawBytes == 0 ? 0.0 : 100.0 * compactBytes / rawBytes);
 
     ProjectionIndexRegistry.installWildcard(resourceKey, FIELD_NAMES, leaves, builder.numericColumnNonIntegralFlags());
     return leaves.size();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/JNFun.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/JNFun.java
@@ -46,7 +46,6 @@ import io.brackit.query.function.json.JSONFun;
 import io.brackit.query.jdm.Signature;
 import io.brackit.query.module.Functions;
 
-import static io.brackit.query.compiler.XQ.ItemType;
 import static io.sirix.query.function.jn.index.create.CreateCASIndex.CREATE_CAS_INDEX;
 import static io.sirix.query.function.jn.index.create.CreateNameIndex.CREATE_NAME_INDEX;
 import static io.sirix.query.function.jn.index.create.CreatePathIndex.CREATE_PATH_INDEX;

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/JNFun.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/JNFun.java
@@ -9,6 +9,7 @@ import io.sirix.query.function.jn.diff.Diff;
 import io.sirix.query.function.jn.index.create.CreateCASIndex;
 import io.sirix.query.function.jn.index.create.CreateNameIndex;
 import io.sirix.query.function.jn.index.create.CreatePathIndex;
+import io.sirix.query.function.jn.index.create.CreateProjectionIndex;
 import io.sirix.query.function.jn.index.create.CreateValidTimeIndex;
 import io.sirix.query.function.jn.index.drop.DropValidTimeIndex;
 import io.sirix.query.function.jn.index.find.FindCASIndex;
@@ -49,6 +50,7 @@ import static io.brackit.query.compiler.XQ.ItemType;
 import static io.sirix.query.function.jn.index.create.CreateCASIndex.CREATE_CAS_INDEX;
 import static io.sirix.query.function.jn.index.create.CreateNameIndex.CREATE_NAME_INDEX;
 import static io.sirix.query.function.jn.index.create.CreatePathIndex.CREATE_PATH_INDEX;
+import static io.sirix.query.function.jn.index.create.CreateProjectionIndex.CREATE_PROJECTION_INDEX;
 import static io.sirix.query.function.jn.index.create.CreateValidTimeIndex.CREATE_VALID_TIME_INDEX;
 import static io.sirix.query.function.jn.index.drop.DropValidTimeIndex.DROP_VALID_TIME_INDEX;
 import static io.sirix.query.function.jn.index.find.FindCASIndex.FIND_CAS_INDEX;
@@ -187,6 +189,17 @@ public final class JNFun {
         SequenceType.JSON_ITEM, new SequenceType(AtomicType.STR, Cardinality.ZeroOrMany))));
     Functions.predefine(
         new CreatePathIndex(CREATE_PATH_INDEX, new Signature(SequenceType.JSON_ITEM, SequenceType.JSON_ITEM)));
+
+    // create-projection-index
+    Functions.predefine(new CreateProjectionIndex(CREATE_PROJECTION_INDEX,
+        new Signature(SequenceType.JSON_ITEM, SequenceType.JSON_ITEM,
+            new SequenceType(AtomicType.STR, Cardinality.One),
+            new SequenceType(AtomicType.STR, Cardinality.ZeroOrMany),
+            new SequenceType(AtomicType.STR, Cardinality.ZeroOrMany))));
+    Functions.predefine(new CreateProjectionIndex(CREATE_PROJECTION_INDEX,
+        new Signature(SequenceType.JSON_ITEM, SequenceType.JSON_ITEM,
+            new SequenceType(AtomicType.STR, Cardinality.One),
+            new SequenceType(AtomicType.STR, Cardinality.ZeroOrMany))));
 
     // create-cas-index
     Functions.predefine(new CreateCASIndex(CREATE_CAS_INDEX,

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateProjectionIndex.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateProjectionIndex.java
@@ -1,0 +1,191 @@
+package io.sirix.query.function.jn.index.create;
+
+import io.brackit.query.QueryContext;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.function.AbstractFunction;
+import io.brackit.query.function.json.JSONFun;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Iter;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.Signature;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.module.StaticContext;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.index.projection.ProjectionIndexBuilder;
+import io.sirix.index.projection.ProjectionIndexHOTStorage;
+import io.sirix.index.projection.ProjectionIndexLeafCodec;
+import io.sirix.index.projection.ProjectionIndexRegistry;
+import io.sirix.query.json.JsonDBItem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Function for creating a columnar <em>projection index</em> over a set of
+ * record fields — the analytical fast path behind aggregate / filter /
+ * group-by queries. Supported signatures:
+ * <ul>
+ * <li><code>jn:create-projection-index($doc as json-item(), $rootPath as xs:string,
+ * $fields as xs:string*, $types as xs:string*) as json-item()</code></li>
+ * <li><code>jn:create-projection-index($doc as json-item(), $rootPath as xs:string,
+ * $fields as xs:string*) as json-item()</code> — every field typed as
+ * {@code string}</li>
+ * </ul>
+ *
+ * <p>{@code $rootPath} selects the record set (e.g. {@code /[]} for a
+ * top-level array, {@code /wrapper/records/[]} for a nested one);
+ * {@code $fields} are the projected column paths relative to the document
+ * root; {@code $types} declare the per-column primitive shape —
+ * {@code "long"} (also accepts {@code integer}/{@code decimal}/{@code
+ * double}), {@code "boolean"}, or {@code "string"}.
+ *
+ * <p>The projection is built over the document's most recent revision,
+ * persisted compactly (see {@code ProjectionIndexLeafCodec}) and installed
+ * in the in-memory registry, where the analytical executor picks it up
+ * automatically. Calling the function again on a resource whose projection
+ * is already persisted re-hydrates it instead of rebuilding — the intended
+ * per-session bootstrap after re-opening a database.
+ *
+ * <p><b>Experimental.</b> One projection per resource; the projection is a
+ * static snapshot of the indexed revision (it is not yet maintained by
+ * update transactions) and requires the resource to be created with a path
+ * summary.
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class CreateProjectionIndex extends AbstractFunction {
+
+  /** Projection index function name. */
+  public static final QNm CREATE_PROJECTION_INDEX =
+      new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "create-projection-index");
+
+  /** IndexDef id — one projection sub-tree per resource for now. */
+  private static final int INDEX_NUMBER = 0;
+
+  public CreateProjectionIndex(final QNm name, final Signature signature) {
+    super(name, signature, true);
+  }
+
+  @Override
+  public Sequence execute(final StaticContext sctx, final QueryContext ctx, final Sequence[] args) {
+    if (args.length != 3 && args.length != 4) {
+      throw new QueryException(new QNm("No valid arguments specified!"));
+    }
+    final JsonDBItem document = (JsonDBItem) args[0];
+    final JsonResourceSession session = document.getTrx().getResourceSession();
+    if (!session.getResourceConfig().withPathSummary) {
+      throw new QueryException(new QNm(
+          "jn:create-projection-index requires a resource created with a path summary "
+              + "(buildPathSummary=true) — the projection builder resolves its paths through it."));
+    }
+
+    final Path<QNm> rootPath = Path.parse(((Str) args[1]).stringValue(), PathParser.Type.JSON);
+    final List<Path<QNm>> fieldPaths = new ArrayList<>();
+    final List<String> fieldNames = new ArrayList<>();
+    forEachString(args[2], value -> {
+      fieldPaths.add(Path.parse(value, PathParser.Type.JSON));
+      fieldNames.add(lastStep(value));
+    });
+    if (fieldPaths.isEmpty()) {
+      throw new QueryException(new QNm("At least one projected field path is required."));
+    }
+    final List<Type> fieldTypes = new ArrayList<>(fieldPaths.size());
+    if (args.length == 4 && args[3] != null) {
+      forEachString(args[3], value -> fieldTypes.add(mapType(value)));
+      if (fieldTypes.size() != fieldPaths.size()) {
+        throw new QueryException(new QNm("Field/type count mismatch: " + fieldPaths.size()
+            + " fields vs " + fieldTypes.size() + " types."));
+      }
+    } else {
+      for (int i = 0; i < fieldPaths.size(); i++) {
+        fieldTypes.add(Type.STR);
+      }
+    }
+
+    final IndexDef def = IndexDefs.createProjectionIdxDef(rootPath, fieldPaths, fieldTypes,
+        INDEX_NUMBER, IndexDef.DbType.JSON);
+    final String resourceKey = session.getResourceConfig().getResource().toString();
+    final int revision = session.getMostRecentRevisionNumber();
+    final String[] names = fieldNames.toArray(new String[0]);
+
+    // Fast path: a persisted projection exists — hydrate it instead of
+    // rebuilding (the per-session bootstrap after re-opening a database).
+    // The shape must match: silently hydrating a projection with a
+    // different column count would mislabel columns and corrupt results.
+    try (JsonNodeReadOnlyTrx probeRtx = session.beginNodeReadOnlyTrx(revision)) {
+      final List<byte[]> persisted =
+          ProjectionIndexHOTStorage.readAll(probeRtx.getStorageEngineReader(), INDEX_NUMBER);
+      if (!persisted.isEmpty()) {
+        final List<byte[]> decoded = new ArrayList<>(persisted.size());
+        for (final byte[] payload : persisted) {
+          decoded.add(ProjectionIndexLeafCodec.decode(payload));
+        }
+        final byte[] first = decoded.get(0);
+        final int persistedColumns = first == null ? -1
+            : (first[4] & 0xFF) | ((first[5] & 0xFF) << 8) | ((first[6] & 0xFF) << 16) | ((first[7] & 0xFF) << 24);
+        if (persistedColumns != names.length) {
+          throw new QueryException(new QNm(
+              "A projection with " + persistedColumns + " columns is already persisted for this "
+                  + "resource; re-creating with " + names.length + " columns is not supported yet."));
+        }
+        ProjectionIndexRegistry.installWildcard(resourceKey, names, decoded);
+        return def.materialize();
+      }
+    }
+
+    // Build over the most recent revision, persist compactly, install.
+    final List<byte[]> leaves = new ArrayList<>();
+    final ProjectionIndexBuilder builder;
+    try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision);
+         PathSummaryReader pathSummary = session.openPathSummary(revision)) {
+      builder = new ProjectionIndexBuilder(def, pathSummary, leaves::add);
+      builder.build(rtx);
+    }
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final ProjectionIndexHOTStorage storage =
+          new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
+      for (int i = 0; i < leaves.size(); i++) {
+        storage.put(i, ProjectionIndexLeafCodec.encode(leaves.get(i)));
+      }
+      wtx.commit();
+    }
+    ProjectionIndexRegistry.installWildcard(resourceKey, names, leaves,
+        builder.numericColumnNonIntegralFlags());
+    return def.materialize();
+  }
+
+  private static void forEachString(final Sequence sequence, final Consumer<String> consumer) {
+    final Iter it = sequence.iterate();
+    Item next = it.next();
+    while (next != null) {
+      consumer.accept(((Str) next.atomize()).stringValue());
+      next = it.next();
+    }
+  }
+
+  /** Column name = the final object-key step of the field path. */
+  private static String lastStep(final String fieldPath) {
+    final int slash = fieldPath.lastIndexOf('/');
+    return slash < 0 ? fieldPath : fieldPath.substring(slash + 1);
+  }
+
+  private static Type mapType(final String type) {
+    return switch (type.toLowerCase()) {
+      case "long", "integer", "int", "decimal", "double", "float", "number" -> Type.LON;
+      case "boolean", "bool" -> Type.BOOL;
+      case "string", "str" -> Type.STR;
+      default -> throw new QueryException(new QNm(
+          "Unknown projection column type '" + type + "' — use long, boolean, or string."));
+    };
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateProjectionIndex.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateProjectionIndex.java
@@ -23,11 +23,19 @@ import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.index.projection.ProjectionIndexBuilder;
 import io.sirix.index.projection.ProjectionIndexHOTStorage;
 import io.sirix.index.projection.ProjectionIndexLeafCodec;
+import io.sirix.index.projection.ProjectionIndexLeafPage;
+import io.sirix.index.projection.ProjectionIndexMetadata;
 import io.sirix.index.projection.ProjectionIndexRegistry;
 import io.sirix.query.json.JsonDBItem;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongSet;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 
 /**
@@ -46,20 +54,36 @@ import java.util.function.Consumer;
  * top-level array, {@code /wrapper/records/[]} for a nested one);
  * {@code $fields} are the projected column paths relative to the document
  * root; {@code $types} declare the per-column primitive shape —
- * {@code "long"} (also accepts {@code integer}/{@code decimal}/{@code
- * double}), {@code "boolean"}, or {@code "string"}.
+ * {@code "long"} (also accepts {@code integer}/{@code int}),
+ * {@code "boolean"} ({@code bool}), or {@code "string"} ({@code str}).
+ * Floating-point column types are not supported yet: numeric columns store
+ * 64-bit longs and non-integral values are flagged unrepresentable, so
+ * declaring a {@code double} column would silently degrade — it is rejected
+ * instead.
  *
- * <p>The projection is built over the document's most recent revision,
- * persisted compactly (see {@code ProjectionIndexLeafCodec}) and installed
- * in the in-memory registry, where the analytical executor picks it up
- * automatically. Calling the function again on a resource whose projection
+ * <p>The projection is built over the revision of the passed document,
+ * written compactly (see {@code ProjectionIndexLeafCodec}) together with a
+ * self-describing {@link ProjectionIndexMetadata} payload into the session's
+ * write transaction — call {@code sdb:commit($doc)} afterwards to persist,
+ * exactly like the sibling {@code jn:create-path-index} family — and
+ * installed in the in-memory registry, where the analytical executor picks
+ * it up automatically. Calling the function again on a resource whose projection
  * is already persisted re-hydrates it instead of rebuilding — the intended
- * per-session bootstrap after re-opening a database.
+ * per-session bootstrap after re-opening a database. Hydration validates the
+ * requested shape (root path, field paths, column types) against the
+ * persisted metadata and fails loudly on a mismatch instead of silently
+ * mislabeling columns. Use the same path spellings across calls — the
+ * comparison is textual.
  *
  * <p><b>Experimental.</b> One projection per resource; the projection is a
  * static snapshot of the indexed revision (it is not yet maintained by
  * update transactions) and requires the resource to be created with a path
- * summary.
+ * summary. It is persisted only when the passed document is at the most
+ * recent revision — for older revisions the projection is still built and
+ * installed for this session, but not stored. The registry entry answers for
+ * any record-set path of the resource, so a resource with several distinct
+ * record sets sharing field names should not use a projection yet; creation
+ * rejects field names that resolve ambiguously under the record set.
  *
  * @author Johannes Lichtenberger
  */
@@ -71,6 +95,9 @@ public final class CreateProjectionIndex extends AbstractFunction {
 
   /** IndexDef id — one projection sub-tree per resource for now. */
   private static final int INDEX_NUMBER = 0;
+
+  /** HOT slot of the {@link ProjectionIndexMetadata} payload; leaves at 1..N. */
+  private static final int METADATA_SLOT = 0;
 
   public CreateProjectionIndex(final QNm name, final Signature signature) {
     super(name, signature, true);
@@ -89,12 +116,26 @@ public final class CreateProjectionIndex extends AbstractFunction {
               + "(buildPathSummary=true) — the projection builder resolves its paths through it."));
     }
 
-    final Path<QNm> rootPath = Path.parse(((Str) args[1]).stringValue(), PathParser.Type.JSON);
+    final String rootPathString = ((Str) args[1]).stringValue();
+    final Path<QNm> rootPath = Path.parse(rootPathString, PathParser.Type.JSON);
+    final List<String> fieldPathStrings = new ArrayList<>();
     final List<Path<QNm>> fieldPaths = new ArrayList<>();
     final List<String> fieldNames = new ArrayList<>();
+    final Set<String> seenNames = new HashSet<>();
     forEachString(args[2], value -> {
+      final String name = lastStep(value);
+      if (name.isEmpty() || "[]".equals(name)) {
+        throw new QueryException(new QNm(
+            "Projected field path '" + value + "' must end in an object-key step."));
+      }
+      if (!seenNames.add(name)) {
+        throw new QueryException(new QNm(
+            "Duplicate projected field name '" + name + "' — column lookup is by trailing "
+                + "field name, which must be unique."));
+      }
+      fieldPathStrings.add(value);
       fieldPaths.add(Path.parse(value, PathParser.Type.JSON));
-      fieldNames.add(lastStep(value));
+      fieldNames.add(name);
     });
     if (fieldPaths.isEmpty()) {
       throw new QueryException(new QNm("At least one projected field path is required."));
@@ -111,57 +152,157 @@ public final class CreateProjectionIndex extends AbstractFunction {
         fieldTypes.add(Type.STR);
       }
     }
+    final byte[] columnKinds = new byte[fieldTypes.size()];
+    for (int i = 0; i < fieldTypes.size(); i++) {
+      columnKinds[i] = columnKindOf(fieldTypes.get(i));
+    }
 
     final IndexDef def = IndexDefs.createProjectionIdxDef(rootPath, fieldPaths, fieldTypes,
         INDEX_NUMBER, IndexDef.DbType.JSON);
     final String resourceKey = session.getResourceConfig().getResource().toString();
-    final int revision = session.getMostRecentRevisionNumber();
     final String[] names = fieldNames.toArray(new String[0]);
+
+    // Already bootstrapped this session? The registry is the live source of
+    // truth for the executor — nothing to do when the same shape is in.
+    final ProjectionIndexRegistry.Handle installed = ProjectionIndexRegistry.lookup(resourceKey, null);
+    if (installed != null && Arrays.equals(installed.fieldNames(), names)) {
+      return def.materialize();
+    }
+
+    final int revision = document.getTrx().getRevisionNumber();
 
     // Fast path: a persisted projection exists — hydrate it instead of
     // rebuilding (the per-session bootstrap after re-opening a database).
-    // The shape must match: silently hydrating a projection with a
-    // different column count would mislabel columns and corrupt results.
+    // The persisted metadata (slot 0) is authoritative for the projection's
+    // shape; silently hydrating under a different field list would mislabel
+    // columns and corrupt query results, so a mismatch fails loudly.
     try (JsonNodeReadOnlyTrx probeRtx = session.beginNodeReadOnlyTrx(revision)) {
       final List<byte[]> persisted =
           ProjectionIndexHOTStorage.readAll(probeRtx.getStorageEngineReader(), INDEX_NUMBER);
       if (!persisted.isEmpty()) {
-        final List<byte[]> decoded = new ArrayList<>(persisted.size());
-        for (final byte[] payload : persisted) {
-          decoded.add(ProjectionIndexLeafCodec.decode(payload));
+        final ProjectionIndexMetadata metadata = ProjectionIndexMetadata.parse(persisted.get(0));
+        if (metadata != null) {
+          if (!metadata.matches(rootPathString, fieldPathStrings.toArray(new String[0]), columnKinds)) {
+            throw new QueryException(new QNm(
+                "A projection with a different shape is already persisted for this resource "
+                    + "(root " + metadata.rootPath() + ", fields "
+                    + Arrays.toString(metadata.fieldPaths())
+                    + "); re-creating with a different shape is not supported yet."));
+          }
+          final List<byte[]> decoded = new ArrayList<>(persisted.size() - 1);
+          for (int i = 1; i < persisted.size(); i++) {
+            decoded.add(ProjectionIndexLeafCodec.decode(persisted.get(i)));
+          }
+          ProjectionIndexRegistry.installWildcard(resourceKey, metadata.fieldNames(), decoded);
+          return def.materialize();
         }
-        final byte[] first = decoded.get(0);
-        final int persistedColumns = first == null ? -1
-            : (first[4] & 0xFF) | ((first[5] & 0xFF) << 8) | ((first[6] & 0xFF) << 16) | ((first[7] & 0xFF) << 24);
+        // Metadata-less store (persisted by the bench setups): the column
+        // count is the only shape evidence available — check it before
+        // decoding the full leaf list.
+        final byte[] first = ProjectionIndexLeafCodec.decode(persisted.get(0));
+        final int persistedColumns =
+            first == null || first.length < 8 ? -1 : ProjectionIndexLeafPage.columnCountOf(first);
         if (persistedColumns != names.length) {
           throw new QueryException(new QNm(
               "A projection with " + persistedColumns + " columns is already persisted for this "
                   + "resource; re-creating with " + names.length + " columns is not supported yet."));
+        }
+        final List<byte[]> decoded = new ArrayList<>(persisted.size());
+        decoded.add(first);
+        for (int i = 1; i < persisted.size(); i++) {
+          decoded.add(ProjectionIndexLeafCodec.decode(persisted.get(i)));
         }
         ProjectionIndexRegistry.installWildcard(resourceKey, names, decoded);
         return def.materialize();
       }
     }
 
-    // Build over the most recent revision, persist compactly, install.
+    // Build over the passed document's revision, persist compactly (most
+    // recent revision only), install.
     final List<byte[]> leaves = new ArrayList<>();
     final ProjectionIndexBuilder builder;
     try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(revision);
          PathSummaryReader pathSummary = session.openPathSummary(revision)) {
+      assertUnambiguousFieldNames(pathSummary, rootPath, fieldPaths, fieldNames);
       builder = new ProjectionIndexBuilder(def, pathSummary, leaves::add);
       builder.build(rtx);
     }
-    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-      final ProjectionIndexHOTStorage storage =
-          new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
-      for (int i = 0; i < leaves.size(); i++) {
-        storage.put(i, ProjectionIndexLeafCodec.encode(leaves.get(i)));
-      }
-      wtx.commit();
+    if (revision == session.getMostRecentRevisionNumber()) {
+      persist(session, rootPathString, fieldPathStrings, names, columnKinds, leaves);
     }
     ProjectionIndexRegistry.installWildcard(resourceKey, names, leaves,
         builder.numericColumnNonIntegralFlags());
     return def.materialize();
+  }
+
+  /**
+   * Write metadata (slot 0) + compact leaves (slots 1..N) into the session's
+   * write transaction — reused when one is open (beginning a second would
+   * throw), begun otherwise. Deliberately NOT committed here, matching the
+   * sibling index-creation functions ({@code jn:create-path-index} etc.):
+   * the caller's {@code sdb:commit($doc)} persists the writes. Committing a
+   * separate revision here would be undone by {@code sdb:commit}, which
+   * reverts to the passed document's revision before committing.
+   */
+  private static void persist(final JsonResourceSession session, final String rootPathString,
+      final List<String> fieldPathStrings, final String[] names, final byte[] columnKinds,
+      final List<byte[]> leaves) {
+    final Optional<JsonNodeTrx> existingWtx = session.getNodeTrx();
+    final JsonNodeTrx wtx = existingWtx.orElseGet(session::beginNodeTrx);
+    final ProjectionIndexHOTStorage storage =
+        new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER);
+    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(rootPathString,
+        fieldPathStrings.toArray(new String[0]), names, columnKinds);
+    storage.put(METADATA_SLOT, metadata.serialize());
+    for (int i = 0; i < leaves.size(); i++) {
+      storage.put(i + 1, ProjectionIndexLeafCodec.encode(leaves.get(i)));
+    }
+  }
+
+  /**
+   * Column lookup in the executor is by trailing field name. If a projected
+   * name also exists at a DIFFERENT path under the record set (e.g. both
+   * {@code /[]/age} and {@code /[]/address/age}), queries touching the other
+   * occurrence would silently read the projected column — reject the
+   * creation as ambiguous instead.
+   */
+  private static void assertUnambiguousFieldNames(final PathSummaryReader pathSummary,
+      final Path<QNm> rootPath, final List<Path<QNm>> fieldPaths, final List<String> fieldNames) {
+    final LongSet rootPcrs = pathSummary.getPCRsForPaths(Set.of(rootPath));
+    for (int i = 0; i < fieldPaths.size(); i++) {
+      final String name = fieldNames.get(i);
+      final LongSet ownPcrs = pathSummary.getPCRsForPaths(Set.of(fieldPaths.get(i)));
+      final Path<QNm> anyWithName = new Path<QNm>().descendantObjectField(new QNm(name));
+      final LongIterator byName = pathSummary.getPCRsForPaths(Set.of(anyWithName)).iterator();
+      while (byName.hasNext()) {
+        final long pcr = byName.nextLong();
+        if (!ownPcrs.contains(pcr) && isUnderAny(pathSummary, pcr, rootPcrs)) {
+          throw new QueryException(new QNm(
+              "Projected field name '" + name + "' is ambiguous: it also occurs at a different "
+                  + "path under the record set. Column lookup is by trailing field name, so the "
+                  + "projection cannot distinguish the two occurrences."));
+        }
+      }
+    }
+  }
+
+  /** Whether the path-summary node {@code pcr} has an ancestor in {@code rootPcrs}. */
+  private static boolean isUnderAny(final PathSummaryReader pathSummary, final long pcr,
+      final LongSet rootPcrs) {
+    final long saved = pathSummary.getNodeKey();
+    try {
+      if (!pathSummary.moveTo(pcr)) {
+        return false;
+      }
+      while (pathSummary.moveToParent()) {
+        if (rootPcrs.contains(pathSummary.getNodeKey())) {
+          return true;
+        }
+      }
+      return false;
+    } finally {
+      pathSummary.moveTo(saved);
+    }
   }
 
   private static void forEachString(final Sequence sequence, final Consumer<String> consumer) {
@@ -181,11 +322,23 @@ public final class CreateProjectionIndex extends AbstractFunction {
 
   private static Type mapType(final String type) {
     return switch (type.toLowerCase()) {
-      case "long", "integer", "int", "decimal", "double", "float", "number" -> Type.LON;
+      case "long", "integer", "int" -> Type.LON;
       case "boolean", "bool" -> Type.BOOL;
       case "string", "str" -> Type.STR;
       default -> throw new QueryException(new QNm(
-          "Unknown projection column type '" + type + "' — use long, boolean, or string."));
+          "Unsupported projection column type '" + type + "' — use long (integer/int), boolean "
+              + "(bool), or string (str). Floating-point columns are not supported: numeric "
+              + "columns store 64-bit longs and would silently degrade for non-integral values."));
     };
+  }
+
+  private static byte columnKindOf(final Type type) {
+    if (type == Type.LON) {
+      return ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG;
+    }
+    if (type == Type.BOOL) {
+      return ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN;
+    }
+    return ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT;
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -66,6 +66,7 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -893,6 +894,33 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     final Object2LongOpenHashMap<String> merged = new Object2LongOpenHashMap<>();
     merged.defaultReturnValue(0L);
     try {
+      // Dense composite path: canonical dicts for EVERY group column turn
+      // the per-row work into one mixed-radix array increment (no composite
+      // String, no hashing) — see conjunctiveCountByGroupMultiDense. Leaves
+      // with out-of-canon values fall back per leaf into a hashmap that is
+      // merged below.
+      if (MULTI_DENSE_GROUPBY_ENABLED) {
+        final byte[][][] canon = new byte[cols.length][][];
+        boolean denseEligible = true;
+        long cellCount = 1L;
+        for (int i = 0; i < cols.length; i++) {
+          canon[i] = handle.canonicalDict(cols[i], DENSE_GROUPBY_PROBE_LEAVES, DENSE_GROUPBY_CARD_LIMIT);
+          if (canon[i] == null) {
+            denseEligible = false;
+            break;
+          }
+          cellCount *= canon[i].length + 1L;
+          // Also bound by what an int-indexed long[] can hold — a user-raised
+          // maxCells above 2^31 must not truncate at the (int) cast below.
+          if (cellCount > MULTI_DENSE_MAX_CELLS || cellCount > Integer.MAX_VALUE - 8) {
+            denseEligible = false;
+            break;
+          }
+        }
+        if (denseEligible) {
+          return denseMultiGroupCounts(leafPayloads, preds, cols, canon, (int) cellCount, merged);
+        }
+      }
       if (leafCount < 64) {
         ProjectionIndexByteScan.conjunctiveCountByGroupMulti(leafPayloads, preds, cols, merged);
         return merged;
@@ -922,7 +950,93 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     } catch (final IllegalStateException ise) {
       // Column-kind drift across leaves or similar — typed kernel handles it.
       return null;
+    } catch (final RuntimeException re) {
+      // The parallel() driver rewraps worker exceptions in a plain
+      // RuntimeException — unwrap so kernel-level IllegalStateExceptions
+      // still route to the typed-kernel fallback at any leaf count.
+      for (Throwable cause = re.getCause(); cause != null; cause = cause.getCause()) {
+        if (cause instanceof IllegalStateException) {
+          return null;
+        }
+      }
+      throw re;
     }
+  }
+
+  /**
+   * Parallel driver + decode for the dense composite group-by kernel: one
+   * mixed-radix {@code long[cellCount]} accumulator per worker, summed on
+   * merge, then each non-zero cell is decoded ONCE into the executor's
+   * composite key encoding ({@code 's<len>:<utf8>'} per column, {@code 'm'}
+   * for missing — identical to the composite hashmap kernel). Per-leaf
+   * fallbacks (out-of-canon dict values) land in per-worker hashmaps merged
+   * the same way as the legacy path.
+   */
+  private Object2LongOpenHashMap<String> denseMultiGroupCounts(final List<byte[]> leafPayloads,
+      final ProjectionIndexScan.ColumnPredicate[] preds, final int[] cols, final byte[][][] canon,
+      final int cellCount, final Object2LongOpenHashMap<String> merged) {
+    final int leafCount = leafPayloads.size();
+    final long[] totals = new long[cellCount];
+    if (leafCount < 64) {
+      ProjectionIndexByteScan.conjunctiveCountByGroupMultiDense(leafPayloads, preds, cols, canon, totals, merged);
+    } else {
+      final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
+      final long[][] perThreadCounts = new long[eff][];
+      @SuppressWarnings("unchecked")
+      final Object2LongOpenHashMap<String>[] perThreadFallback = new Object2LongOpenHashMap[eff];
+      final int chunkSize = (leafCount + eff - 1) / eff;
+      parallel(eff, idx -> {
+        final int from = idx * chunkSize;
+        final int to = Math.min(from + chunkSize, leafCount);
+        if (from >= to) return;
+        final long[] localCounts = new long[cellCount];
+        final Object2LongOpenHashMap<String> localFallback = new Object2LongOpenHashMap<>();
+        localFallback.defaultReturnValue(0L);
+        ProjectionIndexByteScan.conjunctiveCountByGroupMultiDense(
+            leafPayloads.subList(from, to), preds, cols, canon, localCounts, localFallback);
+        perThreadCounts[idx] = localCounts;
+        perThreadFallback[idx] = localFallback;
+      });
+      for (final long[] c : perThreadCounts) {
+        if (c == null) continue;
+        for (int i = 0; i < cellCount; i++) {
+          totals[i] += c[i];
+        }
+      }
+      for (final var m : perThreadFallback) {
+        if (m == null) continue;
+        final ObjectIterator<Object2LongMap.Entry<String>> it = m.object2LongEntrySet().fastIterator();
+        while (it.hasNext()) {
+          final Object2LongMap.Entry<String> e = it.next();
+          merged.addTo(e.getKey(), e.getLongValue());
+        }
+      }
+    }
+    // Decode non-zero cells into composite keys — at most cellCount
+    // (canonical-cardinality product) String builds for the whole query.
+    final StringBuilder kb = new StringBuilder(32);
+    final int[] ids = new int[cols.length];
+    for (int cell = 0; cell < cellCount; cell++) {
+      final long count = totals[cell];
+      if (count == 0L) continue;
+      int rem = cell;
+      for (int g = cols.length - 1; g >= 0; g--) {
+        final int radix = canon[g].length + 1;
+        ids[g] = rem % radix;
+        rem /= radix;
+      }
+      kb.setLength(0);
+      for (int g = 0; g < cols.length; g++) {
+        if (ids[g] == canon[g].length) {
+          kb.append('m');
+          continue;
+        }
+        final String v = new String(canon[g][ids[g]], StandardCharsets.UTF_8);
+        kb.append('s').append(v.length()).append(':').append(v);
+      }
+      merged.addTo(kb.toString(), count);
+    }
+    return merged;
   }
 
   /**
@@ -2978,6 +3092,33 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    */
   private static final boolean DENSE_GROUPBY_ENABLED =
       Boolean.parseBoolean(System.getProperty("sirix.projection.denseGroupBy", "false"));
+
+  /**
+   * Dense COMPOSITE group-by gate. Unlike the single-key case (where the
+   * hashmap path's one intrinsified probe per row is competitive at tiny
+   * cardinality — see {@link #DENSE_GROUPBY_ENABLED}), the composite kernel
+   * replaces TWO hash probes plus lazy composite-String assembly per row
+   * with a single mixed-radix array increment, which wins outright; hence
+   * default ON. Disable via {@code -Dsirix.projection.denseMultiGroupBy=false}.
+   */
+  private static final boolean MULTI_DENSE_GROUPBY_ENABLED =
+      Boolean.parseBoolean(System.getProperty("sirix.projection.denseMultiGroupBy", "true"));
+
+  /**
+   * Upper bound on the dense composite accumulator ({@code prod(canonLen+1)}
+   * cells, one {@code long} each, per worker). 1M cells = 8 MB per worker —
+   * beyond that the hashmap path is the better trade.
+   */
+  private static final long MULTI_DENSE_MAX_CELLS =
+      Long.parseLong(System.getProperty("sirix.projection.denseMultiGroupBy.maxCells", String.valueOf(1L << 20)));
+
+  /**
+   * Cardinality bail-out for the dictionary-union count-distinct kernel
+   * ({@link ProjectionIndexByteScan#distinctPresentStrings}); beyond this the
+   * group-counting path (any cardinality) takes over.
+   */
+  private static final int COUNT_DISTINCT_DICT_CARD_LIMIT =
+      Integer.parseInt(System.getProperty("sirix.projection.countDistinct.cardLimit", "1024"));
 
   /**
    * Probe-leaf cap for canonical-dict cardinality estimation. Default 16
@@ -5127,6 +5268,16 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     // Sparse-evidence gate: without presence data, rows MISSING the field
     // would contribute the "" default as a phantom distinct value.
     if (!handle.columnSparseClean(groupColumn)) return null;
+    // Dictionary-union fast path: with the column sparse-clean, every
+    // non-empty dict entry was interned by a real present row, so the
+    // distinct set is the union of the per-leaf dictionaries — no per-row
+    // scan at all (only a "" entry needs per-row disambiguation, and only
+    // on leaves with missing rows). Valid because count-distinct has no
+    // predicate: every row counts.
+    final long dictDistinct = parallelDistinctPresentStrings(handle, groupColumn);
+    if (dictDistinct >= 0) {
+      return new Int64(dictDistinct);
+    }
     final ProjectionIndexScan.ColumnPredicate[] emptyPreds = new ProjectionIndexScan.ColumnPredicate[0];
     // Missing rows produce ZERO items under `return $d` ($d is the empty
     // sequence) — they are counted out, not a distinct value.
@@ -5142,6 +5293,62 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     }
     if (agg == null) return null;
     return new Int64(agg.size());
+  }
+
+  /**
+   * Parallel driver for {@link ProjectionIndexByteScan#distinctPresentStrings}:
+   * per-worker dictionary unions over leaf chunks, merged with a final
+   * byte-wise dedupe (both sides are canonical-cardinality small). Returns
+   * the exact distinct-present count, or {@code -1} when any chunk declines
+   * (kind mismatch / malformed leaf / cardinality beyond
+   * {@link #COUNT_DISTINCT_DICT_CARD_LIMIT}) — callers fall back.
+   */
+  private long parallelDistinctPresentStrings(final ProjectionIndexRegistry.Handle handle,
+      final int groupColumn) {
+    final List<byte[]> leafPayloads = handle.leafPayloads();
+    if (leafPayloads.isEmpty()) return 0L;
+    final int leafCount = leafPayloads.size();
+    if (leafCount < 64) {
+      final ArrayList<byte[]> set =
+          ProjectionIndexByteScan.distinctPresentStrings(leafPayloads, groupColumn, COUNT_DISTINCT_DICT_CARD_LIMIT);
+      return set == null ? -1L : set.size();
+    }
+    final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
+    @SuppressWarnings("unchecked")
+    final ArrayList<byte[]>[] perThread = new ArrayList[eff];
+    final boolean[] declined = new boolean[1];
+    final int chunkSize = (leafCount + eff - 1) / eff;
+    parallel(eff, idx -> {
+      final int from = idx * chunkSize;
+      final int to = Math.min(from + chunkSize, leafCount);
+      if (from >= to) return;
+      final ArrayList<byte[]> local = ProjectionIndexByteScan.distinctPresentStrings(
+          leafPayloads.subList(from, to), groupColumn, COUNT_DISTINCT_DICT_CARD_LIMIT);
+      if (local == null) {
+        declined[0] = true;
+      } else {
+        perThread[idx] = local;
+      }
+    });
+    if (declined[0]) return -1L;
+    final ArrayList<byte[]> merged = new ArrayList<>(16);
+    for (final ArrayList<byte[]> local : perThread) {
+      if (local == null) continue;
+      for (final byte[] value : local) {
+        boolean present = false;
+        for (int c = 0; c < merged.size(); c++) {
+          if (Arrays.equals(merged.get(c), value)) {
+            present = true;
+            break;
+          }
+        }
+        if (!present) {
+          if (merged.size() >= COUNT_DISTINCT_DICT_CARD_LIMIT) return -1L;
+          merged.add(value);
+        }
+      }
+    }
+    return merged.size();
   }
 
   /**

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -948,17 +948,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       return merged;
     } catch (final IllegalStateException ise) {
       // Column-kind drift across leaves or similar — typed kernel handles it.
+      // parallel() rethrows worker-side IllegalStateExceptions unwrapped, so
+      // this single catch covers both the serial and parallel branches.
       return null;
-    } catch (final RuntimeException re) {
-      // The parallel() driver rewraps worker exceptions in a plain
-      // RuntimeException — unwrap so kernel-level IllegalStateExceptions
-      // still route to the typed-kernel fallback at any leaf count.
-      for (Throwable cause = re.getCause(); cause != null; cause = cause.getCause()) {
-        if (cause instanceof IllegalStateException) {
-          return null;
-        }
-      }
-      throw re;
     }
   }
 
@@ -7535,6 +7527,15 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
       while (cause.getCause() != null && cause.getCause() != cause) {
         cause = cause.getCause();
+      }
+      // Kernel-level IllegalStateExceptions are a FALLBACK signal (column-kind
+      // drift, canonical-dict miss, ...): every tryProjection* caller catches
+      // them to route to the typed kernels / interpreter. Rethrow them
+      // unwrapped so the fallback contract holds at ANY leaf count — wrapping
+      // them here made the same query succeed under 64 leaves and hard-fail
+      // above (worker exceptions only occur on the parallel path).
+      if (cause instanceof IllegalStateException ise) {
+        throw ise;
       }
       final String msg = cause.getClass().getSimpleName() + ": " + cause.getMessage();
       throw new RuntimeException("Parallel scan failed — " + msg, e);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -33,7 +33,6 @@ import io.sirix.index.projection.ProjectionIndexByteScan;
 import io.sirix.index.projection.ProjectionIndexLeafPage;
 import io.sirix.index.projection.ProjectionIndexRegistry;
 import io.sirix.index.projection.ProjectionIndexScan;
-import io.sirix.index.path.summary.HyperLogLogSketch;
 import io.sirix.index.path.summary.PathNode;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.node.NodeKind;

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
@@ -1,5 +1,10 @@
 package io.sirix.query;
 
+import io.brackit.query.QueryException;
+import io.sirix.index.projection.ProjectionIndexRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -29,6 +34,19 @@ public final class ProjectionIndexFunctionTest extends AbstractJsonTest {
             ('long', 'boolean', 'string'))
         return {"revision": sdb:commit($doc)}
       """;
+
+  // The registry is a JVM-wide static — the on-disk stores are wiped between
+  // tests, so a surviving entry would serve stale leaves for a fresh
+  // same-named resource.
+  @BeforeEach
+  public void clearProjectionRegistryBefore() {
+    ProjectionIndexRegistry.clear();
+  }
+
+  @AfterEach
+  public void clearProjectionRegistryAfter() {
+    ProjectionIndexRegistry.clear();
+  }
 
   @Test
   public void createProjectionIndexAndAggregate() throws IOException {
@@ -64,7 +82,7 @@ public final class ProjectionIndexFunctionTest extends AbstractJsonTest {
 
   @Test
   public void createProjectionIndexIsIdempotent() throws IOException {
-    // Second call hydrates the persisted projection instead of rebuilding.
+    // Second call short-circuits on the already-installed registry entry.
     final String query = """
           let $doc := jn:doc('json-path1','sales.jn')
           let $stats := jn:create-projection-index($doc, '/[]',
@@ -73,5 +91,92 @@ public final class ProjectionIndexFunctionTest extends AbstractJsonTest {
           return count($doc[])
         """;
     test(STORE_QUERY, CREATE_INDEX_QUERY, query, "5");
+  }
+
+  @Test
+  public void hydratesFromPersistedMetadataAfterRegistryClear() throws IOException {
+    // Simulates a fresh process: the in-memory registry is empty but the
+    // projection (metadata at slot 0 + compact leaves) is persisted —
+    // re-creating with the same shape must hydrate, not rebuild, and the
+    // hydrated projection must serve correct results.
+    query(STORE_QUERY);
+    query(CREATE_INDEX_QUERY);
+    ProjectionIndexRegistry.clear();
+    final String hydrateAndAggregate = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/age', '/[]/active', '/[]/dept'),
+              ('long', 'boolean', 'string'))
+          return sum(for $r in $doc[] return $r.age)
+        """;
+    test(hydrateAndAggregate, "211");
+  }
+
+  @Test
+  public void rehydratingWithDifferentShapeFails() throws IOException {
+    // A persisted projection carries its shape in the metadata payload —
+    // re-creating under a different field list must fail loudly instead of
+    // silently mislabeling the persisted columns.
+    query(STORE_QUERY);
+    query(CREATE_INDEX_QUERY);
+    ProjectionIndexRegistry.clear();
+    final String mismatched = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          return jn:create-projection-index($doc, '/[]',
+              ('/[]/age', '/[]/dept'),
+              ('long', 'string'))
+        """;
+    final QueryException e = Assertions.assertThrows(QueryException.class, () -> query(mismatched));
+    Assertions.assertTrue(e.getMessage().contains("different shape"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  public void duplicateFieldNamesAreRejected() {
+    query(STORE_QUERY);
+    final String duplicate = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          return jn:create-projection-index($doc, '/[]',
+              ('/[]/age', '/[]/nested/age'),
+              ('long', 'long'))
+        """;
+    final QueryException e = Assertions.assertThrows(QueryException.class, () -> query(duplicate));
+    Assertions.assertTrue(e.getMessage().contains("Duplicate projected field name"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  public void floatingPointColumnTypesAreRejected() {
+    query(STORE_QUERY);
+    final String floating = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          return jn:create-projection-index($doc, '/[]',
+              ('/[]/age'), ('double'))
+        """;
+    final QueryException e = Assertions.assertThrows(QueryException.class, () -> query(floating));
+    Assertions.assertTrue(e.getMessage().contains("Unsupported projection column type"),
+        () -> "unexpected message: " + e.getMessage());
+  }
+
+  @Test
+  public void ambiguousFieldNameUnderRecordSetIsRejected() {
+    // "age" exists both at /[]/age and /[]/addr/age — the executor resolves
+    // columns by trailing field name, so the projection cannot distinguish
+    // the two occurrences and creation must refuse.
+    final String storeAmbiguous = """
+          jn:store('json-path1','amb.jn','[
+            {"age": 30, "addr": {"age": 99}},
+            {"age": 45, "addr": {"age": 12}}
+          ]')
+        """;
+    query(storeAmbiguous);
+    final String create = """
+          let $doc := jn:doc('json-path1','amb.jn')
+          return jn:create-projection-index($doc, '/[]',
+              ('/[]/age'), ('long'))
+        """;
+    final QueryException e = Assertions.assertThrows(QueryException.class, () -> query(create));
+    Assertions.assertTrue(e.getMessage().contains("ambiguous"),
+        () -> "unexpected message: " + e.getMessage());
   }
 }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
@@ -1,0 +1,77 @@
+package io.sirix.query;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * End-to-end coverage of {@code jn:create-projection-index}: create a
+ * columnar projection over stored records via JSONiq and run the analytical
+ * query shapes it serves. Results must be identical with and without the
+ * projection installed — the function's job is acceleration, not semantics.
+ */
+public final class ProjectionIndexFunctionTest extends AbstractJsonTest {
+
+  private static final String STORE_QUERY = """
+        jn:store('json-path1','sales.jn','[
+          {"age": 30, "active": true,  "dept": "Eng"},
+          {"age": 45, "active": false, "dept": "Sales"},
+          {"age": 52, "active": true,  "dept": "Eng"},
+          {"age": 23, "active": true,  "dept": "HR"},
+          {"age": 61, "active": false, "dept": "Eng"}
+        ]')
+      """;
+
+  private static final String CREATE_INDEX_QUERY = """
+        let $doc := jn:doc('json-path1','sales.jn')
+        let $stats := jn:create-projection-index($doc, '/[]',
+            ('/[]/age', '/[]/active', '/[]/dept'),
+            ('long', 'boolean', 'string'))
+        return {"revision": sdb:commit($doc)}
+      """;
+
+  @Test
+  public void createProjectionIndexAndAggregate() throws IOException {
+    final String query = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          return sum(for $r in $doc[] return $r.age)
+        """;
+    test(STORE_QUERY, CREATE_INDEX_QUERY, query, "211");
+  }
+
+  @Test
+  public void createProjectionIndexAndFilterCount() throws IOException {
+    final String query = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          return count(for $r in $doc[] where $r.age > 40 and $r.active return $r)
+        """;
+    test(STORE_QUERY, CREATE_INDEX_QUERY, query, "1");
+  }
+
+  @Test
+  public void createProjectionIndexAndGroupBy() throws IOException {
+    final String query = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          for $r in $doc[]
+          let $d := $r.dept
+          group by $d
+          order by $d
+          return {"dept": $d, "count": count($r)}
+        """;
+    test(STORE_QUERY, CREATE_INDEX_QUERY, query,
+        "{\"dept\":\"Eng\",\"count\":3} {\"dept\":\"HR\",\"count\":1} {\"dept\":\"Sales\",\"count\":1}");
+  }
+
+  @Test
+  public void createProjectionIndexIsIdempotent() throws IOException {
+    // Second call hydrates the persisted projection instead of rebuilding.
+    final String query = """
+          let $doc := jn:doc('json-path1','sales.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/age', '/[]/active', '/[]/dept'),
+              ('long', 'boolean', 'string'))
+          return count($doc[])
+        """;
+    test(STORE_QUERY, CREATE_INDEX_QUERY, query, "5");
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Makes the projection-index analytical layer production-shaped along four axes, driven by a Brackit-vs-Sirix-vs-DuckDB-vs-ClickHouse benchmark campaign at 1M/10M/100M records:

**Aggregate correctness across close/re-open.** NUMERIC_LONG integrality provenance ("did this column ever see a truncated non-integral value?") previously lived only in builder memory, so any re-opened database silently lost the sum/avg/min/max fast path (every aggregate fell back to a full storage scan — ~3.9 s instead of ~3 ms at 1M records). The flags now persist in each leaf's presence-tail flags byte (bit1), and the registry handle lazily re-derives them from the persisted bytes. The leaf wire format is consolidated to a single mandatory presence tail (`PIX1` magic); tail-less payloads are rejected as corrupt.

**Analytical kernels.** Two shapes that trailed DuckDB got dedicated kernels: `conjunctiveCountByGroupMultiDense` (composite group-by as canonical-id mixed-radix array counts — one array increment per row, no hashing, per-leaf hashmap fallback for out-of-canon values) and `distinctPresentStrings` (count-distinct as the union of per-leaf dictionaries with presence-aware empty-string disambiguation). At 10M/4 threads: `groupBy2Keys` 133 ms → 34 ms, `countDistinct` 29 ms → 4 ms — both now ahead of DuckDB (42.6 / 6.3 ms) and ClickHouse (103.6 / 70.3 ms) on the same box.

**Compact storage codec.** `ProjectionIndexLeafCodec` persists leaves in a bit-packed form (delta/FOR record keys, frame-of-reference numerics, packed dict-ids, marker-byte presence) and decodes back **byte-identically** to the flat scan layout on hydrate — scan kernels untouched. Persisted projections shrink to **5.6%** (100M: 4.11 GB → 230 MB), dropping the index tax over the versioned document store from ~130% to ~7%. 100M disk-cold reopen hydrates 97,657 leaves in ~8 s.

**Path features + JSONiq surface.** Multi-PCR roots and field paths (descendant patterns like `//records/[]` spanning sibling subtrees build one projection; self-nested root PCRs fail fast with a clear error instead of silently mis-indexing), plus a `jn:create-projection-index` function (create / persist / idempotent hydrate) documented in the README with JSONiq examples.

Also included: an 8-angle code review of the whole change was run and its confirmed findings fixed (bit-packing corruption at 59–63-bit widths — empirically reproduced and now covered by width sweep tests; dense cell-count int-overflow gate; `IllegalStateException` unwrapping through the parallel driver so kernel fallbacks engage at any leaf count; null-leaf guard in the codec; fail-closed integrality probe on truncated payloads). New benchmark harnesses: pure-Brackit in-memory baseline (`runBrackitScale`, optional JSON-file mode for disk-cold runs) and a ClickHouse harness (`bench/ch_bench.py`) next to the existing DuckDB one.

## Related issue

No issue — grew out of a benchmarking request (Brackit aggregate performance vs Sirix with/without projection indexes); each bottleneck the benchmarks exposed was fixed in turn. Complements the projection-index interim state tracked as task #57 (IndexController wiring remains follow-up work).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [x] Performance improvement
- [ ] Documentation only

Breaking: projection leaves persisted by earlier dev builds (previous tail magic) are not readable — deliberate, per "no deployed databases" decision; rebuild via `-Dsirix.projection.forceRebuild=true`.

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — full projection suites in sirix-core and sirix-query, scan suites, `JsonIntegrationTest`, plus the new codec/kernel/nested-path/function tests
- [x] Added or updated tests covering the change (5 new test classes: codec round-trip incl. adversarial width sweeps, dense-composite parity, integrality persistence, nested/multi-PCR paths, JSONiq function e2e)
- [x] For behavioral changes to the storage engine: projection leaves remain opaque HOT values (slot-level CoW versioning unchanged); codec decode is byte-identity-verified so hydrated state equals written state
- [x] Updated documentation (README: "Projection indexes" section with JSONiq examples)
- [x] No unrelated formatting churn

## Notes for reviewers

- The flat scan layout is now explicitly the *in-memory* form; the codec owns the persisted form. `ProjectionIndexLeafPage`'s javadoc documents both.
- Bit-packed runs clamp at 56 bits (wider ranges take the aligned raw-64 path) — this is the fix for the byte-at-a-time reader's shift overflow; the width sweep test pins it.
- Known follow-ups, deliberately out of scope: IndexController/IndexListener wiring + `indexes.xml` cataloging (task #57), consolidating the codec's bit-packer with `NumberRegionCompact` and the three `getIntLE` copies, hoisting per-row loads in the dense composite hot loop, and update-transaction maintenance of projections.

---
_Generated by [Claude Code](https://claude.ai/code/session_01He5pE8hqw5HmaAUPZSDtZk)_