### PR TITLE
Create resources with valid-time support and auto-created interval index via JSONiq

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/ValidTimeConfig.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ValidTimeConfig.java
@@ -127,6 +127,28 @@ public final class ValidTimeConfig {
   }
 
   /**
+   * Converts a (possibly dotted) valid-time path to slash-separated path-step form suitable for
+   * {@link io.brackit.query.util.path.Path#parse(String)}: the "$." prefix is stripped and dots
+   * become path separators (e.g. {@code "$.meta.validFrom"} → {@code "meta/validFrom"}).
+   *
+   * @param path the configured path
+   * @return the slash-separated path steps
+   */
+  public static String toSlashSeparatedPath(String path) {
+    final String normalized = normalizePath(path);
+    final StringBuilder steps = new StringBuilder(normalized.length());
+    for (final String segment : normalized.split("\\.")) {
+      if (!segment.isEmpty()) {
+        if (!steps.isEmpty()) {
+          steps.append('/');
+        }
+        steps.append(segment);
+      }
+    }
+    return steps.toString();
+  }
+
+  /**
    * Gets the normalized validFrom path (without "$." prefix).
    *
    * @return the normalized validFrom path

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ValidTimeConfig.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ValidTimeConfig.java
@@ -135,6 +135,7 @@ public final class ValidTimeConfig {
    * @return the slash-separated path steps
    */
   public static String toSlashSeparatedPath(String path) {
+    requireNonNull(path, "path must not be null");
     final String normalized = normalizePath(path);
     final StringBuilder steps = new StringBuilder(normalized.length());
     for (final String segment : normalized.split("\\.")) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -27,7 +27,10 @@ import com.google.gson.stream.JsonToken;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
 import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.ValidTimeConfig;
 import io.sirix.access.trx.node.AbstractNodeHashing;
 import io.sirix.access.trx.node.AbstractNodeReadOnlyTrx;
 import io.sirix.access.trx.node.AbstractNodeTrxImpl;
@@ -60,6 +63,7 @@ import io.sirix.exception.SirixException;
 import io.sirix.exception.SirixIOException;
 import io.sirix.exception.SirixUsageException;
 import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
 import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathSummaryWriter;
 import io.sirix.index.path.summary.PathSummaryWriter.OPType;
@@ -318,31 +322,24 @@ final class JsonNodeTrxImpl extends
    * @param validTimeConfig the valid time configuration
    * @return set of index definitions for validFrom and validTo paths
    */
-  private Set<IndexDef> createValidTimeIndexDefs(io.sirix.access.ValidTimeConfig validTimeConfig) {
-    final Set<IndexDef> indexDefs = new HashSet<>();
-
-    // Use xs:dateTime type for the CAS indexes since valid time values are typically timestamps
-    final var dateTimeType = io.brackit.query.jdm.Type.DATI;
-
-    // Dotted (nested) configured paths such as "$.meta.validFrom" are converted to slash-separated
-    // path steps — a raw Path.parse on the dotted form throws and would abort resource creation.
-
-    // Create index for validFrom path
-    final var validFromPath =
-        io.sirix.access.ValidTimeConfig.toSlashSeparatedPath(validTimeConfig.getNormalizedValidFromPath());
-    final var validFromPaths =
-        Set.of(io.brackit.query.util.path.Path.parse(validFromPath, io.brackit.query.util.path.PathParser.Type.JSON));
-    indexDefs.add(
-        io.sirix.index.IndexDefs.createCASIdxDef(false, dateTimeType, validFromPaths, 0, IndexDef.DbType.JSON));
-
-    // Create index for validTo path
-    final var validToPath =
-        io.sirix.access.ValidTimeConfig.toSlashSeparatedPath(validTimeConfig.getNormalizedValidToPath());
-    final var validToPaths =
-        Set.of(io.brackit.query.util.path.Path.parse(validToPath, io.brackit.query.util.path.PathParser.Type.JSON));
-    indexDefs.add(io.sirix.index.IndexDefs.createCASIdxDef(false, dateTimeType, validToPaths, 1, IndexDef.DbType.JSON));
-
+  private Set<IndexDef> createValidTimeIndexDefs(ValidTimeConfig validTimeConfig) {
+    final Set<IndexDef> indexDefs = new HashSet<>(4);
+    indexDefs.add(createValidTimeCasIdxDef(validTimeConfig.getNormalizedValidFromPath(), 0));
+    indexDefs.add(createValidTimeCasIdxDef(validTimeConfig.getNormalizedValidToPath(), 1));
     return indexDefs;
+  }
+
+  /**
+   * Creates a CAS index definition over one valid-time field, using xs:dateTime since valid time
+   * values are timestamps. Dotted (nested) configured paths such as "$.meta.validFrom" are
+   * converted to slash-separated path steps — a raw Path.parse on the dotted form throws and would
+   * abort resource creation. (Brackit's Path is fully qualified because java.nio.file.Path is
+   * already imported.)
+   */
+  private static IndexDef createValidTimeCasIdxDef(final String configuredFieldPath, final int indexDefNo) {
+    final var path = io.brackit.query.util.path.Path.parse(
+        ValidTimeConfig.toSlashSeparatedPath(configuredFieldPath), PathParser.Type.JSON);
+    return IndexDefs.createCASIdxDef(false, Type.DATI, Set.of(path), indexDefNo, IndexDef.DbType.JSON);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -324,15 +324,20 @@ final class JsonNodeTrxImpl extends
     // Use xs:dateTime type for the CAS indexes since valid time values are typically timestamps
     final var dateTimeType = io.brackit.query.jdm.Type.DATI;
 
+    // Dotted (nested) configured paths such as "$.meta.validFrom" are converted to slash-separated
+    // path steps — a raw Path.parse on the dotted form throws and would abort resource creation.
+
     // Create index for validFrom path
-    final var validFromPath = validTimeConfig.getNormalizedValidFromPath();
+    final var validFromPath =
+        io.sirix.access.ValidTimeConfig.toSlashSeparatedPath(validTimeConfig.getNormalizedValidFromPath());
     final var validFromPaths =
         Set.of(io.brackit.query.util.path.Path.parse(validFromPath, io.brackit.query.util.path.PathParser.Type.JSON));
     indexDefs.add(
         io.sirix.index.IndexDefs.createCASIdxDef(false, dateTimeType, validFromPaths, 0, IndexDef.DbType.JSON));
 
     // Create index for validTo path
-    final var validToPath = validTimeConfig.getNormalizedValidToPath();
+    final var validToPath =
+        io.sirix.access.ValidTimeConfig.toSlashSeparatedPath(validTimeConfig.getNormalizedValidToPath());
     final var validToPaths =
         Set.of(io.brackit.query.util.path.Path.parse(validToPath, io.brackit.query.util.path.PathParser.Type.JSON));
     indexDefs.add(io.sirix.index.IndexDefs.createCASIdxDef(false, dateTimeType, validToPaths, 1, IndexDef.DbType.JSON));

--- a/bundles/sirix-mcp/src/main/java/io/sirix/mcp/GuardedJsonDBStore.java
+++ b/bundles/sirix-mcp/src/main/java/io/sirix/mcp/GuardedJsonDBStore.java
@@ -144,6 +144,13 @@ public final class GuardedJsonDBStore implements JsonDBStore {
     return delegate.createFromJsonStrings(collName, jsons);
   }
 
+  @Override
+  public JsonDBCollection createFromJsonStrings(String collName, Stream<Str> jsons, Object options) {
+    accessControl.checkWriteAccess();
+    accessControl.checkDatabaseAccess(collName);
+    return delegate.createFromJsonStrings(collName, jsons, options);
+  }
+
   // --- Drop: check write + database access ---
 
   @Override

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateValidTimeIndex.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateValidTimeIndex.java
@@ -83,6 +83,18 @@ public final class CreateValidTimeIndex extends AbstractFunction {
           + "Configure valid time paths when creating the resource."));
     }
 
+    // Idempotent: the interval index always indexes the resource's two configured valid-time
+    // fields (regardless of $paths), so a second definition would be a full duplicate — a second
+    // builder pass plus a second listener maintaining a redundant HOT tree on every write. This
+    // matters since resources created with valid-time options via jn:store/jn:load already carry
+    // an auto-created interval index. Checked on the READ-side controller BEFORE acquiring a write
+    // transaction, so the common already-indexed case neither begins a wtx that would be left open
+    // nor reverts an existing wtx as a side effect.
+    final IndexDef alreadyExisting = findValidTimeIndexDef(resourceSession.getRtxIndexController(rtx.getRevisionNumber()));
+    if (alreadyExisting != null) {
+      return alreadyExisting.materialize();
+    }
+
     final var optionalWriteTrx = resourceSession.getNodeTrx();
     final JsonNodeTrx wtx = optionalWriteTrx.orElseGet(resourceSession::beginNodeTrx);
 
@@ -95,15 +107,11 @@ public final class CreateValidTimeIndex extends AbstractFunction {
       throw new QueryException(new QNm("Document not found."));
     }
 
-    // Idempotent: the interval index always indexes the resource's two configured valid-time
-    // fields (regardless of $paths), so a second definition would be a full duplicate — a second
-    // builder pass plus a second listener maintaining a redundant HOT tree on every write. This
-    // matters since resources created with valid-time options via jn:store/jn:load already carry
-    // an auto-created interval index.
-    for (final IndexDef existingIndexDef : controller.getIndexes().getIndexDefs()) {
-      if (existingIndexDef.getType() == IndexType.VALIDTIME) {
-        return existingIndexDef.materialize();
-      }
+    // Re-check on the write-side controller: an index may have been created earlier within this
+    // still-open write transaction (not yet visible to the read-side controller).
+    final IndexDef existingInWtx = findValidTimeIndexDef(controller);
+    if (existingInWtx != null) {
+      return existingInWtx.materialize();
     }
 
     final Set<Path<QNm>> paths = new LinkedHashSet<>();
@@ -139,5 +147,23 @@ public final class CreateValidTimeIndex extends AbstractFunction {
     }
 
     return validTimeIdxDef.materialize();
+  }
+
+  /**
+   * Find an existing valid-time interval index definition in the given controller's catalogue.
+   *
+   * @param controller the index controller, may be {@code null}
+   * @return the VALIDTIME index definition, or {@code null} if none exists
+   */
+  private static IndexDef findValidTimeIndexDef(final JsonIndexController controller) {
+    if (controller == null) {
+      return null;
+    }
+    for (final IndexDef indexDef : controller.getIndexes().getIndexDefs()) {
+      if (indexDef.getType() == IndexType.VALIDTIME) {
+        return indexDef;
+      }
+    }
+    return null;
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateValidTimeIndex.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/create/CreateValidTimeIndex.java
@@ -12,6 +12,7 @@ import io.brackit.query.jdm.Sequence;
 import io.brackit.query.jdm.Signature;
 import io.brackit.query.module.StaticContext;
 import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
 import io.sirix.access.ValidTimeConfig;
 import io.sirix.access.trx.node.json.JsonIndexController;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
@@ -19,11 +20,9 @@ import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.exception.SirixIOException;
 import io.sirix.index.IndexDef;
-import io.sirix.index.IndexDefs;
 import io.sirix.index.IndexType;
-import io.sirix.query.compiler.optimizer.PlanCache;
-import io.sirix.query.compiler.optimizer.stats.StatisticsCatalog;
 import io.sirix.query.json.JsonDBItem;
+import io.sirix.query.json.ValidTimeIndexes;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -96,12 +95,23 @@ public final class CreateValidTimeIndex extends AbstractFunction {
       throw new QueryException(new QNm("Document not found."));
     }
 
+    // Idempotent: the interval index always indexes the resource's two configured valid-time
+    // fields (regardless of $paths), so a second definition would be a full duplicate — a second
+    // builder pass plus a second listener maintaining a redundant HOT tree on every write. This
+    // matters since resources created with valid-time options via jn:store/jn:load already carry
+    // an auto-created interval index.
+    for (final IndexDef existingIndexDef : controller.getIndexes().getIndexDefs()) {
+      if (existingIndexDef.getType() == IndexType.VALIDTIME) {
+        return existingIndexDef.materialize();
+      }
+    }
+
     final Set<Path<QNm>> paths = new LinkedHashSet<>();
     if (args.length == 2 && args[1] != null) {
       final Iter it = args[1].iterate();
       Item next = it.next();
       while (next != null) {
-        paths.add(Path.parse(((Str) next).stringValue(), io.brackit.query.util.path.PathParser.Type.JSON));
+        paths.add(Path.parse(((Str) next).stringValue(), PathParser.Type.JSON));
         next = it.next();
       }
     }
@@ -110,30 +120,22 @@ public final class CreateValidTimeIndex extends AbstractFunction {
     // valid-time fields by NAME from the resource's ValidTimeConfig, so the exact path is not
     // load-bearing for correctness.
     if (paths.isEmpty()) {
-      paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidFromPath(),
-          io.brackit.query.util.path.PathParser.Type.JSON));
-      paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidToPath(),
-          io.brackit.query.util.path.PathParser.Type.JSON));
+      paths.addAll(ValidTimeIndexes.defaultPaths(validTimeConfig));
     }
 
-    final IndexDef validTimeIdxDef = IndexDefs.createValidTimeIdxDef(paths,
-        controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME), IndexDef.DbType.JSON);
+    String databaseName = null;
     try {
-      controller.createIndexes(Set.of(validTimeIdxDef), wtx);
+      databaseName = document.getCollection().getDatabase().getName();
+    } catch (final Exception e) {
+      // Statistics invalidation is best-effort; a missing database name must not prevent creation.
+    }
+
+    final IndexDef validTimeIdxDef;
+    try {
+      validTimeIdxDef = ValidTimeIndexes.createIntervalIndex(controller, wtx, paths, databaseName,
+          resourceSession.getResourceConfig().getName());
     } catch (final SirixIOException e) {
       throw new QueryException(new QNm("I/O exception: " + e.getMessage()), e);
-    }
-
-    // Invalidate cached query plans so the optimizer considers this new index.
-    PlanCache.signalIndexSchemaChange();
-
-    // Invalidate stale histogram statistics for this resource since the index schema changed.
-    try {
-      final String dbName = document.getCollection().getDatabase().getName();
-      final String resName = resourceSession.getResourceConfig().getName();
-      StatisticsCatalog.getInstance().invalidate(dbName, resName);
-    } catch (final Exception e) {
-      // Histogram invalidation is best-effort; must not prevent index creation.
     }
 
     return validTimeIdxDef.materialize();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/io/Store.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/io/Store.java
@@ -170,7 +170,7 @@ public final class Store extends AbstractFunction {
           list.add((Str) item);
         }
 
-        store.createFromJsonStrings(collectionName, new ArrayStream<>(list.toArray(new Str[0])));
+        store.createFromJsonStrings(collectionName, new ArrayStream<>(list.toArray(new Str[0])), options);
       }
     }
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/io/Store.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/io/Store.java
@@ -157,7 +157,7 @@ public final class Store extends AbstractFunction {
         store.create(collectionName, resourceName, (String) null, options);
       } else {
         try (final JsonReader reader = JsonShredder.createStringReader(((Str) nodes).stringValue())) {
-          store.create(collectionName, resourceName, reader);
+          store.create(collectionName, resourceName, reader, options);
         } catch (final Exception e) {
           throw new QueryException(new QNm("Failed to insert subtree: " + e.getMessage()));
         }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -395,7 +395,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
   @Override
   public Options options() {
     return new Options(null, null, false, buildPathSummary, buildPathStatistics, storageType, useDeweyIDs, hashType,
-        versioningType, numberOfNodesBeforeAutoCommit);
+        versioningType, numberOfNodesBeforeAutoCommit, null, true);
   }
 
   @Override
@@ -476,6 +476,9 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   @Override
   public JsonDBCollection create(String collName, String optResName, String json, Object options) {
+    if (json == null) {
+      return createCollection(collName, optResName, null, options);
+    }
     return createCollection(collName, optResName, JsonShredder.createStringReader(json), options);
   }
 
@@ -536,6 +539,15 @@ public final class BasicJsonDBStore implements JsonDBStore {
       collections.put(database, collection);
 
       if (reader == null) {
+        // Even without initial data, persist the valid-time interval index definition so the
+        // change listener maintains the index for all subsequent insertions.
+        if (resourceOptions.autoCreateValidTimeIndex() && resourceOptions.validTimeConfig() != null) {
+          try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
+              final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
+            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+            wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
+          }
+        }
         return collection;
       }
 
@@ -548,6 +560,9 @@ public final class BasicJsonDBStore implements JsonDBStore {
       try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
           final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+        if (resourceOptions.autoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       }
       return collection;
@@ -557,8 +572,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
   }
 
   private Options createResource(Object options, Database<JsonResourceSession> database, String resourceName) {
-    final var resourceOptions = OptionsFactory.createOptions(options, new Options(null, null, false, buildPathSummary,
-        buildPathStatistics, storageType, useDeweyIDs, hashType, versioningType, numberOfNodesBeforeAutoCommit));
+    final var resourceOptions = OptionsFactory.createOptions(options, options());
 
     database.createResource(buildResourceConfiguration(resourceOptions, resourceName));
     return resourceOptions;
@@ -566,17 +580,21 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   /** Build (but do not create) the {@link ResourceConfiguration} for {@code resourceName} from resolved {@code options}. */
   private ResourceConfiguration buildResourceConfiguration(Options resourceOptions, String resourceName) {
-    return ResourceConfiguration.newBuilder(resourceName)
-                                .useTextCompression(resourceOptions.useTextCompression())
-                                .buildPathSummary(resourceOptions.buildPathSummary())
-                                .buildPathStatistics(resourceOptions.buildPathStatistics())
-                                .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                                .storageType(resourceOptions.storageType())
-                                .useDeweyIDs(resourceOptions.useDeweyIDs())
-                                .hashKind(resourceOptions.hashType())
-                                .versioningApproach(versioningType)
-                                .storeNodeHistory(storeNodeHistory)
-                                .build();
+    final ResourceConfiguration.Builder builder =
+        ResourceConfiguration.newBuilder(resourceName)
+                             .useTextCompression(resourceOptions.useTextCompression())
+                             .buildPathSummary(resourceOptions.buildPathSummary())
+                             .buildPathStatistics(resourceOptions.buildPathStatistics())
+                             .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
+                             .storageType(resourceOptions.storageType())
+                             .useDeweyIDs(resourceOptions.useDeweyIDs())
+                             .hashKind(resourceOptions.hashType())
+                             .versioningApproach(versioningType)
+                             .storeNodeHistory(storeNodeHistory);
+    if (resourceOptions.validTimeConfig() != null) {
+      builder.validTimeConfig(resourceOptions.validTimeConfig());
+    }
+    return builder.build();
   }
 
   @Override
@@ -588,9 +606,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       Databases.createJsonDatabase(dbConf);
       final var database = Databases.openJsonDatabase(dbConf.getDatabaseFile());
       databases.add(database);
-      final Options resourceOptions = OptionsFactory.createOptions(options, new Options(null, null, false,
-          buildPathSummary, buildPathStatistics, storageType, useDeweyIDs, hashType, versioningType,
-          numberOfNodesBeforeAutoCommit));
+      final Options resourceOptions = OptionsFactory.createOptions(options, options());
       int numberOfResources = database.listResources().size();
       final var resourceNames = new ArrayList<String>(jsonReaders.size());
       final var partitions = new ArrayList<Callable<JsonReader>>(jsonReaders.size());
@@ -603,6 +619,17 @@ public final class BasicJsonDBStore implements JsonDBStore {
       // join that left a half-created database on any partition failure.
       ParallelJsonShredder.shred(database, resourceNames, partitions,
           name -> buildResourceConfiguration(resourceOptions, name), numberOfNodesBeforeAutoCommit, 0);
+      // The parallel shredder commits internally, so the valid-time interval index is created in a
+      // follow-up revision per resource (builder pass over the shredded data + change listener).
+      if (resourceOptions.autoCreateValidTimeIndex() && resourceOptions.validTimeConfig() != null) {
+        for (final String resourceName : resourceNames) {
+          try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
+              final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
+            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+            wtx.commit();
+          }
+        }
+      }
       final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       return collection;

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -10,7 +10,6 @@ import io.brackit.query.jdm.json.Object;
 import io.brackit.query.jsonitem.object.ArrayObject;
 import io.sirix.access.DatabaseConfiguration;
 import io.sirix.access.Databases;
-import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.AfterCommitState;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.api.Database;
@@ -545,11 +544,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
         // Even without initial data, persist the valid-time interval index definition so the
         // change listener maintains the index for all subsequent insertions.
         if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
-          try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
-              final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
-            wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
-          }
+          createValidTimeIndexInOwnRevision(database, resourceName, collName, resourceOptions);
         }
         return collection;
       }
@@ -577,13 +572,23 @@ public final class BasicJsonDBStore implements JsonDBStore {
   private Options createResource(Object options, Database<JsonResourceSession> database, String resourceName) {
     final var resourceOptions = OptionsFactory.createOptions(options, options());
 
-    database.createResource(buildResourceConfiguration(resourceOptions, resourceName));
+    database.createResource(ResourceConfigurations.create(resourceName, resourceOptions));
     return resourceOptions;
   }
 
-  /** Build (but do not create) the {@link ResourceConfiguration} for {@code resourceName} from resolved {@code options}. */
-  private ResourceConfiguration buildResourceConfiguration(Options resourceOptions, String resourceName) {
-    return ResourceConfigurations.create(resourceName, resourceOptions);
+  /**
+   * Create the valid-time interval index for an already-committed resource in a follow-up revision:
+   * used when the data commit is out of the caller's hands (parallel shredder) or when there is no
+   * data yet (empty resource) — the definition is persisted so the change listener maintains the
+   * index for subsequent insertions.
+   */
+  private void createValidTimeIndexInOwnRevision(final Database<JsonResourceSession> database,
+      final String resourceName, final String collName, final Options resourceOptions) {
+    try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
+        final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
+      ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+      wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
+    }
   }
 
   @Override
@@ -607,16 +612,12 @@ public final class BasicJsonDBStore implements JsonDBStore {
       // pool, shared with the single-resource parallel shredder. Replaces a raw CompletableFuture
       // join that left a half-created database on any partition failure.
       ParallelJsonShredder.shred(database, resourceNames, partitions,
-          name -> buildResourceConfiguration(resourceOptions, name), numberOfNodesBeforeAutoCommit, 0);
+          name -> ResourceConfigurations.create(name, resourceOptions), numberOfNodesBeforeAutoCommit, 0);
       // The parallel shredder commits internally, so the valid-time interval index is created in a
       // follow-up revision per resource (builder pass over the shredded data + change listener).
       if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
         for (final String resourceName : resourceNames) {
-          try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
-              final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
-            wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
-          }
+          createValidTimeIndexInOwnRevision(database, resourceName, collName, resourceOptions);
         }
       }
       final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
@@ -667,6 +668,10 @@ public final class BasicJsonDBStore implements JsonDBStore {
       Databases.createJsonDatabase(dbConf);
       final var database = Databases.openJsonDatabase(dbConf.getDatabaseFile());
       databases.add(database);
+      // Resolve the options ONCE for all resources of this call.
+      final Options resourceOptions = OptionsFactory.createOptions(options, options());
+      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
+      collections.put(database, collection);
       int i = database.listResources().size() + 1;
       try (jsonStrings) {
         Str string;
@@ -676,23 +681,22 @@ public final class BasicJsonDBStore implements JsonDBStore {
             continue;
           }
           final String resourceName = "resource" + i;
-          createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName, options);
+          createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName,
+              resourceOptions);
           i++;
         }
       }
-      return new JsonDBCollectionImpl(collName, database, this);
+      return collection;
     } catch (final SirixRuntimeException e) {
       throw new DocumentException(e.getCause());
     }
   }
 
   private void createResource(String collName, final Database<JsonResourceSession> database, final JsonReader reader,
-      final String resourceName, final Object options) {
-    final Options resourceOptions = createResource(options, database, resourceName);
+      final String resourceName, final Options resourceOptions) {
+    database.createResource(ResourceConfigurations.create(resourceName, resourceOptions));
     try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
         final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
-      final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
-      collections.put(database, collection);
       wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
       if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
         ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
@@ -729,17 +733,9 @@ public final class BasicJsonDBStore implements JsonDBStore {
       // Hardened concurrent fan-out: all-or-nothing rollback + bounded pool, shared with the
       // single-resource parallel shredder. Replaces a raw CompletableFuture join that left a
       // half-created database on any partition failure (and never closed the file readers).
+      final Options resourceOptions = options();
       ParallelJsonShredder.shred(database, resourceNames, partitions,
-          name -> ResourceConfiguration.newBuilder(name)
-                                       .storageType(storageType)
-                                       .useDeweyIDs(useDeweyIDs)
-                                       .useTextCompression(false)
-                                       .buildPathSummary(buildPathSummary)
-                                       .hashKind(hashType)
-                                       .versioningApproach(versioningType)
-                                       .storeNodeHistory(storeNodeHistory)
-                                       .build(),
-          numberOfNodesBeforeAutoCommit, 0);
+          name -> ResourceConfigurations.create(name, resourceOptions), numberOfNodesBeforeAutoCommit, 0);
       final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
       return collection;

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -395,7 +395,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
   @Override
   public Options options() {
     return new Options(null, null, false, buildPathSummary, buildPathStatistics, storageType, useDeweyIDs, hashType,
-        versioningType, numberOfNodesBeforeAutoCommit, null, true);
+        versioningType, numberOfNodesBeforeAutoCommit, storeNodeHistory, null, true);
   }
 
   @Override
@@ -462,6 +462,9 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   @Override
   public JsonDBCollection create(String collName, String json, Object options) {
+    if (json == null) {
+      return createCollection(collName, null, null, options);
+    }
     return createCollection(collName, null, JsonShredder.createStringReader(json), options);
   }
 
@@ -541,10 +544,10 @@ public final class BasicJsonDBStore implements JsonDBStore {
       if (reader == null) {
         // Even without initial data, persist the valid-time interval index definition so the
         // change listener maintains the index for all subsequent insertions.
-        if (resourceOptions.autoCreateValidTimeIndex() && resourceOptions.validTimeConfig() != null) {
+        if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
           try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
               final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
             wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
           }
         }
@@ -560,8 +563,8 @@ public final class BasicJsonDBStore implements JsonDBStore {
       try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
           final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
-        if (resourceOptions.autoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       }
@@ -580,21 +583,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   /** Build (but do not create) the {@link ResourceConfiguration} for {@code resourceName} from resolved {@code options}. */
   private ResourceConfiguration buildResourceConfiguration(Options resourceOptions, String resourceName) {
-    final ResourceConfiguration.Builder builder =
-        ResourceConfiguration.newBuilder(resourceName)
-                             .useTextCompression(resourceOptions.useTextCompression())
-                             .buildPathSummary(resourceOptions.buildPathSummary())
-                             .buildPathStatistics(resourceOptions.buildPathStatistics())
-                             .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                             .storageType(resourceOptions.storageType())
-                             .useDeweyIDs(resourceOptions.useDeweyIDs())
-                             .hashKind(resourceOptions.hashType())
-                             .versioningApproach(versioningType)
-                             .storeNodeHistory(storeNodeHistory);
-    if (resourceOptions.validTimeConfig() != null) {
-      builder.validTimeConfig(resourceOptions.validTimeConfig());
-    }
-    return builder.build();
+    return ResourceConfigurations.create(resourceName, resourceOptions);
   }
 
   @Override
@@ -621,12 +610,12 @@ public final class BasicJsonDBStore implements JsonDBStore {
           name -> buildResourceConfiguration(resourceOptions, name), numberOfNodesBeforeAutoCommit, 0);
       // The parallel shredder commits internally, so the valid-time interval index is created in a
       // follow-up revision per resource (builder pass over the shredded data + change listener).
-      if (resourceOptions.autoCreateValidTimeIndex() && resourceOptions.validTimeConfig() != null) {
+      if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
         for (final String resourceName : resourceNames) {
           try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
               final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
-            wtx.commit();
+            ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+            wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
           }
         }
       }
@@ -661,6 +650,12 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   @Override
   public JsonDBCollection createFromJsonStrings(String collName, final @Nullable Stream<Str> jsonStrings) {
+    return createFromJsonStrings(collName, jsonStrings, new ArrayObject(new QNm[0], new Sequence[0]));
+  }
+
+  @Override
+  public JsonDBCollection createFromJsonStrings(String collName, final @Nullable Stream<Str> jsonStrings,
+      final Object options) {
     if (jsonStrings == null) {
       return null;
     }
@@ -672,7 +667,6 @@ public final class BasicJsonDBStore implements JsonDBStore {
       Databases.createJsonDatabase(dbConf);
       final var database = Databases.openJsonDatabase(dbConf.getDatabaseFile());
       databases.add(database);
-      final Object emptyOptions = new ArrayObject(new QNm[0], new Sequence[0]);
       int i = database.listResources().size() + 1;
       try (jsonStrings) {
         Str string;
@@ -682,8 +676,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
             continue;
           }
           final String resourceName = "resource" + i;
-          createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName,
-              emptyOptions);
+          createResource(collName, database, JsonShredder.createStringReader(currentString), resourceName, options);
           i++;
         }
       }
@@ -695,12 +688,16 @@ public final class BasicJsonDBStore implements JsonDBStore {
 
   private void createResource(String collName, final Database<JsonResourceSession> database, final JsonReader reader,
       final String resourceName, final Object options) {
-    createResource(options, database, resourceName);
+    final Options resourceOptions = createResource(options, database, resourceName);
     try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
         final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
       final JsonDBCollection collection = new JsonDBCollectionImpl(collName, database, this);
       collections.put(database, collection);
-      wtx.insertSubtreeAsFirstChild(reader);
+      wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+      if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
+        ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+      }
+      wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
     }
   }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
@@ -10,7 +10,6 @@ import io.brackit.query.jsonitem.AbstractJsonItemCollection;
 import io.brackit.query.jsonitem.object.ArrayObject;
 import io.brackit.query.node.stream.ArrayStream;
 import io.sirix.access.Databases;
-import io.sirix.access.ResourceConfiguration;
 import io.sirix.api.Database;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
@@ -265,12 +264,12 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
 
       final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
 
-      database.createResource(buildResourceConfiguration(resName, resourceOptions));
+      database.createResource(ResourceConfigurations.create(resName, resourceOptions));
       final JsonResourceSession resourceSession = database.beginResourceSession(resName);
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
-        if (resourceOptions.autoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, name);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {
@@ -293,27 +292,6 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
 
   public JsonDBItem add(final String resourceName, final JsonReader reader) {
     return add(resourceName, reader, new ArrayObject(new QNm[0], new Sequence[0]));
-  }
-
-  /**
-   * Build the {@link ResourceConfiguration} for a new resource from resolved {@code Options},
-   * including the valid-time (bitemporal) configuration when specified.
-   */
-  private static ResourceConfiguration buildResourceConfiguration(final String resourceName,
-      final Options resourceOptions) {
-    final ResourceConfiguration.Builder builder =
-        ResourceConfiguration.newBuilder(resourceName)
-                             .useTextCompression(resourceOptions.useTextCompression())
-                             .storageType(resourceOptions.storageType())
-                             .useDeweyIDs(resourceOptions.useDeweyIDs())
-                             .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                             .buildPathSummary(resourceOptions.buildPathSummary())
-                             .buildPathStatistics(resourceOptions.buildPathStatistics())
-                             .hashKind(resourceOptions.hashType());
-    if (resourceOptions.validTimeConfig() != null) {
-      builder.validTimeConfig(resourceOptions.validTimeConfig());
-    }
-    return builder.build();
   }
 
   @Override
@@ -386,12 +364,12 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
       final String resourceName = "resource" + (database.listResources().size() + 1);
       final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
 
-      database.createResource(buildResourceConfiguration(resourceName, resourceOptions));
+      database.createResource(ResourceConfigurations.create(resourceName, resourceOptions));
       final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
-        if (resourceOptions.autoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, name);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
@@ -265,18 +265,13 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
 
       final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
 
-      database.createResource(ResourceConfiguration.newBuilder(resName)
-                                                   .useTextCompression(resourceOptions.useTextCompression())
-                                                   .storageType(resourceOptions.storageType())
-                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
-                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                                                   .buildPathSummary(resourceOptions.buildPathSummary())
-                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
-                                                   .hashKind(resourceOptions.hashType())
-                                                   .build());
+      database.createResource(buildResourceConfiguration(resName, resourceOptions));
       final JsonResourceSession resourceSession = database.beginResourceSession(resName);
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+        if (resourceOptions.autoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {
         resourceSession.close();
@@ -298,6 +293,27 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
 
   public JsonDBItem add(final String resourceName, final JsonReader reader) {
     return add(resourceName, reader, new ArrayObject(new QNm[0], new Sequence[0]));
+  }
+
+  /**
+   * Build the {@link ResourceConfiguration} for a new resource from resolved {@code Options},
+   * including the valid-time (bitemporal) configuration when specified.
+   */
+  private static ResourceConfiguration buildResourceConfiguration(final String resourceName,
+      final Options resourceOptions) {
+    final ResourceConfiguration.Builder builder =
+        ResourceConfiguration.newBuilder(resourceName)
+                             .useTextCompression(resourceOptions.useTextCompression())
+                             .storageType(resourceOptions.storageType())
+                             .useDeweyIDs(resourceOptions.useDeweyIDs())
+                             .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
+                             .buildPathSummary(resourceOptions.buildPathSummary())
+                             .buildPathStatistics(resourceOptions.buildPathStatistics())
+                             .hashKind(resourceOptions.hashType());
+    if (resourceOptions.validTimeConfig() != null) {
+      builder.validTimeConfig(resourceOptions.validTimeConfig());
+    }
+    return builder.build();
   }
 
   @Override
@@ -370,18 +386,13 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
       final String resourceName = "resource" + (database.listResources().size() + 1);
       final var resourceOptions = OptionsFactory.createOptions(options, jsonDbStore.options());
 
-      database.createResource(ResourceConfiguration.newBuilder(resourceName)
-                                                   .useTextCompression(resourceOptions.useTextCompression())
-                                                   .storageType(resourceOptions.storageType())
-                                                   .useDeweyIDs(resourceOptions.useDeweyIDs())
-                                                   .customCommitTimestamps(resourceOptions.commitTimestamp() != null)
-                                                   .buildPathSummary(resourceOptions.buildPathSummary())
-                                                   .buildPathStatistics(resourceOptions.buildPathStatistics())
-                                                   .hashKind(resourceOptions.hashType())
-                                                   .build());
+      database.createResource(buildResourceConfiguration(resourceName, resourceOptions));
       final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
+        if (resourceOptions.autoCreateValidTimeIndex()) {
+          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx);
+        }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {
         resourceSession.close();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBStore.java
@@ -59,6 +59,19 @@ public interface JsonDBStore extends JsonStore, AutoCloseable {
   @Override
   JsonDBCollection createFromJsonStrings(String collName, Stream<Str> jsons);
 
+  /**
+   * Create a collection from a stream of JSON strings, one resource per string, applying the given
+   * resource-creation options (e.g. valid-time configuration) to every created resource.
+   *
+   * @param collName the collection/database name
+   * @param jsons the JSON fragments
+   * @param options the resource-creation options
+   * @return the created collection
+   */
+  default JsonDBCollection createFromJsonStrings(String collName, Stream<Str> jsons, Object options) {
+    return createFromJsonStrings(collName, jsons);
+  }
+
   @Override
   void drop(String name);
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/Options.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/Options.java
@@ -20,6 +20,8 @@ import java.time.Instant;
  * @param hashType the hash type used for integrity hashes
  * @param versioningType the page versioning approach
  * @param numberOfNodesBeforeAutoCommit auto-commit threshold during imports
+ * @param storeNodeHistory whether the record-to-revisions index is maintained (store-level setting,
+ *        not exposed as a query option)
  * @param validTimeConfig optional valid-time (bitemporal) field configuration; {@code null} if the
  *        resource has no valid-time support
  * @param autoCreateValidTimeIndex whether the valid-time interval index is created automatically
@@ -28,6 +30,16 @@ import java.time.Instant;
 public record Options(String commitMessage, Instant commitTimestamp, boolean useTextCompression,
     boolean buildPathSummary, boolean buildPathStatistics,
     StorageType storageType, boolean useDeweyIDs, HashType hashType,
-    VersioningType versioningType, int numberOfNodesBeforeAutoCommit,
+    VersioningType versioningType, int numberOfNodesBeforeAutoCommit, boolean storeNodeHistory,
     ValidTimeConfig validTimeConfig, boolean autoCreateValidTimeIndex) {
+
+  /**
+   * Whether the valid-time interval index should be auto-created for a resource built from these
+   * options: requires both a valid-time configuration and the auto-create flag.
+   *
+   * @return {@code true} if the interval index should be created automatically
+   */
+  public boolean shouldAutoCreateValidTimeIndex() {
+    return autoCreateValidTimeIndex && validTimeConfig != null;
+  }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/Options.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/Options.java
@@ -1,13 +1,33 @@
 package io.sirix.query.json;
 
+import io.sirix.access.ValidTimeConfig;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.io.StorageType;
 import io.sirix.settings.VersioningType;
 
 import java.time.Instant;
 
+/**
+ * Resolved resource-creation options for the JSONiq store layer.
+ *
+ * @param commitMessage optional commit message for the initial commit
+ * @param commitTimestamp optional custom commit timestamp for the initial commit
+ * @param useTextCompression whether text values are compressed
+ * @param buildPathSummary whether a path summary is built
+ * @param buildPathStatistics whether per-path value statistics are maintained
+ * @param storageType the storage backend
+ * @param useDeweyIDs whether DeweyIDs are generated
+ * @param hashType the hash type used for integrity hashes
+ * @param versioningType the page versioning approach
+ * @param numberOfNodesBeforeAutoCommit auto-commit threshold during imports
+ * @param validTimeConfig optional valid-time (bitemporal) field configuration; {@code null} if the
+ *        resource has no valid-time support
+ * @param autoCreateValidTimeIndex whether the valid-time interval index is created automatically
+ *        when {@code validTimeConfig} is set (default {@code true})
+ */
 public record Options(String commitMessage, Instant commitTimestamp, boolean useTextCompression,
     boolean buildPathSummary, boolean buildPathStatistics,
     StorageType storageType, boolean useDeweyIDs, HashType hashType,
-    VersioningType versioningType, int numberOfNodesBeforeAutoCommit) {
+    VersioningType versioningType, int numberOfNodesBeforeAutoCommit,
+    ValidTimeConfig validTimeConfig, boolean autoCreateValidTimeIndex) {
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
@@ -1,7 +1,6 @@
 package io.sirix.query.json;
 
 import io.brackit.query.QueryException;
-import io.brackit.query.atomic.Bool;
 import io.brackit.query.atomic.DateTime;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.QNm;
@@ -21,22 +20,28 @@ class OptionsFactory {
 
   private static final DateTimeToInstant DATE_TIME_TO_INSTANT = new DateTimeToInstant();
 
+  private static final QNm COMMIT_MESSAGE = new QNm("commitMessage");
+  private static final QNm COMMIT_TIMESTAMP = new QNm("commitTimestamp");
+  private static final QNm USE_TEXT_COMPRESSION = new QNm("useTextCompression");
+  private static final QNm BUILD_PATH_SUMMARY = new QNm("buildPathSummary");
+  private static final QNm BUILD_PATH_STATISTICS = new QNm("buildPathStatistics");
+  private static final QNm STORAGE_TYPE = new QNm("storageType");
+  private static final QNm USE_DEWEY_IDS = new QNm("useDeweyIDs");
+  private static final QNm HASH_TYPE = new QNm("hashType");
+  private static final QNm VERSION_TYPE = new QNm("versionType");
+  private static final QNm NUMBER_OF_NODES_BEFORE_AUTO_COMMIT = new QNm("numberOfNodesBeforeAutoCommit");
+  private static final QNm VALID_FROM_PATH = new QNm("validFromPath");
+  private static final QNm VALID_TO_PATH = new QNm("validToPath");
+  private static final QNm USE_CONVENTIONAL_VALID_TIME = new QNm("useConventionalValidTime");
+  private static final QNm AUTO_CREATE_VALID_TIME_INDEX = new QNm("autoCreateValidTimeIndex");
+
   public static Options createOptions(Object providedOptions, Options defaultOptions) {
-    final Sequence commitMessageSequence = providedOptions.get(new QNm("commitMessage"));
-    final Sequence dateTimeSequence = providedOptions.get(new QNm("commitTimestamp"));
-    final Sequence useTextCompressionSequence = providedOptions.get(new QNm("useTextCompression"));
-    final Sequence buildPathSummarySequence = providedOptions.get(new QNm("buildPathSummary"));
-    final Sequence buildPathStatisticsSequence = providedOptions.get(new QNm("buildPathStatistics"));
-    final Sequence storageTypeSequence = providedOptions.get(new QNm("storageType"));
-    final Sequence useDeweyIDsSequence = providedOptions.get(new QNm("useDeweyIDs"));
-    final Sequence hashTypeSequence = providedOptions.get(new QNm("hashType"));
-    final Sequence versioningTypeSequence = providedOptions.get(new QNm("versionType"));
-    final Sequence numberOfNodesBeforeAutoCommitSequence =
-        providedOptions.get(new QNm("numberOfNodesBeforeAutoCommit"));
-    final Sequence validFromPathSequence = providedOptions.get(new QNm("validFromPath"));
-    final Sequence validToPathSequence = providedOptions.get(new QNm("validToPath"));
-    final Sequence useConventionalValidTimeSequence = providedOptions.get(new QNm("useConventionalValidTime"));
-    final Sequence autoCreateValidTimeIndexSequence = providedOptions.get(new QNm("autoCreateValidTimeIndex"));
+    final Sequence commitMessageSequence = providedOptions.get(COMMIT_MESSAGE);
+    final Sequence dateTimeSequence = providedOptions.get(COMMIT_TIMESTAMP);
+    final Sequence storageTypeSequence = providedOptions.get(STORAGE_TYPE);
+    final Sequence hashTypeSequence = providedOptions.get(HASH_TYPE);
+    final Sequence versioningTypeSequence = providedOptions.get(VERSION_TYPE);
+    final Sequence numberOfNodesBeforeAutoCommitSequence = providedOptions.get(NUMBER_OF_NODES_BEFORE_AUTO_COMMIT);
 
     final String commitMessage = commitMessageSequence != null
         ? ((Str) commitMessageSequence).stringValue()
@@ -44,19 +49,17 @@ class OptionsFactory {
     final Instant commitTimestamp = dateTimeSequence != null
         ? DATE_TIME_TO_INSTANT.convert(new DateTime(dateTimeSequence.toString()))
         : null;
-    final boolean useTextCompression = useTextCompressionSequence != null && useTextCompressionSequence.booleanValue();
-    final boolean buildPathSummary = buildPathSummarySequence == null
-        ? defaultOptions.buildPathSummary()
-        : buildPathSummarySequence.booleanValue();
-    final boolean buildPathStatistics = buildPathStatisticsSequence == null
-        ? defaultOptions.buildPathStatistics()
-        : buildPathStatisticsSequence.booleanValue();
+    final boolean useTextCompression =
+        toBoolean(providedOptions.get(USE_TEXT_COMPRESSION), "useTextCompression", false);
+    final boolean buildPathSummary =
+        toBoolean(providedOptions.get(BUILD_PATH_SUMMARY), "buildPathSummary", defaultOptions.buildPathSummary());
+    final boolean buildPathStatistics = toBoolean(providedOptions.get(BUILD_PATH_STATISTICS), "buildPathStatistics",
+        defaultOptions.buildPathStatistics());
     final StorageType storageType = storageTypeSequence == null
         ? defaultOptions.storageType()
         : StorageType.valueOf(storageTypeSequence.toString());
-    final boolean useDeweyIDs = useDeweyIDsSequence == null
-        ? defaultOptions.useDeweyIDs()
-        : useDeweyIDsSequence.booleanValue();
+    final boolean useDeweyIDs =
+        toBoolean(providedOptions.get(USE_DEWEY_IDS), "useDeweyIDs", defaultOptions.useDeweyIDs());
     final HashType hashType = hashTypeSequence == null
         ? defaultOptions.hashType()
         : HashType.fromString(hashTypeSequence.toString());
@@ -67,10 +70,10 @@ class OptionsFactory {
         ? defaultOptions.numberOfNodesBeforeAutoCommit()
         : ((Int64) numberOfNodesBeforeAutoCommitSequence).intValue();
     final ValidTimeConfig validTimeConfig =
-        resolveValidTimeConfig(validFromPathSequence, validToPathSequence, useConventionalValidTimeSequence,
-            defaultOptions);
-    final boolean autoCreateValidTimeIndex =
-        toBoolean(autoCreateValidTimeIndexSequence, "autoCreateValidTimeIndex", defaultOptions.autoCreateValidTimeIndex());
+        resolveValidTimeConfig(providedOptions.get(VALID_FROM_PATH), providedOptions.get(VALID_TO_PATH),
+            providedOptions.get(USE_CONVENTIONAL_VALID_TIME), defaultOptions);
+    final boolean autoCreateValidTimeIndex = toBoolean(providedOptions.get(AUTO_CREATE_VALID_TIME_INDEX),
+        "autoCreateValidTimeIndex", defaultOptions.autoCreateValidTimeIndex());
     return new Options(commitMessage, commitTimestamp, useTextCompression, buildPathSummary,
         buildPathStatistics, storageType, useDeweyIDs,
         hashType, versioningType, numberOfNodesBeforeAutoCommit, defaultOptions.storeNodeHistory(),
@@ -122,9 +125,6 @@ class OptionsFactory {
         return false;
       }
       throw new QueryException(new QNm("Option " + optionName + " must be a boolean (got: '" + value + "')."));
-    }
-    if (sequence instanceof Bool bool) {
-      return bool.booleanValue();
     }
     return sequence.booleanValue();
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
@@ -1,10 +1,12 @@
 package io.sirix.query.json;
 
+import io.brackit.query.QueryException;
 import io.brackit.query.atomic.DateTime;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Sequence;
+import io.sirix.access.ValidTimeConfig;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.io.StorageType;
 
@@ -30,6 +32,10 @@ class OptionsFactory {
     final Sequence versioningTypeSequence = providedOptions.get(new QNm("versionType"));
     final Sequence numberOfNodesBeforeAutoCommitSequence =
         providedOptions.get(new QNm("numberOfNodesBeforeAutoCommit"));
+    final Sequence validFromPathSequence = providedOptions.get(new QNm("validFromPath"));
+    final Sequence validToPathSequence = providedOptions.get(new QNm("validToPath"));
+    final Sequence useConventionalValidTimeSequence = providedOptions.get(new QNm("useConventionalValidTime"));
+    final Sequence autoCreateValidTimeIndexSequence = providedOptions.get(new QNm("autoCreateValidTimeIndex"));
 
     final String commitMessage = commitMessageSequence != null
         ? ((Str) commitMessageSequence).stringValue()
@@ -59,8 +65,45 @@ class OptionsFactory {
     final int numberOfNodesBeforeAutoCommit = numberOfNodesBeforeAutoCommitSequence == null
         ? defaultOptions.numberOfNodesBeforeAutoCommit()
         : ((Int64) numberOfNodesBeforeAutoCommitSequence).intValue();
+    final ValidTimeConfig validTimeConfig =
+        resolveValidTimeConfig(validFromPathSequence, validToPathSequence, useConventionalValidTimeSequence,
+            defaultOptions);
+    final boolean autoCreateValidTimeIndex = autoCreateValidTimeIndexSequence == null
+        ? defaultOptions.autoCreateValidTimeIndex()
+        : autoCreateValidTimeIndexSequence.booleanValue();
     return new Options(commitMessage, commitTimestamp, useTextCompression, buildPathSummary,
         buildPathStatistics, storageType, useDeweyIDs,
-        hashType, versioningType, numberOfNodesBeforeAutoCommit);
+        hashType, versioningType, numberOfNodesBeforeAutoCommit, validTimeConfig, autoCreateValidTimeIndex);
+  }
+
+  /**
+   * Resolve the valid-time (bitemporal) configuration from the provided options. Mirrors the REST
+   * API's resource-creation parameters: {@code useConventionalValidTime} wins over explicit paths;
+   * explicit paths must be given as a pair.
+   */
+  private static ValidTimeConfig resolveValidTimeConfig(final Sequence validFromPathSequence,
+      final Sequence validToPathSequence, final Sequence useConventionalValidTimeSequence,
+      final Options defaultOptions) {
+    final boolean useConventionalValidTime =
+        useConventionalValidTimeSequence != null && useConventionalValidTimeSequence.booleanValue();
+    if (useConventionalValidTime) {
+      return ValidTimeConfig.withConventionalPaths();
+    }
+    final String validFromPath = validFromPathSequence != null
+        ? ((Str) validFromPathSequence).stringValue()
+        : null;
+    final String validToPath = validToPathSequence != null
+        ? ((Str) validToPathSequence).stringValue()
+        : null;
+    if (validFromPath != null && validToPath != null) {
+      if (validFromPath.isEmpty() || validToPath.isEmpty()) {
+        throw new QueryException(new QNm("Options validFromPath and validToPath must not be empty."));
+      }
+      return ValidTimeConfig.withPaths(validFromPath, validToPath);
+    }
+    if (validFromPath != null || validToPath != null) {
+      throw new QueryException(new QNm("Options validFromPath and validToPath must be specified together."));
+    }
+    return defaultOptions.validTimeConfig();
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/OptionsFactory.java
@@ -1,6 +1,7 @@
 package io.sirix.query.json;
 
 import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Bool;
 import io.brackit.query.atomic.DateTime;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.QNm;
@@ -68,12 +69,12 @@ class OptionsFactory {
     final ValidTimeConfig validTimeConfig =
         resolveValidTimeConfig(validFromPathSequence, validToPathSequence, useConventionalValidTimeSequence,
             defaultOptions);
-    final boolean autoCreateValidTimeIndex = autoCreateValidTimeIndexSequence == null
-        ? defaultOptions.autoCreateValidTimeIndex()
-        : autoCreateValidTimeIndexSequence.booleanValue();
+    final boolean autoCreateValidTimeIndex =
+        toBoolean(autoCreateValidTimeIndexSequence, "autoCreateValidTimeIndex", defaultOptions.autoCreateValidTimeIndex());
     return new Options(commitMessage, commitTimestamp, useTextCompression, buildPathSummary,
         buildPathStatistics, storageType, useDeweyIDs,
-        hashType, versioningType, numberOfNodesBeforeAutoCommit, validTimeConfig, autoCreateValidTimeIndex);
+        hashType, versioningType, numberOfNodesBeforeAutoCommit, defaultOptions.storeNodeHistory(),
+        validTimeConfig, autoCreateValidTimeIndex);
   }
 
   /**
@@ -85,16 +86,12 @@ class OptionsFactory {
       final Sequence validToPathSequence, final Sequence useConventionalValidTimeSequence,
       final Options defaultOptions) {
     final boolean useConventionalValidTime =
-        useConventionalValidTimeSequence != null && useConventionalValidTimeSequence.booleanValue();
+        toBoolean(useConventionalValidTimeSequence, "useConventionalValidTime", false);
     if (useConventionalValidTime) {
       return ValidTimeConfig.withConventionalPaths();
     }
-    final String validFromPath = validFromPathSequence != null
-        ? ((Str) validFromPathSequence).stringValue()
-        : null;
-    final String validToPath = validToPathSequence != null
-        ? ((Str) validToPathSequence).stringValue()
-        : null;
+    final String validFromPath = toStringValue(validFromPathSequence, "validFromPath");
+    final String validToPath = toStringValue(validToPathSequence, "validToPath");
     if (validFromPath != null && validToPath != null) {
       if (validFromPath.isEmpty() || validToPath.isEmpty()) {
         throw new QueryException(new QNm("Options validFromPath and validToPath must not be empty."));
@@ -105,5 +102,44 @@ class OptionsFactory {
       throw new QueryException(new QNm("Options validFromPath and validToPath must be specified together."));
     }
     return defaultOptions.validTimeConfig();
+  }
+
+  /**
+   * Interpret a boolean option value. Unlike the raw XQuery effective boolean value (under which
+   * any non-empty string — including {@code "false"} — is {@code true}), a string value is parsed
+   * textually so {@code {"option": "false"}} behaves as users expect.
+   */
+  private static boolean toBoolean(final Sequence sequence, final String optionName, final boolean defaultValue) {
+    if (sequence == null) {
+      return defaultValue;
+    }
+    if (sequence instanceof Str str) {
+      final String value = str.stringValue();
+      if ("true".equalsIgnoreCase(value)) {
+        return true;
+      }
+      if ("false".equalsIgnoreCase(value)) {
+        return false;
+      }
+      throw new QueryException(new QNm("Option " + optionName + " must be a boolean (got: '" + value + "')."));
+    }
+    if (sequence instanceof Bool bool) {
+      return bool.booleanValue();
+    }
+    return sequence.booleanValue();
+  }
+
+  /**
+   * Extract a string option value with a clear error message instead of a raw
+   * {@link ClassCastException} for non-string values.
+   */
+  private static String toStringValue(final Sequence sequence, final String optionName) {
+    if (sequence == null) {
+      return null;
+    }
+    if (sequence instanceof Str str) {
+      return str.stringValue();
+    }
+    throw new QueryException(new QNm("Option " + optionName + " must be a string."));
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ResourceConfigurations.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ResourceConfigurations.java
@@ -1,0 +1,43 @@
+package io.sirix.query.json;
+
+import io.sirix.access.ResourceConfiguration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Single translation point from resolved store-layer {@link Options} to a
+ * {@link ResourceConfiguration}. Every JSONiq resource-creation path (fresh collection, add to
+ * existing collection, parallel shredder) must go through this mapper so a new option cannot be
+ * wired into one path and silently ignored in another.
+ */
+final class ResourceConfigurations {
+
+  private ResourceConfigurations() {
+    throw new AssertionError("May not be instantiated!");
+  }
+
+  /**
+   * Build (but do not create) the {@link ResourceConfiguration} for {@code resourceName} from the
+   * resolved {@code options}.
+   *
+   * @param resourceName the resource name
+   * @param options the resolved options
+   * @return the resource configuration
+   */
+  static ResourceConfiguration create(final String resourceName, final Options options) {
+    requireNonNull(resourceName, "resourceName must not be null");
+    requireNonNull(options, "options must not be null");
+    return ResourceConfiguration.newBuilder(resourceName)
+                                .useTextCompression(options.useTextCompression())
+                                .buildPathSummary(options.buildPathSummary())
+                                .buildPathStatistics(options.buildPathStatistics())
+                                .customCommitTimestamps(options.commitTimestamp() != null)
+                                .storageType(options.storageType())
+                                .useDeweyIDs(options.useDeweyIDs())
+                                .hashKind(options.hashType())
+                                .versioningApproach(options.versioningType())
+                                .storeNodeHistory(options.storeNodeHistory())
+                                .validTimeConfig(options.validTimeConfig())
+                                .build();
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -107,26 +107,23 @@ public final class ValidTimeIndexes {
    * @param wtx the open write transaction (data may already be inserted but not yet committed)
    * @param databaseName the database (collection) name for statistics invalidation, may be
    *        {@code null}
-   * @return {@code true} if the index was created, {@code false} if the resource has no valid-time
-   *         configuration or the index already exists
    */
-  static boolean createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
+  static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
       final JsonNodeTrx wtx, final @Nullable String databaseName) {
     requireNonNull(resourceSession, "resourceSession must not be null");
     requireNonNull(wtx, "wtx must not be null");
 
     final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
     if (validTimeConfig == null) {
-      return false;
+      return;
     }
 
     final JsonIndexController controller = resourceSession.getWtxIndexController(wtx.getRevisionNumber());
     if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) > 0) {
-      return false;
+      return;
     }
 
     createIntervalIndex(controller, wtx, defaultPaths(validTimeConfig), databaseName,
         resourceSession.getResourceConfig().getName());
-    return true;
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -11,61 +11,122 @@ import io.sirix.index.IndexDef;
 import io.sirix.index.IndexDefs;
 import io.sirix.index.IndexType;
 import io.sirix.query.compiler.optimizer.PlanCache;
+import io.sirix.query.compiler.optimizer.stats.StatisticsCatalog;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * Helper for auto-creating the valid-time (bitemporal) interval index when a resource is created
- * through the JSONiq store layer with a {@link ValidTimeConfig} (e.g. via the
- * {@code jn:store}/{@code jn:load} options {@code validFromPath}/{@code validToPath} or
- * {@code useConventionalValidTime}).
- *
- * <p>
- * The created index is the same persistent Relational-Interval-Tree the explicit
- * {@code jn:create-valid-time-index} function builds: existing data in the write transaction is
- * indexed by a builder pass and a change listener maintains the index for subsequent modifications.
- * </p>
+ * Shared recipe for creating the valid-time (bitemporal) interval index — the persistent
+ * Relational-Interval-Tree over each record's {@code [validFrom, validTo]} interval. Used both by
+ * the explicit {@code jn:create-valid-time-index} function and by the store layer's auto-creation
+ * when a resource is created with a {@link ValidTimeConfig} (e.g. via the {@code jn:store}/
+ * {@code jn:load} options {@code validFromPath}/{@code validToPath} or
+ * {@code useConventionalValidTime}), so the two creation paths cannot drift.
  *
  * @author Johannes Lichtenberger
  */
-final class ValidTimeIndexes {
+public final class ValidTimeIndexes {
 
   private ValidTimeIndexes() {
     throw new AssertionError("May not be instantiated!");
   }
 
   /**
-   * Create the valid-time interval index within the given write transaction when the resource is
-   * configured with valid-time paths and no interval index exists yet. Does not commit — the caller
-   * owns the transaction lifecycle, so data shred and index creation land in one revision.
+   * Derive the default indexed paths {@code /[]/<validFrom>} and {@code /[]/<validTo>} from the
+   * resource's valid-time field configuration. Dotted (nested) configured paths such as
+   * {@code $.meta.validFrom} are split into individual steps so the derived path always parses.
+   * The builder/listener match valid-time fields by NAME from the resource's
+   * {@link ValidTimeConfig}, so the exact path only serves index identification/serialization.
    *
-   * @param resourceSession the resource session the write transaction belongs to
-   * @param wtx the open write transaction (data may already be inserted but not yet committed)
+   * @param validTimeConfig the resource's valid-time configuration
+   * @return the two default paths, in validFrom/validTo order
    */
-  static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
-      final JsonNodeTrx wtx) {
-    final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
-    if (validTimeConfig == null) {
-      return;
-    }
-
-    final JsonIndexController controller = resourceSession.getWtxIndexController(wtx.getRevisionNumber());
-    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) > 0) {
-      return;
-    }
-
-    // Same default paths as jn:create-valid-time-index: /[]/<validFrom> and /[]/<validTo>. The
-    // builder/listener match valid-time fields by NAME from the resource's ValidTimeConfig, so the
-    // paths only serve index identification/serialization.
+  public static Set<Path<QNm>> defaultPaths(final ValidTimeConfig validTimeConfig) {
+    requireNonNull(validTimeConfig, "validTimeConfig must not be null");
     final Set<Path<QNm>> paths = new LinkedHashSet<>(4);
-    paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidFromPath(), PathParser.Type.JSON));
-    paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidToPath(), PathParser.Type.JSON));
+    paths.add(toArrayFieldPath(validTimeConfig.getNormalizedValidFromPath()));
+    paths.add(toArrayFieldPath(validTimeConfig.getNormalizedValidToPath()));
+    return paths;
+  }
 
-    final IndexDef validTimeIdxDef = IndexDefs.createValidTimeIdxDef(paths, 0, IndexDef.DbType.JSON);
+  private static Path<QNm> toArrayFieldPath(final String fieldPath) {
+    return Path.parse("/[]/" + ValidTimeConfig.toSlashSeparatedPath(fieldPath), PathParser.Type.JSON);
+  }
+
+  /**
+   * Create a valid-time interval index over the given paths within the given write transaction:
+   * registers the index definition, builds the index from the transaction's current data and
+   * attaches a change listener for subsequent modifications. Also invalidates cached query plans
+   * and (best-effort) stale histogram statistics. Does NOT commit — the caller owns the
+   * transaction lifecycle.
+   *
+   * @param controller the write-transaction index controller
+   * @param wtx the open write transaction
+   * @param paths the indexed paths (see {@link #defaultPaths(ValidTimeConfig)})
+   * @param databaseName the database name for statistics invalidation, may be {@code null}
+   * @param resourceName the resource name for statistics invalidation, may be {@code null}
+   * @return the created index definition
+   */
+  public static IndexDef createIntervalIndex(final JsonIndexController controller, final JsonNodeTrx wtx,
+      final Set<Path<QNm>> paths, final @Nullable String databaseName, final @Nullable String resourceName) {
+    requireNonNull(controller, "controller must not be null");
+    requireNonNull(wtx, "wtx must not be null");
+    requireNonNull(paths, "paths must not be null");
+
+    final IndexDef validTimeIdxDef = IndexDefs.createValidTimeIdxDef(paths,
+        controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME), IndexDef.DbType.JSON);
     controller.createIndexes(Set.of(validTimeIdxDef), wtx);
 
     // Invalidate cached query plans so the optimizer considers the new index.
     PlanCache.signalIndexSchemaChange();
+
+    // Invalidate stale histogram statistics since the index schema changed. Best-effort; must not
+    // prevent index creation.
+    if (databaseName != null && resourceName != null) {
+      try {
+        StatisticsCatalog.getInstance().invalidate(databaseName, resourceName);
+      } catch (final Exception e) {
+        // Histogram invalidation is best-effort.
+      }
+    }
+
+    return validTimeIdxDef;
+  }
+
+  /**
+   * Create the valid-time interval index within the given write transaction when the resource is
+   * configured with valid-time paths and no interval index exists yet (idempotent). Does not
+   * commit — the caller owns the transaction lifecycle, so data shred and index creation can land
+   * in one revision.
+   *
+   * @param resourceSession the resource session the write transaction belongs to
+   * @param wtx the open write transaction (data may already be inserted but not yet committed)
+   * @param databaseName the database (collection) name for statistics invalidation, may be
+   *        {@code null}
+   * @return {@code true} if the index was created, {@code false} if the resource has no valid-time
+   *         configuration or the index already exists
+   */
+  static boolean createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
+      final JsonNodeTrx wtx, final @Nullable String databaseName) {
+    requireNonNull(resourceSession, "resourceSession must not be null");
+    requireNonNull(wtx, "wtx must not be null");
+
+    final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
+    if (validTimeConfig == null) {
+      return false;
+    }
+
+    final JsonIndexController controller = resourceSession.getWtxIndexController(wtx.getRevisionNumber());
+    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) > 0) {
+      return false;
+    }
+
+    createIntervalIndex(controller, wtx, defaultPaths(validTimeConfig), databaseName,
+        resourceSession.getResourceConfig().getName());
+    return true;
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -1,0 +1,71 @@
+package io.sirix.query.json;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.access.ValidTimeConfig;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.IndexType;
+import io.sirix.query.compiler.optimizer.PlanCache;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Helper for auto-creating the valid-time (bitemporal) interval index when a resource is created
+ * through the JSONiq store layer with a {@link ValidTimeConfig} (e.g. via the
+ * {@code jn:store}/{@code jn:load} options {@code validFromPath}/{@code validToPath} or
+ * {@code useConventionalValidTime}).
+ *
+ * <p>
+ * The created index is the same persistent Relational-Interval-Tree the explicit
+ * {@code jn:create-valid-time-index} function builds: existing data in the write transaction is
+ * indexed by a builder pass and a change listener maintains the index for subsequent modifications.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class ValidTimeIndexes {
+
+  private ValidTimeIndexes() {
+    throw new AssertionError("May not be instantiated!");
+  }
+
+  /**
+   * Create the valid-time interval index within the given write transaction when the resource is
+   * configured with valid-time paths and no interval index exists yet. Does not commit — the caller
+   * owns the transaction lifecycle, so data shred and index creation land in one revision.
+   *
+   * @param resourceSession the resource session the write transaction belongs to
+   * @param wtx the open write transaction (data may already be inserted but not yet committed)
+   */
+  static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
+      final JsonNodeTrx wtx) {
+    final ValidTimeConfig validTimeConfig = resourceSession.getResourceConfig().getValidTimeConfig();
+    if (validTimeConfig == null) {
+      return;
+    }
+
+    final JsonIndexController controller = resourceSession.getWtxIndexController(wtx.getRevisionNumber());
+    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) > 0) {
+      return;
+    }
+
+    // Same default paths as jn:create-valid-time-index: /[]/<validFrom> and /[]/<validTo>. The
+    // builder/listener match valid-time fields by NAME from the resource's ValidTimeConfig, so the
+    // paths only serve index identification/serialization.
+    final Set<Path<QNm>> paths = new LinkedHashSet<>(4);
+    paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidFromPath(), PathParser.Type.JSON));
+    paths.add(Path.parse("/[]/" + validTimeConfig.getNormalizedValidToPath(), PathParser.Type.JSON));
+
+    final IndexDef validTimeIdxDef = IndexDefs.createValidTimeIdxDef(paths, 0, IndexDef.DbType.JSON);
+    controller.createIndexes(Set.of(validTimeIdxDef), wtx);
+
+    // Invalidate cached query plans so the optimizer considers the new index.
+    PlanCache.signalIndexSchemaChange();
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
@@ -27,6 +27,7 @@ import io.sirix.query.json.BasicJsonDBStore;
 import io.sirix.query.json.JsonDBCollection;
 import io.sirix.query.json.JsonDBItem;
 import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.VersioningType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -258,6 +259,112 @@ public final class StoreValidTimeAutoIndexTest {
   }
 
   @Test
+  @DisplayName("sequence-form jn:store: valid-time options apply to every created resource")
+  void storeSequenceOfFragmentsAppliesValidTimeOptions() {
+    final List<Record> records = buildDataset();
+    final String json1 = toJson(records.subList(0, 3), VALID_FROM, VALID_TO);
+    final String json2 = toJson(records.subList(3, records.size()), VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "', (), ('" + json1 + "', '" + json2 + "'), true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\"})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB))) {
+      final List<Path> resources = database.listResources();
+      assertEquals(2, resources.size(), "one resource per JSON fragment must exist");
+      for (final Path resource : resources) {
+        try (JsonResourceSession session = database.beginResourceSession(resource.getFileName().toString())) {
+          assertNotNull(session.getResourceConfig().getValidTimeConfig(),
+              "every resource of a sequence-form store must have a valid-time config");
+          assertEquals(1,
+              session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                     .getIndexes()
+                     .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+              "every resource of a sequence-form store must have the auto-created interval index");
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("string boolean values: \"false\" disables, unlike raw effective boolean value")
+  void stringBooleanOptionValuesAreParsedTextually() {
+    final String json = toJson(buildDataset(), VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\", "
+        + "\"autoCreateValidTimeIndex\": \"false\"})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      assertNotNull(session.getResourceConfig().getValidTimeConfig(), "resource must have a valid-time config");
+      assertEquals(0,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "the string value \"false\" must disable auto index creation");
+    }
+  }
+
+  @Test
+  @DisplayName("nested (dotted) valid-time paths do not break auto index creation")
+  void nestedValidTimePathsDoNotBreakAutoIndexCreation() {
+    final String json = "[{\"id\": 1, \"meta\": {\"validFrom\": \"2020-01-01T00:00:00Z\", "
+        + "\"validTo\": \"2021-01-01T00:00:00Z\"}}]";
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"$.meta.validFrom\", \"validToPath\": \"$.meta.validTo\"})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      final ValidTimeConfig config = session.getResourceConfig().getValidTimeConfig();
+      assertNotNull(config, "resource must have a valid-time config");
+      assertEquals("meta.validFrom", config.getNormalizedValidFromPath());
+      assertEquals(1,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "dotted valid-time paths must not abort the store or skip index creation");
+    }
+  }
+
+  @Test
+  @DisplayName("jn:create-valid-time-index after auto-creation is idempotent (no duplicate index)")
+  void explicitCreateAfterAutoCreateIsIdempotent() {
+    final String json = toJson(buildDataset(), VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\"})");
+
+    // The documented explicit workflow, run on an already auto-indexed resource.
+    storeViaQuery("let $doc := jn:doc('" + DB + "','" + RES + "') "
+        + "let $idx := jn:create-valid-time-index($doc) return sdb:commit($doc)");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      assertEquals(1,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "jn:create-valid-time-index on an auto-indexed resource must not create a duplicate index");
+    }
+  }
+
+  @Test
+  @DisplayName("versionType option is honored on resource creation")
+  void versionTypeOptionIsHonored() {
+    final String json = toJson(buildDataset(), VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"versionType\": \"FULL\"})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      assertEquals(VersioningType.FULL, session.getResourceConfig().versioningType,
+          "the versionType option must reach the resource configuration");
+    }
+  }
+
+  @Test
   @DisplayName("store an empty resource with valid-time options: index definition persisted for future data")
   void storeEmptyResourcePersistsIndexDefinition() {
     storeViaQuery("jn:store('" + DB + "','" + RES + "','', true(), "
@@ -298,7 +405,7 @@ public final class StoreValidTimeAutoIndexTest {
   }
 
   private static List<Instant> sampleTimes(final List<Record> recs) {
-    final Set<Instant> times = new LinkedHashSet<>();
+    final Set<Instant> times = new LinkedHashSet<>(3 + 4 * recs.size());
     times.add(Instant.parse("1900-01-01T00:00:00Z"));
     times.add(Instant.parse("2998-01-01T00:00:00Z"));
     times.add(Instant.parse("2021-01-15T00:00:00Z"));

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
@@ -1,0 +1,367 @@
+/*
+ * [New BSD License]
+ * Copyright (c) 2026, SirixDB Contributors
+ * All rights reserved.
+ */
+package io.sirix.query.function.jn.temporal;
+
+import io.brackit.query.Query;
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.Numeric;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Iter;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.jdm.json.Object;
+import io.sirix.JsonTestHelper;
+import io.sirix.JsonTestHelper.PATHS;
+import io.sirix.access.Databases;
+import io.sirix.access.ValidTimeConfig;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexType;
+import io.sirix.query.SirixCompileChain;
+import io.sirix.query.SirixQueryContext;
+import io.sirix.query.json.BasicJsonDBStore;
+import io.sirix.query.json.JsonDBCollection;
+import io.sirix.query.json.JsonDBItem;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * END-TO-END test for creating a resource with valid-time support and an AUTO-CREATED valid-time
+ * interval index purely via JSONiq: {@code jn:store($coll, $res, $data, true(), $options)} with the
+ * options {@code validFromPath}/{@code validToPath} (or {@code useConventionalValidTime}). No Java
+ * API calls are needed to configure the resource — the options object drives the
+ * {@link ValidTimeConfig} and the interval index is created in the same transaction/revision as the
+ * initial shred.
+ *
+ * @author Johannes Lichtenberger
+ */
+@DisplayName("jn:store with valid-time options — auto-created interval index end-to-end")
+public final class StoreValidTimeAutoIndexTest {
+
+  private static final Path sirixPath = PATHS.PATH1.getFile();
+  private static final String DB = "vt-store-options-db";
+  private static final String RES = "vt-resource";
+
+  private static final String VALID_FROM = "validFrom";
+  private static final String VALID_TO = "validTo";
+
+  private record Record(int id, Instant validFrom, Instant validTo) {
+    boolean validAt(final Instant t) {
+      return !t.isBefore(validFrom) && !t.isAfter(validTo);
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  @DisplayName("store with validFromPath/validToPath: config set, interval index auto-created, valid-at correct")
+  void storeWithValidTimePathsAutoCreatesIntervalIndex() throws IOException {
+    final List<Record> records = buildDataset();
+    final String json = toJson(records, VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\"})");
+
+    // COLD reopen: the valid-time config and the interval index must be persisted, and data + index
+    // must have landed in ONE revision.
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      final ValidTimeConfig config = session.getResourceConfig().getValidTimeConfig();
+      assertNotNull(config, "resource must have a valid-time config");
+      assertEquals(VALID_FROM, config.getNormalizedValidFromPath());
+      assertEquals(VALID_TO, config.getNormalizedValidToPath());
+
+      final int mostRecentRevision = session.getMostRecentRevisionNumber();
+      assertEquals(1, mostRecentRevision, "data + auto-created index must land in a single revision");
+      assertEquals(1,
+          session.getRtxIndexController(mostRecentRevision).getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "exactly one VALIDTIME interval index must have been auto-created");
+    }
+
+    // Query correctness + interval-index fast path against a brute-force oracle.
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+      store.lookup(DB);
+      try (var ctx = SirixQueryContext.createWithJsonStore(store);
+          var chain = SirixCompileChain.createWithJsonStore(store)) {
+        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB);
+        for (final Instant t : sampleTimes(records)) {
+          final Set<Integer> brute = bruteForce(records, t);
+          assertEquals(brute, idsFromValidAt(chain, ctx, t), "jn:valid-at must equal brute force at t=" + t);
+
+          final ValidTimeIntervalIndex.Result fast =
+              ValidTimeIntervalIndex.tryIndexScan(collection.getDocument(RES), t, validTimeConfig);
+          assertNotNull(fast, "the auto-created interval index must be usable at t=" + t);
+          assertEquals(brute, idsOfItems(fast.items()), "interval-index scan must equal brute force at t=" + t);
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("store with useConventionalValidTime: _validFrom/_validTo config + auto-created index")
+  void storeWithConventionalValidTimeOption() throws IOException {
+    final List<Record> records = buildDataset();
+    final String json = toJson(records, "_validFrom", "_validTo");
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"useConventionalValidTime\": true()})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      final ValidTimeConfig config = session.getResourceConfig().getValidTimeConfig();
+      assertNotNull(config, "resource must have a valid-time config");
+      assertEquals("_validFrom", config.getNormalizedValidFromPath());
+      assertEquals("_validTo", config.getNormalizedValidToPath());
+      assertEquals(1,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "exactly one VALIDTIME interval index must have been auto-created");
+    }
+
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+      store.lookup(DB);
+      try (var ctx = SirixQueryContext.createWithJsonStore(store);
+          var chain = SirixCompileChain.createWithJsonStore(store)) {
+        for (final Instant t : sampleTimes(records)) {
+          assertEquals(bruteForce(records, t), idsFromValidAt(chain, ctx, t),
+              "jn:valid-at must equal brute force at t=" + t);
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("autoCreateValidTimeIndex: false() — config set but NO interval index; valid-at falls back")
+  void autoCreateValidTimeIndexOptOut() throws IOException {
+    final List<Record> records = buildDataset();
+    final String json = toJson(records, VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\", "
+        + "\"autoCreateValidTimeIndex\": false()})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      assertNotNull(session.getResourceConfig().getValidTimeConfig(), "resource must have a valid-time config");
+      assertEquals(0,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "no VALIDTIME interval index must exist after opting out");
+    }
+
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+      store.lookup(DB);
+      try (var ctx = SirixQueryContext.createWithJsonStore(store);
+          var chain = SirixCompileChain.createWithJsonStore(store)) {
+        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB);
+        final Instant t = Instant.parse("2021-01-15T00:00:00Z");
+        assertNull(ValidTimeIntervalIndex.tryIndexScan(collection.getDocument(RES), t, validTimeConfig),
+            "the interval-index fast path must NOT apply after opting out");
+        assertEquals(bruteForce(records, t), idsFromValidAt(chain, ctx, t),
+            "jn:valid-at must still be correct via fallback at t=" + t);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("validFromPath without validToPath is rejected")
+  void validTimePathOptionsMustBePaired() {
+    assertThrows(QueryException.class,
+        () -> storeViaQuery("jn:store('" + DB + "','" + RES + "','[]', true(), "
+            + "{\"validFromPath\": \"" + VALID_FROM + "\"})"),
+        "specifying only one of validFromPath/validToPath must fail");
+  }
+
+  @Test
+  @DisplayName("insert after store: the auto-created index is maintained by the change listener")
+  void insertAfterStoreMaintainsAutoCreatedIndex() throws IOException {
+    final List<Record> records = new ArrayList<>(buildDataset());
+    final String json = toJson(records, VALID_FROM, VALID_TO);
+
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','" + json + "', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\"})");
+
+    // Insert a record in a LATER revision — the listener registered from the persisted index
+    // definition must maintain the interval index.
+    final int newId = 999;
+    final Instant newFrom = Instant.parse("2030-01-01T00:00:00Z");
+    final Instant newTo = Instant.parse("2030-12-31T00:00:00Z");
+    records.add(new Record(newId, newFrom, newTo));
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES);
+        JsonNodeTrx wtx = session.beginNodeTrx()) {
+      wtx.moveToDocumentRoot();
+      wtx.moveToFirstChild(); // the top-level array
+      wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(
+          "{\"id\": " + newId + ", \"" + VALID_FROM + "\": \"" + newFrom + "\", \"" + VALID_TO + "\": \"" + newTo
+              + "\"}"), JsonNodeTrx.Commit.NO);
+      wtx.commit();
+    }
+    Databases.getGlobalBufferManager().clearAllCaches();
+
+    final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build()) {
+      store.lookup(DB);
+      try (var ctx = SirixQueryContext.createWithJsonStore(store);
+          var chain = SirixCompileChain.createWithJsonStore(store)) {
+        final JsonDBCollection collection = (JsonDBCollection) store.lookup(DB);
+        for (final Instant t : List.of(newFrom, newTo, newFrom.minusMillis(1), Instant.parse("2021-01-15T00:00:00Z"))) {
+          final Set<Integer> brute = bruteForce(records, t);
+          assertEquals(brute, idsFromValidAt(chain, ctx, t),
+              "jn:valid-at must equal brute force after a post-store insert at t=" + t);
+
+          final ValidTimeIntervalIndex.Result fast =
+              ValidTimeIntervalIndex.tryIndexScan(collection.getDocument(RES), t, validTimeConfig);
+          assertNotNull(fast, "the interval index must still be usable after a post-store insert at t=" + t);
+          assertEquals(brute, idsOfItems(fast.items()),
+              "interval-index scan must include listener-maintained entries at t=" + t);
+        }
+        assertTrue(idsFromValidAt(chain, ctx, newFrom).contains(newId),
+            "the inserted record must be found at its validFrom");
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("store an empty resource with valid-time options: index definition persisted for future data")
+  void storeEmptyResourcePersistsIndexDefinition() {
+    storeViaQuery("jn:store('" + DB + "','" + RES + "','', true(), "
+        + "{\"validFromPath\": \"" + VALID_FROM + "\", \"validToPath\": \"" + VALID_TO + "\"})");
+
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(sirixPath.resolve(DB));
+        JsonResourceSession session = database.beginResourceSession(RES)) {
+      assertNotNull(session.getResourceConfig().getValidTimeConfig(), "resource must have a valid-time config");
+      assertEquals(1,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
+          "the VALIDTIME index definition must be persisted even without initial data");
+    }
+  }
+
+  // ---- helpers -------------------------------------------------------------------------------
+
+  private static void storeViaQuery(final String storeQuery) {
+    try (var store = BasicJsonDBStore.newBuilder().location(sirixPath).build();
+        var ctx = SirixQueryContext.createWithJsonStore(store);
+        var chain = SirixCompileChain.createWithJsonStore(store)) {
+      new Query(chain, storeQuery).evaluate(ctx);
+    }
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  private static List<Record> buildDataset() {
+    final List<Record> recs = new ArrayList<>(8);
+    recs.add(new Record(1, Instant.parse("2020-01-01T00:00:00Z"), Instant.parse("2020-12-31T23:59:59Z")));
+    recs.add(new Record(2, Instant.parse("2020-06-01T00:00:00Z"), Instant.parse("2021-06-01T00:00:00Z")));
+    recs.add(new Record(3, Instant.parse("2021-01-01T00:00:00Z"), Instant.parse("2021-12-31T23:59:59Z")));
+    recs.add(new Record(4, Instant.parse("2019-01-01T00:00:00Z"), Instant.parse("2022-01-01T00:00:00Z")));
+    recs.add(new Record(5, Instant.parse("2021-01-15T00:00:00Z"), Instant.parse("2021-01-15T00:00:00Z")));
+    recs.add(new Record(6, Instant.parse("2018-01-01T00:00:00Z"), Instant.parse("2018-06-01T00:00:00Z")));
+    recs.add(new Record(7, Instant.parse("2023-01-01T00:00:00Z"), Instant.parse("2999-12-31T23:59:59Z")));
+    return recs;
+  }
+
+  private static List<Instant> sampleTimes(final List<Record> recs) {
+    final Set<Instant> times = new LinkedHashSet<>();
+    times.add(Instant.parse("1900-01-01T00:00:00Z"));
+    times.add(Instant.parse("2998-01-01T00:00:00Z"));
+    times.add(Instant.parse("2021-01-15T00:00:00Z"));
+    for (final Record r : recs) {
+      times.add(r.validFrom());
+      times.add(r.validTo());
+      times.add(r.validFrom().minusMillis(1));
+      times.add(r.validTo().plusMillis(1));
+    }
+    return new ArrayList<>(times);
+  }
+
+  private static String toJson(final List<Record> recs, final String validFromField, final String validToField) {
+    final StringBuilder sb = new StringBuilder(recs.size() * 96);
+    sb.append("[");
+    for (int i = 0; i < recs.size(); i++) {
+      final Record r = recs.get(i);
+      if (i > 0) {
+        sb.append(",");
+      }
+      sb.append("{\"id\": ").append(r.id())
+        .append(", \"").append(validFromField).append("\": \"").append(r.validFrom())
+        .append("\", \"").append(validToField).append("\": \"").append(r.validTo()).append("\"}");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  private static Set<Integer> bruteForce(final List<Record> records, final Instant t) {
+    final Set<Integer> brute = new TreeSet<>();
+    for (final Record r : records) {
+      if (r.validAt(t)) {
+        brute.add(r.id());
+      }
+    }
+    return brute;
+  }
+
+  private static Set<Integer> idsFromValidAt(final SirixCompileChain chain, final SirixQueryContext ctx,
+      final Instant t) {
+    final Sequence result =
+        new Query(chain, "jn:valid-at('" + DB + "', '" + RES + "', xs:dateTime('" + t + "'))").evaluate(ctx);
+    final Set<Integer> ids = new TreeSet<>();
+    if (result == null) {
+      return ids;
+    }
+    final Iter iter = result.iterate();
+    try {
+      Item item;
+      while ((item = iter.next()) != null) {
+        ids.add(((Numeric) ((Object) item).get(new QNm("id"))).intValue());
+      }
+    } finally {
+      iter.close();
+    }
+    return ids;
+  }
+
+  private static Set<Integer> idsOfItems(final List<JsonDBItem> items) {
+    final Set<Integer> ids = new TreeSet<>();
+    for (final JsonDBItem item : items) {
+      ids.add(((Numeric) ((Object) item).get(new QNm("id"))).intValue());
+    }
+    return ids;
+  }
+}

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonSessionDBStore.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonSessionDBStore.kt
@@ -82,14 +82,14 @@ class JsonSessionDBStore(
         return wrap(dbStore.create(name, resourceName, path, options))
     }
 
-    override fun create(name: String, resourceName: String, json: String): JsonDBCollection {
+    override fun create(name: String, resourceName: String, json: String?): JsonDBCollection {
         Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
         return wrap(dbStore.create(name, resourceName, json))
     }
 
     override fun create(
-        name: String, resourceName: String, json: String, options: Object
+        name: String, resourceName: String, json: String?, options: Object
     ): JsonDBCollection {
         Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
@@ -129,6 +129,12 @@ class JsonSessionDBStore(
         Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
 
         return wrap(dbStore.createFromJsonStrings(name, jsons))
+    }
+
+    override fun createFromJsonStrings(name: String, jsons: Stream<Str>, options: Object): JsonDBCollection {
+        Auth.checkIfAuthorized(user, name, AuthRole.CREATE, authz)
+
+        return wrap(dbStore.createFromJsonStrings(name, jsons, options))
     }
 
     override fun drop(name: String) {


### PR DESCRIPTION
## What does this PR do?

Makes it possible to create a database resource with valid-time (bitemporal) support **and** an auto-created valid-time interval index purely via JSONiq — previously this required the Java API (`ResourceConfiguration.Builder#validTimePaths`) or REST query params, and a separate `jn:create-valid-time-index` call:

```xquery
jn:store('mydb', 'myres', $data, true(),
         {"validFromPath": "validFrom", "validToPath": "validTo"})
```

New `jn:store`/`jn:load` options: `validFromPath` + `validToPath` (must be a pair), `useConventionalValidTime: true()` for the `_validFrom`/`_validTo` convention, and `autoCreateValidTimeIndex: false()` to opt out. When the config is set, the persistent Relational-Interval-Tree index (same as `jn:create-valid-time-index` builds) is created in the same write transaction as the initial shred, so data and index land in one revision and `jn:valid-at`/`jn:open-bitemporal` take the index fast path immediately.

The second commit fixes issues found in a self-review of the first:

- **Sequence-form `jn:store` dropped the options object** — new `createFromJsonStrings(coll, jsons, options)` overload wired through `BasicJsonDBStore`, the MCP guard and the REST auth wrapper.
- **`jn:create-valid-time-index` is now idempotent** — it returns the existing VALIDTIME definition instead of building a duplicate index (second builder pass + a redundant listener-maintained HOT tree) on an already auto-indexed resource.
- **`versionType` option was parsed but never applied**; all creation paths now share one `Options`→`ResourceConfiguration` mapper (`ResourceConfigurations`), which also fixes `JsonDBCollectionImpl.add` ignoring the store's versioning approach and `storeNodeHistory`.
- **Dotted valid-time paths (`$.meta.validFrom`) aborted resource creation** with a path-parse error in the core CAS bootstrap — `ValidTimeConfig.toSlashSeparatedPath` converts them to path steps, shared by core and the query layer.
- **String boolean option values** (`"false"`) were true under the XQuery effective boolean value for the new options; they are now parsed textually, and non-string path values get a descriptive error instead of a `ClassCastException`.
- The parallel-shredder follow-up index commit dropped `commitMessage`/`commitTimestamp`; the REST `JsonSessionDBStore` NPE'd on the empty-fragment path (non-nullable Kotlin param); two null-json overloads NPE'd; `jn:store`'s string path silently discarded the options object entirely (pre-existing — even `commitMessage` never applied).

## Related issue

No issue — follow-up to the bitemporal valid-time work (`jn:valid-at`, `jn:create-valid-time-index`), closing the gap that the valid-time config could not be set from JSONiq at resource-creation time.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — see notes: full build not run in this environment; targeted modules compiled and the full `jn.temporal` + integration test suites pass
- [x] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: the relevant invariant in [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — no storage-engine/commit-protocol changes; index-catalog serialization untouched
- [ ] Updated documentation (README / docs) where relevant — the new options are documented in javadoc; happy to add a docs section if wanted
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- **Build caveat**: the sandbox blocked downloading the wrapper's Gradle 9.4.1, so everything was built/tested with Gradle 8.14.3 on JDK 25 (`:sirix-query` main+test, `:sirix-core`, `:sirix-mcp`, `:sirix-rest-api` Kotlin). Test runs: the complete `io.sirix.query.function.jn.temporal.*` suite (end-to-end, drop, optimizer-rewrite, both differentials, bitemporal integration, stress), `JsonIntegrationTest`, and the new 11-test `StoreValidTimeAutoIndexTest` — all green. A CI run under the wrapper version would be good confirmation.
- **Known pre-existing issue surfaced (not fixed here)**: the core bootstrap CAS auto-indexing for valid-time paths (`JsonNodeTrxImpl.createValidTimeIndexesIfNeeded`) never persists its definitions — empirically, a cold reopen shows 0 CAS defs for any valid-time resource (all creation paths, including REST/Java API, before this PR). Reviving it would add two always-maintained CAS indexes to every valid-time resource, so it needs a deliberate decision: fix the persistence or remove the dead code. The auto-created interval index covers the `jn:valid-at` fast path either way.
- **Follow-up candidate**: REST-created valid-time resources (`validFromPath` query params) still don't get the interval index — the REST handler could call the now-shared `ValidTimeIndexes` recipe after shredding for parity with `jn:store`.
- Large imports that overflow `numberOfNodesBeforeAutoCommit` create the index definition only at the final commit's revision (intermediate auto-commit revisions fall back to scans — results stay correct). The in-transaction builder pass also re-traverses the shredded document once; for the parallel-shredder path the index lands in a follow-up revision per resource since the shredder commits internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wkCeRawExQ5MSCaQC7iW4

---
_Generated by [Claude Code](https://claude.ai/code/session_015wkCeRawExQ5MSCaQC7iW4)_