### PR TITLE
perf: reduce per-operation allocations on core hot paths

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -1225,20 +1225,15 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
 
   @Override
   public final StructNode getStructuralNodeView() {
-    if (currentNode instanceof StructNode structNode) {
-      return structNode;
-    }
-    if (SINGLETON_ENABLED && singletonMode && currentSingleton instanceof StructNode structNode) {
-      return structNode;
-    }
-    return getStructuralNode();
+    return getCurrentNodeView() instanceof StructNode structNode ? structNode : getStructuralNode();
   }
 
   /**
    * Get a live, allocation-free view of the current node. In singleton mode this returns the
    * reused per-kind singleton bound to the current position instead of a deep-copy snapshot —
    * callers must consume it before the next cursor move and must never retain it. Non-singleton
-   * positions fall back to {@link #getCurrentNode()}.
+   * positions fall back to {@link #getCurrentNode()}. Single source of the view dispatch chain
+   * ({@link #getStructuralNodeView()} is expressed through it).
    *
    * @return live view of the current node
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeReadOnlyTrx.java
@@ -1234,6 +1234,24 @@ public abstract class AbstractNodeReadOnlyTrx<T extends NodeCursor & NodeReadOnl
     return getStructuralNode();
   }
 
+  /**
+   * Get a live, allocation-free view of the current node. In singleton mode this returns the
+   * reused per-kind singleton bound to the current position instead of a deep-copy snapshot —
+   * callers must consume it before the next cursor move and must never retain it. Non-singleton
+   * positions fall back to {@link #getCurrentNode()}.
+   *
+   * @return live view of the current node
+   */
+  protected final ImmutableNode getCurrentNodeView() {
+    if (currentNode != null) {
+      return currentNode;
+    }
+    if (SINGLETON_ENABLED && singletonMode && currentSingleton != null) {
+      return currentSingleton;
+    }
+    return getCurrentNode();
+  }
+
   @Override
   public boolean moveToNextFollowing() {
     assertNotClosed();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeReadOnlyTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeReadOnlyTrxImpl.java
@@ -378,7 +378,7 @@ public final class JsonNodeReadOnlyTrxImpl extends
         || kind == NodeKind.OBJECT_NAMED_OBJECT || kind == NodeKind.OBJECT_NAMED_ARRAY) {
       final int nameKey = getFusedNamedNodeKey(kind);
       if (nameKey == -1) {
-        return new QNm("");
+        return NodeKind.EMPTY_QNM;
       }
       final String localName = storageEngineReader.getName(nameKey, NodeKind.OBJECT_NAMED_OBJECT);
       return new QNm(localName);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeFactoryImpl.java
@@ -86,15 +86,15 @@ final class XmlNodeFactoryImpl implements XmlNodeFactory {
     this.reusableElementNode = new ElementNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber,
         Fixed.NULL_NODE_KEY.getStandardProperty(), Fixed.NULL_NODE_KEY.getStandardProperty(),
         Fixed.NULL_NODE_KEY.getStandardProperty(), Fixed.NULL_NODE_KEY.getStandardProperty(), 0, 0, 0, 0, -1, -1, -1,
-        hashFunction, (SirixDeweyID) null, reusableElementAttributeKeys, reusableElementNamespaceKeys, new QNm(""));
+        hashFunction, (SirixDeweyID) null, reusableElementAttributeKeys, reusableElementNamespaceKeys, NodeKind.EMPTY_QNM);
     this.reusableAttributeNode = new AttributeNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, -1, -1, -1,
-        0, new byte[0], hashFunction, (SirixDeweyID) null, new QNm(""));
+        0, new byte[0], hashFunction, (SirixDeweyID) null, NodeKind.EMPTY_QNM);
     this.reusableNamespaceNode = new NamespaceNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, -1, -1, -1,
-        0, hashFunction, (SirixDeweyID) null, new QNm(""));
+        0, hashFunction, (SirixDeweyID) null, NodeKind.EMPTY_QNM);
     this.reusablePINode = new PINode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber,
         Fixed.NULL_NODE_KEY.getStandardProperty(), Fixed.NULL_NODE_KEY.getStandardProperty(),
         Fixed.NULL_NODE_KEY.getStandardProperty(), Fixed.NULL_NODE_KEY.getStandardProperty(), 0, 0, 0, 0, -1, -1, -1,
-        new byte[0], false, hashFunction, (SirixDeweyID) null, new QNm(""));
+        new byte[0], false, hashFunction, (SirixDeweyID) null, NodeKind.EMPTY_QNM);
     this.reusableTextNode =
         new TextNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, Fixed.NULL_NODE_KEY.getStandardProperty(),
             Fixed.NULL_NODE_KEY.getStandardProperty(), 0, new byte[0], false, hashFunction, (SirixDeweyID) null);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
@@ -489,19 +489,13 @@ public final class XmlNodeReadOnlyTrxImpl extends
     return null;
   }
 
+  /**
+   * Snapshot-based variant for callers whose result escapes the current cursor position
+   * ({@link #getNameNode()}); every name-bearing kind implements {@link NameNode}, so a single
+   * instanceof covers all cases.
+   */
   private NameNode currentNameNodeOrNull() {
-    final NodeKind kind = getKind();
-    if (kind == NodeKind.ELEMENT || kind == NodeKind.PROCESSING_INSTRUCTION) {
-      return (NameNode) getStructuralNode();
-    }
-    if (kind == NodeKind.ATTRIBUTE || kind == NodeKind.NAMESPACE) {
-      return (NameNode) getCurrentNode();
-    }
-    final var currentNode = getCurrentNode();
-    if (currentNode instanceof NameNode nameNode) {
-      return nameNode;
-    }
-    return null;
+    return getCurrentNode() instanceof NameNode nameNode ? nameNode : null;
   }
 
   /**
@@ -520,19 +514,13 @@ public final class XmlNodeReadOnlyTrxImpl extends
     return getCurrentNodeView() instanceof ValueNode valueNode ? valueNode : null;
   }
 
+  /**
+   * Snapshot-based variant for callers whose result escapes the current cursor position
+   * ({@link #getValueNode()}); every value-bearing kind implements {@link ValueNode}, so a single
+   * instanceof covers all cases.
+   */
   private ValueNode currentValueNodeOrNull() {
-    final NodeKind kind = getKind();
-    if (kind == NodeKind.TEXT || kind == NodeKind.COMMENT || kind == NodeKind.PROCESSING_INSTRUCTION) {
-      return (ValueNode) getStructuralNode();
-    }
-    if (kind == NodeKind.ATTRIBUTE) {
-      return (ValueNode) getCurrentNode();
-    }
-    final var currentNode = getCurrentNode();
-    if (currentNode instanceof ValueNode valueNode) {
-      return valueNode;
-    }
-    return null;
+    return getCurrentNode() instanceof ValueNode valueNode ? valueNode : null;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeReadOnlyTrxImpl.java
@@ -126,7 +126,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   public boolean moveToAttribute(final int index) {
     assertNotClosed();
     if (getKind() == NodeKind.ELEMENT) {
-      final ElementNode element = (ElementNode) getStructuralNode();
+      final ElementNode element = (ElementNode) getStructuralNodeView();
       if (element.getAttributeCount() > index) {
         return moveTo(element.getAttributeKey(index));
       } else {
@@ -141,7 +141,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   public boolean moveToNamespace(final int index) {
     assertNotClosed();
     if (getKind() == NodeKind.ELEMENT) {
-      final ElementNode element = (ElementNode) getStructuralNode();
+      final ElementNode element = (ElementNode) getStructuralNodeView();
       if (element.getNamespaceCount() > index) {
         return moveTo(element.getNamespaceKey(index));
       } else {
@@ -155,7 +155,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public QNm getName() {
     assertNotClosed();
-    final NameNode nameNode = currentNameNodeOrNull();
+    final NameNode nameNode = currentNameNodeViewOrNull();
     if (nameNode != null) {
       final NodeKind kind = getKind();
       final String uri = storageEngineReader.getName(nameNode.getURIKey(), NodeKind.NAMESPACE);
@@ -217,10 +217,10 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public boolean moveToLastChild() {
     assertNotClosed();
-    if (getStructuralNode().hasFirstChild()) {
+    if (getStructuralNodeView().hasFirstChild()) {
       moveToFirstChild();
 
-      while (getStructuralNode().hasRightSibling()) {
+      while (getStructuralNodeView().hasRightSibling()) {
         moveToRightSibling();
       }
 
@@ -260,7 +260,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   public int getAttributeCount() {
     assertNotClosed();
     if (getKind() == NodeKind.ELEMENT) {
-      return ((ElementNode) getStructuralNode()).getAttributeCount();
+      return ((ElementNode) getStructuralNodeView()).getAttributeCount();
     }
     return 0;
   }
@@ -269,7 +269,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   public int getNamespaceCount() {
     assertNotClosed();
     if (getKind() == NodeKind.ELEMENT) {
-      return ((ElementNode) getStructuralNode()).getNamespaceCount();
+      return ((ElementNode) getStructuralNodeView()).getNamespaceCount();
     }
     return 0;
   }
@@ -277,13 +277,13 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public boolean isNameNode() {
     assertNotClosed();
-    return currentNameNodeOrNull() != null;
+    return currentNameNodeViewOrNull() != null;
   }
 
   @Override
   public int getPrefixKey() {
     assertNotClosed();
-    final NameNode nameNode = currentNameNodeOrNull();
+    final NameNode nameNode = currentNameNodeViewOrNull();
     if (nameNode != null) {
       return nameNode.getPrefixKey();
     }
@@ -293,7 +293,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public int getLocalNameKey() {
     assertNotClosed();
-    final NameNode nameNode = currentNameNodeOrNull();
+    final NameNode nameNode = currentNameNodeViewOrNull();
     if (nameNode != null) {
       return nameNode.getLocalNameKey();
     }
@@ -316,7 +316,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   public long getAttributeKey(final int index) {
     assertNotClosed();
     if (getKind() == NodeKind.ELEMENT) {
-      return ((ElementNode) getStructuralNode()).getAttributeKey(index);
+      return ((ElementNode) getStructuralNodeView()).getAttributeKey(index);
     }
     return -1;
   }
@@ -332,7 +332,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public int getURIKey() {
     assertNotClosed();
-    final NameNode nameNode = currentNameNodeOrNull();
+    final NameNode nameNode = currentNameNodeViewOrNull();
     if (nameNode != null) {
       return nameNode.getURIKey();
     }
@@ -360,7 +360,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public String getNamespaceURI() {
     assertNotClosed();
-    final NameNode nameNode = currentNameNodeOrNull();
+    final NameNode nameNode = currentNameNodeViewOrNull();
     if (nameNode != null) {
       return storageEngineReader.getName(nameNode.getURIKey(), NodeKind.NAMESPACE);
     }
@@ -412,20 +412,20 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public boolean hasAttributes() {
     assertNotClosed();
-    return getKind() == NodeKind.ELEMENT && ((ElementNode) getStructuralNode()).getAttributeCount() > 0;
+    return getKind() == NodeKind.ELEMENT && ((ElementNode) getStructuralNodeView()).getAttributeCount() > 0;
   }
 
   @Override
   public boolean hasNamespaces() {
     assertNotClosed();
-    return getKind() == NodeKind.ELEMENT && ((ElementNode) getStructuralNode()).getNamespaceCount() > 0;
+    return getKind() == NodeKind.ELEMENT && ((ElementNode) getStructuralNodeView()).getNamespaceCount() > 0;
   }
 
   @Override
   public SirixDeweyID getLeftSiblingDeweyID() {
     assertNotClosed();
     if (resourceSession.getResourceConfig().areDeweyIDsStored) {
-      final StructNode node = getStructuralNode();
+      final StructNode node = getStructuralNodeView();
       final long nodeKey = node.getNodeKey();
       SirixDeweyID deweyID = null;
       if (node.hasLeftSibling()) {
@@ -442,7 +442,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public SirixDeweyID getRightSiblingDeweyID() {
     if (resourceSession.getResourceConfig().areDeweyIDsStored) {
-      final StructNode node = getStructuralNode();
+      final StructNode node = getStructuralNodeView();
       final long nodeKey = node.getNodeKey();
       SirixDeweyID deweyID = null;
       if (node.hasRightSibling()) {
@@ -475,7 +475,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public SirixDeweyID getFirstChildDeweyID() {
     if (resourceSession.getResourceConfig().areDeweyIDsStored) {
-      final StructNode node = getStructuralNode();
+      final StructNode node = getStructuralNodeView();
       final long nodeKey = node.getNodeKey();
       SirixDeweyID deweyID = null;
       if (node.hasFirstChild()) {
@@ -504,6 +504,22 @@ public final class XmlNodeReadOnlyTrxImpl extends
     return null;
   }
 
+  /**
+   * Live-view variant of {@link #currentNameNodeOrNull()} — no snapshot allocation. The returned
+   * node must be consumed before the next cursor move and never retained.
+   */
+  private NameNode currentNameNodeViewOrNull() {
+    return getCurrentNodeView() instanceof NameNode nameNode ? nameNode : null;
+  }
+
+  /**
+   * Live-view variant of {@link #currentValueNodeOrNull()} — no snapshot allocation. The returned
+   * node must be consumed before the next cursor move and never retained.
+   */
+  private ValueNode currentValueNodeViewOrNull() {
+    return getCurrentNodeView() instanceof ValueNode valueNode ? valueNode : null;
+  }
+
   private ValueNode currentValueNodeOrNull() {
     final NodeKind kind = getKind();
     if (kind == NodeKind.TEXT || kind == NodeKind.COMMENT || kind == NodeKind.PROCESSING_INSTRUCTION) {
@@ -525,11 +541,11 @@ public final class XmlNodeReadOnlyTrxImpl extends
 
     final String returnVal;
 
-    final ValueNode valueNode = currentValueNodeOrNull();
+    final ValueNode valueNode = currentValueNodeViewOrNull();
     if (valueNode != null) {
       returnVal = new String(valueNode.getRawValue(), Constants.DEFAULT_ENCODING);
     } else if (getKind() == NodeKind.NAMESPACE) {
-      returnVal = storageEngineReader.getName(((NamespaceNode) getCurrentNode()).getURIKey(), NodeKind.NAMESPACE);
+      returnVal = storageEngineReader.getName(((NamespaceNode) getCurrentNodeView()).getURIKey(), NodeKind.NAMESPACE);
     } else {
       returnVal = "";
     }
@@ -540,7 +556,7 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public int getNameCount(String name, NodeKind kind) {
     assertNotClosed();
-    if (currentNameNodeOrNull() != null) {
+    if (currentNameNodeViewOrNull() != null) {
       return storageEngineReader.getNameCount(NamePageHash.generateHashForString(name), kind);
     }
     return 0;
@@ -549,13 +565,13 @@ public final class XmlNodeReadOnlyTrxImpl extends
   @Override
   public boolean isValueNode() {
     assertNotClosed();
-    return currentValueNodeOrNull() != null;
+    return currentValueNodeViewOrNull() != null;
   }
 
   @Override
   public byte[] getRawValue() {
     assertNotClosed();
-    final ValueNode valueNode = currentValueNodeOrNull();
+    final ValueNode valueNode = currentValueNodeViewOrNull();
     if (valueNode != null) {
       return valueNode.getRawValue();
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -43,7 +43,7 @@ import io.sirix.io.Reader;
 import io.sirix.node.DeletedNode;
 import io.sirix.node.MemorySegmentBytesIn;
 import io.sirix.node.NodeKind;
-import io.sirix.node.SirixDeweyID;
+
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.interfaces.FlyweightNode;
 import io.sirix.node.interfaces.Node;
@@ -85,7 +85,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-
 
 import static io.sirix.utils.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -475,11 +474,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // Flyweight format: create binding shell and bind to page memory (zero-copy read)
       final FlyweightNode fn = FlyweightNodeFactory.createAndBind(
           slottedPage, offset, nodeKey, resourceConfig.nodeHashFunction);
-      // Propagate DeweyID from page to flyweight node (stored inline after record data)
+      // Propagate DeweyID from page to flyweight node (stored inline after record data).
+      // setDeweyIDBytes stores raw bytes lazily — no SirixDeweyID parsing until getDeweyID().
       if (resourceConfig.areDeweyIDsStored && fn instanceof Node node) {
         final byte[] deweyIdBytes = kvlPage.getDeweyIdAsByteArray(offset);
         if (deweyIdBytes != null) {
-          node.setDeweyID(new SirixDeweyID(deweyIdBytes));
+          node.setDeweyIDBytes(deweyIdBytes);
         }
       }
       // Propagate FSST symbol table to flyweight string nodes for lazy decompression

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/ForAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/ForAxis.java
@@ -84,17 +84,17 @@ public final class ForAxis extends AbstractAxis {
       mIsFirst = false;
     } else {
       if (mReturn.hasNext()) {
-        return mReturn.next();
+        return mReturn.nextLong();
       }
     }
 
     // Check for more items in the binding sequence.
     while (mRange.hasNext()) {
-      mRange.next();
+      mRange.nextLong();
 
       mReturn.reset(getStartKey());
       if (mReturn.hasNext()) {
-        return mReturn.next();
+        return mReturn.nextLong();
       }
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/JsonDescendantAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/JsonDescendantAxis.java
@@ -21,10 +21,9 @@
 
 package io.sirix.axis;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import io.sirix.api.NodeCursor;
-import io.sirix.utils.Pair;
 import io.sirix.settings.Fixed;
 
 /**
@@ -35,8 +34,11 @@ import io.sirix.settings.Fixed;
  */
 public final class JsonDescendantAxis extends AbstractAxis {
 
-  /** Stack for remembering next nodeKey in document order. */
-  private Deque<Pair<Long, Integer>> rightSiblingKeyStack;
+  /** Stack for remembering next nodeKey in document order (parallel to {@link #depthStack}). */
+  private LongArrayList rightSiblingKeyStack;
+
+  /** Stack for remembering the depth of the corresponding key in {@link #rightSiblingKeyStack}. */
+  private IntArrayList depthStack;
 
   /** Determines if it's the first call to hasNext(). */
   private boolean first;
@@ -67,7 +69,13 @@ public final class JsonDescendantAxis extends AbstractAxis {
   public void reset(final long nodeKey) {
     super.reset(nodeKey);
     first = true;
-    rightSiblingKeyStack = new ArrayDeque<>();
+    if (rightSiblingKeyStack == null) {
+      rightSiblingKeyStack = new LongArrayList();
+      depthStack = new IntArrayList();
+    } else {
+      rightSiblingKeyStack.clear();
+      depthStack.clear();
+    }
   }
 
   @Override
@@ -98,7 +106,8 @@ public final class JsonDescendantAxis extends AbstractAxis {
     if (firstChildKey != Fixed.NULL_NODE_KEY.getStandardProperty()) {
       final long rightSiblingKey = cursor.getRightSiblingKey();
       if (rightSiblingKey != Fixed.NULL_NODE_KEY.getStandardProperty()) {
-        rightSiblingKeyStack.push(new Pair<>(rightSiblingKey, depth));
+        rightSiblingKeyStack.add(rightSiblingKey);
+        depthStack.add(depth);
       }
       depth++;
       return firstChildKey;
@@ -118,10 +127,9 @@ public final class JsonDescendantAxis extends AbstractAxis {
     }
 
     // Then follow right sibling on stack.
-    if (rightSiblingKeyStack.size() > 0) {
-      final var pair = rightSiblingKeyStack.pop();
-      key = pair.getFirst();
-      depth = pair.getSecond();
+    if (!rightSiblingKeyStack.isEmpty()) {
+      key = rightSiblingKeyStack.popLong();
+      depth = depthStack.popInt();
 
       if (depth == 0) {
         return done();

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/JsonDescendantAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/JsonDescendantAxis.java
@@ -69,6 +69,7 @@ public final class JsonDescendantAxis extends AbstractAxis {
   public void reset(final long nodeKey) {
     super.reset(nodeKey);
     first = true;
+    depth = 0;
     if (rightSiblingKeyStack == null) {
       rightSiblingKeyStack = new LongArrayList();
       depthStack = new IntArrayList();

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/NestedAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/NestedAxis.java
@@ -72,7 +72,7 @@ public final class NestedAxis extends AbstractAxis {
     if (isFirst) {
       isFirst = false;
       if (parentAxis.hasNext()) {
-        childAxis.reset(parentAxis.next());
+        childAxis.reset(parentAxis.nextLong());
       } else {
         return done();
       }
@@ -82,13 +82,13 @@ public final class NestedAxis extends AbstractAxis {
     boolean hasNext;
     while (!(hasNext = childAxis.hasNext())) {
       if (parentAxis.hasNext()) {
-        childAxis.reset(parentAxis.next());
+        childAxis.reset(parentAxis.nextLong());
       } else {
         break;
       }
     }
     if (hasNext) {
-      return childAxis.next();
+      return childAxis.nextLong();
     }
 
     return done();

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/NonStructuralWrapperAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/NonStructuralWrapperAxis.java
@@ -80,7 +80,7 @@ public final class NonStructuralWrapperAxis extends AbstractAxis {
     }
 
     if (mParentAxis.hasNext()) {
-      final long key = mParentAxis.next();
+      final long key = mParentAxis.nextLong();
       mFirst = false;
       mNspIndex = 0;
       mAttIndex = 0;

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/Util.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/concurrent/Util.java
@@ -22,7 +22,7 @@ public final class Util {
    */
   public static long getNext(final Axis axis) {
     return axis.hasNext()
-        ? axis.next()
+        ? axis.nextLong()
         : Fixed.NULL_NODE_KEY.getStandardProperty();
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/filter/FilterAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/filter/FilterAxis.java
@@ -85,8 +85,10 @@ public final class FilterAxis<R extends NodeReadOnlyTrx & NodeCursor> extends Ab
     while (axis.hasNext()) {
       final long nodeKey = axis.nextLong();
       boolean filterResult = true;
-      for (final Filter<R> filter : axisFilter) {
-        filterResult = filter.filter();
+      // Indexed loop: no per-node Iterator allocation on this hot path.
+      final int filterCount = axisFilter.size();
+      for (int i = 0; i < filterCount; i++) {
+        filterResult = axisFilter.get(i).filter();
         if (!filterResult) {
           break;
         }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/filter/PredicateFilterAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/filter/PredicateFilterAxis.java
@@ -80,7 +80,7 @@ public final class PredicateFilterAxis extends AbstractAxis {
       predicate.reset(currKey);
 
       if (predicate.hasNext()) {
-        predicate.next();
+        predicate.nextLong();
         if (isBooleanFalse()) {
           return done();
         }

--- a/bundles/sirix-core/src/main/java/io/sirix/axis/pathsummary/filter/FilterAxis.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/axis/pathsummary/filter/FilterAxis.java
@@ -78,8 +78,10 @@ public final class FilterAxis extends AbstractAxis {
     while (axis.hasNext()) {
       final var node = axis.next();
       boolean filterResult = true;
-      for (final Predicate<PathNode> filter : axisFilter) {
-        filterResult = filter.test(node);
+      // Indexed loop: no per-node Iterator allocation on this hot path.
+      final int filterCount = axisFilter.size();
+      for (int i = 0; i < filterCount; i++) {
+        filterResult = axisFilter.get(i).test(node);
         if (!filterResult) {
           break;
         }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
@@ -1,6 +1,5 @@
 package io.sirix.index.name;
 
-import static java.util.Objects.requireNonNull;
 
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
@@ -18,6 +17,8 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
 
 /**
  * Names index structure.
@@ -251,14 +252,11 @@ public final class Names {
     final int key = name.hashCode();
     final byte[] previousByteValue = nameMap.get(key);
 
-    final String previousStringValue;
-    if (previousByteValue != null) {
-      previousStringValue = new String(previousByteValue, Constants.DEFAULT_ENCODING);
-    } else {
-      previousStringValue = null;
-    }
+    // Encode once and compare raw bytes — avoids materializing a String per call on the
+    // shredding hot path, and the encoded bytes are needed for the insert anyway.
+    final byte[] nameBytes = getBytes(name);
 
-    if (previousStringValue == null || !previousStringValue.equals(name)) {
+    if (previousByteValue == null || !Arrays.equals(previousByteValue, nameBytes)) {
       final int newKey;
 
       if (nameMap.containsKey(key)) {
@@ -278,7 +276,7 @@ public final class Names {
       countNodeMap.put(newKey, maxNodeKey);
       storageEngineWriter.createRecord(hashCountEntryNode, IndexType.NAME, indexNumber);
 
-      nameMap.put(newKey, requireNonNull(getBytes(name)));
+      nameMap.put(newKey, nameBytes);
       countNameMapping.put(newKey, 1);
 
       return newKey;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
@@ -1,6 +1,5 @@
 package io.sirix.index.name;
 
-
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.index.IndexType;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/RBTreeReader.java
@@ -18,10 +18,10 @@ import io.sirix.node.interfaces.StructNode;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
 import io.sirix.settings.Fixed;
 
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+
 import java.io.PrintStream;
-import java.util.ArrayDeque;
 import java.util.Comparator;
-import java.util.Deque;
 import java.util.Optional;
 
 import static io.sirix.utils.Preconditions.checkArgument;
@@ -775,9 +775,9 @@ public final class RBTreeReader<K extends Comparable<? super K>, V extends Refer
     private boolean first;
 
     /**
-     * All AVLNode keys which are part of the result sequence.
+     * All AVLNode keys which are part of the result sequence (primitive stack — no boxing).
      */
-    private final Deque<Long> keys;
+    private final LongArrayList keys;
 
     /**
      * Start node key.
@@ -792,7 +792,7 @@ public final class RBTreeReader<K extends Comparable<? super K>, V extends Refer
      */
     public RBNodeIterator(final long nodeKey) {
       first = true;
-      keys = new ArrayDeque<>();
+      keys = new LongArrayList();
       checkArgument(nodeKey >= 0, "nodeKey must be >= 0!");
       key = nodeKey;
     }
@@ -802,7 +802,7 @@ public final class RBTreeReader<K extends Comparable<? super K>, V extends Refer
       if (!first) {
         if (!keys.isEmpty()) {
           // Subsequent results.
-          moveTo(keys.pop());
+          moveTo(keys.popLong());
           final RBNodeKey<K> node = getCurrentNodeAsRBNodeKey();
           stackOperation(node);
           return node;

--- a/bundles/sirix-core/src/main/java/io/sirix/node/AbstractFlyweightNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/AbstractFlyweightNode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, Sirix Contributors
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.sirix.node;
+
+import io.sirix.node.interfaces.FlyweightNode;
+
+/**
+ * Base class for flyweight (page-direct) node implementations, owning the field-offset scratch
+ * array used when serializing a record to a page heap. The array is serialize-only state — reads
+ * never touch it — so it is allocated lazily on first serialization instead of once per node
+ * shell (which would cost an {@code int[]} on every record read).
+ *
+ * @author Johannes Lichtenberger
+ */
+public abstract class AbstractFlyweightNode implements FlyweightNode {
+
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
+
+  /**
+   * Number of entries in this record kind's field-offset table (the per-kind
+   * {@code FIELD_COUNT} from {@link io.sirix.page.NodeFieldLayout}).
+   *
+   * @return the field count
+   */
+  protected abstract int heapOffsetFieldCount();
+
+  /**
+   * Get the lazily-allocated field-offset scratch array for use with the static
+   * {@code writeNewRecord} methods and {@code serializeToHeap}.
+   *
+   * @return the reused offset array
+   */
+  public final int[] getHeapOffsets() {
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[heapOffsetFieldCount()];
+      heapOffsets = offsets;
+    }
+    return offsets;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
@@ -2046,11 +2046,11 @@ public enum NodeKind implements DeweyIdSerializer {
   private static final NodeKind[] INSTANCEFORID = new NodeKind[128];
 
   /**
-   * Shared empty-name placeholder used by legacy deserialization; the real name is resolved from
-   * the name page via the name keys. {@link QNm} is immutable, so sharing one instance is safe and
-   * avoids an allocation per deserialized name node.
+   * Shared empty-name placeholder; the real name is resolved from the name page via the name
+   * keys. {@link QNm} is immutable, so sharing one instance is safe and avoids an allocation
+   * per deserialized/created name node.
    */
-  private static final QNm EMPTY_QNM = new QNm("");
+  public static final QNm EMPTY_QNM = new QNm("");
 
   static {
     for (final NodeKind node : values()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
@@ -157,7 +157,7 @@ public enum NodeKind implements DeweyIdSerializer {
 
       return new ElementNode(nodeKey, parentKey, previousRevision, lastModifiedRevision, rightSiblingKey,
           leftSiblingKey, firstChildKey, lastChildKey, childCount, descendantCount, hash, pathNodeKey, prefixKey,
-          localNameKey, uriKey, resourceConfiguration.nodeHashFunction, deweyID, attrKeys, namespaceKeys, new QNm(""));
+          localNameKey, uriKey, resourceConfiguration.nodeHashFunction, deweyID, attrKeys, namespaceKeys, EMPTY_QNM);
     }
 
     @Override
@@ -227,7 +227,7 @@ public enum NodeKind implements DeweyIdSerializer {
       source.read(value, 0, value.length);
 
       return new AttributeNode(nodeKey, parentKey, previousRevision, lastModifiedRevision, pathNodeKey, prefixKey,
-          localNameKey, uriKey, 0, value, resourceConfiguration.nodeHashFunction, deweyID, new QNm(""));
+          localNameKey, uriKey, 0, value, resourceConfiguration.nodeHashFunction, deweyID, EMPTY_QNM);
     }
 
     @Override
@@ -269,7 +269,7 @@ public enum NodeKind implements DeweyIdSerializer {
       final int lastModifiedRevision = DeltaVarIntCodec.decodeSigned(source);
 
       return new NamespaceNode(nodeKey, parentKey, previousRevision, lastModifiedRevision, pathNodeKey, prefixKey,
-          localNameKey, uriKey, 0, resourceConfiguration.nodeHashFunction, deweyID, new QNm(""));
+          localNameKey, uriKey, 0, resourceConfiguration.nodeHashFunction, deweyID, EMPTY_QNM);
     }
 
     @Override
@@ -373,7 +373,7 @@ public enum NodeKind implements DeweyIdSerializer {
 
       return new PINode(recordID, parentKey, previousRevision, lastModifiedRevision, rightSiblingKey, leftSiblingKey,
           firstChildKey, lastChildKey, childCount, descendantCount, 0, pathNodeKey, prefixKey, localNameKey, uriKey,
-          value, isCompressed, resourceConfiguration.nodeHashFunction, deweyID, new QNm(""));
+          value, isCompressed, resourceConfiguration.nodeHashFunction, deweyID, EMPTY_QNM);
     }
 
     @Override
@@ -2044,6 +2044,13 @@ public enum NodeKind implements DeweyIdSerializer {
    * Mapping of keys -> nodes.
    */
   private static final NodeKind[] INSTANCEFORID = new NodeKind[128];
+
+  /**
+   * Shared empty-name placeholder used by legacy deserialization; the real name is resolved from
+   * the name page via the name keys. {@link QNm} is immutable, so sharing one instance is safe and
+   * avoids an allocation per deserialized name node.
+   */
+  private static final QNm EMPTY_QNM = new QNm("");
 
   static {
     for (final NodeKind node : values()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/delegates/ValueNodeDelegate.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/delegates/ValueNodeDelegate.java
@@ -111,7 +111,9 @@ public class ValueNodeDelegate extends AbstractForwardingNode implements ValueNo
 
   @Override
   public void setRawValue(final byte[] value) {
-    compressed = new String(value).length() > 10;
+    // Byte-length threshold: decoding to a String just to count chars allocated on every
+    // value write; the compression heuristic only needs a rough size cut-off.
+    compressed = value.length > 10;
     this.value = compressed
         ? Compression.compress(value, Deflater.DEFAULT_COMPRESSION)
         : value;

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ArrayNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ArrayNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -64,7 +65,7 @@ import org.jspecify.annotations.Nullable;
  * 
  * @author Johannes Lichtenberger
  */
-public final class ArrayNode implements StructNode, ImmutableJsonNode, FlyweightNode {
+public final class ArrayNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -121,9 +122,6 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.ARRAY_FIELD_COUNT;
 
@@ -400,16 +398,9 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
         hash, childCount, descendantCount);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ArrayNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ArrayNode.java
@@ -122,8 +122,8 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.ARRAY_FIELD_COUNT;
 
@@ -137,7 +137,6 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
   public ArrayNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -163,7 +162,6 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -189,7 +187,6 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -396,7 +393,7 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         firstChildKey, lastChildKey, pathNodeKey,
         previousRevision, lastModifiedRevision,
@@ -407,7 +404,12 @@ public final class ArrayNode implements StructNode, ImmutableJsonNode, Flyweight
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/BooleanNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/BooleanNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -63,7 +64,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Johannes Lichtenberger
  */
-public final class BooleanNode implements StructNode, ImmutableJsonNode, BooleanValueNode, FlyweightNode {
+public final class BooleanNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, BooleanValueNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -113,9 +114,6 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.BOOLEAN_VALUE_FIELD_COUNT;
 
@@ -354,16 +352,9 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
         previousRevision, lastModifiedRevision, value);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/BooleanNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/BooleanNode.java
@@ -114,8 +114,8 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.BOOLEAN_VALUE_FIELD_COUNT;
 
@@ -129,7 +129,6 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
   public BooleanNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -149,7 +148,6 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -169,7 +167,6 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -352,7 +349,7 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision, value);
   }
@@ -361,7 +358,12 @@ public final class BooleanNode implements StructNode, ImmutableJsonNode, Boolean
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/JsonDocumentRootNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/JsonDocumentRootNode.java
@@ -21,6 +21,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -53,7 +54,7 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Supports flyweight binding to a page MemorySegment for zero-copy field access.</p>
  */
-public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode, FlyweightNode {
+public final class JsonDocumentRootNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, FlyweightNode {
 
   // === STRUCTURAL FIELDS (immediate) ===
 
@@ -107,9 +108,6 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
 
   /** Owning page for resize-in-place operations. */
   private KeyValueLeafPage ownerPage;
-
-  /** Reusable offset array for serializeToHeap (avoids allocation). */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.JSON_DOCUMENT_ROOT_FIELD_COUNT;
 
@@ -331,16 +329,9 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
         firstChildKey, lastChildKey, childCount, descendantCount, hash);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/JsonDocumentRootNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/JsonDocumentRootNode.java
@@ -109,7 +109,7 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
   private KeyValueLeafPage ownerPage;
 
   /** Reusable offset array for serializeToHeap (avoids allocation). */
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.JSON_DOCUMENT_ROOT_FIELD_COUNT;
 
@@ -123,7 +123,6 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
   public JsonDocumentRootNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -146,7 +145,6 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
     this.descendantCount = descendantCount;
     this.hashFunction = hashFunction;
     this.deweyIDBytes = SirixDeweyID.newRootID().toBytes();
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -170,7 +168,6 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
     this.descendantCount = descendantCount;
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -330,7 +327,7 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
    * Serialize this node from Java fields. Delegates to static writeNewRecord.
    */
   public int serializeToHeap(final MemorySegment target, final long offset) {
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         firstChildKey, lastChildKey, childCount, descendantCount, hash);
   }
 
@@ -338,7 +335,12 @@ public final class JsonDocumentRootNode implements StructNode, ImmutableJsonNode
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/NullNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/NullNode.java
@@ -110,8 +110,8 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.NULL_VALUE_FIELD_COUNT;
 
@@ -125,7 +125,6 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
   public NullNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -144,7 +143,6 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -163,7 +161,6 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -322,7 +319,7 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision);
   }
@@ -331,7 +328,12 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/NullNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/NullNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -62,7 +63,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Johannes Lichtenberger
  */
-public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightNode {
+public final class NullNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -109,9 +110,6 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.NULL_VALUE_FIELD_COUNT;
 
@@ -324,16 +322,9 @@ public final class NullNode implements StructNode, ImmutableJsonNode, FlyweightN
         previousRevision, lastModifiedRevision);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
@@ -115,8 +115,8 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.NUMBER_VALUE_FIELD_COUNT;
 
@@ -130,7 +130,6 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
   public NumberNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -153,7 +152,6 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
     // Constructed with all values - mark as fully parsed
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -176,7 +174,6 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
     // Constructed with all values - mark as fully parsed
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -398,7 +395,7 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
   public int serializeToHeap(final MemorySegment target, final long offset) {
     if (!metadataParsed) parseMetadataFields();
     if (!valueParsed) parseValueField();
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision, value);
   }
@@ -407,7 +404,12 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -67,7 +68,7 @@ import java.math.BigInteger;
  * 
  * @author Johannes Lichtenberger
  */
-public final class NumberNode implements StructNode, ImmutableJsonNode, NumericValueNode, FlyweightNode {
+public final class NumberNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, NumericValueNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -114,9 +115,6 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.NUMBER_VALUE_FIELD_COUNT;
 
@@ -400,16 +398,9 @@ public final class NumberNode implements StructNode, ImmutableJsonNode, NumericV
         previousRevision, lastModifiedRevision, value);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedArrayNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedArrayNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
@@ -91,7 +92,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1), no autoboxing in any hot accessor.
  */
-public final class ObjectNamedArrayNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
+public final class ObjectNamedArrayNode extends AbstractFlyweightNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
 
   private long nodeKey;
   private long parentKey;
@@ -129,8 +130,6 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_ARRAY_FIELD_COUNT;
 
   public ObjectNamedArrayNode(final long nodeKey, final LongHashFunction hashFunction) {
@@ -352,13 +351,9 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
         childCount, descendantCount);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedArrayNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedArrayNode.java
@@ -129,14 +129,13 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_ARRAY_FIELD_COUNT;
 
   public ObjectNamedArrayNode(final long nodeKey, final LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedArrayNode(final long nodeKey, final long parentKey, final long rightSiblingKey,
@@ -160,7 +159,6 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedArrayNode(final long nodeKey, final long parentKey, final long rightSiblingKey,
@@ -184,7 +182,6 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -347,7 +344,7 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         firstChildKey, lastChildKey,
         nameKey, pathNodeKey,
@@ -356,7 +353,12 @@ public final class ObjectNamedArrayNode implements StructNode, NameNode, Immutab
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedBooleanNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedBooleanNode.java
@@ -115,14 +115,13 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_BOOLEAN_FIELD_COUNT;
 
   public ObjectNamedBooleanNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedBooleanNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -141,7 +140,6 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedBooleanNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -160,7 +158,6 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -310,14 +307,19 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         nameKey, pathNodeKey,
         previousRevision, lastModifiedRevision, hash, value);
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedBooleanNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedBooleanNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
@@ -80,7 +81,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1).
  */
-public final class ObjectNamedBooleanNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
+public final class ObjectNamedBooleanNode extends AbstractFlyweightNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
 
   private long nodeKey;
   private long parentKey;
@@ -115,8 +116,6 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_BOOLEAN_FIELD_COUNT;
 
   public ObjectNamedBooleanNode(long nodeKey, LongHashFunction hashFunction) {
@@ -313,13 +312,9 @@ public final class ObjectNamedBooleanNode implements StructNode, NameNode, Immut
         previousRevision, lastModifiedRevision, hash, value);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNullNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNullNode.java
@@ -116,7 +116,7 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_NULL_FIELD_COUNT;
 
@@ -126,7 +126,6 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
   public ObjectNamedNullNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -147,7 +146,6 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -168,7 +166,6 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -312,14 +309,19 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         nameKey, pathNodeKey,
         previousRevision, lastModifiedRevision, hash);
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNullNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNullNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
@@ -82,7 +83,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1).
  */
-public final class ObjectNamedNullNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
+public final class ObjectNamedNullNode extends AbstractFlyweightNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
 
   private long nodeKey;
   private long parentKey;
@@ -116,8 +117,6 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_NULL_FIELD_COUNT;
 
   /**
@@ -315,13 +314,9 @@ public final class ObjectNamedNullNode implements StructNode, NameNode, Immutabl
         previousRevision, lastModifiedRevision, hash);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNumberNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNumberNode.java
@@ -127,7 +127,7 @@ public final class ObjectNamedNumberNode
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_NUMBER_FIELD_COUNT;
 
@@ -138,7 +138,6 @@ public final class ObjectNamedNumberNode
   public ObjectNamedNumberNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedNumberNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -158,7 +157,6 @@ public final class ObjectNamedNumberNode
     this.deweyIDBytes = deweyID;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedNumberNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -178,7 +176,6 @@ public final class ObjectNamedNumberNode
     this.sirixDeweyID = deweyID;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -347,14 +344,19 @@ public final class ObjectNamedNumberNode
     if (!valueParsed) {
       parseValueField();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         nameKey, pathNodeKey,
         previousRevision, lastModifiedRevision, hash, value);
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNumberNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedNumberNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -89,7 +90,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1).
  */
-public final class ObjectNamedNumberNode
+public final class ObjectNamedNumberNode extends AbstractFlyweightNode
     implements StructNode, NameNode, ImmutableJsonNode, NumericValueNode, FlyweightNode {
 
   private long nodeKey;
@@ -127,8 +128,6 @@ public final class ObjectNamedNumberNode
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_NUMBER_FIELD_COUNT;
 
   /** Thread-local scratch buffer for serializing number payloads. */
@@ -350,13 +349,9 @@ public final class ObjectNamedNumberNode
         previousRevision, lastModifiedRevision, hash, value);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedObjectNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedObjectNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
@@ -88,7 +89,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1), no autoboxing in any hot accessor.
  */
-public final class ObjectNamedObjectNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
+public final class ObjectNamedObjectNode extends AbstractFlyweightNode implements StructNode, NameNode, ImmutableJsonNode, FlyweightNode {
 
   private long nodeKey;
   private long parentKey;
@@ -126,8 +127,6 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_OBJECT_FIELD_COUNT;
 
   /**
@@ -361,13 +360,9 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
         childCount, descendantCount);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedObjectNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedObjectNode.java
@@ -126,7 +126,7 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_OBJECT_FIELD_COUNT;
 
@@ -137,7 +137,6 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
   public ObjectNamedObjectNode(final long nodeKey, final LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /** Primary constructor with all primitive fields. */
@@ -162,7 +161,6 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /** Constructor with SirixDeweyID instead of byte array. */
@@ -187,7 +185,6 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -356,7 +353,7 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         firstChildKey, lastChildKey,
         nameKey, pathNodeKey,
@@ -365,7 +362,12 @@ public final class ObjectNamedObjectNode implements StructNode, NameNode, Immuta
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   public void setDeweyIDAfterCreation(final SirixDeweyID id, final byte[] bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
@@ -127,7 +127,7 @@ public final class ObjectNamedStringNode
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_STRING_FIELD_COUNT;
 
@@ -141,7 +141,6 @@ public final class ObjectNamedStringNode
   public ObjectNamedStringNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedStringNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -170,7 +169,6 @@ public final class ObjectNamedStringNode
     this.fsstSymbolTable = fsstSymbolTable;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   public ObjectNamedStringNode(long nodeKey, long parentKey, long rightSiblingKey, long leftSiblingKey,
@@ -199,7 +197,6 @@ public final class ObjectNamedStringNode
     this.fsstSymbolTable = fsstSymbolTable;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -376,14 +373,19 @@ public final class ObjectNamedStringNode
     if (!valueParsed) {
       parseValueField();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         nameKey, pathNodeKey,
         previousRevision, lastModifiedRevision, hash, value, isCompressed);
   }
 
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNamedStringNode.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
@@ -84,7 +85,7 @@ import java.util.Objects;
  * <p>HFT contract: primitive fields only, {@code final} where possible, zero-alloc
  * bind/unbind, offset-table lookups in O(1).
  */
-public final class ObjectNamedStringNode
+public final class ObjectNamedStringNode extends AbstractFlyweightNode
     implements StructNode, NameNode, ValueNode, ImmutableJsonNode, FlyweightNode {
 
   private long nodeKey;
@@ -127,8 +128,6 @@ public final class ObjectNamedStringNode
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_NAMED_STRING_FIELD_COUNT;
 
   /**
@@ -379,13 +378,9 @@ public final class ObjectNamedStringNode
         previousRevision, lastModifiedRevision, hash, value, isCompressed);
   }
 
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -63,7 +64,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Johannes Lichtenberger
  */
-public final class ObjectNode implements StructNode, ImmutableJsonNode, FlyweightNode {
+public final class ObjectNode extends AbstractFlyweightNode implements StructNode, ImmutableJsonNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -119,9 +120,6 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_FIELD_COUNT;
 
@@ -389,16 +387,9 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
         hash, childCount, descendantCount);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/ObjectNode.java
@@ -120,8 +120,8 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.OBJECT_FIELD_COUNT;
 
@@ -135,7 +135,6 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
   public ObjectNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -160,7 +159,6 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -185,7 +183,6 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -386,7 +383,7 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         firstChildKey, lastChildKey, previousRevision, lastModifiedRevision,
         hash, childCount, descendantCount);
@@ -396,7 +393,12 @@ public final class ObjectNode implements StructNode, ImmutableJsonNode, Flyweigh
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
@@ -123,8 +123,8 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.STRING_VALUE_FIELD_COUNT;
 
@@ -145,7 +145,6 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
   public StringNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -182,7 +181,6 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
     // Constructed with all values - mark as fully parsed
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -219,7 +217,6 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
     // Constructed with all values - mark as fully parsed
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -414,7 +411,7 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
   public int serializeToHeap(final MemorySegment target, final long offset) {
     if (!metadataParsed) parseMetadataFields();
     if (!valueParsed) parseValueField();
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
@@ -423,7 +420,12 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/StringNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.json;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -67,7 +68,7 @@ import java.lang.foreign.ValueLayout;
  * 
  * @author Johannes Lichtenberger
  */
-public final class StringNode implements StructNode, ValueNode, ImmutableJsonNode, FlyweightNode {
+public final class StringNode extends AbstractFlyweightNode implements StructNode, ValueNode, ImmutableJsonNode, FlyweightNode {
 
   // Node identity (mutable for singleton reuse)
   private long nodeKey;
@@ -122,9 +123,6 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.STRING_VALUE_FIELD_COUNT;
 
@@ -416,16 +414,9 @@ public final class StringNode implements StructNode, ValueNode, ImmutableJsonNod
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
@@ -96,7 +96,7 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.ATTRIBUTE_FIELD_COUNT;
 
   /**
@@ -116,7 +116,6 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
   public AttributeNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -138,7 +137,6 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -160,7 +158,6 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   @Override
@@ -743,7 +740,7 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
         parseLazyValue();
       }
     }
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, pathNodeKey, prefixKey, localNameKey, uriKey,
         previousRevision, lastModifiedRevision, value);
   }
@@ -752,7 +749,12 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/AttributeNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.brackit.query.atomic.QNm;
@@ -63,7 +64,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Johannes Lichtenberger
  */
-public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNode, FlyweightNode {
+public final class AttributeNode extends AbstractFlyweightNode implements ValueNode, NameNode, ImmutableXmlNode, FlyweightNode {
 
   // === PRIMITIVE FIELDS ===
   private long nodeKey;
@@ -96,7 +97,6 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.ATTRIBUTE_FIELD_COUNT;
 
   /**
@@ -745,16 +745,9 @@ public final class AttributeNode implements ValueNode, NameNode, ImmutableXmlNod
         previousRevision, lastModifiedRevision, value);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -69,7 +70,7 @@ import java.lang.foreign.ValueLayout;
  *
  * @author Johannes Lichtenberger
  */
-public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNode, FlyweightNode {
+public final class CommentNode extends AbstractFlyweightNode implements StructNode, ValueNode, ImmutableXmlNode, FlyweightNode {
 
   // === IMMEDIATE STRUCTURAL FIELDS ===
   private long nodeKey;
@@ -103,7 +104,6 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.COMMENT_FIELD_COUNT;
 
   /**
@@ -348,16 +348,9 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/CommentNode.java
@@ -103,7 +103,7 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.COMMENT_FIELD_COUNT;
 
   /**
@@ -123,7 +123,6 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   public CommentNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -143,7 +142,6 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
     this.isCompressed = isCompressed;
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -163,7 +161,6 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
     this.isCompressed = isCompressed;
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -346,7 +343,7 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
   @Override
   public int serializeToHeap(final MemorySegment target, final long offset) {
     if (!valueParsed) parseLazyValue();
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
@@ -355,7 +352,12 @@ public final class CommentNode implements StructNode, ValueNode, ImmutableXmlNod
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/ElementNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/ElementNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.brackit.query.atomic.QNm;
@@ -73,7 +74,7 @@ import java.util.List;
  *
  * @author Johannes Lichtenberger
  */
-public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode, FlyweightNode {
+public final class ElementNode extends AbstractFlyweightNode implements StructNode, NameNode, ImmutableXmlNode, FlyweightNode {
 
   // === IMMEDIATE STRUCTURAL FIELDS ===
   private long nodeKey;
@@ -130,9 +131,6 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   /** Whether the payload (attributeKeys, namespaceKeys) has been parsed from page memory. */
   private boolean payloadParsed;
@@ -514,12 +512,13 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
    */
   @Override
   public int serializeToHeap(final MemorySegment target, final long offset) {
+    // Bound-mode getters read page memory, not the Java fields serialized below — serializing a
+    // still-bound node would silently write stale primitives. unbind() (which also materializes
+    // the attr/ns payload) must run first; every call site does so.
+    assert page == null : "serializeToHeap requires an unbound node";
     // Ensure all lazy fields are materialized
     if (!lazyFieldsParsed) {
       parseLazyFields();
-    }
-    if (page != null) {
-      ensurePayloadParsed();
     }
 
     long pos = offset;
@@ -614,16 +613,9 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
     return (int) (pos - offset);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**
@@ -1216,17 +1208,40 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
 
   // === ATTRIBUTE METHODS (dual-mode) ===
 
-  public int getAttributeCount() {
+  /**
+   * Materialize the attribute/namespace key lists in whichever mode the node is in: bound
+   * (parse the payload region from page memory) or unbound-lazy after {@link #readFrom}
+   * (parse the remaining lazy fields, which include the key lists).
+   */
+  private void ensureKeysMaterialized() {
     if (page != null) {
       ensurePayloadParsed();
+    } else if (!lazyFieldsParsed) {
+      parseLazyFields();
+    }
+  }
+
+  /** Absolute offset of the payload region ({@code [attrCount][attrKeys][nsCount][nsKeys]}). */
+  private long payloadStart() {
+    final int payloadFieldOff = page.get(ValueLayout.JAVA_BYTE, recordBase + 1 + NodeFieldLayout.ELEM_PAYLOAD) & 0xFF;
+    return dataRegionStart + payloadFieldOff;
+  }
+
+  public int getAttributeCount() {
+    if (page != null) {
+      if (!payloadParsed) {
+        // Count-only fast path: the attribute count is the leading varint of the payload —
+        // no need to materialize the key lists.
+        return DeltaVarIntCodec.decodeSignedFromSegment(page, payloadStart());
+      }
+    } else if (!lazyFieldsParsed) {
+      parseLazyFields();
     }
     return attributeKeys.size();
   }
 
   public long getAttributeKey(int index) {
-    if (page != null) {
-      ensurePayloadParsed();
-    }
+    ensureKeysMaterialized();
     if (attributeKeys.size() <= index) {
       return Fixed.NULL_NODE_KEY.getStandardProperty();
     }
@@ -1234,8 +1249,8 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   }
 
   public void insertAttribute(long attrKey) {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       // Payload changed: must unbind and re-serialize
       unbind();
     }
@@ -1243,25 +1258,23 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   }
 
   public void removeAttribute(long attrNodeKey) {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       unbind();
     }
     attributeKeys.removeIf(key -> key == attrNodeKey);
   }
 
   public void clearAttributeKeys() {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       unbind();
     }
     attributeKeys.clear();
   }
 
   public List<Long> getAttributeKeys() {
-    if (page != null) {
-      ensurePayloadParsed();
-    }
+    ensureKeysMaterialized();
     return Collections.unmodifiableList(attributeKeys);
   }
 
@@ -1269,15 +1282,25 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
 
   public int getNamespaceCount() {
     if (page != null) {
-      ensurePayloadParsed();
+      if (!payloadParsed) {
+        // Count-only fast path: width-skip the attribute keys, then read the namespace count —
+        // allocation-free, no list materialization.
+        long pos = payloadStart();
+        final int attrCount = DeltaVarIntCodec.decodeSignedFromSegment(page, pos);
+        pos += DeltaVarIntCodec.readSignedVarintWidth(page, pos);
+        for (int i = 0; i < attrCount; i++) {
+          pos += DeltaVarIntCodec.readDeltaEncodedWidth(page, pos);
+        }
+        return DeltaVarIntCodec.decodeSignedFromSegment(page, pos);
+      }
+    } else if (!lazyFieldsParsed) {
+      parseLazyFields();
     }
     return namespaceKeys.size();
   }
 
   public long getNamespaceKey(int namespaceKey) {
-    if (page != null) {
-      ensurePayloadParsed();
-    }
+    ensureKeysMaterialized();
     if (namespaceKeys.size() <= namespaceKey) {
       return Fixed.NULL_NODE_KEY.getStandardProperty();
     }
@@ -1285,33 +1308,31 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   }
 
   public void insertNamespace(long namespaceKey) {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       unbind();
     }
     namespaceKeys.add(namespaceKey);
   }
 
   public void removeNamespace(long namespaceKey) {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       unbind();
     }
     namespaceKeys.removeIf(key -> key == namespaceKey);
   }
 
   public void clearNamespaceKeys() {
+    ensureKeysMaterialized();
     if (page != null) {
-      ensurePayloadParsed();
       unbind();
     }
     namespaceKeys.clear();
   }
 
   public List<Long> getNamespaceKeys() {
-    if (page != null) {
-      ensurePayloadParsed();
-    }
+    ensureKeysMaterialized();
     return Collections.unmodifiableList(namespaceKeys);
   }
 
@@ -1502,8 +1523,10 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
                       .add("leftSibling", leftSiblingKey)
                       .add("firstChild", firstChildKey)
                       .add("lastChild", lastChildKey)
-                      .add("attributeKeys", attributeKeys)
-                      .add("namespaceKeys", namespaceKeys)
+                      // Accessors, not raw fields: a bound node's lists may be unparsed or stale
+                      // from a previous binding.
+                      .add("attributeKeys", getAttributeKeys())
+                      .add("namespaceKeys", getNamespaceKeys())
                       .toString();
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/ElementNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/ElementNode.java
@@ -131,8 +131,8 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   /** Whether the payload (attributeKeys, namespaceKeys) has been parsed from page memory. */
   private boolean payloadParsed;
@@ -149,9 +149,8 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   public ElementNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.attributeKeys = new LongArrayList();
-    this.namespaceKeys = new LongArrayList();
-    this.heapOffsets = new int[FIELD_COUNT];
+    // attributeKeys/namespaceKeys stay null until the payload is parsed lazily —
+    // most reads never touch them.
   }
 
   /**
@@ -187,7 +186,6 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
         : new LongArrayList();
     this.qNm = qNm;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -222,7 +220,6 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
         : new LongArrayList();
     this.qNm = qNm;
     this.lazyFieldsParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -230,8 +227,8 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
   /**
    * Bind this node as a flyweight to a page MemorySegment.
    * When bound, getters/setters read/write directly to page memory via the offset table.
-   * Attribute and namespace keys are eagerly read from the payload region because element
-   * nodes almost always need their attr/ns keys.
+   * Attribute and namespace keys are parsed lazily from the payload region on first access —
+   * plain structural navigation never needs them.
    *
    * @param page       the page MemorySegment
    * @param recordBase absolute byte offset of this record in the page
@@ -249,8 +246,6 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
     this.lazyFieldsParsed = true; // No lazy state when bound
     this.lazySource = null;
     this.payloadParsed = false;
-    // Eagerly parse payload (attribute/namespace keys) since element nodes always need them
-    ensurePayloadParsed();
   }
 
   /**
@@ -523,6 +518,9 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
     if (!lazyFieldsParsed) {
       parseLazyFields();
     }
+    if (page != null) {
+      ensurePayloadParsed();
+    }
 
     long pos = offset;
 
@@ -536,7 +534,7 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
 
     // Data region start
     final long dataStart = pos;
-    final int[] offsets = this.heapOffsets;
+    final int[] offsets = getHeapOffsets();
 
     // Field 0: parentKey (delta-varint)
     offsets[NodeFieldLayout.ELEM_PARENT_KEY] = (int) (pos - dataStart);
@@ -620,7 +618,12 @@ public final class ElementNode implements StructNode, NameNode, ImmutableXmlNode
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/NamespaceNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/NamespaceNode.java
@@ -98,7 +98,7 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.NAMESPACE_FIELD_COUNT;
 
@@ -112,7 +112,6 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
   public NamespaceNode(final long nodeKey, final LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -134,7 +133,6 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -156,7 +154,6 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -333,7 +330,7 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
    */
   @Override
   public int serializeToHeap(final MemorySegment target, final long offset) {
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, pathNodeKey, prefixKey, localNameKey, uriKey,
         previousRevision, lastModifiedRevision, hash);
   }
@@ -342,7 +339,12 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/NamespaceNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/NamespaceNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.brackit.query.atomic.QNm;
@@ -64,7 +65,7 @@ import java.lang.foreign.ValueLayout;
  *
  * @author Johannes Lichtenberger
  */
-public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, FlyweightNode {
+public final class NamespaceNode extends AbstractFlyweightNode implements NameNode, ImmutableXmlNode, Node, FlyweightNode {
 
   // === PRIMITIVE FIELDS ===
   private long nodeKey;
@@ -98,8 +99,6 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
-
   private static final int FIELD_COUNT = NodeFieldLayout.NAMESPACE_FIELD_COUNT;
 
   /**
@@ -335,16 +334,9 @@ public final class NamespaceNode implements NameNode, ImmutableXmlNode, Node, Fl
         previousRevision, lastModifiedRevision, hash);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
@@ -136,8 +136,8 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
 
-  /** Pre-allocated offset array reused across serializations (zero-alloc hot path). */
-  private final int[] heapOffsets;
+  /** Offset array reused across serializations; lazily allocated because reads never need it. */
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.PI_FIELD_COUNT;
 
@@ -151,7 +151,6 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
   public PINode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -181,7 +180,6 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
     this.hashFunction = hashFunction;
     this.deweyIDBytes = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -211,7 +209,6 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
     this.qNm = qNm;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -471,7 +468,7 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
    */
   public int serializeToHeap(final MemorySegment target, final long offset) {
     if (!valueParsed) parseLazyValue();
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         firstChildKey, lastChildKey, pathNodeKey,
         prefixKey, localNameKey, uriKey,
@@ -483,7 +480,12 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/PINode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.brackit.query.atomic.QNm;
@@ -71,7 +72,7 @@ import java.lang.foreign.ValueLayout;
  *
  * @author Johannes Lichtenberger
  */
-public final class PINode implements StructNode, NameNode, ValueNode, ImmutableXmlNode, FlyweightNode {
+public final class PINode extends AbstractFlyweightNode implements StructNode, NameNode, ValueNode, ImmutableXmlNode, FlyweightNode {
 
   // === IMMEDIATE STRUCTURAL FIELDS ===
   private long nodeKey;
@@ -135,9 +136,6 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
 
   /** Owning page for resize-in-place on varint width changes. */
   private KeyValueLeafPage ownerPage;
-
-  /** Offset array reused across serializations; lazily allocated because reads never need it. */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.PI_FIELD_COUNT;
 
@@ -476,16 +474,9 @@ public final class PINode implements StructNode, NameNode, ValueNode, ImmutableX
         childCount, descendantCount, value, isCompressed);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
@@ -108,7 +108,7 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.TEXT_FIELD_COUNT;
 
   /**
@@ -128,7 +128,6 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   public TextNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -150,7 +149,6 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
     this.deweyIDBytes = deweyID;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -172,7 +170,6 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
     this.sirixDeweyID = deweyID;
     this.metadataParsed = true;
     this.valueParsed = true;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -359,7 +356,7 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   public int serializeToHeap(final MemorySegment target, final long offset) {
     if (!metadataParsed) parseMetadataFields();
     if (!valueParsed) parseValuePayload();
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         parentKey, rightSiblingKey, leftSiblingKey,
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
@@ -368,7 +365,12 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/TextNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -69,7 +70,7 @@ import java.lang.foreign.ValueLayout;
  *
  * @author Johannes Lichtenberger
  */
-public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, FlyweightNode {
+public final class TextNode extends AbstractFlyweightNode implements StructNode, ValueNode, ImmutableXmlNode, FlyweightNode {
 
   // === IMMEDIATE STRUCTURAL FIELDS ===
   private long nodeKey;
@@ -108,7 +109,6 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
   private int slotIndex;
   private boolean writeSingleton;
   private KeyValueLeafPage ownerPage;
-  private int[] heapOffsets;
   private static final int FIELD_COUNT = NodeFieldLayout.TEXT_FIELD_COUNT;
 
   /**
@@ -361,16 +361,9 @@ public final class TextNode implements StructNode, ValueNode, ImmutableXmlNode, 
         previousRevision, lastModifiedRevision, value, isCompressed);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/XmlDocumentRootNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/XmlDocumentRootNode.java
@@ -28,6 +28,7 @@
 
 package io.sirix.node.xml;
 
+import io.sirix.node.AbstractFlyweightNode;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -62,7 +63,7 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Supports flyweight binding to a page MemorySegment for zero-copy field access.</p>
  */
-public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, FlyweightNode {
+public final class XmlDocumentRootNode extends AbstractFlyweightNode implements StructNode, ImmutableXmlNode, FlyweightNode {
 
   // === STRUCTURAL FIELDS (immediate) ===
 
@@ -116,9 +117,6 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
 
   /** Owning page for resize-in-place operations. */
   private KeyValueLeafPage ownerPage;
-
-  /** Reusable offset array for serializeToHeap (avoids allocation). */
-  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.XML_DOCUMENT_ROOT_FIELD_COUNT;
 
@@ -348,16 +346,9 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
         firstChildKey, lastChildKey, childCount, descendantCount, hash);
   }
 
-  /**
-   * Get the pre-allocated heap offsets array for use with static writeNewRecord.
-   */
-  public int[] getHeapOffsets() {
-    int[] offsets = heapOffsets;
-    if (offsets == null) {
-      offsets = new int[FIELD_COUNT];
-      heapOffsets = offsets;
-    }
-    return offsets;
+  @Override
+  protected int heapOffsetFieldCount() {
+    return FIELD_COUNT;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/xml/XmlDocumentRootNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/xml/XmlDocumentRootNode.java
@@ -118,7 +118,7 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
   private KeyValueLeafPage ownerPage;
 
   /** Reusable offset array for serializeToHeap (avoids allocation). */
-  private final int[] heapOffsets;
+  private int[] heapOffsets;
 
   private static final int FIELD_COUNT = NodeFieldLayout.XML_DOCUMENT_ROOT_FIELD_COUNT;
 
@@ -132,7 +132,6 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
   public XmlDocumentRootNode(long nodeKey, LongHashFunction hashFunction) {
     this.nodeKey = nodeKey;
     this.hashFunction = hashFunction;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -155,7 +154,6 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
     this.descendantCount = descendantCount;
     this.hashFunction = hashFunction;
     this.deweyIDBytes = SirixDeweyID.newRootID().toBytes();
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   /**
@@ -178,7 +176,6 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
     this.descendantCount = descendantCount;
     this.hashFunction = hashFunction;
     this.sirixDeweyID = deweyID;
-    this.heapOffsets = new int[FIELD_COUNT];
   }
 
   // ==================== FLYWEIGHT BIND/UNBIND ====================
@@ -347,7 +344,7 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
    */
   @Override
   public int serializeToHeap(final MemorySegment target, final long offset) {
-    return writeNewRecord(target, offset, heapOffsets, nodeKey,
+    return writeNewRecord(target, offset, getHeapOffsets(), nodeKey,
         firstChildKey, lastChildKey, childCount, descendantCount, hash);
   }
 
@@ -355,7 +352,12 @@ public final class XmlDocumentRootNode implements StructNode, ImmutableXmlNode, 
    * Get the pre-allocated heap offsets array for use with static writeNewRecord.
    */
   public int[] getHeapOffsets() {
-    return heapOffsets;
+    int[] offsets = heapOffsets;
+    if (offsets == null) {
+      offsets = new int[FIELD_COUNT];
+      heapOffsets = offsets;
+    }
+    return offsets;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -30,6 +30,7 @@ import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.api.visitor.VisitResultType;
 import io.sirix.axis.IncludeSelf;
+import io.sirix.io.PageHasher;
 import io.sirix.node.NodeKind;
 import io.sirix.service.AbstractSerializer;
 import io.sirix.service.xml.serialize.XmlSerializerProperties;
@@ -536,13 +537,7 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
   }
 
   private String printHashValue(JsonNodeReadOnlyTrx rtx) {
-    // Manual zero-padded hex — String.format allocates a Formatter + parses the spec per call.
-    final long hash = rtx.getHash();
-    final char[] hex = new char[16];
-    for (int i = 15; i >= 0; i--) {
-      hex[i] = Character.forDigit((int) ((hash >>> ((15 - i) << 2)) & 0xF), 16);
-    }
-    return new String(hex);
+    return PageHasher.toHexString(rtx.getHash());
   }
 
   private boolean withMetaDataField() {

--- a/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/service/json/serialize/JsonSerializer.java
@@ -361,12 +361,12 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
                      && rtx.getNodeKey() == startNodeKey)) {
               appendObjectStart(true);
             }
-            appendObjectKeyValue(quote("key"), quotedObjectKey(rtx))
+            appendObjectKeyValue(QUOTED_KEY, quotedObjectKey(rtx))
                 .appendSeparator()
-                .appendObjectKey(quote("metadata"))
+                .appendObjectKey(QUOTED_METADATA)
                 .appendObjectStart(true);
             if (withNodeKeyMetaData || withNodeKeyAndChildNodeKeyMetaData) {
-              appendObjectKeyValue(quote("nodeKey"), String.valueOf(rtx.getNodeKey()));
+              appendObjectKeyValue(QUOTED_NODE_KEY, String.valueOf(rtx.getNodeKey()));
               // A fused structural node is object/array-like, so childCount always follows in
               // nodeKeyAndChildCount mode. Emit the separator right after nodeKey (mirroring
               // emitMetaData) instead of buggily gating it on withMetaData before childCount —
@@ -377,12 +377,12 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
             }
             if (withMetaData) {
               if (rtx.getHash() != 0L) {
-                appendObjectKeyValue(quote("hash"), quote(printHashValue(rtx)));
+                appendObjectKeyValue(QUOTED_HASH, quote(printHashValue(rtx)));
                 appendSeparator();
               }
-              appendObjectKeyValue(quote("type"), quote(rtx.getKind().toString()));
+              appendObjectKeyValue(QUOTED_TYPE, quote(rtx.getKind().toString()));
               if (rtx.getHash() != 0L) {
-                appendSeparator().appendObjectKeyValue(quote("descendantCount"),
+                appendSeparator().appendObjectKeyValue(QUOTED_DESCENDANT_COUNT,
                     String.valueOf(rtx.getDescendantCount()));
               }
             }
@@ -390,10 +390,10 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
               if (withMetaData) {
                 appendSeparator();
               }
-              appendObjectKeyValue(quote("childCount"), String.valueOf(rtx.getChildCount()));
+              appendObjectKeyValue(QUOTED_CHILD_COUNT, String.valueOf(rtx.getChildCount()));
             }
             appendObjectEnd(innerHasChildren).appendSeparator();
-            appendObjectKey(quote("value"));
+            appendObjectKey(QUOTED_VALUE);
             // iter#32 P2 metadata-mode shape — match legacy OBJECT/ARRAY body behavior:
             //   OBJECT_NAMED_OBJECT (parent of OBJECT_KEY-shaped children) emits `[{` so the
             //     first OBJECT_KEY-shaped child does NOT open its own wrapper (matches legacy OBJECT).
@@ -464,26 +464,26 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
             if (rtx.hasLeftSibling() && !isStartNode) {
               appendObjectStart(true);
             }
-            appendObjectKeyValue(quote("key"), quotedObjectKey(rtx))
+            appendObjectKeyValue(QUOTED_KEY, quotedObjectKey(rtx))
                 .appendSeparator()
-                .appendObjectKey(quote("metadata"))
+                .appendObjectKey(QUOTED_METADATA)
                 .appendObjectStart(true);
             if (withNodeKeyMetaData || withNodeKeyAndChildNodeKeyMetaData) {
-              appendObjectKeyValue(quote("nodeKey"), String.valueOf(rtx.getNodeKey()));
+              appendObjectKeyValue(QUOTED_NODE_KEY, String.valueOf(rtx.getNodeKey()));
             }
             if (withMetaData) {
               appendSeparator();
               if (rtx.getHash() != 0L) {
-                appendObjectKeyValue(quote("hash"), quote(printHashValue(rtx)));
+                appendObjectKeyValue(QUOTED_HASH, quote(printHashValue(rtx)));
                 appendSeparator();
               }
               // Emit the concrete fused kind name (OBJECT_NAMED_*) — JsonSerializer's existing
               // fixtures expect the precise kind, while JsonLimitedSerializer/JsonRecordSerializer
               // collapse the wire-name to OBJECT_KEY for the pagination-style payload.
-              appendObjectKeyValue(quote("type"), quote(rtx.getKind().toString()));
+              appendObjectKeyValue(QUOTED_TYPE, quote(rtx.getKind().toString()));
             }
             appendObjectEnd(true).appendSeparator();
-            appendObjectKey(quote("value"));
+            appendObjectKey(QUOTED_VALUE);
           } else {
             appendObjectKey(quotedObjectKey(rtx));
           }
@@ -536,7 +536,13 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
   }
 
   private String printHashValue(JsonNodeReadOnlyTrx rtx) {
-    return String.format("%016x", rtx.getHash());
+    // Manual zero-padded hex — String.format allocates a Formatter + parses the spec per call.
+    final long hash = rtx.getHash();
+    final char[] hex = new char[16];
+    for (int i = 15; i >= 0; i--) {
+      hex[i] = Character.forDigit((int) ((hash >>> ((15 - i) << 2)) & 0xF), 16);
+    }
+    return new String(hex);
   }
 
   private boolean withMetaDataField() {
@@ -549,10 +555,10 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
   private void emitMetaData(JsonNodeReadOnlyTrx rtx) throws IOException {
     if (withMetaDataField()) {
-      appendObjectStart(true).appendObjectKey(quote("metadata")).appendObjectStart(true);
+      appendObjectStart(true).appendObjectKey(QUOTED_METADATA).appendObjectStart(true);
 
       if (withNodeKeyMetaData || withNodeKeyAndChildNodeKeyMetaData) {
-        appendObjectKeyValue(quote("nodeKey"), String.valueOf(rtx.getNodeKey()));
+        appendObjectKeyValue(QUOTED_NODE_KEY, String.valueOf(rtx.getNodeKey()));
         if (withMetaData || withNodeKeyAndChildNodeKeyMetaData
             && (rtx.getKind() == NodeKind.OBJECT || rtx.getKind() == NodeKind.ARRAY)) {
           appendSeparator();
@@ -561,12 +567,12 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
 
       if (withMetaData) {
         if (rtx.getHash() != 0L) {
-          appendObjectKeyValue(quote("hash"), quote(printHashValue(rtx)));
+          appendObjectKeyValue(QUOTED_HASH, quote(printHashValue(rtx)));
           appendSeparator();
         }
-        appendObjectKeyValue(quote("type"), quote(rtx.getKind().toString()));
+        appendObjectKeyValue(QUOTED_TYPE, quote(rtx.getKind().toString()));
         if (rtx.getHash() != 0L && (rtx.getKind() == NodeKind.OBJECT || rtx.getKind() == NodeKind.ARRAY)) {
-          appendSeparator().appendObjectKeyValue(quote("descendantCount"), String.valueOf(rtx.getDescendantCount()));
+          appendSeparator().appendObjectKeyValue(QUOTED_DESCENDANT_COUNT, String.valueOf(rtx.getDescendantCount()));
         }
       }
 
@@ -574,10 +580,10 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
         if (withMetaData) {
           appendSeparator();
         }
-        appendObjectKeyValue(quote("childCount"), String.valueOf(rtx.getChildCount()));
+        appendObjectKeyValue(QUOTED_CHILD_COUNT, String.valueOf(rtx.getChildCount()));
       }
 
-      appendObjectEnd(true).appendSeparator().appendObjectKey(quote("value"));
+      appendObjectEnd(true).appendSeparator().appendObjectKey(QUOTED_VALUE);
     }
   }
 
@@ -991,6 +997,17 @@ public final class JsonSerializer extends AbstractSerializer<JsonNodeReadOnlyTrx
     newLine();
     return this;
   }
+
+  // Pre-quoted metadata key literals — emitted once per node in metadata modes; hoisting them
+  // avoids rebuilding the same short strings via concatenation on every node.
+  private static final String QUOTED_KEY = "\"key\"";
+  private static final String QUOTED_METADATA = "\"metadata\"";
+  private static final String QUOTED_NODE_KEY = "\"nodeKey\"";
+  private static final String QUOTED_HASH = "\"hash\"";
+  private static final String QUOTED_TYPE = "\"type\"";
+  private static final String QUOTED_DESCENDANT_COUNT = "\"descendantCount\"";
+  private static final String QUOTED_CHILD_COUNT = "\"childCount\"";
+  private static final String QUOTED_VALUE = "\"value\"";
 
   private String quote(String value) {
     return "\"" + value + "\"";


### PR DESCRIPTION
## What does this PR do?

Removes per-operation allocations left on the core read/write hot paths, then fixes the issues an adversarial review of the change surfaced.

**Read path**
- Flyweight node shells no longer allocate the serialize-only `heapOffsets` scratch array per record read — it now lives, lazily allocated, in a new `AbstractFlyweightNode` base class shared by all 20 flyweight node classes.
- `ElementNode` no longer eagerly allocates two `LongArrayList`s and parses the attribute/namespace payload on every bind; the payload parses lazily on first access, and count-only queries (`hasAttributes()`, `getAttributeCount()`, …) read the leading payload varints allocation-free without materializing the key lists.
- DeweyID-enabled flyweight reads store raw bytes lazily instead of eagerly parsing a `SirixDeweyID` per record.
- 17 XML read accessors migrated from the deep-copy snapshot (`getStructuralNode()`) to the zero-allocation live singleton view, matching the JSON side; accessors whose results escape the cursor position keep snapshot semantics.

**Axes and index scans**
- `JsonDescendantAxis`: per-step `Pair<Long,Integer>` + boxed `ArrayDeque` replaced with two reused primitive stacks; `reset()` now also zeroes the traversal depth (pre-existing reuse bug).
- Boxing `next()` → `nextLong()` in `NestedAxis`, `ForAxis`, `NonStructuralWrapperAxis`, `PredicateFilterAxis`, concurrent `Util`; `FilterAxis` uses an indexed loop instead of a per-node iterator; `RBTreeReader`'s iterator uses a primitive long stack.

**Write path and serialization**
- `Names.setName` compares raw UTF-8 bytes instead of decoding a `String` per inserted name; `ValueNodeDelegate` uses a byte-length compression threshold instead of decoding the value; `NodeKind.EMPTY_QNM` is a shared immutable placeholder reused by deserialization and the node factories.
- `JsonSerializer`: constant metadata keys pre-quoted; hash formatting reuses `PageHasher.toHexString` instead of `String.format("%016x", …)`.

## Related issue

No issue — follow-up to the ongoing allocation-reduction work on hot paths (same goal as #1044/#1086).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Performance improvement
- [ ] Documentation only

## Checklist

- [x] `./gradlew build` passes locally (JDK 25)
- [ ] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed)
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- No storage-format or invariant changes — allocation behavior only. No new tests: the change is exercised by the existing suite (`:sirix-core:test` was green on the first commit; the re-run for the review-fix commit is in flight and I'll report here if anything regresses).
- The one subtle change: `ElementNode`'s attribute/namespace accessors now materialize the key lists in unbound-lazy mode too (`parseLazyFields()` fallback). The first commit's live-view migration would otherwise have returned empty lists on the legacy (non-flyweight, `nodeKindId == 0`) singleton path — flagged by review, fixed in the second commit.
- `serializeToHeap` on `ElementNode` now asserts the must-be-unbound contract instead of half-guarding it; every current call site unbinds first (which materializes the payload).
- Deliberately not done (larger/riskier follow-ups): pooling the flyweight shell object per cursor step, de-`Optional`-ing `RBTreeReader` lookups, and per-visit immutable visitor wrappers.

---
_Generated by [Claude Code](https://claude.ai/code/session_016LQxDFp7t4gxbetp8gcVyY)_