### PR TITLE
Valid-time follow-ups: REST index parity and working xs:dateTime CAS auto-indexing

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -1377,11 +1377,13 @@ public final class ResourceConfiguration {
      * </p>
      *
      * <p>
-     * The persistent valid-time interval index is created automatically by the store layers
-     * (JSONiq {@code jn:store}/{@code jn:load} with valid-time options and the REST create
-     * handler); resources created directly through the Java API can create it explicitly via
-     * {@code jn:create-valid-time-index} or the {@code io.sirix.query.json.ValidTimeIndexes}
-     * helper. Setting this configuration alone does not create any index.
+     * The persistent valid-time interval index and two {@code xs:string} CAS indexes over the
+     * valid-time fields are created automatically by the store layers (JSONiq
+     * {@code jn:store}/{@code jn:load} with valid-time options and the REST create handler);
+     * resources created directly through the Java API can create them explicitly via
+     * {@code jn:create-valid-time-index}/{@code jn:create-cas-index} or the
+     * {@code io.sirix.query.json.ValidTimeIndexes} helper. Setting this configuration alone does
+     * not create any index.
      * </p>
      *
      * @param validTimeConfig the valid time configuration, or null to disable

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -1377,8 +1377,11 @@ public final class ResourceConfiguration {
      * </p>
      *
      * <p>
-     * CAS indexes will be automatically created for the specified paths when the resource is opened for
-     * writing.
+     * The persistent valid-time interval index is created automatically by the store layers
+     * (JSONiq {@code jn:store}/{@code jn:load} with valid-time options and the REST create
+     * handler); resources created directly through the Java API can create it explicitly via
+     * {@code jn:create-valid-time-index} or the {@code io.sirix.query.json.ValidTimeIndexes}
+     * helper. Setting this configuration alone does not create any index.
      * </p>
      *
      * @param validTimeConfig the valid time configuration, or null to disable
@@ -1398,8 +1401,8 @@ public final class ResourceConfiguration {
      * </p>
      *
      * <p>
-     * When set, CAS indexes will be automatically created for these paths to enable optimized
-     * bitemporal queries.
+     * See {@link #validTimeConfig(ValidTimeConfig)} for how the valid-time interval index is
+     * created — setting the paths alone does not create any index.
      * </p>
      *
      * @param validFromPath JSON path to the validFrom field (e.g., "$.validFrom" or "validFrom")

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -1377,7 +1377,7 @@ public final class ResourceConfiguration {
      * </p>
      *
      * <p>
-     * The persistent valid-time interval index and two {@code xs:string} CAS indexes over the
+     * The persistent valid-time interval index and two {@code xs:dateTime} CAS indexes over the
      * valid-time fields are created automatically by the store layers (JSONiq
      * {@code jn:store}/{@code jn:load} with valid-time options and the REST create handler);
      * resources created directly through the Java API can create them explicitly via

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -262,12 +262,12 @@ final class JsonNodeTrxImpl extends
     }
 
     // NOTE: valid-time indexing is handled by the store layers (JSONiq jn:store/jn:load and the
-    // REST create handler), which create the persistent interval index via the shared
-    // io.sirix.query.json.ValidTimeIndexes recipe. A former bootstrap hook here registered two CAS
-    // index definitions for the valid-time fields, but they were never serialized at commit (the
-    // definitions were added to a controller instance that is not the one persisted), so no
-    // released resource ever carried them — the hook was removed instead of revived, because
-    // reviving it would have added two always-maintained CAS indexes to every valid-time resource.
+    // REST create handler), which create the persistent interval index PLUS the two xs:string CAS
+    // indexes over the valid-time fields via the shared io.sirix.query.json.ValidTimeIndexes
+    // recipe. A former bootstrap hook here registered two CAS index definitions directly, but they
+    // were never serialized at commit (the definitions were added to a controller instance that is
+    // not the one persisted) and used xs:dateTime, which the CAS-narrowing fallback ignores — so
+    // the hook was replaced by the store-layer creation rather than revived here.
 
     // Wire write singleton binder for zero-allocation write path.
     if (nodeFactory instanceof JsonNodeFactoryImpl factoryImpl) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -27,10 +27,7 @@ import com.google.gson.stream.JsonToken;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Item;
-import io.brackit.query.jdm.Type;
-import io.brackit.query.util.path.PathParser;
 import io.sirix.access.ResourceConfiguration;
-import io.sirix.access.ValidTimeConfig;
 import io.sirix.access.trx.node.AbstractNodeHashing;
 import io.sirix.access.trx.node.AbstractNodeReadOnlyTrx;
 import io.sirix.access.trx.node.AbstractNodeTrxImpl;
@@ -63,7 +60,6 @@ import io.sirix.exception.SirixException;
 import io.sirix.exception.SirixIOException;
 import io.sirix.exception.SirixUsageException;
 import io.sirix.index.IndexDef;
-import io.sirix.index.IndexDefs;
 import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathSummaryWriter;
 import io.sirix.index.path.summary.PathSummaryWriter.OPType;
@@ -107,7 +103,6 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
@@ -266,80 +261,18 @@ final class JsonNodeTrxImpl extends
       indexController.createIndexListeners(existingIndexDefs, this);
     }
 
-    // Auto-create CAS indexes for valid time paths on bootstrap
-    createValidTimeIndexesIfNeeded(resourceSession.getResourceConfig());
+    // NOTE: valid-time indexing is handled by the store layers (JSONiq jn:store/jn:load and the
+    // REST create handler), which create the persistent interval index via the shared
+    // io.sirix.query.json.ValidTimeIndexes recipe. A former bootstrap hook here registered two CAS
+    // index definitions for the valid-time fields, but they were never serialized at commit (the
+    // definitions were added to a controller instance that is not the one persisted), so no
+    // released resource ever carried them — the hook was removed instead of revived, because
+    // reviving it would have added two always-maintained CAS indexes to every valid-time resource.
 
     // Wire write singleton binder for zero-allocation write path.
     if (nodeFactory instanceof JsonNodeFactoryImpl factoryImpl) {
       wireWriteSingletonBinder(factoryImpl, storageEngineWriter);
     }
-  }
-
-  /**
-   * Creates CAS indexes for valid time paths if configured and this is a new resource.
-   *
-   * <p>
-   * This is called during the first write transaction on a new resource to ensure that bitemporal
-   * queries can use optimized index-based lookups for valid time.
-   * </p>
-   *
-   * @param resourceConfig the resource configuration
-   */
-  private void createValidTimeIndexesIfNeeded(ResourceConfiguration resourceConfig) {
-    // Only create indexes on bootstrap (revision 0)
-    if (nodeReadOnlyTrx.getRevisionNumber() != 0) {
-      return;
-    }
-
-    // Check if valid time configuration exists
-    final var validTimeConfig = resourceConfig.getValidTimeConfig();
-    if (validTimeConfig == null) {
-      return;
-    }
-
-    // Check if indexes already exist
-    final var existingIndexes = indexController.getIndexes().getIndexDefs();
-    if (!existingIndexes.isEmpty()) {
-      return;
-    }
-
-    // Create CAS indexes for validFrom and validTo paths
-    final var indexDefs = createValidTimeIndexDefs(validTimeConfig);
-    if (!indexDefs.isEmpty()) {
-      // Note: we just register the index definitions here, they will be populated
-      // when data is inserted. For bootstrap with no data yet, this just sets up
-      // the index listeners for future insertions.
-      for (IndexDef indexDef : indexDefs) {
-        indexController.getIndexes().add(indexDef);
-      }
-      indexController.createIndexListeners(indexDefs, this);
-    }
-  }
-
-  /**
-   * Creates index definitions for valid time paths.
-   *
-   * @param validTimeConfig the valid time configuration
-   * @return set of index definitions for validFrom and validTo paths
-   */
-  private Set<IndexDef> createValidTimeIndexDefs(ValidTimeConfig validTimeConfig) {
-    final Set<IndexDef> indexDefs = new HashSet<>(4);
-    indexDefs.add(createValidTimeCasIdxDef(validTimeConfig.getNormalizedValidFromPath(), 0));
-    indexDefs.add(createValidTimeCasIdxDef(validTimeConfig.getNormalizedValidToPath(), 1));
-    return indexDefs;
-  }
-
-  /**
-   * Creates a CAS index definition over one valid-time field, using xs:dateTime since valid time
-   * values are timestamps. Dotted (nested) configured paths such as "$.meta.validFrom" are
-   * converted to slash-separated path steps — a raw Path.parse on the dotted form throws and would
-   * abort resource creation. (Brackit's Path is fully qualified because java.nio.file.Path is
-   * already imported.)
-   */
-  private static IndexDef createValidTimeCasIdxDef(final String configuredFieldPath, final int indexDefNo) {
-    final var path = io.brackit.query.util.path.Path.parse(
-        ValidTimeConfig.toSlashSeparatedPath(configuredFieldPath), PathParser.Type.JSON);
-    return IndexDefs.createCASIdxDef(false, Type.DATI, Set.of(path), indexDefNo, IndexDef.DbType.JSON);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -262,12 +262,12 @@ final class JsonNodeTrxImpl extends
     }
 
     // NOTE: valid-time indexing is handled by the store layers (JSONiq jn:store/jn:load and the
-    // REST create handler), which create the persistent interval index PLUS the two xs:string CAS
-    // indexes over the valid-time fields via the shared io.sirix.query.json.ValidTimeIndexes
+    // REST create handler), which create the persistent interval index PLUS the two xs:dateTime
+    // CAS indexes over the valid-time fields via the shared io.sirix.query.json.ValidTimeIndexes
     // recipe. A former bootstrap hook here registered two CAS index definitions directly, but they
     // were never serialized at commit (the definitions were added to a controller instance that is
-    // not the one persisted) and used xs:dateTime, which the CAS-narrowing fallback ignores — so
-    // the hook was replaced by the store-layer creation rather than revived here.
+    // not the one persisted) — the hook was replaced by the store-layer creation rather than
+    // revived here.
 
     // Wire write singleton binder for zero-allocation write path.
     if (nodeFactory instanceof JsonNodeFactoryImpl factoryImpl) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
@@ -25,10 +25,10 @@ public final class CASFilterRange implements Filter {
   /** {@link PathFilter} instance to filter specific paths. */
   private final PathFilter pathFilter;
 
-  /** The minimum value. */
+  /** The minimum value, or {@code null} for an unbounded lower end. */
   private final Atomic min;
 
-  /** The maximum value. */
+  /** The maximum value, or {@code null} for an unbounded upper end. */
   private final Atomic max;
 
   /** {@code true} if the minimum should be included, {@code false} otherwise */
@@ -41,8 +41,8 @@ public final class CASFilterRange implements Filter {
    * Constructor. Initializes the internal state.
    *
    * @param paths paths to match
-   * @param min the minimum value
-   * @param max the maximum value
+   * @param min the minimum value, or {@code null} for an unbounded lower end (one-sided range)
+   * @param max the maximum value, or {@code null} for an unbounded upper end (one-sided range)
    * @param incMin include the minimum value
    * @param incMax include the maximum value
    * @param pcrCollector the PCR collector used
@@ -50,8 +50,8 @@ public final class CASFilterRange implements Filter {
   public CASFilterRange(final Set<Path<QNm>> paths, final Atomic min, final Atomic max, final boolean incMin,
       final boolean incMax, final PCRCollector pcrCollector) {
     this.pathFilter = new PathFilter(requireNonNull(paths), pcrCollector);
-    this.min = requireNonNull(min);
-    this.max = requireNonNull(max);
+    this.min = min;
+    this.max = max;
     this.incMin = incMin;
     this.incMax = incMax;
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
@@ -1,5 +1,7 @@
 package io.sirix.query.function.jn.temporal;
 
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.DateTime;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Sequence;
@@ -18,9 +20,6 @@ import io.sirix.query.json.JsonDBItem;
 import io.sirix.query.json.JsonDBObject;
 
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -30,8 +29,16 @@ import java.util.Set;
 /**
  * Shared helper that accelerates the valid-time point-in-time predicate
  * ({@code validFrom <= validTime <= validTo}) used by {@code jn:open-bitemporal} and
- * {@code jn:valid-at} with a CAS index range scan, falling back to {@code null} (so the caller can
- * keep its existing linear scan) when no suitable index exists.
+ * {@code jn:valid-at} with CAS index range scans, falling back to {@code null} (so the caller can
+ * keep its existing linear scan) when the indexes do not exist.
+ *
+ * <h2>Index shape</h2>
+ * <p>
+ * The scan requires the PAIR of {@link Type#DATI xs:dateTime} CAS indexes over the valid-time
+ * fields — the kind the store layers auto-create for valid-time resources. Candidates are the
+ * UNION of two exact one-sided temporal ranges: {@code validTo >= t} on the validTo index and
+ * {@code validFrom <= t} on the validFrom index.
+ * </p>
  *
  * <h2>How an index hit maps to its record object</h2>
  * <p>
@@ -62,42 +69,31 @@ import java.util.Set;
  *
  * <h2>Why this is provably equal to the scan (the correctness gate)</h2>
  * <p>
- * The CAS values are {@link Type#STR} and compared lexicographically. The range we hand the index
- * is computed at whole-second granularity so that it is a guaranteed <em>superset</em> of every
- * record that chronologically satisfies the predicate (no false negatives), and every surviving
- * candidate is then re-verified by reading both fields with the same {@code validFrom <= t <=
- * validTo} {@link Instant} comparison the scan uses (no false positives). The bound assumes the
- * stored valid-time strings are canonical ISO-8601 UTC instants (what {@code Instant.toString()}
- * produces and what the existing {@code parseInstant} already assumes). See
- * {@link #safeLowerSecondBound(Instant)} / {@link #safeUpperSecondBound(Instant)} for the proof
- * sketch.
+ * xs:dateTime keys compare temporally, so the two one-sided ranges are exact. BOTH indexes are
+ * required: a record whose bound string fails the xs:dateTime cast is absent from that field's
+ * index (the CAS builder skips non-castable values) and is treated as unbounded on that side by the
+ * predicate — but every true match has at least one castable bound satisfying its one-sided range
+ * ({@code validFrom <= t} or {@code validTo >= t}), so the UNION of the two ranges is a superset of
+ * all matches. Every surviving candidate is then re-verified by reading both fields with the same
+ * {@code validFrom <= t <= validTo} {@link Instant} comparison the linear scan uses, removing any
+ * over-fetch (no false positives).
  * </p>
  *
  * @author Johannes Lichtenberger
  */
 public final class ValidTimeIndexScan {
 
-  /** ISO instant formatter truncated to whole seconds, always WITHOUT a fractional part. */
-  private static final DateTimeFormatter SECOND_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
-
-  /** A string that sorts after any canonical ISO-8601 instant string. */
-  private static final String LEX_MAX = "￿";
-
   private static final DateTimeToInstant DATE_TIME_TO_INSTANT = new DateTimeToInstant();
 
   /**
-   * Result of an index-accelerated valid-time scan: the verified, de-duplicated matching records
-   * plus which valid-time field's index was used (for test visibility).
+   * Result of an index-accelerated valid-time scan: the verified, de-duplicated matching records.
    */
   public static final class Result {
     private final List<JsonDBItem> items;
-    private final ValidField indexedField;
     private final long candidatesExamined;
 
-    Result(List<JsonDBItem> items, ValidField indexedField, long candidatesExamined) {
+    Result(List<JsonDBItem> items, long candidatesExamined) {
       this.items = items;
-      this.indexedField = indexedField;
       this.candidatesExamined = candidatesExamined;
     }
 
@@ -106,34 +102,23 @@ public final class ValidTimeIndexScan {
       return items;
     }
 
-    /** Which valid-time field's CAS index narrowed the candidates. */
-    public ValidField indexedField() {
-      return indexedField;
-    }
-
-    /** Number of distinct candidate records the index produced before final verification. */
+    /** Number of distinct candidate records the indexes produced before final verification. */
     public long candidatesExamined() {
       return candidatesExamined;
     }
-  }
-
-  /** Which valid-time field a CAS index was found on / used. */
-  public enum ValidField {
-    VALID_FROM,
-    VALID_TO
   }
 
   private ValidTimeIndexScan() {
   }
 
   /**
-   * Try to evaluate the valid-time point-in-time predicate via a CAS index range scan.
+   * Try to evaluate the valid-time point-in-time predicate via CAS index range scans.
    *
    * @param document the document item (anchored at the top-level array/object node)
    * @param validTime the point in valid time to test
    * @param validTimeConfig the resource's valid-time configuration
-   * @return a {@link Result} when a suitable CAS index was found and used, or {@code null} when the
-   *         caller should fall back to the linear scan
+   * @return a {@link Result} when the pair of xs:dateTime CAS indexes was found and used, or
+   *         {@code null} when the caller should fall back to the linear scan
    */
   public static Result tryIndexScan(final JsonDBItem document, final Instant validTime,
       final ValidTimeConfig validTimeConfig) {
@@ -152,25 +137,26 @@ public final class ValidTimeIndexScan {
     final String validFromField = validTimeConfig.getNormalizedValidFromPath();
     final String validToField = validTimeConfig.getNormalizedValidToPath();
 
-    // Prefer the validTo index: for a point-in-time query "validTo >= t" is usually the more
-    // selective of the two one-sided ranges. Fall back to the validFrom index.
     final IndexDef validToIndex = findCasIndexForField(controller, validToField);
-    if (validToIndex != null) {
-      return runIndexScan(document, rtx, controller, collection, validToIndex, ValidField.VALID_TO, validTime,
-          validFromField, validToField);
-    }
-
     final IndexDef validFromIndex = findCasIndexForField(controller, validFromField);
-    if (validFromIndex != null) {
-      return runIndexScan(document, rtx, controller, collection, validFromIndex, ValidField.VALID_FROM, validTime,
-          validFromField, validToField);
+    if (validToIndex == null || validFromIndex == null) {
+      return null;
     }
 
-    return null;
+    final Atomic pointInTime = new DateTime(validTime.toString());
+    final long documentItemKey = topLevelItemNodeKey(rtx);
+
+    final Set<Long> candidateObjectKeys = new LinkedHashSet<>();
+    // validTo >= t: one-sided range [t, +inf) — null max is unbounded.
+    collectCandidates(rtx, controller, validToIndex, pointInTime, null, documentItemKey, candidateObjectKeys);
+    // validFrom <= t: one-sided range (-inf, t] — null min is unbounded.
+    collectCandidates(rtx, controller, validFromIndex, null, pointInTime, documentItemKey, candidateObjectKeys);
+
+    return verifyCandidates(rtx, collection, candidateObjectKeys, validTime, validFromField, validToField);
   }
 
   /**
-   * Find a CAS index of content type {@link Type#STR} whose last path step matches {@code field}.
+   * Find a CAS index of content type {@link Type#DATI} whose last path step matches {@code field}.
    *
    * <p>
    * Matching on the path's {@link Path#tail() tail} (last step name) avoids reconstructing the full
@@ -183,9 +169,7 @@ public final class ValidTimeIndexScan {
       if (!indexDef.isCasIndex()) {
         continue;
       }
-      // Valid-time values are stored as strings (the CAS index is created with Type.STR). Only such
-      // indexes give the lexicographic ordering our bound math relies on.
-      if (!Type.STR.equals(indexDef.getContentType())) {
+      if (!Type.DATI.equals(indexDef.getContentType())) {
         continue;
       }
       for (final Path<QNm> path : indexDef.getPaths()) {
@@ -198,39 +182,23 @@ public final class ValidTimeIndexScan {
     return null;
   }
 
-  private static Result runIndexScan(final JsonDBItem document, final JsonNodeReadOnlyTrx rtx,
-      final JsonIndexController controller, final JsonDBCollection collection, final IndexDef indexDef,
-      final ValidField field, final Instant validTime, final String validFromField, final String validToField) {
-
+  /**
+   * Run one CAS range scan and add every candidate record OBJECT key within the linear-scan domain
+   * (the document item itself or its direct array children) to {@code candidateObjectKeys}. The
+   * set de-dups records hit via multiple indexed values or via both indexes.
+   */
+  private static void collectCandidates(final JsonNodeReadOnlyTrx rtx, final JsonIndexController controller,
+      final IndexDef indexDef, final Atomic min, final Atomic max, final long documentItemKey,
+      final Set<Long> candidateObjectKeys) {
     // PCR filtering: restrict to the index's own indexed path(s).
     final Set<String> paths = new LinkedHashSet<>();
     for (final Path<QNm> path : indexDef.getPaths()) {
       paths.add(path.toString());
     }
 
-    final Str min;
-    final Str max;
-    if (field == ValidField.VALID_TO) {
-      // Candidates: validTo >= validTime  ->  lexicographic [safeLower, +inf]
-      min = new Str(safeLowerSecondBound(validTime));
-      max = new Str(LEX_MAX);
-    } else {
-      // Candidates: validFrom <= validTime  ->  lexicographic [-inf, safeUpper]
-      min = new Str("");
-      max = new Str(safeUpperSecondBound(validTime));
-    }
-
     final CASFilterRange filter = controller.createCASFilterRange(paths, min, max, true, true, new JsonPCRCollector(rtx));
     final Iterator<NodeReferences> index = controller.openCASIndex(rtx.getStorageEngineReader(), indexDef, filter);
 
-    // The node the linear scan treats as the document item: the first child of the document root
-    // (the top-level array or object). Compute it via explicit navigation so it does not depend on
-    // the shared cursor's transient position.
-    final long documentItemKey = topLevelItemNodeKey(rtx);
-
-    // De-dup candidate record objects by node key (an object could be hit twice if the index path
-    // were multi-valued; also two valid-time fields of one record would map to the same object).
-    final Set<Long> candidateObjectKeys = new LinkedHashSet<>();
     while (index.hasNext()) {
       final NodeReferences refs = index.next();
       final var it = refs.getNodeKeys().getLongIterator();
@@ -247,15 +215,21 @@ public final class ValidTimeIndexScan {
         }
       }
     }
+  }
 
+  /**
+   * Verify each candidate by reading BOTH fields and applying the exact instant predicate; build
+   * the matching items. Sorting by node key gives a deterministic order.
+   */
+  private static Result verifyCandidates(final JsonNodeReadOnlyTrx rtx, final JsonDBCollection collection,
+      final Set<Long> candidateObjectKeys, final Instant validTime, final String validFromField,
+      final String validToField) {
     final long candidatesExamined = candidateObjectKeys.size();
 
-    // Verify each candidate by reading BOTH fields and applying the exact instant predicate; build
-    // the matching items. Sorting by node key gives a deterministic order.
     final List<Long> sortedKeys = new ArrayList<>(candidateObjectKeys);
     sortedKeys.sort(Long::compareTo);
 
-    final List<JsonDBItem> items = new ArrayList<>();
+    final List<JsonDBItem> items = new ArrayList<>(sortedKeys.size());
     for (final long objectKey : sortedKeys) {
       if (!rtx.moveTo(objectKey)) {
         continue;
@@ -269,7 +243,7 @@ public final class ValidTimeIndexScan {
       }
     }
 
-    return new Result(items, field, candidatesExamined);
+    return new Result(items, candidatesExamined);
   }
 
   /**
@@ -322,42 +296,6 @@ public final class ValidTimeIndexScan {
   }
 
   /**
-   * Lexicographic LOWER bound (inclusive) that is &le; every stored string whose instant is &ge;
-   * {@code validTime}, for the {@code validTo >= validTime} query.
-   *
-   * <p>
-   * Proof sketch (canonical ISO-8601 UTC strings): truncating {@code validTime} down to its whole
-   * second and dropping the trailing {@code 'Z'} yields a prefix {@code P = "...SS"}. Any true
-   * match has a floor-second &ge; validTime's floor-second. If strictly greater, the seconds prefix
-   * makes the string lexicographically &gt; P. If equal, the string is {@code "...SS.fracZ"} or
-   * {@code "...SSZ"} — P is a prefix of both, so P &le; both. Hence no true match sorts below P:
-   * the range admits every match (plus possibly a few same-second non-matches, removed by
-   * verification).
-   * </p>
-   */
-  static String safeLowerSecondBound(final Instant validTime) {
-    return SECOND_FORMATTER.format(validTime.truncatedTo(ChronoUnit.SECONDS));
-  }
-
-  /**
-   * Lexicographic UPPER bound (inclusive) that is &ge; every stored string whose instant is &le;
-   * {@code validTime}, for the {@code validFrom <= validTime} query.
-   *
-   * <p>
-   * Proof sketch (canonical ISO-8601 UTC strings): the lexicographically largest string within a
-   * floor-second {@code S} is {@code S + "Z"} (no fraction), because the only characters that can
-   * follow the seconds are {@code '.'} (0x2E, starts a fraction) or {@code 'Z'} (0x5A), and
-   * {@code '.' < 'Z'}. Using {@code U = validTime.floorSecond + "Z"} (inclusive) therefore bounds
-   * every true match: a match has floor-second &le; validTime's; if strictly less the whole
-   * seconds prefix makes it &lt; U, and if equal the largest possible string is exactly {@code U}.
-   * So no true match sorts above U.
-   * </p>
-   */
-  static String safeUpperSecondBound(final Instant validTime) {
-    return SECOND_FORMATTER.format(validTime.truncatedTo(ChronoUnit.SECONDS)) + "Z";
-  }
-
-  /**
    * The exact instant predicate, identical in semantics to the linear scan and to the interval-index
    * registration: reads the configured valid-time fields off {@code obj} and tests
    * {@code validFrom <= validTime <= validTo}, where an <em>absent</em> (or unparseable) bound is
@@ -397,7 +335,7 @@ public final class ValidTimeIndexScan {
   }
 
   private static Instant parseInstant(final Sequence seq) {
-    if (seq instanceof io.brackit.query.atomic.DateTime dt) {
+    if (seq instanceof DateTime dt) {
       return DATE_TIME_TO_INSTANT.convert(dt);
     }
     if (seq instanceof Str str) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/BasicJsonDBStore.java
@@ -559,7 +559,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
           final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
         if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+          ValidTimeIndexes.createValidTimeIndexesIfConfigured(resourceSession, wtx, collName);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       }
@@ -586,7 +586,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
       final String resourceName, final String collName, final Options resourceOptions) {
     try (final JsonResourceSession resourceSession = database.beginResourceSession(resourceName);
         final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
-      ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+      ValidTimeIndexes.createValidTimeIndexesIfConfigured(resourceSession, wtx, collName);
       wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
     }
   }
@@ -699,7 +699,7 @@ public final class BasicJsonDBStore implements JsonDBStore {
         final JsonNodeTrx wtx = beginImportTrx(resourceSession)) {
       wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
       if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
-        ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, collName);
+        ValidTimeIndexes.createValidTimeIndexesIfConfigured(resourceSession, wtx, collName);
       }
       wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
     }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/JsonDBCollectionImpl.java
@@ -269,7 +269,7 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
         if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, name);
+          ValidTimeIndexes.createValidTimeIndexesIfConfigured(resourceSession, wtx, name);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {
@@ -369,7 +369,7 @@ public final class JsonDBCollectionImpl extends AbstractJsonItemCollection<JsonD
       try (final JsonNodeTrx wtx = resourceSession.beginNodeTrx()) {
         wtx.insertSubtreeAsFirstChild(reader, JsonNodeTrx.Commit.NO);
         if (resourceOptions.shouldAutoCreateValidTimeIndex()) {
-          ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(resourceSession, wtx, name);
+          ValidTimeIndexes.createValidTimeIndexesIfConfigured(resourceSession, wtx, name);
         }
         wtx.commit(resourceOptions.commitMessage(), resourceOptions.commitTimestamp());
       } catch (final Exception e) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -107,12 +107,12 @@ public final class ValidTimeIndexes {
   /**
    * Create the valid-time indexes within the given write transaction when the resource is
    * configured with valid-time paths (idempotent per index kind). Creates the persistent interval
-   * index plus one {@code xs:string} CAS index per valid-time field — the content type the
-   * CAS-narrowing fallback of {@code jn:valid-at} requires (ISO-8601 UTC timestamps compare
-   * chronologically under lexicographic string order). All definitions are created in ONE
-   * {@code createIndexes} call, so the document is traversed once for every builder. Does not
-   * commit — the caller owns the transaction lifecycle, so data shred and index creation can land
-   * in one revision.
+   * index plus one {@code xs:dateTime} CAS index per valid-time field — the semantically correct
+   * content type for timestamps, which the CAS-narrowing fallback of {@code jn:valid-at} scans with
+   * exact temporal ranges (values that fail the xs:dateTime cast are skipped by the CAS builder,
+   * never aborting the insert). All definitions are created in ONE {@code createIndexes} call, so
+   * the document is traversed once for every builder. Does not commit — the caller owns the
+   * transaction lifecycle, so data shred and index creation can land in one revision.
    *
    * @param resourceSession the resource session the write transaction belongs to
    * @param wtx the open write transaction (data may already be inserted but not yet committed)
@@ -140,7 +140,7 @@ public final class ValidTimeIndexes {
       int casIndexDefNo = 0;
       for (final Path<QNm> path : defaultPaths(validTimeConfig)) {
         indexDefsToCreate.add(
-            IndexDefs.createCASIdxDef(false, Type.STR, Set.of(path), casIndexDefNo++, IndexDef.DbType.JSON));
+            IndexDefs.createCASIdxDef(false, Type.DATI, Set.of(path), casIndexDefNo++, IndexDef.DbType.JSON));
       }
     }
     if (indexDefsToCreate.isEmpty()) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -108,7 +108,7 @@ public final class ValidTimeIndexes {
    * @param databaseName the database (collection) name for statistics invalidation, may be
    *        {@code null}
    */
-  static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
+  public static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
       final JsonNodeTrx wtx, final @Nullable String databaseName) {
     requireNonNull(resourceSession, "resourceSession must not be null");
     requireNonNull(wtx, "wtx must not be null");

--- a/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/json/ValidTimeIndexes.java
@@ -1,6 +1,7 @@
 package io.sirix.query.json;
 
 import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
 import io.brackit.query.util.path.Path;
 import io.brackit.query.util.path.PathParser;
 import io.sirix.access.ValidTimeConfig;
@@ -84,8 +85,16 @@ public final class ValidTimeIndexes {
     // Invalidate cached query plans so the optimizer considers the new index.
     PlanCache.signalIndexSchemaChange();
 
-    // Invalidate stale histogram statistics since the index schema changed. Best-effort; must not
-    // prevent index creation.
+    invalidateStatistics(databaseName, resourceName);
+
+    return validTimeIdxDef;
+  }
+
+  /**
+   * Invalidate stale histogram statistics since the index schema changed. Best-effort; must not
+   * prevent index creation.
+   */
+  private static void invalidateStatistics(final @Nullable String databaseName, final @Nullable String resourceName) {
     if (databaseName != null && resourceName != null) {
       try {
         StatisticsCatalog.getInstance().invalidate(databaseName, resourceName);
@@ -93,13 +102,15 @@ public final class ValidTimeIndexes {
         // Histogram invalidation is best-effort.
       }
     }
-
-    return validTimeIdxDef;
   }
 
   /**
-   * Create the valid-time interval index within the given write transaction when the resource is
-   * configured with valid-time paths and no interval index exists yet (idempotent). Does not
+   * Create the valid-time indexes within the given write transaction when the resource is
+   * configured with valid-time paths (idempotent per index kind). Creates the persistent interval
+   * index plus one {@code xs:string} CAS index per valid-time field — the content type the
+   * CAS-narrowing fallback of {@code jn:valid-at} requires (ISO-8601 UTC timestamps compare
+   * chronologically under lexicographic string order). All definitions are created in ONE
+   * {@code createIndexes} call, so the document is traversed once for every builder. Does not
    * commit — the caller owns the transaction lifecycle, so data shred and index creation can land
    * in one revision.
    *
@@ -108,7 +119,7 @@ public final class ValidTimeIndexes {
    * @param databaseName the database (collection) name for statistics invalidation, may be
    *        {@code null}
    */
-  public static void createValidTimeIntervalIndexIfConfigured(final JsonResourceSession resourceSession,
+  public static void createValidTimeIndexesIfConfigured(final JsonResourceSession resourceSession,
       final JsonNodeTrx wtx, final @Nullable String databaseName) {
     requireNonNull(resourceSession, "resourceSession must not be null");
     requireNonNull(wtx, "wtx must not be null");
@@ -119,11 +130,28 @@ public final class ValidTimeIndexes {
     }
 
     final JsonIndexController controller = resourceSession.getWtxIndexController(wtx.getRevisionNumber());
-    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) > 0) {
+
+    final Set<IndexDef> indexDefsToCreate = new LinkedHashSet<>(4);
+    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME) == 0) {
+      indexDefsToCreate.add(
+          IndexDefs.createValidTimeIdxDef(defaultPaths(validTimeConfig), 0, IndexDef.DbType.JSON));
+    }
+    if (controller.getIndexes().getNrOfIndexDefsWithType(IndexType.CAS) == 0) {
+      int casIndexDefNo = 0;
+      for (final Path<QNm> path : defaultPaths(validTimeConfig)) {
+        indexDefsToCreate.add(
+            IndexDefs.createCASIdxDef(false, Type.STR, Set.of(path), casIndexDefNo++, IndexDef.DbType.JSON));
+      }
+    }
+    if (indexDefsToCreate.isEmpty()) {
       return;
     }
 
-    createIntervalIndex(controller, wtx, defaultPaths(validTimeConfig), databaseName,
-        resourceSession.getResourceConfig().getName());
+    controller.createIndexes(indexDefsToCreate, wtx);
+
+    // Invalidate cached query plans so the optimizer considers the new indexes.
+    PlanCache.signalIndexSchemaChange();
+
+    invalidateStatistics(databaseName, resourceSession.getResourceConfig().getName());
   }
 }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
@@ -104,10 +104,13 @@ public final class StoreValidTimeAutoIndexTest {
       assertEquals(VALID_TO, config.getNormalizedValidToPath());
 
       final int mostRecentRevision = session.getMostRecentRevisionNumber();
-      assertEquals(1, mostRecentRevision, "data + auto-created index must land in a single revision");
+      assertEquals(1, mostRecentRevision, "data + auto-created indexes must land in a single revision");
       assertEquals(1,
           session.getRtxIndexController(mostRecentRevision).getIndexes().getNrOfIndexDefsWithType(IndexType.VALIDTIME),
           "exactly one VALIDTIME interval index must have been auto-created");
+      assertEquals(2,
+          session.getRtxIndexController(mostRecentRevision).getIndexes().getNrOfIndexDefsWithType(IndexType.CAS),
+          "two xs:string CAS indexes over the valid-time fields must have been auto-created");
     }
 
     // Query correctness + interval-index fast path against a brute-force oracle.
@@ -182,6 +185,11 @@ public final class StoreValidTimeAutoIndexTest {
                  .getIndexes()
                  .getNrOfIndexDefsWithType(IndexType.VALIDTIME),
           "no VALIDTIME interval index must exist after opting out");
+      assertEquals(0,
+          session.getRtxIndexController(session.getMostRecentRevisionNumber())
+                 .getIndexes()
+                 .getNrOfIndexDefsWithType(IndexType.CAS),
+          "no CAS indexes must exist after opting out");
     }
 
     final ValidTimeConfig validTimeConfig = new ValidTimeConfig(VALID_FROM, VALID_TO);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/StoreValidTimeAutoIndexTest.java
@@ -17,9 +17,11 @@ import io.sirix.JsonTestHelper;
 import io.sirix.JsonTestHelper.PATHS;
 import io.sirix.access.Databases;
 import io.sirix.access.ValidTimeConfig;
+import io.brackit.query.jdm.Type;
 import io.sirix.api.Database;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
 import io.sirix.index.IndexType;
 import io.sirix.query.SirixCompileChain;
 import io.sirix.query.SirixQueryContext;
@@ -110,7 +112,13 @@ public final class StoreValidTimeAutoIndexTest {
           "exactly one VALIDTIME interval index must have been auto-created");
       assertEquals(2,
           session.getRtxIndexController(mostRecentRevision).getIndexes().getNrOfIndexDefsWithType(IndexType.CAS),
-          "two xs:string CAS indexes over the valid-time fields must have been auto-created");
+          "two CAS indexes over the valid-time fields must have been auto-created");
+      for (final IndexDef indexDef : session.getRtxIndexController(mostRecentRevision).getIndexes().getIndexDefs()) {
+        if (indexDef.getType() == IndexType.CAS) {
+          assertEquals(Type.DATI, indexDef.getContentType(),
+              "auto-created valid-time CAS indexes must use xs:dateTime keys");
+        }
+      }
     }
 
     // Query correctness + interval-index fast path against a brute-force oracle.
@@ -128,6 +136,14 @@ public final class StoreValidTimeAutoIndexTest {
               ValidTimeIntervalIndex.tryIndexScan(collection.getDocument(RES), t, validTimeConfig);
           assertNotNull(fast, "the auto-created interval index must be usable at t=" + t);
           assertEquals(brute, idsOfItems(fast.items()), "interval-index scan must equal brute force at t=" + t);
+
+          // The auto-created xs:dateTime CAS pair must power the CAS-narrowing scan (union of the
+          // two one-sided temporal ranges) and agree with brute force as well.
+          final ValidTimeIndexScan.Result casNarrowed =
+              ValidTimeIndexScan.tryIndexScan(collection.getDocument(RES), t, validTimeConfig);
+          assertNotNull(casNarrowed, "the auto-created xs:dateTime CAS indexes must be scannable at t=" + t);
+          assertEquals(brute, idsOfItems(casNarrowed.items()),
+              "the xs:dateTime CAS union scan must equal brute force at t=" + t);
         }
       }
     }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScanDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScanDifferentialTest.java
@@ -129,10 +129,10 @@ public final class ValidTimeIndexScanDifferentialTest {
 
         final var validFromPath = parse("/[]/validFrom", io.brackit.query.util.path.PathParser.Type.JSON);
         final var validFromIndex =
-            IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
+            IndexDefs.createCASIdxDef(false, Type.DATI, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
         final var validToPath = parse("/[]/validTo", io.brackit.query.util.path.PathParser.Type.JSON);
         final var validToIndex =
-            IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(validToPath), 1, IndexDef.DbType.JSON);
+            IndexDefs.createCASIdxDef(false, Type.DATI, Collections.singleton(validToPath), 1, IndexDef.DbType.JSON);
 
         indexController.createIndexes(Set.of(validFromIndex, validToIndex), wtx);
         wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(json), JsonNodeTrx.Commit.NO);
@@ -214,8 +214,8 @@ public final class ValidTimeIndexScanDifferentialTest {
             indexPathTakenCount++;
             final Set<Integer> directIndexIds = idsOfItems(indexScan.items());
             assertEquals(brute, directIndexIds,
-                "Direct index-scan result must equal brute force at t=" + t + " (field used: "
-                    + indexScan.indexedField() + ", candidates examined: " + indexScan.candidatesExamined() + ")");
+                "Direct index-scan result must equal brute force at t=" + t + " (candidates examined: "
+                    + indexScan.candidatesExamined() + ")");
             // All result items wrap the document's trx; ids are materialized, so release it now.
             indexedDoc.getTrx().close();
 
@@ -249,8 +249,8 @@ public final class ValidTimeIndexScanDifferentialTest {
   }
 
   @Test
-  @DisplayName("validFrom-only index path (safeUpperSecondBound) == brute force for all t")
-  void validFromOnlyIndexEqualsBruteForce() throws IOException {
+  @DisplayName("a single xs:dateTime index does NOT enable the index path; jn:valid-at falls back correctly")
+  void validFromOnlyIndexFallsBackToLinearScan() throws IOException {
     records = buildDataset();
     final String json = toJson(records);
 
@@ -262,10 +262,12 @@ public final class ValidTimeIndexScanDifferentialTest {
       try (JsonResourceSession session = database.beginResourceSession(INDEXED_RESOURCE);
           JsonNodeTrx wtx = session.beginNodeTrx()) {
         final var indexController = session.getWtxIndexController(wtx.getRevisionNumber());
-        // ONLY a validFrom CAS index — forces the validFrom branch (range validFrom <= t).
+        // ONLY a validFrom CAS index. The union scan needs BOTH xs:dateTime indexes for its
+        // superset guarantee (a record whose validFrom fails the cast is only reachable via the
+        // validTo range), so a single index must NOT enable the index path.
         final var validFromPath = parse("/[]/validFrom", io.brackit.query.util.path.PathParser.Type.JSON);
         final var validFromIndex =
-            IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
+            IndexDefs.createCASIdxDef(false, Type.DATI, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
         indexController.createIndexes(Set.of(validFromIndex), wtx);
         wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(json), JsonNodeTrx.Commit.NO);
         wtx.commit();
@@ -296,17 +298,13 @@ public final class ValidTimeIndexScanDifferentialTest {
             }
 
             final JsonDBItem doc = collection.getDocument(INDEXED_RESOURCE);
-            final ValidTimeIndexScan.Result indexScan = ValidTimeIndexScan.tryIndexScan(doc, t, validTimeConfig);
-            assertNotNull(indexScan, "Index path must be taken (validFrom index exists) at t=" + t);
-            assertEquals(ValidTimeIndexScan.ValidField.VALID_FROM, indexScan.indexedField(),
-                "Only the validFrom index exists, so it must be the one used at t=" + t);
-            assertEquals(brute, idsOfItems(indexScan.items()),
-                "validFrom-only index path must equal brute force at t=" + t);
+            assertNull(ValidTimeIndexScan.tryIndexScan(doc, t, validTimeConfig),
+                "a single xs:dateTime index must NOT enable the index path at t=" + t);
             doc.getTrx().close();
 
-            // And the function as a whole (through execute()).
+            // The function as a whole falls back to the linear scan and stays correct.
             assertEquals(brute, idsFromValidAtQuery(chain, ctx, INDEXED_RESOURCE, t),
-                "jn:valid-at (validFrom-only index) must equal brute force at t=" + t);
+                "jn:valid-at (single-index fallback) must equal brute force at t=" + t);
           }
         }
       }
@@ -330,10 +328,10 @@ public final class ValidTimeIndexScanDifferentialTest {
         final var indexController = session.getWtxIndexController(wtx.getRevisionNumber());
         final var validFromPath = parse("/[]/validFrom", io.brackit.query.util.path.PathParser.Type.JSON);
         final var validFromIndex =
-            IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
+            IndexDefs.createCASIdxDef(false, Type.DATI, Collections.singleton(validFromPath), 0, IndexDef.DbType.JSON);
         final var validToPath = parse("/[]/validTo", io.brackit.query.util.path.PathParser.Type.JSON);
         final var validToIndex =
-            IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(validToPath), 1, IndexDef.DbType.JSON);
+            IndexDefs.createCASIdxDef(false, Type.DATI, Collections.singleton(validToPath), 1, IndexDef.DbType.JSON);
         indexController.createIndexes(Set.of(validFromIndex, validToIndex), wtx);
         wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(json), JsonNodeTrx.Commit.NO);
         wtx.commit();

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
@@ -15,6 +15,7 @@ import io.sirix.access.ValidTimeConfig
 import io.sirix.access.trx.node.HashType
 import io.sirix.api.Database
 import io.sirix.api.json.JsonResourceSession
+import io.sirix.query.json.ValidTimeIndexes
 import io.sirix.rest.KotlinJsonStreamingShredder
 import io.sirix.rest.crud.AbstractCreateHandler
 import io.sirix.rest.crud.Revisions
@@ -106,7 +107,7 @@ class JsonCreate(
                     val manager = database.beginResourceSession(resPathName)
 
                     manager.use {
-                        val maxNodeKey = insertJsonSubtreeAsFirstChild(manager, ctx)
+                        val maxNodeKey = insertJsonSubtreeAsFirstChild(manager, ctx, dbFile?.fileName?.toString())
 
                         if (maxNodeKey < MAX_NODES_TO_SERIALIZE) {
                             body = serializeResource(manager, ctx)
@@ -146,7 +147,8 @@ class JsonCreate(
 
     private suspend fun insertJsonSubtreeAsFirstChild(
         manager: JsonResourceSession,
-        ctx: RoutingContext
+        ctx: RoutingContext,
+        databaseName: String?
     ): Long {
         val commitMessage = ctx.queryParam("commitMessage").getOrNull(0)
         val commitTimestampAsString = ctx.queryParam("commitTimestamp").getOrNull(0)
@@ -182,6 +184,15 @@ class JsonCreate(
             // #region debug trace
             debugLog("shredder_completed")
             // #endregion
+            // Auto-create the valid-time interval index in the SAME transaction as the shred (data
+            // and index land in one revision), mirroring the JSONiq jn:store behavior. No-op when
+            // the resource has no valid-time configuration or the index already exists; opt out
+            // with ?autoCreateValidTimeIndex=false.
+            val autoCreateValidTimeIndex =
+                ctx.queryParam("autoCreateValidTimeIndex").getOrNull(0)?.toBoolean() ?: true
+            if (autoCreateValidTimeIndex) {
+                ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(manager, wtx, databaseName)
+            }
             wtx.commit(commitMessage, commitTimestamp)
             return@use wtx.maxNodeKey
         }

--- a/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
+++ b/bundles/sirix-rest-api/src/main/kotlin/io/sirix/rest/crud/json/JsonCreate.kt
@@ -191,7 +191,7 @@ class JsonCreate(
             val autoCreateValidTimeIndex =
                 ctx.queryParam("autoCreateValidTimeIndex").getOrNull(0)?.toBoolean() ?: true
             if (autoCreateValidTimeIndex) {
-                ValidTimeIndexes.createValidTimeIntervalIndexIfConfigured(manager, wtx, databaseName)
+                ValidTimeIndexes.createValidTimeIndexesIfConfigured(manager, wtx, databaseName)
             }
             wtx.commit(commitMessage, commitTimestamp)
             return@use wtx.maxNodeKey

--- a/bundles/sirix-rest-api/src/main/resources/openapi.yaml
+++ b/bundles/sirix-rest-api/src/main/resources/openapi.yaml
@@ -552,6 +552,10 @@ paths:
           in: query
           description: 'EXPERIMENTAL (JSON only): use the conventional validFrom/validTo field names for bitemporal queries.'
           schema: { type: boolean, default: false }
+        - name: autoCreateValidTimeIndex
+          in: query
+          description: 'EXPERIMENTAL (JSON only): auto-create the valid-time interval index when a valid-time configuration is set (data and index land in one revision).'
+          schema: { type: boolean, default: true }
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## What does this PR do?

Follow-ups to #1118, completing the valid-time auto-indexing story:

**1. REST parity.** Resources created over HTTP with `validFromPath`/`validToPath` or `useConventionalValidTime` now get the valid-time indexes automatically, created inside the same write transaction as the streaming shred (data + indexes land in one revision), exactly like the JSONiq `jn:store` path. New `autoCreateValidTimeIndex` query parameter (default `true`) opts out; documented in the OpenAPI spec. The REST handler calls the same shared `ValidTimeIndexes` recipe as the JSONiq layer, so the entry points cannot drift.

**2. Working CAS auto-indexing with `xs:dateTime` keys.** The core bootstrap hook (`JsonNodeTrxImpl.createValidTimeIndexesIfNeeded`) promised auto-created CAS indexes but never delivered them — its definitions were added to a controller instance that is never the one serialized at commit (empirically: a cold reopen always showed 0 CAS defs). It is removed and replaced by store-layer creation that actually persists: every valid-time resource now gets the interval index **plus one `xs:dateTime` CAS index per valid-time field**, all built in a single document traversal (one `createIndexes` call).

**3. CAS-narrowing scan reworked for `xs:dateTime`.** `ValidTimeIndexScan` now collects candidates as the UNION of two exact one-sided temporal ranges — `validTo >= t` on the validTo index, `validFrom <= t` on the validFrom index — followed by the same per-record verification. The union is what keeps it provably equal to the linear scan: a bound that fails the `xs:dateTime` cast is skipped by the CAS builder (inserts never abort) and treated as unbounded by the predicate, but every true match has at least one castable bound satisfying its one-sided range. Exact temporal comparison also removes the whole-second truncation slack of the old lexicographic bounds. Since the feature is unreleased, the `xs:string` scan path is deleted rather than kept for compatibility; a single `xs:dateTime` index deliberately does not enable the index path (linear-scan fallback) because the superset guarantee needs the pair. `CASFilterRange` accepts null min/max for one-sided ranges (its filter logic always treated null as unbounded; only the constructor rejected it).

## Related issue

Follow-up to #1118 — implements the two items listed there under "Notes for reviewers" (REST interval-index parity; resolving the dead CAS bootstrap), with the CAS indexes revived as `xs:dateTime` per maintainer direction.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — targeted modules built/tested with Gradle 8.14.3 (sandbox cannot fetch the wrapper distribution); full suites listed below are green
- [x] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: the relevant invariant in [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed) — no commit-protocol/page-structure changes; `CASFilterRange` change is argument-validation relaxation only
- [x] Updated documentation (README / docs) where relevant — OpenAPI spec + javadoc (`ResourceConfiguration` no longer promises indexes core never created)
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- **Test evidence**: the differential test's full boundary sweep (~900 instants, including exact `validFrom`/`validTo` boundaries ±1ms over 178 records) runs against the `xs:dateTime` union scan and matches the brute-force oracle at every instant; the repurposed single-index test pins the fallback contract; `StoreValidTimeAutoIndexTest` asserts the auto-created defs carry `xs:dateTime` keys, that data + all three indexes land in one revision, and that interval scan, CAS union scan and `jn:valid-at` all agree with brute force. Full `jn.temporal` suite + `JsonIntegrationTest` + JSON core tests green locally.
- **REST tests** require Docker/Keycloak (not available in the sandbox) — the `Test sirix-rest-api` CI job is the gate for the Kotlin change.
- The removed bootstrap's `xs:dateTime` choice is restored, but note the old hook would have been doubly ineffective: its defs never persisted *and* the then-current scan only accepted `xs:string` indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wkCeRawExQ5MSCaQC7iW4

---
_Generated by [Claude Code](https://claude.ai/code/session_015wkCeRawExQ5MSCaQC7iW4)_