### PR TITLE
Projection index follow-ups + always-maintained semantics (no invalidation ladder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,13 +749,17 @@ at their revision. Update transactions maintain projections **incrementally** (w
 index-controller listener lifecycle, like the other index types): changes are attributed to their
 records as they happen, and at commit time only the touched leaves are patched — updated records are
 re-extracted in place, deleted records drop out, and new records append to the tail — so the same
-catalogued projection keeps serving across updates with no re-creation call. Changes the incremental
-path cannot attribute exactly (subtree moves, removing a record-set array itself, unresolvable
-structure, or more dirty records per transaction than `-Dsirix.projection.maxIncrementalRecords`,
-default 100 000, where a rebuild is cheaper) fall back to **invalidation**: the persisted columns are marked stale inside the
-transaction, queries at later revisions transparently use the regular pipeline, and re-running
-`jn:create-projection-index` rebuilds under the same definition; calling it with a different shape
-creates an additional projection. Uncommitted state is servable too: an executor constructed over an
+catalogued projection keeps serving across updates with no re-creation call — including replacing a
+record set wholesale (deleting the array drops its rows, a fresh record set at the same path is
+picked up automatically) and, for descendant-pattern roots, record sets appearing and disappearing.
+Changes the incremental path cannot attribute exactly (subtree moves, unresolvable structure, or
+more dirty records per transaction than `-Dsirix.projection.maxIncrementalRecords`, default
+100 000, where patching approaches rebuild cost) degrade to an **automatic full rebuild inside the
+same commit** — the projection stays exactly maintained, like the other index families, with no
+manual intervention. Only an unexpected failure of both the incremental patch and the rebuild
+tombstones the projection (a corruption valve: queries transparently use the regular pipeline and
+re-running `jn:create-projection-index` rebuilds under the same definition); calling it with a
+different shape creates an additional projection. Uncommitted state is servable too: an executor constructed over an
 open write transaction (`new SirixVectorizedExecutor(wtx, threads)`) answers unpredicated aggregates,
 group-bys and count-distinct from the transaction's own state — pending maintenance is applied on
 read (read-your-writes) and the leaves are read through the transaction log, uncached, so committed

--- a/build.gradle
+++ b/build.gradle
@@ -244,6 +244,22 @@ subprojects {
             events "failed"
             exceptionFormat "short"
         }
+        // Re-print every failure at the END of the run: the GitHub Actions
+        // log API only serves a bounded tail, so per-test failure lines from
+        // early in a long run are unretrievable — this summary is not.
+        def failedTests = []
+        afterTest { desc, result ->
+            if (result.resultType == TestResult.ResultType.FAILURE) {
+                failedTests << "${desc.className} > ${desc.name}: ${result.exception?.toString()?.take(400)}"
+            }
+        }
+        afterSuite { desc, result ->
+            if (desc.parent == null && !failedTests.empty) {
+                println "\n===== FAILED TESTS (${failedTests.size()}) ====="
+                failedTests.each { println "FAILED-TEST: ${it}" }
+                println "===== END FAILED TESTS ====="
+            }
+        }
         useJUnit()
         jvmArgs(["--enable-preview",
                  "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED",

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractIndexController.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractIndexController.java
@@ -39,6 +39,7 @@ import io.sirix.index.vector.VectorIndexListener;
 import io.sirix.index.vector.VectorSearchResult;
 import io.sirix.node.NodeKind;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -284,6 +285,49 @@ public abstract class AbstractIndexController<R extends NodeReadOnlyTrx & NodeCu
     return null;
   }
 
+  /**
+   * Per-transaction cache entry for a wtx-visible decoded projection handle:
+   * valid only for the SAME listener instance (listeners are rebound per
+   * transaction epoch) at the SAME maintenance epoch (any new dirty change,
+   * invalidation, or apply pass bumps it).
+   */
+  private record UncommittedHandle(ProjectionIndexChangeListener listener, long epoch,
+      ProjectionIndexRegistry.Handle handle) {
+  }
+
+  /** Decoded wtx handles per definition id; cleared with the listeners. */
+  private final Int2ObjectOpenHashMap<UncommittedHandle> uncommittedHandles =
+      new Int2ObjectOpenHashMap<>();
+
+  private ProjectionIndexRegistry.@Nullable Handle uncommittedHandleFor(
+      final StorageEngineReader reader, final IndexDef def) {
+    final ProjectionIndexChangeListener listener = projectionListenerFor(def.getID());
+    if (listener != null) {
+      final UncommittedHandle cached = uncommittedHandles.get(def.getID());
+      if (cached != null && cached.listener() == listener
+          && cached.epoch() == listener.maintenanceEpoch()) {
+        return cached.handle();
+      }
+    }
+    final ProjectionIndexRegistry.Handle handle =
+        ProjectionIndexCatalog.loadUncommitted(reader, def);
+    if (handle != null && listener != null) {
+      uncommittedHandles.put(def.getID(),
+          new UncommittedHandle(listener, listener.maintenanceEpoch(), handle));
+    }
+    return handle;
+  }
+
+  private @Nullable ProjectionIndexChangeListener projectionListenerFor(final int indexDefId) {
+    for (final PathNodeKeyChangeListener listener : primitiveListeners) {
+      if (listener instanceof final ProjectionIndexChangeListener projectionListener
+          && projectionListener.indexDefId() == indexDefId) {
+        return projectionListener;
+      }
+    }
+    return null;
+  }
+
   /** Remove any bound projection change listener for this definition id (from both listener sets). */
   private void removeProjectionListenerFor(final int indexDefId) {
     listeners.removeIf(listener -> listener instanceof final ProjectionIndexChangeListener p
@@ -340,6 +384,9 @@ public abstract class AbstractIndexController<R extends NodeReadOnlyTrx & NodeCu
   public void clearChangeListeners() {
     listeners.clear();
     primitiveListeners.clear();
+    // Wtx handle cache entries are bound to listener instances — clearing
+    // the listeners invalidates them (and releases the decoded payloads).
+    uncommittedHandles.clear();
   }
 
   @Override
@@ -492,12 +539,22 @@ public abstract class AbstractIndexController<R extends NodeReadOnlyTrx & NodeCu
       // Wtx-visible serving (read-your-writes): bring the leaves up to date
       // with this transaction's changes — the same work its commit would do,
       // an O(1) no-op when nothing is dirty — then read through the
-      // transaction log with no shared caching (uncommitted state is
-      // mutable; caching it under a revision key would poison
-      // committed-revision serving).
+      // transaction log. No SHARED caching (uncommitted state is mutable;
+      // caching it under a revision key would poison committed-revision
+      // serving), but decoded handles are memoized PER TRANSACTION against
+      // the definition listener's maintenance epoch, so repeated analytics
+      // over an unchanged state decode once.
       applyPendingIndexMaintenance();
-      return ProjectionIndexCatalog.lookupCoveringUncommitted(indexes, storageEngineReader,
-          sourcePath, requiredFields);
+      final IndexDef[] candidates =
+          ProjectionIndexCatalog.selectUncommittedCandidateDefs(indexes, sourcePath, requiredFields);
+      for (final IndexDef candidate : candidates) {
+        final ProjectionIndexRegistry.Handle handle =
+            uncommittedHandleFor(storageEngineReader, candidate);
+        if (handle != null) {
+          return handle;
+        }
+      }
+      return null;
     }
     // Committed reader — the cached catalog front-end (probe + decoded-leaf
     // tiers keyed by resource and revision).

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonIndexController.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonIndexController.java
@@ -113,8 +113,20 @@ public final class JsonIndexController extends AbstractIndexController<JsonNodeR
     final int buildRevision = nodeWriteTrx.getRevisionNumber();
     final ProjectionIndexHOTStorage storage =
         new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
+    // Per-leaf record-key fences — the maintenance zone maps, persisted with
+    // the metadata so a commit locates touched leaves in one slot-0 read.
+    final long[] leafFirstKeys = new long[leaves.size()];
+    final long[] leafLastKeys = new long[leaves.size()];
+    for (int i = 0; i < leaves.size(); i++) {
+      final long[] range = ProjectionIndexLeafCodec.recordKeyRange(leaves.get(i));
+      if (range == null) {
+        throw new IllegalStateException("Serialised projection leaf " + i + " carries no header");
+      }
+      leafFirstKeys[i] = range[0];
+      leafLastKeys[i] = range[1];
+    }
     final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(rootPath, paths, names,
-        builder.columnKinds(), leaves.size(), buildRevision);
+        builder.columnKinds(), leaves.size(), buildRevision, leafFirstKeys, leafLastKeys);
     storage.put(0, metadata.serialize());
     for (int i = 0; i < leaves.size(); i++) {
       storage.put(i + 1, ProjectionIndexLeafCodec.encode(leaves.get(i)));

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonIndexController.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonIndexController.java
@@ -24,8 +24,6 @@ import io.sirix.index.path.json.JsonPathIndexImpl;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.index.projection.ProjectionIndexBuilder;
 import io.sirix.index.projection.ProjectionIndexChangeListener;
-import io.sirix.index.projection.ProjectionIndexHOTStorage;
-import io.sirix.index.projection.ProjectionIndexLeafCodec;
 import io.sirix.index.projection.ProjectionIndexMetadata;
 import io.sirix.index.vector.json.JsonVectorIndexImpl;
 import io.brackit.query.atomic.QNm;
@@ -33,9 +31,7 @@ import io.brackit.query.util.path.Path;
 import io.brackit.query.util.path.PathException;
 import io.brackit.query.util.path.PathParser;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -97,40 +93,11 @@ public final class JsonIndexController extends AbstractIndexController<JsonNodeR
           "Projection indexes require a resource created with a path summary "
               + "(buildPathSummary=true) — the builder resolves its paths through it.");
     }
-    final StorageEngineWriter storageEngineWriter = nodeWriteTrx.getStorageEngineWriter();
-    final List<byte[]> leaves = new ArrayList<>();
-    final ProjectionIndexBuilder builder =
-        new ProjectionIndexBuilder(indexDef, nodeWriteTrx.getPathSummary(), leaves::add);
-    builder.build(nodeWriteTrx);
-
-    final List<Path<QNm>> fieldPaths = indexDef.getProjectionFields();
-    final String[] paths = new String[fieldPaths.size()];
-    for (int i = 0; i < paths.length; i++) {
-      paths[i] = fieldPaths.get(i).toString();
-    }
-    final String rootPath = indexDef.getProjectionRootPath().toString();
-    final String[] names = ProjectionIndexChangeListener.trailingFieldNames(indexDef);
-    final int buildRevision = nodeWriteTrx.getRevisionNumber();
-    final ProjectionIndexHOTStorage storage =
-        new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
-    // Per-leaf record-key fences — the maintenance zone maps, persisted with
-    // the metadata so a commit locates touched leaves in one slot-0 read.
-    final long[] leafFirstKeys = new long[leaves.size()];
-    final long[] leafLastKeys = new long[leaves.size()];
-    for (int i = 0; i < leaves.size(); i++) {
-      final long[] range = ProjectionIndexLeafCodec.recordKeyRange(leaves.get(i));
-      if (range == null) {
-        throw new IllegalStateException("Serialised projection leaf " + i + " carries no header");
-      }
-      leafFirstKeys[i] = range[0];
-      leafLastKeys[i] = range[1];
-    }
-    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(rootPath, paths, names,
-        builder.columnKinds(), leaves.size(), buildRevision, leafFirstKeys, leafLastKeys);
-    storage.put(0, metadata.serialize());
-    for (int i = 0; i < leaves.size(); i++) {
-      storage.put(i + 1, ProjectionIndexLeafCodec.encode(leaves.get(i)));
-    }
+    // Creation fails loudly on a root path with no instances (caller
+    // error); the maintenance rebuild path reuses the same core with the
+    // empty record set allowed.
+    ProjectionIndexBuilder.buildAndPersist(indexDef, nodeWriteTrx.getPathSummary(), nodeWriteTrx,
+        nodeWriteTrx.getStorageEngineWriter(), false);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/xml/XmlNodeTrxImpl.java
@@ -284,7 +284,11 @@ final class XmlNodeTrxImpl extends
 
   private void notifyPrimitiveIndexChange(final IndexController.ChangeType type, final ImmutableNode node,
       final long pathNodeKey) {
-    if (!indexController.hasPathIndex() && !indexController.hasNameIndex() && !indexController.hasCASIndex()) {
+    // Same composite gate as the JSON side — an inlined enumeration here
+    // silently drops notifications for any index type added to
+    // hasAnyPrimitiveIndex() later (exactly what happened to PROJECTION on
+    // the JSON side).
+    if (!indexController.hasAnyPrimitiveIndex()) {
       return;
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -6,6 +6,7 @@ package io.sirix.index.projection;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.jdm.Type;
 import io.brackit.query.util.path.Path;
+import io.sirix.api.StorageEngineWriter;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.axis.DescendantAxis;
 import io.sirix.index.IndexDef;
@@ -16,7 +17,9 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -167,6 +170,76 @@ public final class ProjectionIndexBuilder {
       return ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG;
     }
     return ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT;
+  }
+
+  /**
+   * Build the projection over the transaction's CURRENT state and persist
+   * leaves + metadata into the definition's HOT sub-tree — the shared core
+   * of the controller's index creation and the change listener's
+   * commit-time full rebuild. All writes ride the given writer; the
+   * caller's commit persists them.
+   *
+   * @param emptyRecordSetAllowed creation fails loudly when the root path
+   *        resolves to no path class (declaring an index over a
+   *        non-existent record set is a caller error), while the
+   *        maintenance rebuild persists the truthful EMPTY projection (the
+   *        record set was removed by the committing transaction)
+   */
+  public static void buildAndPersist(final IndexDef indexDef, final PathSummaryReader pathSummary,
+      final JsonNodeReadOnlyTrx rtx, final StorageEngineWriter storageEngineWriter,
+      final boolean emptyRecordSetAllowed) {
+    if (emptyRecordSetAllowed
+        && pathSummary.getPCRsForPaths(Set.of(indexDef.getProjectionRootPath())).isEmpty()) {
+      final List<Type> fieldTypes = indexDef.getProjectionFieldTypes();
+      final byte[] columnKinds = new byte[fieldTypes.size()];
+      for (int i = 0; i < columnKinds.length; i++) {
+        columnKinds[i] = mapTypeToColumnKind(fieldTypes.get(i));
+      }
+      persist(indexDef, storageEngineWriter, List.of(), columnKinds, rtx.getRevisionNumber());
+      return;
+    }
+    final List<byte[]> leaves = new ArrayList<>();
+    final ProjectionIndexBuilder builder =
+        new ProjectionIndexBuilder(indexDef, pathSummary, leaves::add);
+    builder.build(rtx);
+    persist(indexDef, storageEngineWriter, leaves, builder.columnKinds(), rtx.getRevisionNumber());
+  }
+
+  /**
+   * Persist serialised leaves and their self-describing metadata (shape,
+   * build revision, per-leaf record-key fences) into the definition's HOT
+   * sub-tree: metadata at slot 0, leaves at slots 1..N. A rebuild that
+   * shrinks the projection leaves stale payloads at higher slots — the
+   * metadata's leaf count bounds every read, so they are never consumed.
+   */
+  public static void persist(final IndexDef indexDef, final StorageEngineWriter storageEngineWriter,
+      final List<byte[]> leaves, final byte[] columnKinds, final int buildRevision) {
+    final List<Path<QNm>> fieldPaths = indexDef.getProjectionFields();
+    final String[] paths = new String[fieldPaths.size()];
+    for (int i = 0; i < paths.length; i++) {
+      paths[i] = fieldPaths.get(i).toString();
+    }
+    final String rootPath = indexDef.getProjectionRootPath().toString();
+    final String[] names = ProjectionIndexChangeListener.trailingFieldNames(indexDef);
+    final ProjectionIndexHOTStorage storage =
+        new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
+    // Per-leaf record-key fences — the maintenance zone maps, persisted with
+    // the metadata so a commit locates touched leaves in one slot-0 read.
+    final long[] leafFirstKeys = new long[leaves.size()];
+    final long[] leafLastKeys = new long[leaves.size()];
+    for (int i = 0; i < leaves.size(); i++) {
+      final long[] range = ProjectionIndexLeafCodec.recordKeyRange(leaves.get(i));
+      if (range == null) {
+        throw new IllegalStateException("Serialised projection leaf " + i + " carries no header");
+      }
+      leafFirstKeys[i] = range[0];
+      leafLastKeys[i] = range[1];
+    }
+    storage.put(0, new ProjectionIndexMetadata(rootPath, paths, names, columnKinds, leaves.size(),
+        buildRevision, leafFirstKeys, leafLastKeys).serialize());
+    for (int i = 0; i < leaves.size(); i++) {
+      storage.put(i + 1, ProjectionIndexLeafCodec.encode(leaves.get(i)));
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -9,11 +9,14 @@ import io.brackit.query.atomic.QNm;
 import io.brackit.query.util.path.Path;
 import io.sirix.access.trx.node.json.JsonIndexController;
 import io.sirix.api.StorageEngineReader;
+import org.jspecify.annotations.Nullable;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.index.IndexDef;
 import io.sirix.index.Indexes;
+import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.utils.LogWrapper;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
@@ -45,10 +48,12 @@ import java.util.concurrent.atomic.LongAdder;
  * the query's canonical source path AND its trailing field names cover the
  * query's columns; among several matches the narrowest wins and unusable
  * candidates (stale, unreadable) are skipped in favor of the next match.
- * Descendant-pattern roots ({@code //...}) aggregate across every matching
- * subtree by design, which a path-specific query must not be served from —
- * they fail closed to the generic pipeline (pattern-aware matching is a
- * possible follow-up).
+ * Descendant-pattern roots ({@code //...}) are resolved against the queried
+ * revision's path summary when the pattern matches exactly ONE path class —
+ * the definition then serves under that concrete path. A pattern matching
+ * several subtrees aggregates across all of them by design, which a
+ * path-specific query must not be served from — those (and unresolvable
+ * patterns) fail closed to the generic pipeline.
  *
  * <h2>Caching</h2>
  * Two tiers, both bounded:
@@ -209,52 +214,73 @@ public final class ProjectionIndexCatalog {
     return null;
   }
 
+  // ==================== wtx-visible (uncommitted) serving ====================
+  // The caller (AbstractIndexController#openProjectionIndex) has already
+  // flushed the transaction's pending incremental maintenance and passes the
+  // transaction's own reader — the storage-engine writer, whose reads see
+  // the transaction log.
+
+  private static final IndexDef[] NO_DEFS = new IndexDef[0];
+
   /**
-   * Wtx-visible serving: select and decode the projection covering
-   * {@code requiredFields} from a write transaction's UNCOMMITTED state.
-   * The caller ({@code AbstractIndexController#openProjectionIndex}) has
-   * already flushed the transaction's pending incremental maintenance, and
-   * passes the transaction's own reader — the storage-engine writer — whose
-   * reads see the transaction log. NO cache tier is involved: uncommitted
-   * state is mutable within the transaction, so caching it under a revision
-   * key would poison committed-revision serving. Every call re-reads and
-   * re-decodes, which is the price of read-your-writes and is only paid by
-   * callers that opt into it.
-   *
-   * @param indexes the write transaction's index catalog (the controller's
-   *                own {@link Indexes})
-   * @param reader  the transaction's reader (its writer — sees the trx log)
-   * @return a usable handle over the transaction's current state, or
-   *         {@code null} (callers fall back to the generic wtx-reading
-   *         pipeline)
+   * Root-matching, covering candidate DEFINITIONS for an uncommitted (wtx)
+   * lookup, ordered narrowest-first. Selection only — the caller loads each
+   * candidate via {@link #loadUncommitted} (so it can interpose its own
+   * per-transaction handle cache between selection and decode). Descendant-
+   * pattern roots stay fail-closed here: without a path summary the pattern
+   * cannot be proven unambiguous against the transaction's current state.
    */
-  public static ProjectionIndexRegistry.Handle lookupCoveringUncommitted(final Indexes indexes,
-      final StorageEngineReader reader, final String[] sourcePath, final String[] requiredFields) {
+  public static IndexDef[] selectUncommittedCandidateDefs(final Indexes indexes,
+      final String[] sourcePath, final String[] requiredFields) {
     final String canonicalSourcePath = canonicalSourcePath(sourcePath);
     if (canonicalSourcePath == null) {
-      return null;
+      return NO_DEFS;
     }
     try {
       final DefEntry[] entries = defEntriesFrom(indexes);
       if (entries.length == 0) {
-        return null;
+        return NO_DEFS;
       }
       final DefEntry[] candidates = selectCandidates(entries, canonicalSourcePath, requiredFields);
-      for (final DefEntry candidate : candidates) {
-        final Probe probe = probeMetadata(reader, candidate.def, -1);
-        if (probe == UNUSABLE || probe.buildRevision < 0) {
-          continue;
-        }
-        final ProjectionIndexRegistry.Handle handle = decodeLeaves(reader, candidate.def, false);
-        if (handle != NOT_USABLE) {
-          SERVED.increment();
-          return handle;
-        }
+      if (candidates.length == 0) {
+        return NO_DEFS;
       }
-      return null;
+      final IndexDef[] defs = new IndexDef[candidates.length];
+      for (int i = 0; i < defs.length; i++) {
+        defs[i] = candidates[i].def;
+      }
+      return defs;
     } catch (final RuntimeException e) {
-      LOGGER.warn("Uncommitted projection lookup failed for source path "
+      LOGGER.warn("Uncommitted projection candidate selection failed for source path "
           + canonicalSourcePath + ": " + e.getMessage());
+      return NO_DEFS;
+    }
+  }
+
+  /**
+   * Probe + decode ONE definition from the transaction's own reader (its
+   * writer — sees the transaction log). NO shared cache tier: uncommitted
+   * state is mutable within the transaction, so caching it under a revision
+   * key would poison committed-revision serving; the CALLER caches per
+   * transaction, keyed by the maintenance epoch of the definition's
+   * listener.
+   */
+  public static ProjectionIndexRegistry.@Nullable Handle loadUncommitted(
+      final StorageEngineReader reader, final IndexDef def) {
+    try {
+      final Probe probe = probeMetadata(reader, def, -1);
+      if (probe == UNUSABLE || probe.buildRevision < 0) {
+        return null;
+      }
+      final ProjectionIndexRegistry.Handle handle = decodeLeaves(reader, def, false);
+      if (handle == NOT_USABLE) {
+        return null;
+      }
+      SERVED.increment();
+      return handle;
+    } catch (final RuntimeException e) {
+      LOGGER.warn("Uncommitted projection load failed for definition #" + def.getID()
+          + ": " + e.getMessage());
       return null;
     }
   }
@@ -431,8 +457,52 @@ public final class ProjectionIndexCatalog {
       final int revision) {
     return DEFS.get(new DefsKey(resourceKey, revision), key -> {
       final JsonIndexController controller = session.getRtxIndexController(revision);
-      return defEntriesFrom(controller.getIndexes());
+      return resolveDescendantRoots(session, revision, defEntriesFrom(controller.getIndexes()));
     });
+  }
+
+  /**
+   * Rewrite descendant-pattern roots ({@code //...}) to CONCRETE paths via
+   * the revision's path summary so the exact-match serving contract applies:
+   * a pattern matching exactly ONE path class serves under that path class's
+   * concrete path. Ambiguous patterns (several matching subtrees — the
+   * projection aggregates across all of them, which a path-specific query
+   * must not be served from) and unresolvable patterns keep the pattern
+   * string, which never equals a concrete query path — fail closed. Resolved
+   * per (resource, revision) and cached with the entries, so the summary
+   * walk happens once, not per query.
+   */
+  private static DefEntry[] resolveDescendantRoots(final JsonResourceSession session,
+      final int revision, final DefEntry[] entries) {
+    PathSummaryReader summary = null;
+    try {
+      for (int i = 0; i < entries.length; i++) {
+        final DefEntry entry = entries[i];
+        if (!entry.rootPath.contains("//")) {
+          continue;
+        }
+        if (summary == null) {
+          summary = session.openPathSummary(revision);
+        }
+        final LongSet pcrs = summary.getPCRsForPath(entry.def.getProjectionRootPath());
+        if (pcrs.size() != 1 || !summary.moveTo(pcrs.iterator().nextLong())) {
+          continue;
+        }
+        final Path<QNm> concrete = summary.getPath();
+        if (concrete != null) {
+          entries[i] = new DefEntry(entry.def, concrete.toString(), entry.fieldNames);
+        }
+      }
+    } catch (final RuntimeException e) {
+      // Unresolved patterns simply never match a query path — fail closed.
+      LOGGER.warn("Projection descendant-root resolution failed at revision " + revision + ": "
+          + e.getMessage());
+    } finally {
+      if (summary != null) {
+        summary.close();
+      }
+    }
+    return entries;
   }
 
   /** Fresh (uncached) projection def entries of an index catalog. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
@@ -22,6 +22,7 @@ import io.sirix.node.interfaces.NameNode;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
 import io.sirix.node.json.ArrayNode;
 import io.sirix.utils.LogWrapper;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
@@ -120,6 +121,16 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   private final IndexDef indexDef;
 
   /**
+   * Whether the record-set root is a descendant pattern ({@code //...}).
+   * Such projections aggregate over EVERY matching subtree, so a brand-new
+   * path class matching the pattern (a whole new record-set container
+   * appearing mid-transaction) silently widens the record set — the
+   * persisted rows no longer cover the definition and the projection must
+   * be invalidated (see {@link #classifyUnseenPcr}).
+   */
+  private final boolean descendantRootPattern;
+
+  /**
    * Navigation handle over the owning write transaction's current state,
    * used ONLY in the apply phase (pre-commit re-extraction). {@code null}
    * degrades to the legacy invalidation-only contract: the first relevant
@@ -140,6 +151,32 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   /** Record nodeKeys touched by this transaction; lazily allocated. */
   private @Nullable LongOpenHashSet dirtyRecordKeys;
 
+  /**
+   * Positive resolution memo: nodeKey → enclosing record's nodeKey, for
+   * nodes proven to lie INSIDE a record. Bulk subtree mutations notify
+   * every descendant; without the memo each notification re-walks the full
+   * ancestor chain (O(nodes × depth) raw record reads) — with it, a walk
+   * stops at the first memoized ancestor. Only positive verdicts are
+   * memoized: a NOT_UNDER node can still have record descendants (it may be
+   * an ancestor of the record set), so negative memoization would be wrong.
+   * Lazily allocated; writes stop at {@link #MEMO_CAP} entries.
+   */
+  private @Nullable Long2LongOpenHashMap resolvedRecordMemo;
+
+  /** Scratch for the walked ancestor chain (memoized on resolution). */
+  private long[] walkChain = new long[32];
+
+  /**
+   * Monotone per-listener maintenance epoch: bumped whenever the pending
+   * state changes (new dirty record, invalidation) and when an apply pass
+   * rewrites leaves. Lets wtx-serving callers cache a decoded handle and
+   * revalidate it with one long compare instead of re-decoding per query.
+   */
+  private long maintenanceEpoch;
+
+  private static final int MEMO_CAP = 1 << 20;
+  private static final long MEMO_MISS = Long.MIN_VALUE;
+
   public ProjectionIndexChangeListener(final StorageEngineWriter storageEngineWriter,
       final PathSummaryReader pathSummary, final IndexDef indexDef,
       final @Nullable JsonNodeReadOnlyTrx maintenanceTrx) {
@@ -152,6 +189,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     this.pathSummary = pathSummary;
     this.indexDef = indexDef;
     this.maintenanceTrx = maintenanceTrx;
+    this.descendantRootPattern = indexDef.getProjectionRootPath().toString().contains("//");
   }
 
   /** Catalogue id of the definition this listener maintains. */
@@ -282,7 +320,12 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   /**
    * Classify an unseen PCR (e.g. a brand-new field path created by this
    * transaction) by whether its ancestor chain crosses a record-set root,
-   * and cache the verdict so the hot path stays a single set lookup.
+   * and cache the verdict so the hot path stays a single set lookup. For
+   * descendant-pattern roots the new PCR may itself BE a new record-set
+   * root (a second matching subtree appearing mid-transaction) — the
+   * seeded root PCRs cannot know it, so the pattern is re-checked against
+   * the new path class and a match invalidates (the persisted rows no
+   * longer cover the widened record set).
    */
   private boolean classifyUnseenPcr(final long pathNodeKey) {
     boolean relevant = false;
@@ -298,12 +341,37 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       }
       node = pathSummary.getPathNodeForPathNodeKey(parentKey);
     }
+    if (!relevant && descendantRootPattern && matchesRootPattern(pathNodeKey)) {
+      invalidate();
+      return false;
+    }
     if (relevant) {
       relevantPcrs.add(pathNodeKey);
     } else {
       irrelevantPcrs.add(pathNodeKey);
     }
     return relevant;
+  }
+
+  /**
+   * Whether the (unseen) path class {@code pathNodeKey} matches the
+   * definition's descendant root pattern. Cursor-neutral; unreadable or
+   * failing reconstructions count as a match — fail closed into
+   * invalidation.
+   */
+  private boolean matchesRootPattern(final long pathNodeKey) {
+    final long savedNodeKey = pathSummary.getNodeKey();
+    try {
+      if (!pathSummary.moveTo(pathNodeKey)) {
+        return true;
+      }
+      final Path<QNm> path = pathSummary.getPath();
+      return path == null || indexDef.getProjectionRootPath().matches(path);
+    } catch (final RuntimeException e) {
+      return true;
+    } finally {
+      pathSummary.moveTo(savedNodeKey);
+    }
   }
 
   /**
@@ -328,6 +396,14 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       // A single-record root (fused object at the root path) IS the record.
       return nodeKey;
     }
+    if (resolvedRecordMemo == null) {
+      resolvedRecordMemo = new Long2LongOpenHashMap();
+      resolvedRecordMemo.defaultReturnValue(MEMO_MISS);
+    }
+    final long selfMemo = resolvedRecordMemo.get(nodeKey);
+    if (selfMemo != MEMO_MISS) {
+      return selfMemo;
+    }
     long childKey = nodeKey;
     if (parentKey == PARENT_UNKNOWN) {
       final ImmutableNode self = readNode(nodeKey);
@@ -336,13 +412,23 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       }
       parentKey = self.getParentKey();
     }
+    int chainLength = 0;
+    walkChain[chainLength++] = nodeKey;
     for (int depth = 0; depth < MAX_ANCESTOR_WALK; depth++) {
       if (parentKey <= 0) {
         // Reached the document root without crossing a record-set root:
         // the change cannot affect any indexed row. (Deleting a container
         // ABOVE the record set is covered by the post-order notifications
-        // of the record-set nodes themselves.)
+        // of the record-set nodes themselves.) NOT memoized: a node outside
+        // every record can still be an ancestor OF the record set, and its
+        // descendants' walks must not inherit this verdict.
         return NOT_UNDER_RECORD_SET;
+      }
+      final long ancestorMemo = resolvedRecordMemo.get(parentKey);
+      if (ancestorMemo != MEMO_MISS) {
+        // The parent is proven inside record R — so is the whole chain.
+        memoizeChain(chainLength, ancestorMemo);
+        return ancestorMemo;
       }
       final ImmutableNode parent = readNode(parentKey);
       if (parent == null) {
@@ -352,12 +438,31 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       if (parentPcr > 0 && rootPcrs.contains(parentPcr)) {
         // Crossed the root: under an array-like root the record is the
         // element we came from; a non-array root IS the record.
-        return isArrayLike(parent.getKind()) ? childKey : parentKey;
+        final long recordKey = isArrayLike(parent.getKind()) ? childKey : parentKey;
+        memoizeChain(chainLength, recordKey);
+        if (recordKey == parentKey && resolvedRecordMemo.size() < MEMO_CAP) {
+          resolvedRecordMemo.put(recordKey, recordKey);
+        }
+        return recordKey;
       }
       childKey = parentKey;
+      if (chainLength == walkChain.length) {
+        walkChain = Arrays.copyOf(walkChain, walkChain.length * 2);
+      }
+      walkChain[chainLength++] = parentKey;
       parentKey = parent.getParentKey();
     }
     return UNRESOLVED;
+  }
+
+  /** Memoize every walked chain node as lying inside {@code recordKey}. */
+  private void memoizeChain(final int chainLength, final long recordKey) {
+    if (resolvedRecordMemo.size() >= MEMO_CAP) {
+      return;
+    }
+    for (int i = 0; i < chainLength; i++) {
+      resolvedRecordMemo.put(walkChain[i], recordKey);
+    }
   }
 
   private static boolean isArrayLike(final NodeKind kind) {
@@ -388,11 +493,24 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     if (dirtyRecordKeys == null) {
       dirtyRecordKeys = new LongOpenHashSet();
     }
-    dirtyRecordKeys.add(recordKey);
+    if (dirtyRecordKeys.add(recordKey)) {
+      maintenanceEpoch++;
+    }
     if (dirtyRecordKeys.size() > MAX_INCREMENTAL_RECORDS) {
       // Patching this many leaves approaches rebuild cost — invalidate.
       invalidate();
     }
+  }
+
+  /**
+   * Monotone epoch of this listener's maintenance state — changes whenever
+   * the pending dirty set changes, the projection is invalidated, or an
+   * apply pass rewrites leaves. Wtx-serving callers cache decoded handles
+   * against it: equal epoch (same listener instance) ⇒ the persisted leaves
+   * are byte-identical to when the handle was decoded.
+   */
+  public long maintenanceEpoch() {
+    return maintenanceEpoch;
   }
 
   /**
@@ -412,6 +530,8 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     }
     try {
       applyIncremental(dirty);
+      // Leaves (possibly) rewritten — cached decodes are stale.
+      maintenanceEpoch++;
     } catch (final RuntimeException e) {
       LOGGER.warn("Incremental projection maintenance failed for index "
           + indexDef.getID() + " — falling back to invalidation", e);
@@ -446,16 +566,17 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     }
 
     final int leafCount = meta.leafCount();
-    // Per-leaf record-key zone maps (slots 1..leafCount). Empty leaves carry
-    // the degenerate (MAX_VALUE, MIN_VALUE) range and never match.
-    final long[] firsts = new long[leafCount + 1];
-    final long[] lasts = new long[leafCount + 1];
+    // Per-leaf record-key zone maps (slots 1..leafCount), read straight from
+    // the metadata's persisted fences — ONE slot-0 read per commit instead
+    // of probing every leaf's head chunk (O(leafCount) HOT descents). Empty
+    // leaves carry the degenerate (MAX_VALUE, MIN_VALUE) range and never
+    // match. Non-final: appends grow the arrays.
+    long[] firsts = new long[leafCount + 1];
+    long[] lasts = new long[leafCount + 1];
     long globalMaxLast = Long.MIN_VALUE;
     for (int slot = 1; slot <= leafCount; slot++) {
-      if (!readZoneMap(storage, slot, firsts, lasts)) {
-        invalidate();
-        return;
-      }
+      firsts[slot] = meta.leafFirstRecordKey(slot - 1);
+      lasts[slot] = meta.leafLastRecordKey(slot - 1);
       if (lasts[slot] > globalMaxLast) {
         globalMaxLast = lasts[slot];
       }
@@ -561,7 +682,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
           tail = rebuilt;
           tailSlot = slot;
         } else {
-          writeLeaf(storage, slot, rebuilt);
+          writeLeaf(storage, slot, rebuilt, firsts, lasts);
         }
       }
 
@@ -586,6 +707,8 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
             tail = new ProjectionIndexLeafPage(defKinds);
             tailSlot = 1;
             newLeafCount = 1;
+            firsts = Arrays.copyOf(firsts, 2);
+            lasts = Arrays.copyOf(lasts, 2);
           } else {
             final byte[] encoded = storage.get(leafCount);
             if (encoded == null) {
@@ -602,8 +725,13 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
             continue; // created and deleted within this transaction
           }
           if (!extractor.appendTo(tail, recordKey)) {
-            writeLeaf(storage, tailSlot, tail);
+            writeLeaf(storage, tailSlot, tail, firsts, lasts);
             newLeafCount++;
+            if (newLeafCount + 1 > firsts.length) {
+              // A fresh slot — grow the fence arrays before its write.
+              firsts = Arrays.copyOf(firsts, Math.max(newLeafCount + 1, firsts.length * 2));
+              lasts = Arrays.copyOf(lasts, firsts.length);
+            }
             tail = new ProjectionIndexLeafPage(defKinds);
             tailSlot = newLeafCount;
             extractor.appendTo(tail, recordKey);
@@ -611,15 +739,19 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
         }
       }
       if (tail != null) {
-        writeLeaf(storage, tailSlot, tail);
+        writeLeaf(storage, tailSlot, tail, firsts, lasts);
       }
 
       // Refresh the metadata: the committing revision becomes the new build
-      // revision, which re-keys the catalog's decoded-leaf cache so readers
-      // of the new revision decode the patched leaves.
+      // revision (re-keying the catalog's decoded-leaf cache), and the
+      // updated per-leaf fences ride along for the next commit's location.
+      final long[] fenceFirsts = new long[newLeafCount];
+      final long[] fenceLasts = new long[newLeafCount];
+      System.arraycopy(firsts, 1, fenceFirsts, 0, newLeafCount);
+      System.arraycopy(lasts, 1, fenceLasts, 0, newLeafCount);
       storage.put(0, new ProjectionIndexMetadata(meta.rootPath(), meta.fieldPaths(),
           meta.fieldNames(), meta.columnKinds(), newLeafCount,
-          rtx.getRevisionNumber()).serialize());
+          rtx.getRevisionNumber(), fenceFirsts, fenceLasts).serialize());
     } finally {
       if (!rtx.moveTo(savedNodeKey)) {
         rtx.moveToDocumentRoot();
@@ -627,31 +759,12 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     }
   }
 
+  /** Write a leaf and fold its record-key range into the fence arrays. */
   private static void writeLeaf(final ProjectionIndexHOTStorage storage, final long slot,
-      final ProjectionIndexLeafPage leaf) {
+      final ProjectionIndexLeafPage leaf, final long[] firsts, final long[] lasts) {
+    firsts[(int) slot] = leaf.firstRecordKey();
+    lasts[(int) slot] = leaf.lastRecordKey();
     storage.put(slot, ProjectionIndexLeafCodec.encode(leaf.serialize()));
-  }
-
-  /**
-   * Read leaf {@code slot}'s record-key zone map from its head chunk without
-   * materialising the full payload (falling back to the full read when a
-   * tiny configured chunk size splits the header). Header parsing is owned
-   * by the codec ({@link ProjectionIndexLeafCodec#recordKeyRange}) — the
-   * single canonical reader for both persisted forms.
-   */
-  private static boolean readZoneMap(final ProjectionIndexHOTStorage storage, final int slot,
-      final long[] firsts, final long[] lasts) {
-    long[] range = ProjectionIndexLeafCodec.recordKeyRange(storage.getChunk(slot, 0));
-    if (range == null) {
-      // Head chunk absent or shorter than the header — full payload.
-      range = ProjectionIndexLeafCodec.recordKeyRange(storage.get(slot));
-    }
-    if (range == null) {
-      return false;
-    }
-    firsts[slot] = range[0];
-    lasts[slot] = range[1];
-    return true;
   }
 
   /** Whether the non-empty leaf ranges are ascending and non-overlapping. */
@@ -673,6 +786,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   private void invalidate() {
     invalidated = true;
     dirtyRecordKeys = null;
+    maintenanceEpoch++;
     // The tombstone rides the write transaction: invisible to readers of
     // committed revisions until commit, discarded entirely on rollback.
     // Nothing else is needed — query-side consumers discover projections

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
@@ -63,25 +63,37 @@ import java.util.Set;
  * invisible to concurrent readers until commit, discarded on rollback, and
  * historical revisions keep serving their own immutable snapshots.
  *
- * <h2>Fallback ladder</h2>
- * Anything the incremental path cannot handle provably-correctly falls back
- * to the pre-existing invalidation contract — overwriting slot 0 with a
- * {@link ProjectionIndexMetadata#staleTombstone() stale tombstone} so
- * post-commit readers use the generic pipeline until the projection is
- * re-created:
+ * <h2>Always maintained — the rebuild fallback</h2>
+ * Like the PATH/CAS/NAME listeners, this listener keeps its index EXACTLY
+ * maintained across every operation — there is no invalidation ladder.
+ * Changes the incremental patch cannot attribute provably-correctly degrade
+ * to an automatic FULL REBUILD inside the same commit (the shared
+ * {@link ProjectionIndexBuilder#buildAndPersist} core re-extracts the whole
+ * record set from the transaction's current state — always correct, cost
+ * bounded by the index size, no manual re-creation involved):
  * <ul>
- *   <li>structural changes to a record SET itself (an array at the root
- *       path inserted/removed);</li>
+ *   <li>subtree moves ({@link #structuralChange()} — the moved nodes fire
+ *       no per-node notifications, so attribution is impossible);</li>
  *   <li>an unresolvable ancestor chain (record read failure mid-walk);</li>
- *   <li>an unresolvable record-set root path (no PCRs);</li>
  *   <li>more than {@code -Dsirix.projection.maxIncrementalRecords} dirty
- *       records in one transaction (a rebuild is cheaper);</li>
- *   <li>a dirty record that should be indexed but cannot be located in any
- *       leaf (inconsistent snapshot);</li>
- *   <li>any unexpected failure during the apply phase.</li>
+ *       records in one transaction (patching approaches rebuild cost);</li>
+ *   <li>any inconsistency discovered while patching (a dirty record that
+ *       cannot be located in any leaf, a missing leaf payload, foreign
+ *       metadata under this definition's sub-tree).</li>
  * </ul>
- * The tombstone is written EAGERLY at fallback time (not deferred to
- * pre-commit), so correctness never depends on the apply phase running.
+ * Cheap exact cases never rebuild: record-set array instances appearing or
+ * disappearing are no-ops (their records notify individually — pre-order on
+ * insert, post-order on delete), and a NEW path class matching the root
+ * path (an exact-path record set re-appearing, or a descendant pattern
+ * widening to another subtree) reseeds the root-PCR set so subsequent
+ * notifications attribute normally.
+ *
+ * <p>The {@link ProjectionIndexMetadata#staleTombstone() stale tombstone}
+ * survives only as a CORRUPTION VALVE: if the apply phase <em>and</em> the
+ * rebuild both fail with an unexpected exception, slot 0 is overwritten so
+ * readers fall back to the always-correct generic pipeline until a manual
+ * {@code jn:create-projection-index} re-run — the projection analogue of any
+ * other index family surfacing an unexpected page-layer failure.
  *
  * <h2>Hot-path cost</h2>
  * The relevant-PCR sets are seeded LAZILY on the first notification, so
@@ -98,20 +110,18 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
 
   /**
    * Dirty-record ceiling per transaction. Beyond this, per-leaf patching
-   * approaches full-rebuild cost, so the listener falls back to the
-   * tombstone (the next {@code jn:create-projection-index} rebuilds).
+   * approaches full-rebuild cost, so the listener degrades to the
+   * commit-time full rebuild.
    */
   private static final int MAX_INCREMENTAL_RECORDS =
       Integer.getInteger("sirix.projection.maxIncrementalRecords", 100_000);
 
-  /** Hard bound on the record ancestor walk — malformed chains fail closed. */
+  /** Hard bound on the record ancestor walk — malformed chains rebuild. */
   private static final int MAX_ANCESTOR_WALK = 512;
 
   /** Resolution verdict: change is not under any record — no row affected. */
   private static final long NOT_UNDER_RECORD_SET = -2L;
-  /** Resolution verdict: structural change to a record SET — invalidate. */
-  private static final long STRUCTURAL_CHANGE = -3L;
-  /** Resolution verdict: chain unresolvable — invalidate (fail closed). */
+  /** Resolution verdict: chain unresolvable — degrade to the full rebuild. */
   private static final long UNRESOLVED = -4L;
   /** Sentinel for "parent key not provided by this listen overload". */
   private static final long PARENT_UNKNOWN = Long.MIN_VALUE;
@@ -119,16 +129,6 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   private final StorageEngineWriter storageEngineWriter;
   private final PathSummaryReader pathSummary;
   private final IndexDef indexDef;
-
-  /**
-   * Whether the record-set root is a descendant pattern ({@code //...}).
-   * Such projections aggregate over EVERY matching subtree, so a brand-new
-   * path class matching the pattern (a whole new record-set container
-   * appearing mid-transaction) silently widens the record set — the
-   * persisted rows no longer cover the definition and the projection must
-   * be invalidated (see {@link #classifyUnseenPcr}).
-   */
-  private final boolean descendantRootPattern;
 
   /**
    * Navigation handle over the owning write transaction's current state,
@@ -146,7 +146,21 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   private LongOpenHashSet irrelevantPcrs;
 
   private boolean seeded;
+
+  /**
+   * Corruption valve ONLY — set when both the incremental apply and the
+   * full rebuild failed unexpectedly (or, in legacy invalidation-only mode
+   * without a maintenance transaction, on the first relevant change).
+   */
   private boolean invalidated;
+
+  /**
+   * The pending state cannot be patched incrementally (subtree move,
+   * over-ceiling transaction, unresolvable chain) — {@link #beforeCommit()}
+   * performs a full rebuild instead. Dirty-key collection stops while set:
+   * the rebuild re-extracts everything anyway.
+   */
+  private boolean rebuildPending;
 
   /** Record nodeKeys touched by this transaction; lazily allocated. */
   private @Nullable LongOpenHashSet dirtyRecordKeys;
@@ -189,7 +203,6 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     this.pathSummary = pathSummary;
     this.indexDef = indexDef;
     this.maintenanceTrx = maintenanceTrx;
-    this.descendantRootPattern = indexDef.getProjectionRootPath().toString().contains("//");
   }
 
   /** Catalogue id of the definition this listener maintains. */
@@ -201,13 +214,30 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
    * Subtree MOVES cannot be attributed incrementally: a record moved OUT of
    * the record set still exists (so re-extraction would keep its row), and
    * moved plain containers/value elements fire no per-node notifications at
-   * all. Fail closed — tombstone, rebuild on the next create.
+   * all. Degrade to the commit-time full rebuild — the index stays exactly
+   * maintained, like the other index families.
    */
   @Override
   public void structuralChange() {
-    if (!invalidated) {
-      invalidate();
+    scheduleRebuild();
+  }
+
+  /**
+   * Downgrade from incremental patching to a full rebuild at commit. In
+   * legacy invalidation-only mode (no maintenance transaction) a rebuild is
+   * impossible — tombstone as before.
+   */
+  private void scheduleRebuild() {
+    if (invalidated || rebuildPending) {
+      return;
     }
+    if (maintenanceTrx == null) {
+      invalidate();
+      return;
+    }
+    rebuildPending = true;
+    dirtyRecordKeys = null;
+    maintenanceEpoch++;
   }
 
   @Override
@@ -225,25 +255,23 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
 
   private void onChange(final long nodeKey, final NodeKind kind, final long parentKey,
       final long pathNodeKey) {
-    if (invalidated) {
-      return;
+    if (invalidated || rebuildPending) {
+      return; // the rebuild re-extracts everything — attribution is moot
     }
     if (!seeded) {
       seed();
     }
-    // Unresolvable record set — every change is potentially relevant and no
-    // record identity can be established: fail safe.
-    if (rootPcrs.isEmpty()) {
-      invalidate();
-      return;
-    }
     if (maintenanceTrx == null) {
       // Legacy invalidation-only mode: first relevant change tombstones.
-      if (isRelevantForInvalidation(pathNodeKey)) {
+      // An unresolvable record set makes every change potentially relevant.
+      if (rootPcrs.isEmpty() || isRelevantForInvalidation(pathNodeKey)) {
         invalidate();
       }
       return;
     }
+    // NOTE: an EMPTY root-PCR set is fine here — the record set simply has
+    // no instances (yet). A change creating one arrives with a new matching
+    // path class, which classifyUnseenPcr reseeds as a root.
     if (pathNodeKey > 0) {
       if (irrelevantPcrs.contains(pathNodeKey)) {
         return;
@@ -259,7 +287,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       return;
     }
     if (recordKey < 0) {
-      invalidate();
+      scheduleRebuild();
       return;
     }
     markDirty(recordKey);
@@ -320,12 +348,13 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
   /**
    * Classify an unseen PCR (e.g. a brand-new field path created by this
    * transaction) by whether its ancestor chain crosses a record-set root,
-   * and cache the verdict so the hot path stays a single set lookup. For
-   * descendant-pattern roots the new PCR may itself BE a new record-set
-   * root (a second matching subtree appearing mid-transaction) — the
-   * seeded root PCRs cannot know it, so the pattern is re-checked against
-   * the new path class and a match invalidates (the persisted rows no
-   * longer cover the widened record set).
+   * and cache the verdict so the hot path stays a single set lookup. The
+   * new PCR may itself BE a new record-set root — an exact-path record set
+   * re-appearing after removal, or a descendant pattern widening to another
+   * matching subtree — which the seeded root PCRs cannot know: the root
+   * path is re-checked against the new path class and a match RESEEDS the
+   * root set, so the new roots' records attribute normally (their node
+   * keys are fresh, hence pure appends at apply time).
    */
   private boolean classifyUnseenPcr(final long pathNodeKey) {
     boolean relevant = false;
@@ -341,9 +370,10 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       }
       node = pathSummary.getPathNodeForPathNodeKey(parentKey);
     }
-    if (!relevant && descendantRootPattern && matchesRootPattern(pathNodeKey)) {
-      invalidate();
-      return false;
+    if (!relevant && matchesRootPath(pathNodeKey)) {
+      rootPcrs.add(pathNodeKey);
+      relevantPcrs.add(pathNodeKey);
+      return true;
     }
     if (relevant) {
       relevantPcrs.add(pathNodeKey);
@@ -355,20 +385,27 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
 
   /**
    * Whether the (unseen) path class {@code pathNodeKey} matches the
-   * definition's descendant root pattern. Cursor-neutral; unreadable or
-   * failing reconstructions count as a match — fail closed into
-   * invalidation.
+   * definition's root path (exact or descendant pattern — {@code matches}
+   * covers both). Cursor-neutral; an unreadable or failing reconstruction
+   * cannot be proven irrelevant, so it degrades to the full rebuild and
+   * reports no match.
    */
-  private boolean matchesRootPattern(final long pathNodeKey) {
+  private boolean matchesRootPath(final long pathNodeKey) {
     final long savedNodeKey = pathSummary.getNodeKey();
     try {
       if (!pathSummary.moveTo(pathNodeKey)) {
-        return true;
+        scheduleRebuild();
+        return false;
       }
       final Path<QNm> path = pathSummary.getPath();
-      return path == null || indexDef.getProjectionRootPath().matches(path);
+      if (path == null) {
+        scheduleRebuild();
+        return false;
+      }
+      return indexDef.getProjectionRootPath().matches(path);
     } catch (final RuntimeException e) {
-      return true;
+      scheduleRebuild();
+      return false;
     } finally {
       pathSummary.moveTo(savedNodeKey);
     }
@@ -382,16 +419,18 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
    * listen time.
    *
    * @return the record's nodeKey, or one of the negative verdicts
-   *         ({@link #NOT_UNDER_RECORD_SET} / {@link #STRUCTURAL_CHANGE} /
-   *         {@link #UNRESOLVED})
+   *         ({@link #NOT_UNDER_RECORD_SET} / {@link #UNRESOLVED})
    */
   private long resolveRecordKey(final long nodeKey, final NodeKind kind, long parentKey,
       final long pathNodeKey) {
     if (pathNodeKey > 0 && rootPcrs.contains(pathNodeKey)) {
       if (isArrayLike(kind)) {
-        // The record SET itself (its array node) was inserted/removed —
-        // structural; rows cannot be attributed individually.
-        return STRUCTURAL_CHANGE;
+        // The record SET's array instance itself appeared or disappeared —
+        // no row of its own. Its records are attributed individually: an
+        // insert notifies the array BEFORE its records (pre-order), a
+        // delete notifies the records BEFORE the array (post-order), so
+        // every row lands in the dirty set through its own notification.
+        return NOT_UNDER_RECORD_SET;
       }
       // A single-record root (fused object at the root path) IS the record.
       return nodeKey;
@@ -497,8 +536,9 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       maintenanceEpoch++;
     }
     if (dirtyRecordKeys.size() > MAX_INCREMENTAL_RECORDS) {
-      // Patching this many leaves approaches rebuild cost — invalidate.
-      invalidate();
+      // Patching this many leaves approaches rebuild cost — rebuild once
+      // at commit instead of tracking further keys.
+      scheduleRebuild();
     }
   }
 
@@ -518,40 +558,86 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
    * per commit through the uniform {@link ChangeListener} lifecycle
    * ({@link IndexController#applyPendingIndexMaintenance()})
    * BEFORE page serialization, so all writes ride the committing
-   * transaction. Any failure degrades to the tombstone — a stale-but-honest
-   * projection beats a wrong one.
+   * transaction. Incremental patching that discovers an inconsistency
+   * degrades to the full rebuild; only an unexpected failure of BOTH paths
+   * tombstones (corruption valve) — a stale-but-honest projection beats a
+   * wrong one.
    */
   @Override
   public void beforeCommit() {
     final LongOpenHashSet dirty = dirtyRecordKeys;
     dirtyRecordKeys = null;
-    if (invalidated || dirty == null || dirty.isEmpty() || maintenanceTrx == null) {
+    if (invalidated || maintenanceTrx == null) {
+      return;
+    }
+    if (!rebuildPending && (dirty == null || dirty.isEmpty())) {
       return;
     }
     try {
-      applyIncremental(dirty);
+      if (rebuildPending || !applyIncremental(dirty)) {
+        rebuildFully();
+      }
+      rebuildPending = false;
       // Leaves (possibly) rewritten — cached decodes are stale.
       maintenanceEpoch++;
     } catch (final RuntimeException e) {
-      LOGGER.warn("Incremental projection maintenance failed for index "
+      LOGGER.warn("Projection maintenance (incremental and rebuild) failed for index "
           + indexDef.getID() + " — falling back to invalidation", e);
       invalidate();
     }
   }
 
-  private void applyIncremental(final LongOpenHashSet dirty) {
+  /**
+   * Full commit-time rebuild over the transaction's current state — the
+   * exact-maintenance fallback for changes the incremental patch cannot
+   * attribute. Reuses the creation path's build core; a record set with no
+   * remaining instances persists as the truthful EMPTY projection. A
+   * pre-existing tombstone (corruption valve fired in an earlier commit)
+   * is respected — only {@code jn:create-projection-index} resurrects.
+   */
+  private void rebuildFully() {
+    final JsonNodeReadOnlyTrx rtx = maintenanceTrx;
+    final ProjectionIndexHOTStorage storage =
+        new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
+    final ProjectionIndexMetadata meta = ProjectionIndexMetadata.parse(storage.get(0));
+    if (meta == null || meta.isStale()) {
+      // No live snapshot to maintain (bench/legacy store, or a valve
+      // tombstone from an earlier commit) — nothing to rebuild.
+      return;
+    }
+    final long savedNodeKey = rtx.getNodeKey();
+    try {
+      ProjectionIndexBuilder.buildAndPersist(indexDef, pathSummary, rtx, storageEngineWriter,
+          true);
+    } finally {
+      if (!rtx.moveTo(savedNodeKey)) {
+        rtx.moveToDocumentRoot();
+      }
+    }
+  }
+
+  /**
+   * Patch the persisted leaves for the given dirty records.
+   *
+   * @return {@code true} when the persisted state is consistent afterwards
+   *         (including "nothing to maintain"); {@code false} when an
+   *         inconsistency was discovered and the caller must run the full
+   *         rebuild instead
+   */
+  private boolean applyIncremental(final LongOpenHashSet dirty) {
     final JsonNodeReadOnlyTrx rtx = maintenanceTrx;
     final ProjectionIndexHOTStorage storage =
         new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
     final ProjectionIndexMetadata meta = ProjectionIndexMetadata.parse(storage.get(0));
     if (meta == null || meta.isStale()) {
       // No live snapshot to maintain: a metadata-less (bench/legacy) store,
-      // a projection already invalidated in an earlier commit, or a def
-      // whose build never ran. Nothing to do.
-      return;
+      // a valve tombstone from an earlier commit, or a def whose build
+      // never ran. Nothing to do.
+      return true;
     }
     // Shape guard: the persisted snapshot must describe exactly this
-    // definition, or patching would splice rows into foreign columns.
+    // definition, or patching would splice rows into foreign columns —
+    // the rebuild replaces the foreign payloads with this definition's.
     final List<Path<QNm>> fieldPaths = indexDef.getProjectionFields();
     final List<Type> fieldTypes = indexDef.getProjectionFieldTypes();
     final String[] defPaths = new String[fieldPaths.size()];
@@ -561,8 +647,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       defKinds[i] = ProjectionIndexBuilder.mapTypeToColumnKind(fieldTypes.get(i));
     }
     if (!meta.matches(indexDef.getProjectionRootPath().toString(), defPaths, defKinds)) {
-      invalidate();
-      return;
+      return false;
     }
 
     final int leafCount = meta.leafCount();
@@ -609,9 +694,8 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
         }
         if (slot > leafCount || firsts[slot] > k) {
           // In a gap although the key predates the snapshot's max: the
-          // record was never indexed — inconsistent, fail closed.
-          invalidate();
-          return;
+          // record was never indexed — inconsistent, rebuild.
+          return false;
         }
         if (slot != lastTouched) {
           touchedSlots.add(slot);
@@ -620,8 +704,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       }
     } else {
       if ((long) appendFrom * leafCount > 50_000_000L) {
-        invalidate();
-        return;
+        return false; // quadratic scan too expensive — rebuild instead
       }
       final LongOpenHashSet touched = new LongOpenHashSet();
       for (int i = 0; i < appendFrom; i++) {
@@ -636,8 +719,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
           }
         }
         if (!found) {
-          invalidate();
-          return;
+          return false;
         }
       }
       touchedSlots.sort(null);
@@ -659,8 +741,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
         final long slot = touchedSlots.getLong(t);
         final byte[] encoded = storage.get(slot);
         if (encoded == null) {
-          invalidate();
-          return;
+          return false; // declared leaf missing — inconsistent, rebuild
         }
         final ProjectionIndexLeafPage old =
             ProjectionIndexLeafPage.deserialize(ProjectionIndexLeafCodec.decode(encoded));
@@ -688,13 +769,12 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
 
       // Every pre-existing dirty key must have been located in its leaf;
       // an unlocated one means the snapshot never indexed a record it
-      // should have — fail closed. (Keys of records both created and
-      // deleted by this transaction are in the append partition and are
-      // skipped harmlessly there.)
+      // should have — rebuild. (Keys of records both created and deleted
+      // by this transaction are in the append partition and are skipped
+      // harmlessly there.)
       for (int i = 0; i < appendFrom; i++) {
         if (!located.contains(keys[i])) {
-          invalidate();
-          return;
+          return false;
         }
       }
 
@@ -712,8 +792,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
           } else {
             final byte[] encoded = storage.get(leafCount);
             if (encoded == null) {
-              invalidate();
-              return;
+              return false; // declared tail leaf missing — rebuild
             }
             tail = ProjectionIndexLeafPage.deserialize(ProjectionIndexLeafCodec.decode(encoded));
             tailSlot = leafCount;
@@ -752,6 +831,7 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
       storage.put(0, new ProjectionIndexMetadata(meta.rootPath(), meta.fieldPaths(),
           meta.fieldNames(), meta.columnKinds(), newLeafCount,
           rtx.getRevisionNumber(), fenceFirsts, fenceLasts).serialize());
+      return true;
     } finally {
       if (!rtx.moveTo(savedNodeKey)) {
         rtx.moveToDocumentRoot();
@@ -783,8 +863,16 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     return true;
   }
 
+  /**
+   * Corruption valve (and the legacy invalidation-only contract): overwrite
+   * slot 0 with the stale tombstone so every reader falls back to the
+   * generic pipeline until a manual {@code jn:create-projection-index}
+   * re-run. Regular maintenance never calls this — unattributable changes
+   * degrade to {@link #rebuildFully()} instead.
+   */
   private void invalidate() {
     invalidated = true;
+    rebuildPending = false;
     dirtyRecordKeys = null;
     maintenanceEpoch++;
     // The tombstone rides the write transaction: invisible to readers of

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
@@ -19,7 +19,10 @@ import java.util.Arrays;
  *
  * <p>Wire form: {@link #MAGIC} ("PIXM" little-endian), a version byte, a
  * flags byte ({@link #FLAG_STALE}), the leaf count and build revision as
- * little-endian ints, the root path as a length-prefixed UTF-8 string, an
+ * little-endian ints, per leaf a (firstRecordKey, lastRecordKey) fence pair
+ * as little-endian longs (the incremental maintenance's zone maps — one
+ * slot-0 read instead of probing every leaf), the root path as a
+ * length-prefixed UTF-8 string, an
  * int column count, then per column: path (UTF-8, length-prefixed), name
  * (UTF-8, length-prefixed), and one column-kind byte
  * ({@link ProjectionIndexLeafPage#COLUMN_KIND_NUMERIC_LONG} /
@@ -59,17 +62,32 @@ public final class ProjectionIndexMetadata {
   private final byte[] columnKinds;
   private final int leafCount;
   private final int buildRevision;
+
+  /**
+   * Per-leaf record-key fences, index-aligned with leaf slots 1..leafCount
+   * (entry {@code i} describes slot {@code i + 1}). Read by the incremental
+   * maintenance's leaf location in ONE slot-0 read instead of probing every
+   * leaf's head chunk per commit (O(leafCount) HOT descents). Empty leaves
+   * carry the degenerate ({@code Long.MAX_VALUE}, {@code Long.MIN_VALUE})
+   * range.
+   */
+  private final long[] leafFirstRecordKeys;
+  private final long[] leafLastRecordKeys;
+
   private final byte flags;
 
   public ProjectionIndexMetadata(final String rootPath, final String[] fieldPaths,
       final String[] fieldNames, final byte[] columnKinds, final int leafCount,
-      final int buildRevision) {
-    this(rootPath, fieldPaths, fieldNames, columnKinds, leafCount, buildRevision, (byte) 0);
+      final int buildRevision, final long[] leafFirstRecordKeys,
+      final long[] leafLastRecordKeys) {
+    this(rootPath, fieldPaths, fieldNames, columnKinds, leafCount, buildRevision,
+        leafFirstRecordKeys, leafLastRecordKeys, (byte) 0);
   }
 
   private ProjectionIndexMetadata(final String rootPath, final String[] fieldPaths,
       final String[] fieldNames, final byte[] columnKinds, final int leafCount,
-      final int buildRevision, final byte flags) {
+      final int buildRevision, final long[] leafFirstRecordKeys,
+      final long[] leafLastRecordKeys, final byte flags) {
     if (fieldPaths.length != fieldNames.length || fieldPaths.length != columnKinds.length) {
       throw new IllegalArgumentException("paths/names/kinds must be index-aligned");
     }
@@ -79,19 +97,27 @@ public final class ProjectionIndexMetadata {
     if (buildRevision < 0) {
       throw new IllegalArgumentException("buildRevision must be >= 0, got " + buildRevision);
     }
+    if (leafFirstRecordKeys.length != leafCount || leafLastRecordKeys.length != leafCount) {
+      throw new IllegalArgumentException("leaf record-key fences must carry one entry per leaf ("
+          + leafCount + "), got " + leafFirstRecordKeys.length + "/" + leafLastRecordKeys.length);
+    }
     this.rootPath = rootPath;
     this.fieldPaths = fieldPaths.clone();
     this.fieldNames = fieldNames.clone();
     this.columnKinds = columnKinds.clone();
     this.leafCount = leafCount;
     this.buildRevision = buildRevision;
+    this.leafFirstRecordKeys = leafFirstRecordKeys.clone();
+    this.leafLastRecordKeys = leafLastRecordKeys.clone();
     this.flags = flags;
   }
+
+  private static final long[] NO_FENCES = new long[0];
 
   /** Minimal stale marker the change listener writes over slot 0 on invalidation. */
   public static ProjectionIndexMetadata staleTombstone() {
     return new ProjectionIndexMetadata("", new String[0], new String[0], new byte[0], 0, 0,
-        FLAG_STALE);
+        NO_FENCES, NO_FENCES, FLAG_STALE);
   }
 
   public String rootPath() {
@@ -124,6 +150,16 @@ public final class ProjectionIndexMetadata {
     return buildRevision;
   }
 
+  /** First record key of 0-based leaf {@code i} (slot {@code i + 1}). */
+  public long leafFirstRecordKey(final int i) {
+    return leafFirstRecordKeys[i];
+  }
+
+  /** Last record key of 0-based leaf {@code i} (slot {@code i + 1}). */
+  public long leafLastRecordKey(final int i) {
+    return leafLastRecordKeys[i];
+  }
+
   /** Whether an update transaction invalidated this projection. */
   public boolean isStale() {
     return (flags & FLAG_STALE) != 0;
@@ -144,6 +180,10 @@ public final class ProjectionIndexMetadata {
     out.write(flags);
     putIntLE(out, leafCount);
     putIntLE(out, buildRevision);
+    for (int i = 0; i < leafCount; i++) {
+      putLongLE(out, leafFirstRecordKeys[i]);
+      putLongLE(out, leafLastRecordKeys[i]);
+    }
     putString(out, rootPath);
     putIntLE(out, fieldPaths.length);
     for (int i = 0; i < fieldPaths.length; i++) {
@@ -184,6 +224,18 @@ public final class ProjectionIndexMetadata {
       if (buildRevision < 0) {
         throw new IllegalStateException("Implausible projection build revision " + buildRevision);
       }
+      if (pos[0] + 16L * leafCount > payload.length) {
+        throw new IllegalStateException("Truncated projection leaf fences (" + leafCount
+            + " leaves declared, " + (payload.length - pos[0]) + " bytes left)");
+      }
+      final long[] firstKeys = new long[leafCount];
+      final long[] lastKeys = new long[leafCount];
+      for (int i = 0; i < leafCount; i++) {
+        firstKeys[i] = getLongLE(payload, pos[0]);
+        pos[0] += 8;
+        lastKeys[i] = getLongLE(payload, pos[0]);
+        pos[0] += 8;
+      }
       final String rootPath = getString(payload, pos);
       final int n = getIntLE(payload, pos[0]);
       pos[0] += 4;
@@ -199,7 +251,7 @@ public final class ProjectionIndexMetadata {
         kinds[i] = payload[pos[0]++];
       }
       return new ProjectionIndexMetadata(rootPath, paths, names, kinds, leafCount, buildRevision,
-          flags);
+          firstKeys, lastKeys, flags);
     } catch (final IndexOutOfBoundsException truncated) {
       throw new IllegalStateException("Corrupt projection metadata payload", truncated);
     }
@@ -227,6 +279,15 @@ public final class ProjectionIndexMetadata {
     out.write(v >>> 8);
     out.write(v >>> 16);
     out.write(v >>> 24);
+  }
+
+  private static void putLongLE(final ByteArrayOutputStream out, final long v) {
+    putIntLE(out, (int) v);
+    putIntLE(out, (int) (v >>> 32));
+  }
+
+  private static long getLongLE(final byte[] b, final int off) {
+    return (getIntLE(b, off) & 0xFFFFFFFFL) | ((long) getIntLE(b, off + 4) << 32);
   }
 
   private static int getIntLE(final byte[] b, final int off) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexMetadataTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexMetadataTest.java
@@ -28,9 +28,20 @@ public final class ProjectionIndexMetadataTest {
   private static final byte[] KINDS = { ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG,
       ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN, ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT };
 
+  private static long[] fences(final int leafCount, final long base) {
+    final long[] fences = new long[leafCount];
+    for (int i = 0; i < leafCount; i++) {
+      fences[i] = base + i * 1000L;
+    }
+    return fences;
+  }
+
   @Test
   public void roundTripsThroughSerializeAndParse() {
-    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 42, 7);
+    final long[] firsts = fences(42, 1);
+    final long[] lasts = fences(42, 900);
+    final ProjectionIndexMetadata metadata =
+        new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 42, 7, firsts, lasts);
     final ProjectionIndexMetadata parsed = ProjectionIndexMetadata.parse(metadata.serialize());
     assertEquals(ROOT, parsed.rootPath());
     assertArrayEquals(PATHS, parsed.fieldPaths());
@@ -38,6 +49,10 @@ public final class ProjectionIndexMetadataTest {
     assertArrayEquals(KINDS, parsed.columnKinds());
     assertEquals(42, parsed.leafCount());
     assertEquals(7, parsed.buildRevision());
+    for (int i = 0; i < 42; i++) {
+      assertEquals(firsts[i], parsed.leafFirstRecordKey(i), "first fence " + i);
+      assertEquals(lasts[i], parsed.leafLastRecordKey(i), "last fence " + i);
+    }
     assertFalse(parsed.isStale());
   }
 
@@ -52,7 +67,8 @@ public final class ProjectionIndexMetadataTest {
 
   @Test
   public void matchesComparesRootFieldPathsAndKinds() {
-    final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 1, 1);
+    final ProjectionIndexMetadata metadata =
+        new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 1, 1, fences(1, 1), fences(1, 9));
     assertTrue(metadata.matches(ROOT, PATHS, KINDS));
     assertFalse(metadata.matches("/[]", PATHS, KINDS));
     assertFalse(metadata.matches(ROOT, new String[] { PATHS[0], PATHS[1] },
@@ -73,11 +89,15 @@ public final class ProjectionIndexMetadataTest {
 
   @Test
   public void truncatedPayloadFailsLoudly() {
-    final byte[] serialized = new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 1, 1).serialize();
+    final byte[] serialized =
+        new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 1, 1, fences(1, 1), fences(1, 9))
+            .serialize();
     // A cut below 6 bytes fails the magic-length precheck and parses to null
     // instead — the loud-failure contract starts at the header fields.
     assertNull(ProjectionIndexMetadata.parse(Arrays.copyOf(serialized, 5)));
-    for (final int cut : new int[] { 6, 9, serialized.length / 2, serialized.length - 1 }) {
+    // Cuts inside the header, the leaf fences, and the string section all
+    // fail loudly (fences span bytes 14..30 for one leaf).
+    for (final int cut : new int[] { 6, 9, 15, 29, serialized.length / 2, serialized.length - 1 }) {
       final byte[] truncated = Arrays.copyOf(serialized, cut);
       assertThrows(IllegalStateException.class, () -> ProjectionIndexMetadata.parse(truncated),
           "cut at " + cut);
@@ -87,8 +107,14 @@ public final class ProjectionIndexMetadataTest {
   @Test
   public void misalignedArraysAreRejected() {
     assertThrows(IllegalArgumentException.class,
-        () -> new ProjectionIndexMetadata(ROOT, PATHS, new String[] { "age" }, KINDS, 1, 1));
+        () -> new ProjectionIndexMetadata(ROOT, PATHS, new String[] { "age" }, KINDS, 1, 1,
+            fences(1, 1), fences(1, 9)));
     assertThrows(IllegalArgumentException.class,
-        () -> new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, -1, 1));
+        () -> new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, -1, 1, fences(0, 0),
+            fences(0, 0)));
+    // Fence arrays must carry exactly one entry per leaf.
+    assertThrows(IllegalArgumentException.class,
+        () -> new ProjectionIndexMetadata(ROOT, PATHS, NAMES, KINDS, 2, 1, fences(1, 1),
+            fences(2, 9)));
   }
 }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/ScaleBenchProjectionSetup.java
@@ -229,9 +229,21 @@ final class ScaleBenchProjectionSetup {
       for (int i = 0; i < fieldPathStrings.length; i++) {
         fieldPathStrings[i] = projectedFieldPaths.get(i).toString();
       }
+      // Per-leaf record-key fences — required metadata since the maintenance
+      // zone maps moved into slot 0 (raw form: keys at offsets 8/16).
+      final long[] leafFirstKeys = new long[leaves.size()];
+      final long[] leafLastKeys = new long[leaves.size()];
+      for (int i = 0; i < leaves.size(); i++) {
+        final long[] range = ProjectionIndexLeafCodec.recordKeyRange(leaves.get(i));
+        if (range == null) {
+          throw new IllegalStateException("Serialised projection leaf " + i + " carries no header");
+        }
+        leafFirstKeys[i] = range[0];
+        leafLastKeys[i] = range[1];
+      }
       final ProjectionIndexMetadata metadata = new ProjectionIndexMetadata(rootPath.toString(),
           fieldPathStrings, FIELD_NAMES, builder.columnKinds(), leaves.size(),
-          wtx.getRevisionNumber());
+          wtx.getRevisionNumber(), leafFirstKeys, leafLastKeys);
       storage.put(0, metadata.serialize());
       for (int i = 0; i < leaves.size(); i++) {
         // Persist in the compact codec form (FOR/bit-packed values, packed

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -161,13 +161,15 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
-  public void staleTombstoneRecreateRebuildsUnderSameDefAndServes() throws IOException {
-    // The recovery ladder every listener fallback depends on: a structural
-    // change tombstones the projection while its definition STAYS catalogued;
-    // re-running jn:create-projection-index with the same shape must refuse
-    // the stale snapshot, REBUILD under the same definition id, and the
-    // rebuilt projection must SERVE (servedCount delta — value-only
-    // assertions cannot distinguish rebuild from fallback).
+  public void recordSetReplacementIsMaintainedWithoutRecreate() throws IOException {
+    // The parity guarantee with the other index families: deleting the
+    // whole record set (rows drop out via the records' own post-order
+    // notifications) and inserting a fresh one at the same path (a NEW
+    // path class the listener reseeds as a root; its records append) keeps
+    // the SAME projection continuously maintained — no tombstone, no
+    // re-creation call — and it must SERVE the new values (servedCount
+    // delta; value-only assertions cannot distinguish serving from
+    // fallback).
     query("""
           jn:store('json-path1','two.jn','{
             "a": [{"age": 10}, {"age": 20}],
@@ -179,22 +181,13 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
           let $stats := jn:create-projection-index($doc, '/a/[]', ('/a/[]/age'), ('long'))
           return {"revision": sdb:commit($doc)}
         """);
-    // Structural fallback: removing the record-set array tombstones the
-    // projection; the definition remains catalogued.
     query("""
           let $doc := jn:doc('json-path1','two.jn')
           return delete json $doc.a
         """);
-    // New record set at the same path, then a same-shape re-create — must
-    // rebuild over the stale tombstone (id 0 reused).
     query("""
           let $doc := jn:doc('json-path1','two.jn')
           return insert json {"a": [{"age": 5}, {"age": 7}]} into $doc
-        """);
-    query("""
-          let $doc := jn:doc('json-path1','two.jn')
-          let $stats := jn:create-projection-index($doc, '/a/[]', ('/a/[]/age'), ('long'))
-          return {"revision": sdb:commit($doc)}
         """);
     ProjectionIndexRegistry.clear();
 
@@ -219,8 +212,8 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
           Assertions.assertEquals("12", out.toString());
         }
         Assertions.assertTrue(ProjectionIndexCatalog.servedCount() > servedBefore,
-            "the REBUILT projection must serve — a short-circuit on the stale snapshot or a "
-                + "silent fallback would leave the counter unchanged");
+            "the continuously maintained projection must serve the replaced record set — a "
+                + "tombstone or silent fallback would leave the counter unchanged");
       } finally {
         SequentialPipelineStrategy.setVectorizedExecutor(null);
         executor.close();

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexDescendantRootServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexDescendantRootServingTest.java
@@ -1,0 +1,215 @@
+package io.sirix.query;
+
+import io.brackit.query.Query;
+import io.brackit.query.compiler.translator.SequentialPipelineStrategy;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.Databases;
+import io.sirix.access.trx.node.json.objectvalue.ArrayValue;
+import io.sirix.access.trx.node.json.objectvalue.ObjectValue;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.ProjectionIndexCatalog;
+import io.sirix.index.projection.ProjectionIndexRegistry;
+import io.sirix.node.NodeKind;
+import io.sirix.query.json.BasicJsonDBStore;
+import io.sirix.query.json.JsonDBCollection;
+import io.sirix.query.scan.SirixVectorizedExecutor;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+
+/**
+ * Pattern-aware serving for DESCENDANT-rooted projections ({@code //...}):
+ * the catalog resolves the pattern against the queried revision's path
+ * summary — a pattern matching exactly ONE path class serves under that
+ * concrete path, a pattern matching several subtrees (the projection
+ * aggregates across all of them, which a path-specific query must not be
+ * served from) fails closed to the generic pipeline, and a NEW matching
+ * subtree appearing mid-transaction invalidates the projection (the
+ * persisted rows no longer cover the widened record set).
+ */
+public final class ProjectionIndexDescendantRootServingTest extends AbstractJsonTest {
+
+  @BeforeEach
+  public void clearProjectionStateBefore() {
+    ProjectionIndexRegistry.clear();
+    SequentialPipelineStrategy.setVectorizedExecutor(null);
+  }
+
+  @AfterEach
+  public void clearProjectionStateAfter() {
+    ProjectionIndexRegistry.clear();
+    SequentialPipelineStrategy.setVectorizedExecutor(null);
+  }
+
+  private void storeSingleSubtreeAndCreateProjection() {
+    query("""
+          jn:store('json-path1','desc.jn','{
+            "x": {"records": [{"age": 30}, {"age": 45}, {"age": 52}]},
+            "meta": "untouched"
+          }')
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          let $stats := jn:create-projection-index($doc, '//records/[]',
+              ('//records/[]/age'), ('long'))
+          return {"revision": sdb:commit($doc)}
+        """);
+  }
+
+  /** Run {@code queryString} through a catalog-backed executor; returns the serialized result. */
+  private String executeServed(final String resource, final String queryString) throws IOException {
+    try (final BasicJsonDBStore store =
+            BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
+         final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+         final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
+      final JsonResourceSession session = collection.getDatabase().beginResourceSession(resource);
+      final SirixVectorizedExecutor executor =
+          new SirixVectorizedExecutor(session, session.getMostRecentRevisionNumber(), 2);
+      SequentialPipelineStrategy.setVectorizedExecutor(executor);
+      try (final ByteArrayOutputStream out = new ByteArrayOutputStream();
+           final PrintWriter printWriter = new PrintWriter(out)) {
+        new Query(chain, queryString).serialize(ctx, printWriter);
+        printWriter.flush();
+        return out.toString();
+      } finally {
+        SequentialPipelineStrategy.setVectorizedExecutor(null);
+        executor.close();
+      }
+    }
+  }
+
+  @Test
+  public void singleMatchingSubtreeResolvesAndServes() throws IOException {
+    storeSingleSubtreeAndCreateProjection();
+    ProjectionIndexRegistry.clear();
+
+    final long servedBefore = ProjectionIndexCatalog.servedCount();
+    Assertions.assertEquals("127", executeServed("desc.jn", """
+          let $doc := jn:doc('json-path1','desc.jn')
+          return sum(for $r in $doc.x.records[] return $r.age)
+        """));
+    Assertions.assertTrue(ProjectionIndexCatalog.servedCount() > servedBefore,
+        "a descendant pattern matching exactly one subtree must resolve to its concrete "
+            + "path and SERVE, not fall back");
+  }
+
+  @Test
+  public void ambiguousPatternFailsClosed() throws IOException {
+    // TWO matching subtrees: the projection aggregates across both, so a
+    // path-specific query must not be served from it — fail closed, generic
+    // pipeline answers per subtree.
+    query("""
+          jn:store('json-path1','desc2.jn','{
+            "x": {"records": [{"age": 1}, {"age": 2}]},
+            "y": {"records": [{"age": 10}]}
+          }')
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','desc2.jn')
+          let $stats := jn:create-projection-index($doc, '//records/[]',
+              ('//records/[]/age'), ('long'))
+          return {"revision": sdb:commit($doc)}
+        """);
+    ProjectionIndexRegistry.clear();
+
+    final long servedBefore = ProjectionIndexCatalog.servedCount();
+    Assertions.assertEquals("{\"x\":3,\"y\":10}", executeServed("desc2.jn", """
+          let $doc := jn:doc('json-path1','desc2.jn')
+          return {"x": sum(for $r in $doc.x.records[] return $r.age),
+                  "y": sum(for $r in $doc.y.records[] return $r.age)}
+        """));
+    Assertions.assertEquals(servedBefore, ProjectionIndexCatalog.servedCount(),
+        "an ambiguous descendant pattern must never serve a path-specific query");
+  }
+
+  @Test
+  public void incrementallyMaintainedDescendantProjectionStillServes() throws IOException {
+    // The change listener seeds its record-set roots from the PATTERN, so
+    // update/insert/delete maintenance under the (single) matching subtree
+    // must keep the projection serving with the compounded values.
+    storeSingleSubtreeAndCreateProjection();
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return replace json value of $doc.x.records[0].age with 99
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return append json {"age": 7} into $doc.x.records
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return delete json $doc.x.records[1]
+        """);
+    ProjectionIndexRegistry.clear();
+
+    final long servedBefore = ProjectionIndexCatalog.servedCount();
+    // 127 - 30 + 99 + 7 - 45 = 158.
+    Assertions.assertEquals("158", executeServed("desc.jn", """
+          let $doc := jn:doc('json-path1','desc.jn')
+          return sum(for $r in $doc.x.records[] return $r.age)
+        """));
+    Assertions.assertTrue(ProjectionIndexCatalog.servedCount() > servedBefore,
+        "the incrementally maintained descendant-rooted projection must still be SERVED");
+  }
+
+  @Test
+  public void newMatchingSubtreeMidTransactionInvalidates() throws IOException {
+    // A brand-new subtree matching the pattern widens the record set — the
+    // listener must invalidate (fail closed), EVEN IF the subtree is removed
+    // again before the commit: the listener cannot prove the intermediate
+    // states kept the persisted rows consistent. Without the invalidation
+    // the pattern would resolve back to one path class after the commit and
+    // serve the never-rebuilt snapshot.
+    storeSingleSubtreeAndCreateProjection();
+    try (final Database<JsonResourceSession> database = openDatabase();
+         final JsonResourceSession session = database.beginResourceSession("desc.jn")) {
+      try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        Assertions.assertTrue(wtx.moveToDocumentRoot());
+        Assertions.assertTrue(wtx.moveToFirstChild());        // top-level OBJECT
+        final long topObjectKey = wtx.getNodeKey();
+        // Build {"z": {"records": [{"age": 100}]}} — a SECOND subtree
+        // matching //records/[] — inside this transaction.
+        wtx.insertObjectRecordAsLastChild("z", new ObjectValue());
+        wtx.insertObjectRecordAsLastChild("records", new ArrayValue());
+        wtx.insertSubtreeAsLastChild(JsonShredder.createStringReader("{\"age\": 100}"),
+            JsonNodeTrx.Commit.NO);
+        // ... and remove it again before committing.
+        Assertions.assertTrue(wtx.moveTo(topObjectKey));
+        Assertions.assertTrue(wtx.moveToLastChild());
+        Assertions.assertEquals(NodeKind.OBJECT_NAMED_OBJECT, wtx.getKind());
+        wtx.remove();
+        wtx.commit();
+      }
+      // The pattern resolves to ONE path class again — but the projection
+      // was invalidated mid-transaction and must NOT serve.
+      final int mostRecent = session.getMostRecentRevisionNumber();
+      try (final var rtx = session.beginNodeReadOnlyTrx(mostRecent)) {
+        Assertions.assertNull(session.getRtxIndexController(mostRecent)
+                .openProjectionIndex(rtx.getStorageEngineReader(),
+                    new String[] { "x", "records", "[]" }, new String[] { "age" }),
+            "a mid-transaction record-set widening must tombstone the descendant-rooted projection");
+      }
+    }
+    // The generic pipeline stays correct.
+    test("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return sum(for $r in $doc.x.records[] return $r.age)
+        """, "127");
+  }
+
+  private static Database<JsonResourceSession> openDatabase() {
+    final Path dbPath =
+        Path.of(JsonTestHelper.PATHS.PATH1.getFile().getParent().toString(), "json-path1");
+    return Databases.openJsonDatabase(dbPath);
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexDescendantRootServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexDescendantRootServingTest.java
@@ -33,8 +33,8 @@ import java.nio.file.Path;
  * concrete path, a pattern matching several subtrees (the projection
  * aggregates across all of them, which a path-specific query must not be
  * served from) fails closed to the generic pipeline, and a NEW matching
- * subtree appearing mid-transaction invalidates the projection (the
- * persisted rows no longer cover the widened record set).
+ * subtree appearing mid-transaction RESEEDS the listener's root set so the
+ * projection stays exactly maintained across widening and shrinking.
  */
 public final class ProjectionIndexDescendantRootServingTest extends AbstractJsonTest {
 
@@ -163,13 +163,12 @@ public final class ProjectionIndexDescendantRootServingTest extends AbstractJson
   }
 
   @Test
-  public void newMatchingSubtreeMidTransactionInvalidates() throws IOException {
+  public void newMatchingSubtreeMidTransactionIsMaintainedExactly() throws IOException {
     // A brand-new subtree matching the pattern widens the record set — the
-    // listener must invalidate (fail closed), EVEN IF the subtree is removed
-    // again before the commit: the listener cannot prove the intermediate
-    // states kept the persisted rows consistent. Without the invalidation
-    // the pattern would resolve back to one path class after the commit and
-    // serve the never-rebuilt snapshot.
+    // listener RESEEDS its root PCRs so the new subtree's records attribute
+    // normally. Here the subtree is removed again before the commit, so the
+    // maintained projection must end up exactly where it started: still
+    // valid, still serving the original rows.
     storeSingleSubtreeAndCreateProjection();
     try (final Database<JsonResourceSession> database = openDatabase();
          final JsonResourceSession session = database.beginResourceSession("desc.jn")) {
@@ -190,21 +189,59 @@ public final class ProjectionIndexDescendantRootServingTest extends AbstractJson
         wtx.remove();
         wtx.commit();
       }
-      // The pattern resolves to ONE path class again — but the projection
-      // was invalidated mid-transaction and must NOT serve.
+      // The pattern resolves to ONE path class again and the maintained
+      // projection serves the unchanged rows — no tombstone.
       final int mostRecent = session.getMostRecentRevisionNumber();
       try (final var rtx = session.beginNodeReadOnlyTrx(mostRecent)) {
-        Assertions.assertNull(session.getRtxIndexController(mostRecent)
+        Assertions.assertNotNull(session.getRtxIndexController(mostRecent)
                 .openProjectionIndex(rtx.getStorageEngineReader(),
                     new String[] { "x", "records", "[]" }, new String[] { "age" }),
-            "a mid-transaction record-set widening must tombstone the descendant-rooted projection");
+            "a reverted mid-transaction widening must leave the projection maintained and servable");
       }
     }
-    // The generic pipeline stays correct.
-    test("""
+    final long servedBefore = ProjectionIndexCatalog.servedCount();
+    Assertions.assertEquals("127", executeServed("desc.jn", """
           let $doc := jn:doc('json-path1','desc.jn')
           return sum(for $r in $doc.x.records[] return $r.age)
-        """, "127");
+        """));
+    Assertions.assertTrue(ProjectionIndexCatalog.servedCount() > servedBefore);
+  }
+
+  @Test
+  public void widenThenShrinkStaysMaintainedAndServingResumes() throws IOException {
+    // The full life cycle of a descendant pattern's record set: a SECOND
+    // matching subtree appears (reseed — its records append to the
+    // projection; serving pauses on ambiguity), then the FIRST subtree is
+    // deleted (its rows drop out incrementally) — after which the pattern
+    // resolves to one path class again and serving RESUMES from the
+    // continuously maintained projection, with the surviving subtree's
+    // values. No tombstone, no re-creation call anywhere.
+    storeSingleSubtreeAndCreateProjection();
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return insert json {"y": {"records": [{"age": 100}]}} into $doc
+        """);
+    // Ambiguous while both subtrees exist — fail closed, values correct.
+    final long servedWhileAmbiguous = ProjectionIndexCatalog.servedCount();
+    Assertions.assertEquals("227", executeServed("desc.jn", """
+          let $doc := jn:doc('json-path1','desc.jn')
+          return sum(for $r in $doc.x.records[] return $r.age)
+             + sum(for $r in $doc.y.records[] return $r.age)
+        """));
+    Assertions.assertEquals(servedWhileAmbiguous, ProjectionIndexCatalog.servedCount(),
+        "two matching subtrees must not serve a path-specific query");
+    // Shrink back to one subtree.
+    query("""
+          let $doc := jn:doc('json-path1','desc.jn')
+          return delete json $doc.x
+        """);
+    final long servedBefore = ProjectionIndexCatalog.servedCount();
+    Assertions.assertEquals("100", executeServed("desc.jn", """
+          let $doc := jn:doc('json-path1','desc.jn')
+          return sum(for $r in $doc.y.records[] return $r.age)
+        """));
+    Assertions.assertTrue(ProjectionIndexCatalog.servedCount() > servedBefore,
+        "after shrinking back to one subtree the maintained projection must SERVE again");
   }
 
   private static Database<JsonResourceSession> openDatabase() {

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexFunctionTest.java
@@ -287,10 +287,11 @@ public final class ProjectionIndexFunctionTest extends AbstractJsonTest {
   }
 
   @Test
-  public void structuralRecordSetDeleteFallsBackToInvalidation() throws IOException {
-    // Removing the record-set array itself is a structural change the
-    // incremental path refuses — the listener tombstones the projection and
-    // queries stay correct via the generic pipeline.
+  public void structuralRecordSetDeleteIsMaintainedExactly() throws IOException {
+    // Removing the record-set array itself drops every record: the records
+    // fire their own post-order delete notifications, so the maintained
+    // projection ends up truthfully EMPTY (no tombstone) and queries stay
+    // correct.
     query("""
           jn:store('json-path1','two.jn','{
             "a": [{"age": 10}, {"age": 20}],

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexWtxServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexWtxServingTest.java
@@ -147,10 +147,12 @@ public final class ProjectionIndexWtxServingTest extends AbstractJsonTest {
   }
 
   @Test
-  public void moveOutOfRecordSetInvalidatesProjection() throws IOException {
+  public void moveOutOfRecordSetRebuildsAndKeepsServing() throws IOException {
     // A subtree MOVE cannot be attributed incrementally (the moved record
-    // keeps existing outside the record set) — the listener must tombstone,
-    // and neither wtx-visible nor committed serving may keep the phantom row.
+    // keeps existing outside the record set) — the listener degrades to a
+    // commit-time full rebuild, so BOTH wtx-visible and committed serving
+    // continue with the exact post-move rows: no phantom row, no tombstone,
+    // no re-creation call.
     query("""
           jn:store('json-path1','mv.jn','{"records":[{"age":1},{"age":2}],"archive":[]}')
         """);
@@ -184,20 +186,25 @@ public final class ProjectionIndexWtxServingTest extends AbstractJsonTest {
           // Move record 0 out of the record set into "archive".
           wtx.moveSubtreeToFirstChild(record0Key);
 
-          // The projection is tombstoned — no serving, the interpreter
-          // (reading the same transaction) answers instead.
-          Assertions.assertNull(wtxExecutor.executeAggregate(null, recordsPath, "sum", "age"),
-              "a moved-out record must invalidate the projection, not keep a phantom row");
+          // The wtx-visible read applies the pending REBUILD: the moved
+          // record's row is gone, serving continues.
+          final Sequence after = wtxExecutor.executeAggregate(null, recordsPath, "sum", "age");
+          Assertions.assertNotNull(after,
+              "a move must degrade to a rebuild that keeps the projection servable");
+          Assertions.assertEquals(2L, ((Int64) after).longValue(),
+              "the moved-out record must not survive as a phantom row");
         } finally {
           wtxExecutor.close();
         }
         wtx.commit();
       }
-      // Committed serving refuses the stale tombstone too (controller-mediated).
+      // Committed serving keeps working over the rebuilt snapshot too.
       final int mostRecent = session.getMostRecentRevisionNumber();
       try (final var rtx = session.beginNodeReadOnlyTrx(mostRecent)) {
-        Assertions.assertNull(session.getRtxIndexController(mostRecent)
-            .openProjectionIndex(rtx.getStorageEngineReader(), recordsPath, new String[] { "age" }));
+        final ProjectionIndexRegistry.Handle handle = session.getRtxIndexController(mostRecent)
+            .openProjectionIndex(rtx.getStorageEngineReader(), recordsPath, new String[] { "age" });
+        Assertions.assertNotNull(handle,
+            "the rebuilt projection must serve committed readers — no tombstone");
       }
     }
     // The generic pipeline stays correct: only record 1 remains under records.


### PR DESCRIPTION
## What does this PR do?

Two pieces of work on projection indexes.

**Part 1 — the five follow-ups declared when the feature merged (#1117):**

1. **Per-leaf record-key fences in the metadata payload** — `ProjectionIndexMetadata` now persists a (first, last) record-key pair per leaf after the build revision. Incremental maintenance reads its zone maps from ONE slot-0 read instead of probing every leaf's head chunk per commit, eliminating O(leafCount) HOT descents. All creation sites compute fences via the codec's shared `recordKeyRange`.
2. **Ancestor-walk memoization in the change listener** — positive node → enclosing-record resolutions are memoized (capped `Long2LongOpenHashMap`), so bulk subtree mutations stop re-walking the full ancestor chain per notification. Negative verdicts are deliberately never memoized: an ancestor of the record set would wrongly inherit them.
3. **Per-transaction caching of wtx-mode decodes** — the listener exposes a monotone maintenance epoch; `AbstractIndexController` caches the decoded uncommitted handle and revalidates with one identity + epoch compare instead of re-decoding the leaves on every same-state query.
4. **XML notification-gate fix** — `XmlNodeTrxImpl` now gates on `hasAnyPrimitiveIndex()` like the JSON transaction, so projection-only XML resources fire index notifications.
5. **Pattern-aware serving for descendant-rooted projections (`//...`)** — the catalog resolves the pattern against the queried revision's path summary and serves under the concrete path when exactly ONE path class matches; ambiguous or unresolvable patterns keep failing closed to the generic pipeline.

**Part 2 — the fail-closed invalidation ladder is gone; projections are now ALWAYS maintained, like the other index families:**

- Record-set array instances appearing/disappearing are exact no-ops for the listener — their records fire individual notifications (pre-order on insert, post-order on delete), so deleting a whole record set leaves a truthfully empty projection and a replacement record set at the same path is picked up with **no re-creation call**.
- A NEW path class matching the root path (exact re-creation, or a descendant pattern widening to another subtree) **reseeds** the listener's root-PCR set instead of invalidating; the new roots' records attribute normally and append at apply time. Descendant projections stay correct across widen/shrink cycles and serving resumes automatically once the pattern is unambiguous again.
- Everything genuinely unattributable — subtree moves, unresolvable ancestor chains, transactions beyond `-Dsirix.projection.maxIncrementalRecords`, and any inconsistency the incremental patch discovers — degrades to an **automatic full rebuild inside the same commit**, via the build core now shared with index creation (`ProjectionIndexBuilder.buildAndPersist`).
- The stale tombstone survives only as a **corruption valve** (both the patch and the rebuild threw); manual `jn:create-projection-index` recovers.

## Related issue

No issue — follow-up work declared in the #1117 merge summary, plus removing that summary's biggest remaining semantic divergence from the other index types.

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Performance improvement

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — full sirix-core + sirix-query test suites green after each part
- [x] Added or updated tests covering the change (`ProjectionIndexDescendantRootServingTest` incl. widen→shrink lifecycle; move-then-keep-serving; record-set replacement without re-create; metadata fence round-trip/truncation/misalignment)
- [x] For behavioral changes to the storage engine: the relevant invariant in [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (no page-layer invariant touched; the metadata payload is index-private and version-gated)
- [x] Updated documentation (README maintenance section rewritten for the always-maintained contract)
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- The metadata wire format changed (fences inserted after the build revision) but `VERSION` stays 1 by prior agreement: no databases with the earlier layout exist; an unknown/older version still parses to `null` and degrades to a rebuild.
- Descendant-root resolution happens once per (resource, revision) inside the cached `defEntries` computation, not per query; the exactly-one-path-class rule is the serving correctness gate — a pattern matching several subtrees aggregates across all of them by design and must not answer a path-specific query. Maintenance, by contrast, now covers ALL matching subtrees continuously.
- The commit-time rebuild is bounded by index size and only triggers on operations whose cost the transaction already implied (moves of indexed records, 100k+ touched records); the common update path stays the incremental leaf patch.