### PR TITLE
Binary format future-proofing: audit, hardening, and V0 contract completion

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,10 @@ feedback is what drives prioritization.
 - **Web front-end** — the [web front-end](https://github.com/sirixdb/sirixdb-web-gui)
   for visualizing diffs between revisions, running queries, and browsing/updating resources.
 - **Bug fixing & hardening** — driven by real-world usage.
+- **Per-block string dictionaries / wider FSST adoption** — strings dominate residual storage
+  size (the Umbra "Data Blocks" model); slots into the existing PAX-region + structuralFlags +
+  page-envelope-flags extension points without an on-disk format break (see
+  `docs/DISK_FORMAT.md` §5).
 
 ## Near future
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -58,6 +58,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.UUID;
 
 import static io.sirix.utils.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -410,6 +411,16 @@ public final class ResourceConfiguration {
    */
   public final ValidTimeConfig validTimeConfig;
 
+  /**
+   * Per-resource identity UUID, generated at resource creation and written into both files'
+   * superblocks (reserved bytes [40, 56)). Cross-links the binary files to this settings file:
+   * opening a data file with a different resource's settings — the classic
+   * "restored the JSON from the wrong backup" corruption — fails fast instead of misreading.
+   * {@code null} for resources created before the field existed (their superblock UUID is zero,
+   * accepted as legacy).
+   */
+  public final UUID resourceUuid;
+
   // END MEMBERS FOR FIXED FIELDS
 
   /**
@@ -453,6 +464,7 @@ public final class ResourceConfiguration {
     verifyChecksumsOnRead = builder.verifyChecksumsOnRead;
     hashAlgorithm = builder.hashAlgorithm;
     validTimeConfig = builder.validTimeConfig;
+    resourceUuid = builder.resourceUuid;
   }
 
   public BinaryEncodingVersion getBinaryEncodingVersion() {
@@ -602,7 +614,7 @@ public final class ResourceConfiguration {
       "pathSummary", "resourceID", "deweyIDsStored", "persistenter", "storeDiffs", "customCommitTimestamps",
       "storeNodeHistory", "storeChildCount", "stringCompressionType", "indexBackendType", "deweyIdSiblingDistance",
       "verifyChecksumsOnRead", "hashAlgorithm", "validTimeConfig", "validFromPath", "validToPath",
-      "pathStatistics", "repairBulkInsertHashes"};
+      "pathStatistics", "repairBulkInsertHashes", "resourceUuid"};
 
   /**
    * Serialize the configuration.
@@ -676,6 +688,10 @@ public final class ResourceConfiguration {
       jsonWriter.name(JSONNAMES[25]).value(config.withPathStatistics);
       // Bulk-insert hash repair (opt-in).
       jsonWriter.name(JSONNAMES[26]).value(config.repairBulkInsertHashes);
+      // Resource identity UUID (cross-linked to both superblocks).
+      if (config.resourceUuid != null) {
+        jsonWriter.name(JSONNAMES[27]).value(config.resourceUuid.toString());
+      }
       jsonWriter.endObject();
     } catch (final IOException e) {
       throw new SirixIOException(e);
@@ -828,6 +844,7 @@ public final class ResourceConfiguration {
       // Path statistics flag (optional for backward compatibility with older configs)
       boolean pathStatistics = false;
       boolean repairBulkInsertHashes = false;
+      UUID resourceUuid = null;
       while (jsonReader.hasNext()) {
         name = jsonReader.nextName();
         if (name.equals(JSONNAMES[22])) {
@@ -850,6 +867,8 @@ public final class ResourceConfiguration {
           pathStatistics = jsonReader.nextBoolean();
         } else if (name.equals(JSONNAMES[26])) {
           repairBulkInsertHashes = jsonReader.nextBoolean();
+        } else if (name.equals(JSONNAMES[27])) {
+          resourceUuid = UUID.fromString(jsonReader.nextString());
         }
       }
 
@@ -883,7 +902,8 @@ public final class ResourceConfiguration {
              .hashAlgorithm(hashAlgorithm)
              .validTimeConfig(validTimeConfig)
              .buildPathStatistics(pathStatistics)
-             .repairBulkInsertHashes(repairBulkInsertHashes);
+             .repairBulkInsertHashes(repairBulkInsertHashes)
+             .resourceUuid(resourceUuid);
 
       // Deserialized instance.
       final ResourceConfiguration config = new ResourceConfiguration(builder);
@@ -1017,6 +1037,13 @@ public final class ResourceConfiguration {
      * support).
      */
     private ValidTimeConfig validTimeConfig = null;
+
+    /**
+     * Per-resource identity UUID. A fresh random UUID for new resources; overwritten with the
+     * persisted value when deserializing an existing configuration ({@code null} = legacy config
+     * without the field).
+     */
+    private UUID resourceUuid = UUID.randomUUID();
 
     /**
      * Constructor, setting the mandatory fields.
@@ -1400,6 +1427,19 @@ public final class ResourceConfiguration {
      */
     public Builder validTimeConfig(ValidTimeConfig validTimeConfig) {
       this.validTimeConfig = validTimeConfig;
+      return this;
+    }
+
+    /**
+     * Sets the resource identity UUID. Deserialization passes the persisted value ({@code null}
+     * for legacy configs, which disables the superblock cross-check); new resources keep the
+     * generated random default.
+     *
+     * @param resourceUuid the persisted UUID, or {@code null} for a legacy configuration
+     * @return reference to the builder object
+     */
+    public Builder resourceUuid(final UUID resourceUuid) {
+      this.resourceUuid = resourceUuid;
       return this;
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -56,6 +56,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import static io.sirix.utils.Preconditions.checkArgument;
@@ -208,6 +209,14 @@ public final class ResourceConfiguration {
    * there are no alternative encodings to select at runtime.
    */
   public static final BinaryEncodingVersion BINARY_ENCODING_VERSION = BinaryEncodingVersion.V0;
+
+  /**
+   * Stable identifier of the node-hash function baked into the on-disk format (XXH3-64 via
+   * {@code LongHashFunction.xx3()}). Persisted in the resource settings and validated on open so
+   * that a future change of the hash function is detectable instead of silently re-verifying old
+   * resources against the wrong function.
+   */
+  public static final String NODE_HASH_FUNCTION_ID = "XX3";
 
   // END FIXED STANDARD FIELDS
 
@@ -625,8 +634,8 @@ public final class ResourceConfiguration {
       jsonWriter.name(JSONNAMES[5]).value(config.storageType.name());
       // Hashing type.
       jsonWriter.name(JSONNAMES[6]).value(config.hashType.name());
-      // Hash function.
-      jsonWriter.name(JSONNAMES[7]).value(config.nodeHashFunction.toString());
+      // Hash function — stable identifier, validated on deserialize.
+      jsonWriter.name(JSONNAMES[7]).value(NODE_HASH_FUNCTION_ID);
       // Text compression.
       jsonWriter.name(JSONNAMES[8]).value(config.useTextCompression);
       // Path summary.
@@ -677,6 +686,20 @@ public final class ResourceConfiguration {
   }
 
   /**
+   * Reads the next field name and fails fast when it is not the expected one. The resource
+   * settings are format identity — a reordered, truncated, or hand-edited file must be a loud
+   * error, never a misparse (this used to be an {@code assert}, a no-op in production).
+   */
+  private static void expectField(final JsonReader jsonReader, final String expected, final Path configFile)
+      throws IOException {
+    final String name = jsonReader.nextName();
+    if (!name.equals(expected)) {
+      throw new SirixIOException(configFile + ": malformed resource settings — expected field '" + expected
+          + "' but found '" + name + "'");
+    }
+  }
+
+  /**
    * Deserializing a Resource configuration from a JSON-file from the persistent storage. //todo add
    * track child count parameter here
    *
@@ -691,24 +714,19 @@ public final class ResourceConfiguration {
       final JsonReader jsonReader = new JsonReader(fileReader);
       jsonReader.beginObject();
       // Binary encoding version.
-      String name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[0]);
+      expectField(jsonReader, JSONNAMES[0], configFile);
       final BinaryEncodingVersion binaryEncodingVersion = BinaryEncodingVersion.valueOf(jsonReader.nextString());
       // Versioning.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[1]);
+      expectField(jsonReader, JSONNAMES[1], configFile);
       jsonReader.beginObject();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[2]);
+      expectField(jsonReader, JSONNAMES[2], configFile);
       final VersioningType revisioning = VersioningType.valueOf(jsonReader.nextString());
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[3]);
+      expectField(jsonReader, JSONNAMES[3], configFile);
       final int revisionToRestore = jsonReader.nextInt();
       jsonReader.endObject();
       // ByteHandlers.
       final List<ByteHandler> handlerList = new ArrayList<>();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[4]);
+      expectField(jsonReader, JSONNAMES[4], configFile);
       jsonReader.beginArray();
       while (jsonReader.hasNext()) {
         jsonReader.beginObject();
@@ -720,52 +738,48 @@ public final class ResourceConfiguration {
       jsonReader.endArray();
       final ByteHandlerPipeline pipeline = new ByteHandlerPipeline(handlerList.toArray(new ByteHandler[0]));
       // Storage type.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[5]);
+      expectField(jsonReader, JSONNAMES[5], configFile);
       final StorageType storage = StorageType.valueOf(jsonReader.nextString());
       // Hashing type.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[6]);
+      expectField(jsonReader, JSONNAMES[6], configFile);
       final HashType hashing = HashType.valueOf(jsonReader.nextString());
-      // Hashing function (legacy field, no longer used — skip it explicitly).
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[7]);
-      jsonReader.skipValue();
+      // Hashing function identity — validated so a future function change is detectable. Legacy
+      // configs stored LongHashFunction.xx3().toString(); both spellings mean XXH3.
+      expectField(jsonReader, JSONNAMES[7], configFile);
+      final String hashFunctionId = jsonReader.nextString();
+      if (!NODE_HASH_FUNCTION_ID.equals(hashFunctionId)
+          && !hashFunctionId.toLowerCase(Locale.ROOT).contains("xx3")) {
+        throw new SirixIOException(configFile + ": resource was written with node-hash function '"
+            + hashFunctionId + "' but this build only supports '" + NODE_HASH_FUNCTION_ID
+            + "' (XXH3-64) — node hashes would not verify");
+      }
       // Text compression.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[8]);
+      expectField(jsonReader, JSONNAMES[8], configFile);
       final boolean compression = jsonReader.nextBoolean();
       // Path summary.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[9]);
+      expectField(jsonReader, JSONNAMES[9], configFile);
       final boolean pathSummary = jsonReader.nextBoolean();
       // Unique ID.
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[10]);
+      expectField(jsonReader, JSONNAMES[10], configFile);
       final int ID = jsonReader.nextInt();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[11]);
+      expectField(jsonReader, JSONNAMES[11], configFile);
       final boolean deweyIDsStored = jsonReader.nextBoolean();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[12]);
+      expectField(jsonReader, JSONNAMES[12], configFile);
       final Class<?> persistenterClazz = Class.forName(jsonReader.nextString());
       final Constructor<?> persistenterConstr = persistenterClazz.getConstructors()[0];
       final RecordSerializer serializer = (RecordSerializer) persistenterConstr.newInstance();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[13]);
+      expectField(jsonReader, JSONNAMES[13], configFile);
       final boolean storeDiffs = jsonReader.nextBoolean();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[14]);
+      expectField(jsonReader, JSONNAMES[14], configFile);
       final boolean customCommitTimestamps = jsonReader.nextBoolean();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[15]);
+      expectField(jsonReader, JSONNAMES[15], configFile);
       final boolean storeNodeHistory = jsonReader.nextBoolean();
-      name = jsonReader.nextName();
-      assert name.equals(JSONNAMES[16]);
+      expectField(jsonReader, JSONNAMES[16], configFile);
       final boolean storeChildCount = jsonReader.nextBoolean();
 
       // String compression type (optional for backward compatibility with older configs)
       StringCompressionType stringCompressionType = StringCompressionType.NONE;
+      String name;
       if (jsonReader.hasNext()) {
         name = jsonReader.nextName();
         if (name.equals(JSONNAMES[17])) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexByteScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexByteScan.java
@@ -1069,7 +1069,7 @@ public final class ProjectionIndexByteScan {
   //   byte[columnCount] columnFlags        (bit0 = unrepresentable seen,
   //                                         bit1 = non-integral seen)
   //   long[presWords] presence per column  (only when rowCount > 0)
-  //   int tailLen; int magic = "PIX2"
+  //   int tailLen; byte version; int magic = "PIX1"
   // ------------------------------------------------------------------
 
   /**
@@ -1083,9 +1083,10 @@ public final class ProjectionIndexByteScan {
     final int columnCount = getIntLE(payload, 4);
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     final int tailLen = columnCount + columnCount * presWords * 8;
-    if (payload.length != dataEnd + tailLen + 8) return -1;
+    if (payload.length != dataEnd + tailLen + 9) return -1;
     if (getIntLE(payload, payload.length - 4) != ProjectionIndexLeafPage.PRESENCE_TAIL_MAGIC) return -1;
-    if (getIntLE(payload, payload.length - 8) != tailLen) return -1;
+    if (payload[payload.length - 5] != ProjectionIndexLeafPage.PRESENCE_TAIL_VERSION) return -1;
+    if (getIntLE(payload, payload.length - 9) != tailLen) return -1;
     return dataEnd;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafCodec.java
@@ -48,6 +48,14 @@ public final class ProjectionIndexLeafCodec {
   /** Leading magic of a compact payload ("PIXC" little-endian). */
   public static final int COMPACT_MAGIC = 0x43585049;
 
+  /**
+   * Version byte written immediately after {@link #COMPACT_MAGIC}. A future layout change bumps
+   * this instead of minting a new magic; {@link #decode} fails fast on an unknown value (a
+   * version mismatch can only mean a newer writer or corruption — the metadata's own version
+   * gate triggers a rebuild before hydration ever reaches an incompatible leaf).
+   */
+  public static final byte COMPACT_VERSION = 1;
+
   private ProjectionIndexLeafCodec() {
   }
 
@@ -55,7 +63,7 @@ public final class ProjectionIndexLeafCodec {
    * Record-key zone map {@code [firstRecordKey, lastRecordKey]} of a
    * persisted leaf payload, read from its HEAD bytes without materialising
    * the leaf — the single canonical header-range reader for BOTH persisted
-   * forms (compact: keys at offsets 12/20 after the magic; raw serialised:
+   * forms (compact: keys at offsets 13/21 after magic + version byte; raw serialised:
    * offsets 8/16 — see {@link ProjectionIndexLeafPage#columnCountOf} for the
    * raw header's canonical column reader). Callers may pass just the head
    * chunk of a chunked store; returns {@code null} when the bytes are too
@@ -66,10 +74,10 @@ public final class ProjectionIndexLeafCodec {
       return null;
     }
     if (head.length >= 4 && getIntLE(head, 0) == COMPACT_MAGIC) {
-      if (head.length < 28) {
+      if (head.length < 29) {
         return null;
       }
-      return new long[] { getLongLE(head, 12), getLongLE(head, 20) };
+      return new long[] { getLongLE(head, 13), getLongLE(head, 21) };
     }
     if (head.length < 24) {
       return null;
@@ -98,6 +106,7 @@ public final class ProjectionIndexLeafCodec {
     final int columnCount = page.getColumnCount();
     final ByteArrayOutputStream out = new ByteArrayOutputStream(1024);
     putIntLE(out, COMPACT_MAGIC);
+    out.write(COMPACT_VERSION);
     putIntLE(out, rowCount);
     putIntLE(out, columnCount);
     putLongLE(out, page.firstRecordKey());
@@ -258,7 +267,12 @@ public final class ProjectionIndexLeafCodec {
     if (payload == null || payload.length < 4 || getIntLE(payload, 0) != COMPACT_MAGIC) {
       return payload;
     }
-    final Cursor in = new Cursor(payload, 4);
+    if (payload.length < 5 || payload[4] != COMPACT_VERSION) {
+      throw new IllegalStateException("Unknown compact projection-leaf version "
+          + (payload.length < 5 ? "<missing>" : payload[4]) + " (expected " + COMPACT_VERSION
+          + ") — written by a newer version or corrupt");
+    }
+    final Cursor in = new Cursor(payload, 5);
     final int rowCount = in.readInt();
     final int columnCount = in.readInt();
     final long firstRecordKey = in.readLong();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexLeafPage.java
@@ -61,6 +61,7 @@ import java.nio.charset.StandardCharsets;
  *   for each column c (only when rowCount &gt; 0):
  *     long[ceil(rowCount/64)] presenceBits  // bit i = field exists on row i
  *   int  tailLength                   // bytes from tail start to before this field
+ *   byte version = 1                  // tail-layout version, bumped on change
  *   int  magic = 0x50495831 ("PIX1")
  * </pre>
  *
@@ -181,6 +182,12 @@ public final class ProjectionIndexLeafPage {
 
   /** Footer magic of the presence tail ("PIX1" little-endian). */
   public static final int PRESENCE_TAIL_MAGIC = 0x50495831;
+
+  /**
+   * Version byte stored between the tail length and the footer magic. Future tail-layout changes
+   * bump this instead of minting a new magic; readers reject unknown values as corrupt.
+   */
+  public static final byte PRESENCE_TAIL_VERSION = 1;
 
   /** Column flag bit: a present-but-unrepresentable value (null / object / array / kind mismatch) was seen. */
   public static final byte COLUMN_FLAG_UNREPRESENTABLE = 0x01;
@@ -615,13 +622,14 @@ public final class ProjectionIndexLeafPage {
     final int tailStart = bb.position();
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     final int expectedTailLen = columnCount + columnCount * presWords * 8;
-    if (payload.length != tailStart + expectedTailLen + 8
+    if (payload.length != tailStart + expectedTailLen + 9
         || getIntLE(payload, payload.length - 4) != PRESENCE_TAIL_MAGIC
-        || getIntLE(payload, payload.length - 8) != expectedTailLen) {
+        || payload[payload.length - 5] != PRESENCE_TAIL_VERSION
+        || getIntLE(payload, payload.length - 9) != expectedTailLen) {
       throw new IllegalStateException(
           "Corrupt projection leaf: no valid presence tail (payload " + payload.length
               + " bytes, column stream ends at " + tailStart + ", expected tail "
-              + (expectedTailLen + 8) + " bytes)");
+              + (expectedTailLen + 9) + " bytes)");
     }
     for (int c = 0; c < columnCount; c++) {
       page.columnUnrepresentable[c] = (payload[tailStart + c] & COLUMN_FLAG_UNREPRESENTABLE) != 0;
@@ -755,6 +763,7 @@ public final class ProjectionIndexLeafPage {
       }
     }
     dst.set(I, off, columnCount + columnCount * presWords * 8); off += 4;
+    dst.set(ValueLayout.JAVA_BYTE, off++, PRESENCE_TAIL_VERSION);
     dst.set(I, off, PRESENCE_TAIL_MAGIC); off += 4;
     return off;
   }
@@ -788,10 +797,10 @@ public final class ProjectionIndexLeafPage {
     return size + presenceTailSize();
   }
 
-  /** Byte size of the presence tail incl. the 8-byte footer. */
+  /** Byte size of the presence tail incl. the 9-byte footer (tailLen + version + magic). */
   private int presenceTailSize() {
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
-    return columnCount + columnCount * presWords * 8 + 8;
+    return columnCount + columnCount * presWords * 8 + 9;
   }
 
   public byte[] serialize() {
@@ -865,7 +874,7 @@ public final class ProjectionIndexLeafPage {
   private void writePresenceTail(final ByteArrayOutputStream baos) {
     final int presWords = rowCount > 0 ? (rowCount + 63) >>> 6 : 0;
     final int tailLen = columnCount + columnCount * presWords * 8;
-    final ByteBuffer tail = ByteBuffer.allocate(tailLen + 8).order(ByteOrder.LITTLE_ENDIAN);
+    final ByteBuffer tail = ByteBuffer.allocate(tailLen + 9).order(ByteOrder.LITTLE_ENDIAN);
     for (int c = 0; c < columnCount; c++) {
       tail.put(columnFlagsByte(c));
     }
@@ -876,6 +885,7 @@ public final class ProjectionIndexLeafPage {
       }
     }
     tail.putInt(tailLen);
+    tail.put(PRESENCE_TAIL_VERSION);
     tail.putInt(PRESENCE_TAIL_MAGIC);
     baos.write(tail.array(), 0, tail.position());
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdCosineDistance.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdCosineDistance.java
@@ -83,8 +83,8 @@ public final class SimdCosineDistance implements DistanceFunction {
     // --- SIMD main loop over MemorySegment ---
     for (; i < upperBound; i += SPECIES_LENGTH) {
       final long byteOffset = (long) i * Float.BYTES;
-      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.nativeOrder());
-      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.nativeOrder());
+      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
+      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
       dotVec = va.fma(vb, dotVec);
       normAVec = va.fma(va, normAVec);
       normBVec = vb.fma(vb, normBVec);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdInnerProductDistance.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdInnerProductDistance.java
@@ -67,8 +67,8 @@ public final class SimdInnerProductDistance implements DistanceFunction {
     // --- SIMD main loop over MemorySegment ---
     for (; i < upperBound; i += SPECIES_LENGTH) {
       final long byteOffset = (long) i * Float.BYTES;
-      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.nativeOrder());
-      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.nativeOrder());
+      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
+      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
       dotVec = va.fma(vb, dotVec);
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdL2Distance.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/vector/ops/SimdL2Distance.java
@@ -69,8 +69,8 @@ public final class SimdL2Distance implements DistanceFunction {
     // --- SIMD main loop over MemorySegment ---
     for (; i < upperBound; i += SPECIES_LENGTH) {
       final long byteOffset = (long) i * Float.BYTES;
-      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.nativeOrder());
-      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.nativeOrder());
+      final FloatVector va = FloatVector.fromMemorySegment(SPECIES, a, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
+      final FloatVector vb = FloatVector.fromMemorySegment(SPECIES, b, byteOffset, java.nio.ByteOrder.LITTLE_ENDIAN);
       final FloatVector diff = va.sub(vb);
       sumVec = diff.fma(diff, sumVec);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/AbstractReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/AbstractReader.java
@@ -281,7 +281,7 @@ public abstract class AbstractReader implements Reader {
     }
     // The length prefix is written through the buffered page writer (platform byte order, like
     // every page record's prefix — the superblock's endianness check gates foreign hosts).
-    slot.order(java.nio.ByteOrder.nativeOrder());
+    slot.order(java.nio.ByteOrder.LITTLE_ENDIAN);
     final int len = slot.getInt();
     if (len <= 0 || len > IOStorage.BEACON_SLOT_BYTES - Integer.BYTES - Long.BYTES) {
       throw new SirixIOException("Implausible beacon length " + len + " at offset " + offset);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/Superblock.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/Superblock.java
@@ -23,7 +23,10 @@ import java.nio.ByteOrder;
  * 13  1 B  reserved (0)
  * 14  2 B  flags (0)
  * 16  4 B  endianness check pattern {@link #ENDIAN_CHECK} (mis-ordered on a foreign-endian host)
- * 20  4 B  beacon slot size in bytes (data file: {@link IOStorage#BEACON_SLOT_BYTES}; revisions: 0)
+ * 20  4 B  slot size in bytes (data file: {@link IOStorage#BEACON_SLOT_BYTES} beacon slots;
+ *                              revisions: {@link IOStorage#REVISIONS_FILE_RECORD_SIZE} record
+ *                              stride — persisted so the stride is file geometry, not a compiled-in
+ *                              assumption; 0 in pre-stride dev files)
  * 24  8 B  primary beacon offset   (data file: {@link IOStorage#PRIMARY_BEACON_OFFSET}; revisions: 0)
  * 32  8 B  content start offset    (data: {@link IOStorage#DATA_REGION_START};
  *                                   revisions: {@link IOStorage#REVISIONS_RECORDS_START})
@@ -71,7 +74,7 @@ public final class Superblock {
       buf.putLong(IOStorage.PRIMARY_BEACON_OFFSET);
       buf.putLong(IOStorage.DATA_REGION_START);
     } else {
-      buf.putInt(0);
+      buf.putInt(IOStorage.REVISIONS_FILE_RECORD_SIZE);
       buf.putLong(0L);
       buf.putLong(IOStorage.REVISIONS_RECORDS_START);
     }
@@ -119,6 +122,18 @@ public final class Superblock {
     }
     if (role != expectedRole) {
       throw new SirixIOException(fileLabel + ": wrong file role " + role + " (expected " + expectedRole + ")");
+    }
+    final int slotSize = buf.getInt();
+    if (role == ROLE_REVISIONS && slotSize != IOStorage.REVISIONS_FILE_RECORD_SIZE && slotSize != 0) {
+      // 0 = pre-stride dev files (the field was reserved-zero before it carried the stride).
+      throw new SirixIOException(fileLabel + ": revisions record stride " + slotSize
+          + " does not match this build's " + IOStorage.REVISIONS_FILE_RECORD_SIZE
+          + "-byte records — file written by an incompatible version");
+    }
+    if (role == ROLE_DATA && slotSize != IOStorage.BEACON_SLOT_BYTES) {
+      throw new SirixIOException(fileLabel + ": beacon slot size " + slotSize
+          + " does not match this build's " + IOStorage.BEACON_SLOT_BYTES
+          + "-byte slots — file written by an incompatible version");
     }
     final byte[] prefix = new byte[HASHED_PREFIX_BYTES];
     raw.duplicate().get(prefix);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/Superblock.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/Superblock.java
@@ -30,7 +30,8 @@ import java.nio.ByteOrder;
  * 24  8 B  primary beacon offset   (data file: {@link IOStorage#PRIMARY_BEACON_OFFSET}; revisions: 0)
  * 32  8 B  content start offset    (data: {@link IOStorage#DATA_REGION_START};
  *                                   revisions: {@link IOStorage#REVISIONS_RECORDS_START})
- * 40 16 B  reserved (future resource UUID)
+ * 40 16 B  resource UUID (msb u64, lsb u64) — cross-links the file to its resource-settings
+ *          JSON; all-zero in legacy dev files written before the field was populated
  * 56  8 B  XXH3-64 of bytes [0, 56)
  * </pre>
  */
@@ -60,8 +61,13 @@ public final class Superblock {
   private Superblock() {
   }
 
-  /** Builds the 64-byte superblock for the given file role. */
+  /** Builds the 64-byte superblock for the given file role with a zero (legacy) resource UUID. */
   public static ByteBuffer build(final byte fileRole) {
+    return build(fileRole, 0L, 0L);
+  }
+
+  /** Builds the 64-byte superblock for the given file role and resource UUID. */
+  public static ByteBuffer build(final byte fileRole, final long uuidMsb, final long uuidLsb) {
     final ByteBuffer buf = ByteBuffer.allocate(BYTES).order(ByteOrder.LITTLE_ENDIAN);
     buf.put(MAGIC);
     buf.putInt(LAYOUT_VERSION);
@@ -78,7 +84,8 @@ public final class Superblock {
       buf.putLong(0L);
       buf.putLong(IOStorage.REVISIONS_RECORDS_START);
     }
-    buf.position(buf.position() + 16); // reserved
+    buf.putLong(uuidMsb);
+    buf.putLong(uuidLsb);
     final long hash = LongHashFunction.xx3().hashBytes(buf.array(), 0, HASHED_PREFIX_BYTES);
     buf.putLong(hash);
     buf.flip();
@@ -86,11 +93,22 @@ public final class Superblock {
   }
 
   /**
-   * Validates a superblock read from offset 0. Throws {@link SirixIOException} with an actionable
-   * message on any mismatch — wrong magic (not a sirix file / pre-superblock layout), wrong
-   * layout version, foreign endianness, wrong file role, or checksum corruption.
+   * Validates a superblock without a resource-UUID cross-check (recovery paths that run before
+   * the configuration is loaded).
    */
   public static void validate(final ByteBuffer raw, final byte expectedRole, final String fileLabel) {
+    validate(raw, expectedRole, fileLabel, 0L, 0L);
+  }
+
+  /**
+   * Validates a superblock read from offset 0. Throws {@link SirixIOException} with an actionable
+   * message on any mismatch — wrong magic (not a sirix file / pre-superblock layout), wrong
+   * layout version, foreign endianness, wrong file role, geometry drift, checksum corruption, or
+   * a resource-UUID mismatch (the file belongs to a different resource than the settings JSON).
+   * A zero expected or stored UUID skips the cross-check (legacy files/configs).
+   */
+  public static void validate(final ByteBuffer raw, final byte expectedRole, final String fileLabel,
+      final long expectedUuidMsb, final long expectedUuidLsb) {
     if (raw.remaining() < BYTES) {
       throw new SirixIOException(fileLabel + ": file too short for a superblock (" + raw.remaining()
           + " bytes) — not a sirix data file");
@@ -134,6 +152,15 @@ public final class Superblock {
       throw new SirixIOException(fileLabel + ": beacon slot size " + slotSize
           + " does not match this build's " + IOStorage.BEACON_SLOT_BYTES
           + "-byte slots — file written by an incompatible version");
+    }
+    final long storedUuidMsb = buf.getLong(40);
+    final long storedUuidLsb = buf.getLong(48);
+    final boolean storedUuidPresent = storedUuidMsb != 0 || storedUuidLsb != 0;
+    final boolean expectedUuidPresent = expectedUuidMsb != 0 || expectedUuidLsb != 0;
+    if (storedUuidPresent && expectedUuidPresent
+        && (storedUuidMsb != expectedUuidMsb || storedUuidLsb != expectedUuidLsb)) {
+      throw new SirixIOException(fileLabel + ": resource UUID mismatch — the file belongs to a "
+          + "different resource than the settings JSON (wrong-backup restore or copied files)");
     }
     final byte[] prefix = new byte[HASHED_PREFIX_BYTES];
     raw.duplicate().get(prefix);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/SuperblockValidator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/SuperblockValidator.java
@@ -45,11 +45,21 @@ public final class SuperblockValidator {
    * @throws SirixIOException if the superblock is invalid or an I/O error occurs
    */
   public static void validateOnce(final Path path, final byte role) {
+    validateOnce(path, role, 0L, 0L);
+  }
+
+  /**
+   * Validates like {@link #validateOnce(Path, byte)} and additionally cross-checks the superblock's
+   * resource UUID against the resource-settings identity (zero expected UUID = legacy config,
+   * cross-check skipped).
+   */
+  public static void validateOnce(final Path path, final byte role, final long expectedUuidMsb,
+      final long expectedUuidLsb) {
     final Path canonical = canonical(path);
     if (VALIDATED_PATHS.contains(canonical)) {
       return;
     }
-    if (validate(canonical, role)) {
+    if (validate(canonical, role, expectedUuidMsb, expectedUuidLsb)) {
       VALIDATED_PATHS.add(canonical);
     }
   }
@@ -76,7 +86,8 @@ public final class SuperblockValidator {
    * @return {@code true} if a superblock was actually validated, {@code false} for a fresh/empty
    *         file (nothing to validate yet)
    */
-  private static boolean validate(final Path path, final byte role) {
+  private static boolean validate(final Path path, final byte role, final long expectedUuidMsb,
+      final long expectedUuidLsb) {
     try {
       if (!Files.exists(path) || Files.size(path) == 0) {
         return false; // fresh file — the first commit writes the superblock
@@ -92,7 +103,7 @@ public final class SuperblockValidator {
           position += read;
         }
         buf.flip();
-        Superblock.validate(buf, role, path.getFileName().toString());
+        Superblock.validate(buf, role, path.getFileName().toString(), expectedUuidMsb, expectedUuidLsb);
       }
       return true;
     } catch (final IOException e) {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/FFILz4Compressor.java
@@ -102,6 +102,13 @@ public final class FFILz4Compressor implements ByteHandler {
   private static final int MIN_COMPRESSION_SIZE = 64;
 
   /**
+   * The 4-byte decompressed-size frame header is on-disk format — pinned little-endian like
+   * every other persisted scalar (the native-order accessors made it host-defined).
+   */
+  private static final OfInt LE_HEADER_INT =
+      JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
+
+  /**
    * The compression mode for this instance.
    */
   private final CompressionMode compressionMode;
@@ -247,7 +254,10 @@ public final class FFILz4Compressor implements ByteHandler {
 
   @Override
   public boolean supportsMemorySegments() {
-    return NATIVE_LZ4_AVAILABLE;
+    // Always true: without native LZ4 the read side decodes via JavaLz4BlockDecoder and the
+    // write side stores blocks uncompressed (negative-size header) — both directions stay
+    // functional, only the compression ratio degrades.
+    return true;
   }
 
   /**
@@ -335,7 +345,10 @@ public final class FFILz4Compressor implements ByteHandler {
    */
   public int decompressSegment(MemorySegment source, MemorySegment destination, int compressedSize) {
     if (!NATIVE_LZ4_AVAILABLE) {
-      throw new UnsupportedOperationException("Native LZ4 not available");
+      // Read-side portability: decode with the pure-Java block decoder so LZ4-compressed data
+      // stays readable on hosts without liblz4.
+      return JavaLz4BlockDecoder.decompressSafe(source, 0L, compressedSize, destination, 0L,
+          (int) destination.byteSize());
     }
 
     try {
@@ -410,20 +423,18 @@ public final class FFILz4Compressor implements ByteHandler {
    */
   @Override
   public MemorySegment compress(MemorySegment source) {
-    if (!NATIVE_LZ4_AVAILABLE) {
-      throw new UnsupportedOperationException("Native LZ4 not available");
-    }
-
     if (source.byteSize() > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("Source data too large for LZ4: " + source.byteSize());
     }
     int srcSize = (int) source.byteSize();
 
-    // Skip compression for very small data - overhead exceeds benefit
-    if (srcSize < MIN_COMPRESSION_SIZE) {
+    // Skip compression for very small data (overhead exceeds benefit) and when native LZ4 is
+    // unavailable (portability fallback: the stored-uncompressed frame is part of the format,
+    // so a liblz4-less host can still write — it just doesn't compress).
+    if (srcSize < MIN_COMPRESSION_SIZE || !NATIVE_LZ4_AVAILABLE) {
       // Return uncompressed with header (negative size indicates uncompressed)
       MemorySegment result = Arena.ofAuto().allocate(srcSize + 4);
-      result.set(JAVA_INT, 0, -srcSize); // Negative size = uncompressed
+      result.set(LE_HEADER_INT, 0, -srcSize); // Negative size = uncompressed
       MemorySegment.copy(source, 0, result, 4, srcSize);
       return result;
     }
@@ -446,7 +457,7 @@ public final class FFILz4Compressor implements ByteHandler {
       MemorySegment tempCompressed = arena.allocate(maxDstSize + 4);
 
       // Write decompressed size header (for decompression)
-      tempCompressed.set(JAVA_INT, 0, srcSize);
+      tempCompressed.set(LE_HEADER_INT, 0, srcSize);
 
       // Choose compression based on configured mode
       int compressedSize;
@@ -478,7 +489,7 @@ public final class FFILz4Compressor implements ByteHandler {
       if (totalCompressedSize >= srcSize * 0.95) {
         // Compression not beneficial, store uncompressed
         MemorySegment result = Arena.ofAuto().allocate(srcSize + 4);
-        result.set(JAVA_INT, 0, -srcSize); // Negative size = uncompressed
+        result.set(LE_HEADER_INT, 0, -srcSize); // Negative size = uncompressed
         MemorySegment.copy(nativeSource, 0, result, 4, srcSize);
         return result;
       }
@@ -516,9 +527,8 @@ public final class FFILz4Compressor implements ByteHandler {
    */
   @Override
   public DecompressionResult decompressScoped(MemorySegment compressed) {
-    if (!NATIVE_LZ4_AVAILABLE) {
-      throw new UnsupportedOperationException("Native LZ4 not available");
-    }
+    // No native-availability gate here: the stored-uncompressed path needs no LZ4 at all, and
+    // the compressed path falls back to the pure-Java block decoder via decompressSegment.
 
     // Validate the embedded size header BEFORE allocating: it comes from the page payload, so a
     // corrupt page otherwise drove an unbounded allocation (decompression bomb up to 2 GiB),
@@ -528,7 +538,7 @@ public final class FFILz4Compressor implements ByteHandler {
       throw new io.sirix.exception.SirixIOException(
           "Corrupt compressed page: payload shorter than its size header (" + compressed.byteSize() + " bytes)");
     }
-    int sizeHeader = compressed.get(JAVA_INT_UNALIGNED, 0);
+    int sizeHeader = compressed.get(LE_HEADER_INT, 0);
     // abs over the WIDENED long is total (Integer.MIN_VALUE becomes +2^31, which the cap rejects).
     final long declaredSize = Math.abs((long) sizeHeader);
     if (declaredSize > MAX_DECOMPRESSED_SIZE) {
@@ -580,7 +590,7 @@ public final class FFILz4Compressor implements ByteHandler {
     boolean ownershipTransferred = false;
     try {
       int actualSize;
-      if (USE_FAST_DECOMPRESS) {
+      if (USE_FAST_DECOMPRESS && NATIVE_LZ4_AVAILABLE) {
         int bytesRead = decompressSegmentFast(nativeCompressed.asSlice(4), buffer, decompressedSize);
         if (bytesRead < 0) {
           throw new RuntimeException("LZ4 fast decompression failed: " + bytesRead);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/JavaLz4BlockDecoder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/bytepipe/JavaLz4BlockDecoder.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.io.bytepipe;
+
+import io.sirix.exception.SirixIOException;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+
+/**
+ * Pure-Java safe decoder for the LZ4 <em>block</em> format (the format produced by
+ * {@code LZ4_compress_default}/{@code LZ4_compress_HC} and consumed by
+ * {@code LZ4_decompress_safe}).
+ *
+ * <p>Pages whose body carries codec id 1 — and resources whose byte-handler pipeline contains
+ * {@link FFILz4Compressor} — used to be unreadable on hosts without the native {@code liblz4}.
+ * That made on-disk portability depend on a runtime library probe. This decoder removes the
+ * read-side dependency: it is the fallback whenever the FFI probe fails. Write-side LZ4 still
+ * requires the native library (the page-body writer simply picks a pure-Java codec when LZ4 is
+ * unavailable, so nothing unwritable is ever produced).
+ *
+ * <p>Bounds-safe: every read from the source and write to the destination is validated, so a
+ * corrupt or malicious block raises {@link SirixIOException} instead of reading/writing out of
+ * bounds. Match copies honor LZ4 overlap semantics (a distance smaller than the match length
+ * replicates the just-written pattern byte-by-byte, never memmove semantics).
+ */
+public final class JavaLz4BlockDecoder {
+
+  private static final ValueLayout.OfShort LE_SHORT =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  private static final int MIN_MATCH = 4;
+
+  private JavaLz4BlockDecoder() {
+  }
+
+  /**
+   * Decompresses one LZ4 block.
+   *
+   * @param src         segment holding the compressed block
+   * @param srcOff      offset of the block within {@code src}
+   * @param srcLen      compressed length in bytes
+   * @param dst         destination segment
+   * @param dstOff      offset within {@code dst} to write to
+   * @param dstCapacity maximum number of bytes the block may decompress to
+   * @return the number of decompressed bytes written
+   * @throws SirixIOException if the block is malformed or exceeds {@code dstCapacity}
+   */
+  public static int decompressSafe(final MemorySegment src, final long srcOff, final int srcLen,
+      final MemorySegment dst, final long dstOff, final int dstCapacity) {
+    if (srcLen < 0 || dstCapacity < 0) {
+      throw new SirixIOException("LZ4 block decode: negative length (srcLen=" + srcLen
+          + ", dstCapacity=" + dstCapacity + ")");
+    }
+    if (srcLen == 0) {
+      return 0;
+    }
+    long sPos = srcOff;
+    final long sEnd = srcOff + srcLen;
+    long dPos = dstOff;
+    final long dEnd = dstOff + dstCapacity;
+
+    while (true) {
+      if (sPos >= sEnd) {
+        throw new SirixIOException("LZ4 block decode: truncated block (missing token)");
+      }
+      final int token = src.get(ValueLayout.JAVA_BYTE, sPos++) & 0xFF;
+
+      // Literal run.
+      long litLen = token >>> 4;
+      if (litLen == 15) {
+        int b;
+        do {
+          if (sPos >= sEnd) {
+            throw new SirixIOException("LZ4 block decode: truncated literal-length chain");
+          }
+          b = src.get(ValueLayout.JAVA_BYTE, sPos++) & 0xFF;
+          litLen += b;
+        } while (b == 255);
+      }
+      if (sPos + litLen > sEnd) {
+        throw new SirixIOException("LZ4 block decode: literal run exceeds input");
+      }
+      if (dPos + litLen > dEnd) {
+        throw new SirixIOException("LZ4 block decode: output exceeds capacity " + dstCapacity);
+      }
+      if (litLen > 0) {
+        MemorySegment.copy(src, sPos, dst, dPos, litLen);
+        sPos += litLen;
+        dPos += litLen;
+      }
+
+      // The final sequence is literals-only and ends exactly at the input boundary.
+      if (sPos == sEnd) {
+        return (int) (dPos - dstOff);
+      }
+
+      // Match.
+      if (sPos + 2 > sEnd) {
+        throw new SirixIOException("LZ4 block decode: truncated match offset");
+      }
+      final int distance = src.get(LE_SHORT, sPos) & 0xFFFF;
+      sPos += 2;
+      if (distance == 0) {
+        throw new SirixIOException("LZ4 block decode: zero match distance");
+      }
+      long matchLen = token & 0x0F;
+      if (matchLen == 15) {
+        int b;
+        do {
+          if (sPos >= sEnd) {
+            throw new SirixIOException("LZ4 block decode: truncated match-length chain");
+          }
+          b = src.get(ValueLayout.JAVA_BYTE, sPos++) & 0xFF;
+          matchLen += b;
+        } while (b == 255);
+      }
+      matchLen += MIN_MATCH;
+
+      long matchPos = dPos - distance;
+      if (matchPos < dstOff) {
+        throw new SirixIOException("LZ4 block decode: match distance " + distance
+            + " reaches before the output start");
+      }
+      if (dPos + matchLen > dEnd) {
+        throw new SirixIOException("LZ4 block decode: output exceeds capacity " + dstCapacity);
+      }
+      if (distance >= matchLen) {
+        // Non-overlapping — bulk copy.
+        MemorySegment.copy(dst, matchPos, dst, dPos, matchLen);
+        dPos += matchLen;
+      } else {
+        // Overlapping pattern replication — must propagate forward byte-by-byte.
+        for (long i = 0; i < matchLen; i++) {
+          dst.set(ValueLayout.JAVA_BYTE, dPos + i, dst.get(ValueLayout.JAVA_BYTE, matchPos + i));
+        }
+        dPos += matchLen;
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelReader.java
@@ -120,7 +120,7 @@ public final class FileChannelReader extends AbstractReader {
 
   static {
     for (int i = 0; i < POOL_SIZE; i++) {
-      BUF_POOL.offer(ByteBuffer.allocateDirect(BUFFER_BYTES).order(ByteOrder.nativeOrder()));
+      BUF_POOL.offer(ByteBuffer.allocateDirect(BUFFER_BYTES).order(ByteOrder.LITTLE_ENDIAN));
     }
   }
 
@@ -141,7 +141,7 @@ public final class FileChannelReader extends AbstractReader {
         BUF_POOL.offer(b);
       }
       final int cap = Math.max(minCapacity, BUFFER_BYTES);
-      b = ByteBuffer.allocateDirect(cap).order(ByteOrder.nativeOrder());
+      b = ByteBuffer.allocateDirect(cap).order(ByteOrder.LITTLE_ENDIAN);
     }
     return b;
   }
@@ -391,7 +391,7 @@ public final class FileChannelReader extends AbstractReader {
     } catch (IOException e) {
       throw new SirixIOException(e);
     } finally {
-      buffer.order(ByteOrder.nativeOrder());
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
       releaseBuffer(buffer);
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelStorage.java
@@ -118,6 +118,8 @@ public final class FileChannelStorage implements IOStorage {
     byteHandlerPipeline = resourceConfig.byteHandlePipeline;
     this.cache = cache;
     this.revisionIndexHolder = revisionIndexHolder;
+    resourceUuidMsb = resourceConfig.resourceUuid != null ? resourceConfig.resourceUuid.getMostSignificantBits() : 0L;
+    resourceUuidLsb = resourceConfig.resourceUuid != null ? resourceConfig.resourceUuid.getLeastSignificantBits() : 0L;
   }
 
   /**
@@ -131,14 +133,20 @@ public final class FileChannelStorage implements IOStorage {
     this(resourceConfig, cache, new RevisionIndexHolder());
   }
 
+  /** Resource identity UUID halves from the configuration (0/0 = legacy, no cross-check). */
+  private final long resourceUuidMsb;
+  private final long resourceUuidLsb;
+
   /**
    * Superblock checks are open-time, not per-reader — and a NEW storage instance is created per
    * request-scoped open, so the once-per-JVM-per-path registry (not a per-instance flag) is what
    * actually avoids the two extra file opens + header reads per request.
    */
   private void validateSuperblocksOnce() {
-    io.sirix.io.SuperblockValidator.validateOnce(getDataFilePath(), io.sirix.io.Superblock.ROLE_DATA);
-    io.sirix.io.SuperblockValidator.validateOnce(getRevisionFilePath(), io.sirix.io.Superblock.ROLE_REVISIONS);
+    io.sirix.io.SuperblockValidator.validateOnce(getDataFilePath(), io.sirix.io.Superblock.ROLE_DATA,
+        resourceUuidMsb, resourceUuidLsb);
+    io.sirix.io.SuperblockValidator.validateOnce(getRevisionFilePath(), io.sirix.io.Superblock.ROLE_REVISIONS,
+        resourceUuidMsb, resourceUuidLsb);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -621,14 +621,18 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       // because both files may already have grown PAST the header via sparse positioned writes
       // (the revision record lands at REVISIONS_RECORDS_START before this runs), presence is
       // probed via the magic bytes, not the file size.
+      final long uuidMsb = resourceConfiguration.resourceUuid != null
+          ? resourceConfiguration.resourceUuid.getMostSignificantBits() : 0L;
+      final long uuidLsb = resourceConfiguration.resourceUuid != null
+          ? resourceConfiguration.resourceUuid.getLeastSignificantBits() : 0L;
       if (superblockMissing(revisionsFileChannel)) {
-        final ByteBuffer sb = Superblock.build(Superblock.ROLE_REVISIONS);
+        final ByteBuffer sb = Superblock.build(Superblock.ROLE_REVISIONS, uuidMsb, uuidLsb);
         while (sb.hasRemaining()) {
           revisionsFileChannel.write(sb, sb.position());
         }
       }
       if (superblockMissing(dataFileChannel)) {
-        final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA);
+        final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA, uuidMsb, uuidLsb);
         while (sb.hasRemaining()) {
           dataFileChannel.write(sb, sb.position());
         }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/filechannel/FileChannelWriter.java
@@ -190,7 +190,7 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       // left the zero-filled buffer (dataLength=0) and a corrupt/negative length silently
       // truncated INTO older committed revisions (destroying good data) or threw from a
       // negative truncation size.
-      final var buffer = ByteBuffer.allocateDirect(IOStorage.OTHER_BEACON).order(ByteOrder.nativeOrder());
+      final var buffer = ByteBuffer.allocateDirect(IOStorage.OTHER_BEACON).order(ByteOrder.LITTLE_ENDIAN);
       int totalRead = 0;
       while (buffer.hasRemaining()) {
         final int n = dataFileChannel.read(buffer, dataFileRevisionRootPageOffset + totalRead);
@@ -348,7 +348,7 @@ public final class FileChannelWriter extends AbstractForwardingReader implements
       // Data frontier = end of the last revision root page = offset + OTHER_BEACON (4-byte length
       // prefix) + payload length, exactly as FileChannelReader/truncateTo frame it.
       final long revRootOffset = getRevisionFileData(lastRevision).offset();
-      final ByteBuffer lenBuf = ByteBuffer.allocateDirect(IOStorage.OTHER_BEACON).order(ByteOrder.nativeOrder());
+      final ByteBuffer lenBuf = ByteBuffer.allocateDirect(IOStorage.OTHER_BEACON).order(ByteOrder.LITTLE_ENDIAN);
       int read = 0;
       while (lenBuf.hasRemaining()) {
         final int n = dataFileChannel.read(lenBuf, revRootOffset + read);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
@@ -51,7 +51,9 @@ import static java.util.Objects.requireNonNull;
 public final class MMFileReader extends AbstractReader {
 
   static final ValueLayout.OfByte LAYOUT_BYTE = ValueLayout.JAVA_BYTE;
-  static final ValueLayout.OfInt LAYOUT_INT = ValueLayout.JAVA_INT;
+  /** Record length prefixes are pinned little-endian like every other on-disk scalar. */
+  static final ValueLayout.OfInt LAYOUT_INT =
+      ValueLayout.JAVA_INT.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
   /** The revisions records and beacon trailers are pinned little-endian. */
   static final ValueLayout.OfLong LAYOUT_LONG_LE =
       ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMFileReader.java
@@ -177,17 +177,15 @@ public final class MMFileReader extends AbstractReader {
         // For empty pipeline: identity (no decompression needed)
         // For non-empty pipeline: decompressScoped() allocates buffer from pool
         MemorySegment pageSlice = dataFileSegment.asSlice(offset, dataLength);
-        // Verify checksum for non-KVLP pages (KVLP verified after decompression)
+        // The parent-reference hash covers the COMPRESSED payload — verify here, before decode.
         verifyChecksumIfNeeded(pageSlice, reference, resourceConfiguration);
-        // Pass reference for KVLP verification after decompression
         return deserializeFromSegment(resourceConfiguration, pageSlice, reference);
       } else {
         // Fallback: copy to byte[] for stream-based decompression
         final byte[] page = new byte[dataLength];
         MemorySegment.copy(dataFileSegment, LAYOUT_BYTE, offset, page, 0, dataLength);
-        // Verify checksum for non-KVLP pages (KVLP verified after decompression)
+        // The parent-reference hash covers the COMPRESSED payload — verify here, before decode.
         verifyChecksumIfNeeded(page, reference, resourceConfiguration);
-        // Pass reference for KVLP verification after decompression
         return deserialize(resourceConfiguration, page, reference);
       }
     } catch (final IOException e) {

--- a/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/memorymapped/MMStorage.java
@@ -217,6 +217,8 @@ public final class MMStorage implements IOStorage {
     byteHandlerPipeline = resourceConfig.byteHandlePipeline;
     this.cache = cache;
     this.revisionIndexHolder = revisionIndexHolder;
+    resourceUuidMsb = resourceConfig.resourceUuid != null ? resourceConfig.resourceUuid.getMostSignificantBits() : 0L;
+    resourceUuidLsb = resourceConfig.resourceUuid != null ? resourceConfig.resourceUuid.getLeastSignificantBits() : 0L;
   }
 
   /**
@@ -229,14 +231,20 @@ public final class MMStorage implements IOStorage {
     this(resourceConfig, cache, new RevisionIndexHolder());
   }
 
+  /** Resource identity UUID halves from the configuration (0/0 = legacy, no cross-check). */
+  private final long resourceUuidMsb;
+  private final long resourceUuidLsb;
+
   /**
    * Superblock checks are open-time, not per-reader — and a NEW storage instance is created per
    * request-scoped open, so the once-per-JVM-per-path registry (not a per-instance flag) is what
    * actually avoids the two extra file opens + header reads per request.
    */
   private void validateSuperblocksOnce() {
-    io.sirix.io.SuperblockValidator.validateOnce(getDataFilePath(), io.sirix.io.Superblock.ROLE_DATA);
-    io.sirix.io.SuperblockValidator.validateOnce(getRevisionFilePath(), io.sirix.io.Superblock.ROLE_REVISIONS);
+    io.sirix.io.SuperblockValidator.validateOnce(getDataFilePath(), io.sirix.io.Superblock.ROLE_DATA,
+        resourceUuidMsb, resourceUuidLsb);
+    io.sirix.io.SuperblockValidator.validateOnce(getRevisionFilePath(), io.sirix.io.Superblock.ROLE_REVISIONS,
+        resourceUuidMsb, resourceUuidLsb);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
@@ -924,7 +924,12 @@ public final class DeltaVarIntCodec {
     // Shift offsets for fields after the changed field
     for (int i = fieldIndex + 1; i < fieldCount; i++) {
       final int oldOff = srcPage.get(ValueLayout.JAVA_BYTE, srcOffsetTable + i) & 0xFF;
-      dstPage.set(ValueLayout.JAVA_BYTE, dstOffsetTable + i, (byte) (oldOff + widthDelta));
+      final int newOff = oldOff + widthDelta;
+      if ((newOff & ~0xFF) != 0) {
+        throw new IllegalStateException("Record field offset " + newOff + " for field " + i
+            + " exceeds the 1-byte offset-table range (0-255) after resize");
+      }
+      dstPage.set(ValueLayout.JAVA_BYTE, dstOffsetTable + i, (byte) newOff);
     }
 
     return (int) (dstPos - dstRecordBase);

--- a/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
@@ -510,7 +510,7 @@ public final class DeltaVarIntCodec {
     // 12% leaf CPU during analytical scans.
     final long segSize = segment.byteSize();
     if (offset + 8 <= segSize) {
-      final long w = segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset);
+      final long w = segment.get(LE.LONG, offset);
       final int b0 = (int) (w & 0xFF);
       if ((b0 & 0x80) == 0) return b0;
       final int b1 = (int) ((w >>> 8) & 0xFF);
@@ -633,7 +633,7 @@ public final class DeltaVarIntCodec {
    * @return the 8-byte long value
    */
   public static long readLongFromSegment(MemorySegment segment, int offset) {
-    return segment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset);
+    return segment.get(LE.LONG, offset);
   }
 
   // ==================== DIRECT SEGMENT WRITE METHODS (for in-place mutation) ====================
@@ -648,7 +648,7 @@ public final class DeltaVarIntCodec {
    * @param value   the 8-byte long value
    */
   public static void writeLongToSegment(MemorySegment segment, long offset, long value) {
-    segment.set(ValueLayout.JAVA_LONG_UNALIGNED, offset, value);
+    segment.set(LE.LONG, offset, value);
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/GrowingMemorySegment.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/GrowingMemorySegment.java
@@ -256,7 +256,7 @@ public class GrowingMemorySegment {
    */
   public void writeInt(int value) {
     ensureCapacity(position + 4);
-    segment.set(ValueLayout.JAVA_INT_UNALIGNED, position, value);
+    segment.set(LE.INT, position, value);
     position += 4;
   }
 
@@ -266,7 +266,7 @@ public class GrowingMemorySegment {
    */
   public void writeLong(long value) {
     ensureCapacity(position + 8);
-    segment.set(ValueLayout.JAVA_LONG_UNALIGNED, position, value);
+    segment.set(LE.LONG, position, value);
     position += 8;
   }
 
@@ -285,7 +285,7 @@ public class GrowingMemorySegment {
    */
   public void writeDouble(double value) {
     ensureCapacity(position + 8);
-    segment.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, position, value);
+    segment.set(LE.DOUBLE, position, value);
     position += 8;
   }
 
@@ -295,7 +295,7 @@ public class GrowingMemorySegment {
    */
   public void writeFloat(float value) {
     ensureCapacity(position + 4);
-    segment.set(ValueLayout.JAVA_FLOAT_UNALIGNED, position, value);
+    segment.set(LE.FLOAT, position, value);
     position += 4;
   }
 
@@ -305,7 +305,7 @@ public class GrowingMemorySegment {
    */
   public void writeShort(short value) {
     ensureCapacity(position + 2);
-    segment.set(ValueLayout.JAVA_SHORT_UNALIGNED, position, value);
+    segment.set(LE.SHORT, position, value);
     position += 2;
   }
 
@@ -361,7 +361,7 @@ public class GrowingMemorySegment {
   public void writeByteAndInt(byte b, int value) {
     ensureCapacity(position + 5);
     segment.set(ValueLayout.JAVA_BYTE, position, b);
-    segment.set(ValueLayout.JAVA_INT_UNALIGNED, position + 1, value);
+    segment.set(LE.INT, position + 1, value);
     position += 5;
   }
 
@@ -375,7 +375,7 @@ public class GrowingMemorySegment {
   public void writeByteAndLong(byte b, long value) {
     ensureCapacity(position + 9);
     segment.set(ValueLayout.JAVA_BYTE, position, b);
-    segment.set(ValueLayout.JAVA_LONG_UNALIGNED, position + 1, value);
+    segment.set(LE.LONG, position + 1, value);
     position += 9;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/node/LE.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/LE.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.node;
+
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteOrder;
+
+/**
+ * Little-endian pinned {@link ValueLayout}s for every multi-byte scalar that touches the on-disk
+ * format.
+ *
+ * <p>The storage format is defined as little-endian (see {@code docs/DISK_FORMAT.md}). Using the
+ * native-order {@code ValueLayout.JAVA_*} constants made the encoding an accident of the host
+ * CPU — correct on x86/ARM-LE, silently byte-swapped on a big-endian host. Every serializer and
+ * deserializer must use these pinned layouts instead. On little-endian hosts they are
+ * bit-identical (and JIT-identical) to the native-order constants, so the pin costs nothing.
+ *
+ * <p>The {@code _UNALIGNED}-derived constants carry no alignment constraint and are the default
+ * choice for heap/stream offsets; the aligned variants exist for slot-structured access where the
+ * layout guarantees natural alignment.
+ */
+public final class LE {
+
+  /** Unaligned little-endian {@code short}. */
+  public static final ValueLayout.OfShort SHORT =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Unaligned little-endian {@code int}. */
+  public static final ValueLayout.OfInt INT =
+      ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Unaligned little-endian {@code long}. */
+  public static final ValueLayout.OfLong LONG =
+      ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Unaligned little-endian {@code float}. */
+  public static final ValueLayout.OfFloat FLOAT =
+      ValueLayout.JAVA_FLOAT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Unaligned little-endian {@code double}. */
+  public static final ValueLayout.OfDouble DOUBLE =
+      ValueLayout.JAVA_DOUBLE_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Naturally aligned little-endian {@code int}. */
+  public static final ValueLayout.OfInt INT_ALIGNED =
+      ValueLayout.JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Naturally aligned little-endian {@code long}. */
+  public static final ValueLayout.OfLong LONG_ALIGNED =
+      ValueLayout.JAVA_LONG.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Naturally aligned little-endian {@code float}. */
+  public static final ValueLayout.OfFloat FLOAT_ALIGNED =
+      ValueLayout.JAVA_FLOAT.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Naturally aligned little-endian {@code double}. */
+  public static final ValueLayout.OfDouble DOUBLE_ALIGNED =
+      ValueLayout.JAVA_DOUBLE.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  private LE() {
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/node/MemorySegmentBytesIn.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/MemorySegmentBytesIn.java
@@ -32,14 +32,14 @@ public class MemorySegmentBytesIn implements BytesIn<MemorySegment> {
 
   @Override
   public int readInt() {
-    int value = memorySegment.get(ValueLayout.JAVA_INT_UNALIGNED, position);
+    int value = memorySegment.get(LE.INT, position);
     position += Integer.BYTES;
     return value;
   }
 
   @Override
   public long readLong() {
-    long value = memorySegment.get(ValueLayout.JAVA_LONG_UNALIGNED, position);
+    long value = memorySegment.get(LE.LONG, position);
     position += Long.BYTES;
     return value;
   }
@@ -58,21 +58,21 @@ public class MemorySegmentBytesIn implements BytesIn<MemorySegment> {
 
   @Override
   public double readDouble() {
-    double value = memorySegment.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, position);
+    double value = memorySegment.get(LE.DOUBLE, position);
     position += Double.BYTES;
     return value;
   }
 
   @Override
   public float readFloat() {
-    float value = memorySegment.get(ValueLayout.JAVA_FLOAT_UNALIGNED, position);
+    float value = memorySegment.get(LE.FLOAT, position);
     position += Float.BYTES;
     return value;
   }
 
   @Override
   public short readShort() {
-    short value = memorySegment.get(ValueLayout.JAVA_SHORT_UNALIGNED, position);
+    short value = memorySegment.get(LE.SHORT, position);
     position += Short.BYTES;
     return value;
   }
@@ -131,7 +131,7 @@ public class MemorySegmentBytesIn implements BytesIn<MemorySegment> {
   public void readInts(final int[] dst, final int off, final int len) {
     // One native copy vs {@code len} VarHandle reads — used by the compact-dir
     // rebuild in PageKind.deserializeSlottedPage (hot path at cold-cache scan).
-    MemorySegment.copy(memorySegment, ValueLayout.JAVA_INT_UNALIGNED, position, dst, off, len);
+    MemorySegment.copy(memorySegment, LE.INT, position, dst, off, len);
     position += (long) len * Integer.BYTES;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/node/MemorySegmentUtils.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/MemorySegmentUtils.java
@@ -160,7 +160,7 @@ public final class MemorySegmentUtils {
    * @return the int value
    */
   public static int readInt(final MemorySegment memorySegment, final long offset) {
-    return memorySegment.get(ValueLayout.JAVA_INT, offset);
+    return memorySegment.get(LE.INT_ALIGNED, offset);
   }
 
   /**
@@ -171,7 +171,7 @@ public final class MemorySegmentUtils {
    * @return the long value
    */
   public static long readLong(final MemorySegment memorySegment, final long offset) {
-    return memorySegment.get(ValueLayout.JAVA_LONG_UNALIGNED, offset);
+    return memorySegment.get(LE.LONG, offset);
   }
 
   /**
@@ -229,7 +229,7 @@ public final class MemorySegmentUtils {
    * @return the double value
    */
   public static double readDouble(final MemorySegment memorySegment, final long offset) {
-    return memorySegment.get(ValueLayout.JAVA_DOUBLE, offset);
+    return memorySegment.get(LE.DOUBLE_ALIGNED, offset);
   }
 
   /**
@@ -240,7 +240,7 @@ public final class MemorySegmentUtils {
    * @return the float value
    */
   public static float readFloat(final MemorySegment memorySegment, final long offset) {
-    return memorySegment.get(ValueLayout.JAVA_FLOAT, offset);
+    return memorySegment.get(LE.FLOAT_ALIGNED, offset);
   }
 
   /**
@@ -287,7 +287,7 @@ public final class MemorySegmentUtils {
    * @param value the int value to write
    */
   public static void writeInt(final MemorySegment memorySegment, final long offset, final int value) {
-    memorySegment.set(ValueLayout.JAVA_INT, offset, value);
+    memorySegment.set(LE.INT_ALIGNED, offset, value);
   }
 
   /**
@@ -298,7 +298,7 @@ public final class MemorySegmentUtils {
    * @param value the long value to write
    */
   public static void writeLong(final MemorySegment memorySegment, final long offset, final long value) {
-    memorySegment.set(ValueLayout.JAVA_LONG, offset, value);
+    memorySegment.set(LE.LONG_ALIGNED, offset, value);
   }
 
   /**
@@ -352,7 +352,7 @@ public final class MemorySegmentUtils {
    * @param value the double value to write
    */
   public static void writeDouble(final MemorySegment memorySegment, final long offset, final double value) {
-    memorySegment.set(ValueLayout.JAVA_DOUBLE, offset, value);
+    memorySegment.set(LE.DOUBLE_ALIGNED, offset, value);
   }
 
   /**
@@ -363,6 +363,6 @@ public final class MemorySegmentUtils {
    * @param value the float value to write
    */
   public static void writeFloat(final MemorySegment memorySegment, final long offset, final float value) {
-    memorySegment.set(ValueLayout.JAVA_FLOAT, offset, value);
+    memorySegment.set(LE.FLOAT_ALIGNED, offset, value);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NodeKind.java
@@ -129,13 +129,13 @@ public enum NodeKind implements DeweyIdSerializer {
       final int previousRevision = DeltaVarIntCodec.decodeSigned(source);
       final int lastModifiedRevision = DeltaVarIntCodec.decodeSigned(source);
       final long childCount = config.storeChildCount()
-          ? DeltaVarIntCodec.decodeSigned(source)
+          ? DeltaVarIntCodec.decodeSignedLong(source)
           : 0;
       final long hash;
       final long descendantCount;
       if (config.hashType != HashType.NONE) {
         hash = source.readLong();
-        descendantCount = DeltaVarIntCodec.decodeSigned(source);
+        descendantCount = DeltaVarIntCodec.decodeSignedLong(source);
       } else {
         hash = 0L;
         descendantCount = 0L;
@@ -184,11 +184,11 @@ public enum NodeKind implements DeweyIdSerializer {
       DeltaVarIntCodec.encodeSigned(sink, node.getPreviousRevisionNumber());
       DeltaVarIntCodec.encodeSigned(sink, node.getLastModifiedRevisionNumber());
       if (config.storeChildCount()) {
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getChildCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getChildCount());
       }
       if (config.hashType != HashType.NONE) {
         writeHash(sink, node.getHash());
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getDescendantCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getDescendantCount());
       }
 
       // Attribute keys.
@@ -358,11 +358,11 @@ public enum NodeKind implements DeweyIdSerializer {
       final int previousRevision = DeltaVarIntCodec.decodeSigned(source);
       final int lastModifiedRevision = DeltaVarIntCodec.decodeSigned(source);
       final long childCount = config.storeChildCount()
-          ? DeltaVarIntCodec.decodeSigned(source)
+          ? DeltaVarIntCodec.decodeSignedLong(source)
           : 0;
       final long descendantCount;
       if (config.hashType != HashType.NONE) {
-        descendantCount = DeltaVarIntCodec.decodeSigned(source);
+        descendantCount = DeltaVarIntCodec.decodeSignedLong(source);
       } else {
         descendantCount = 0;
       }
@@ -396,10 +396,10 @@ public enum NodeKind implements DeweyIdSerializer {
       DeltaVarIntCodec.encodeSigned(sink, node.getLastModifiedRevisionNumber());
 
       if (config.storeChildCount()) {
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getChildCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getChildCount());
       }
       if (config.hashType != HashType.NONE) {
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getDescendantCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getDescendantCount());
       }
 
       sink.writeByte(node.isCompressed()
@@ -862,13 +862,13 @@ public enum NodeKind implements DeweyIdSerializer {
     public void serialize(final BytesOut<?> sink, final DataRecord record,
         final ResourceConfiguration resourceConfiguration) {
       final RBNodeKey<QNm> node = (RBNodeKey<QNm>) record;
-      final byte[] nspBytes = node.getKey().getNamespaceURI().getBytes();
+      final byte[] nspBytes = node.getKey().getNamespaceURI().getBytes(Constants.DEFAULT_ENCODING);
       sink.writeInt(nspBytes.length);
       sink.write(nspBytes);
-      final byte[] prefixBytes = node.getKey().getPrefix().getBytes();
+      final byte[] prefixBytes = node.getKey().getPrefix().getBytes(Constants.DEFAULT_ENCODING);
       sink.writeInt(prefixBytes.length);
       sink.write(prefixBytes);
-      final byte[] localNameBytes = node.getKey().getLocalName().getBytes();
+      final byte[] localNameBytes = node.getKey().getLocalName().getBytes(Constants.DEFAULT_ENCODING);
       sink.writeInt(localNameBytes.length);
       sink.write(localNameBytes);
       serializeDelegateWithoutIDs(node.getNodeDelegate(), sink);
@@ -970,13 +970,13 @@ public enum NodeKind implements DeweyIdSerializer {
       int prevRev = DeltaVarIntCodec.decodeSigned(source);
       int lastModRev = DeltaVarIntCodec.decodeSigned(source);
       long childCount = resourceConfiguration.storeChildCount()
-          ? DeltaVarIntCodec.decodeSigned(source)
+          ? DeltaVarIntCodec.decodeSignedLong(source)
           : 0;
       long hash = 0;
       long descendantCount = 0;
       if (resourceConfiguration.hashType != HashType.NONE) {
         hash = source.readLong();
-        descendantCount = DeltaVarIntCodec.decodeSigned(source);
+        descendantCount = DeltaVarIntCodec.decodeSignedLong(source);
       }
       return new ObjectNode(recordID, parentKey, prevRev, lastModRev, rightSiblingKey, leftSiblingKey, firstChildKey,
           lastChildKey, childCount, descendantCount, hash, resourceConfiguration.nodeHashFunction, deweyID);
@@ -997,11 +997,11 @@ public enum NodeKind implements DeweyIdSerializer {
       DeltaVarIntCodec.encodeSigned(sink, node.getPreviousRevisionNumber());
       DeltaVarIntCodec.encodeSigned(sink, node.getLastModifiedRevisionNumber());
       if (resourceConfiguration.storeChildCount()) {
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getChildCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getChildCount());
       }
       if (resourceConfiguration.hashType != HashType.NONE) {
         sink.writeLong(node.getHash());
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getDescendantCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getDescendantCount());
       }
     }
 
@@ -1035,13 +1035,13 @@ public enum NodeKind implements DeweyIdSerializer {
       int prevRev = DeltaVarIntCodec.decodeSigned(source);
       int lastModRev = DeltaVarIntCodec.decodeSigned(source);
       long childCount = resourceConfiguration.storeChildCount()
-          ? DeltaVarIntCodec.decodeSigned(source)
+          ? DeltaVarIntCodec.decodeSignedLong(source)
           : 0;
       long hash = 0;
       long descendantCount = 0;
       if (resourceConfiguration.hashType != HashType.NONE) {
         hash = source.readLong();
-        descendantCount = DeltaVarIntCodec.decodeSigned(source);
+        descendantCount = DeltaVarIntCodec.decodeSignedLong(source);
       }
       return new ArrayNode(recordID, parentKey, pathNodeKey, prevRev, lastModRev, rightSiblingKey, leftSiblingKey,
           firstChildKey, lastChildKey, childCount, descendantCount, hash, resourceConfiguration.nodeHashFunction,
@@ -1064,11 +1064,11 @@ public enum NodeKind implements DeweyIdSerializer {
       DeltaVarIntCodec.encodeSigned(sink, node.getPreviousRevisionNumber());
       DeltaVarIntCodec.encodeSigned(sink, node.getLastModifiedRevisionNumber());
       if (resourceConfiguration.storeChildCount()) {
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getChildCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getChildCount());
       }
       if (resourceConfiguration.hashType != HashType.NONE) {
         sink.writeLong(node.getHash());
-        DeltaVarIntCodec.encodeSigned(sink, (int) node.getDescendantCount());
+        DeltaVarIntCodec.encodeSignedLong(sink, node.getDescendantCount());
       }
     }
 
@@ -2041,9 +2041,11 @@ public enum NodeKind implements DeweyIdSerializer {
   private final byte id;
 
   /**
-   * Mapping of keys -> nodes.
+   * Mapping of keys -> nodes. Sized to cover the full unsigned-byte id space so the lookup in
+   * {@link #getKind(byte)} needs no range check — unmapped slots stay {@code null} and are
+   * rejected there.
    */
-  private static final NodeKind[] INSTANCEFORID = new NodeKind[128];
+  private static final NodeKind[] INSTANCEFORID = new NodeKind[256];
 
   /**
    * Shared empty-name placeholder; the real name is resolved from the name page via the name
@@ -2054,7 +2056,7 @@ public enum NodeKind implements DeweyIdSerializer {
 
   static {
     for (final NodeKind node : values()) {
-      INSTANCEFORID[node.id] = node;
+      INSTANCEFORID[node.id & 0xFF] = node;
     }
   }
 
@@ -2081,9 +2083,20 @@ public enum NodeKind implements DeweyIdSerializer {
    *
    * @param id the identifier for the node
    * @return the related node
+   * @throws IllegalStateException if the id maps to no known kind (a record written by a newer
+   *         version of the format, or a corrupt kind byte)
    */
   public static NodeKind getKind(final byte id) {
-    return INSTANCEFORID[id];
+    final NodeKind kind = INSTANCEFORID[id & 0xFF];
+    if (kind == null) {
+      throw unknownKind(id);
+    }
+    return kind;
+  }
+
+  private static IllegalStateException unknownKind(final byte id) {
+    return new IllegalStateException("Unknown NodeKind id: " + (id & 0xFF)
+        + " — record written by a newer version of the storage format, or corrupt data");
   }
 
   /** True for all fused {@code OBJECT_NAMED_*} kinds — records that carry a field nameKey

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NodeLayout.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NodeLayout.java
@@ -22,10 +22,10 @@ import java.util.Optional;
 public final class NodeLayout {
 
   // Basic layouts for fixed-size fields
-  private static final MemoryLayout HASH_LAYOUT = ValueLayout.JAVA_LONG.withName("hash");
-  private static final MemoryLayout REVISION_LAYOUT = ValueLayout.JAVA_INT_UNALIGNED.withName("previousRevision");
+  private static final MemoryLayout HASH_LAYOUT = LE.LONG_ALIGNED.withName("hash");
+  private static final MemoryLayout REVISION_LAYOUT = LE.INT.withName("previousRevision");
   private static final MemoryLayout LAST_MODIFIED_LAYOUT =
-      ValueLayout.JAVA_INT_UNALIGNED.withName("lastModifiedRevision");
+      LE.INT.withName("lastModifiedRevision");
 
   // VarHandles for direct field access
   private static final VarHandle HASH_HANDLE = HASH_LAYOUT.varHandle();

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NodeSerializerImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NodeSerializerImpl.java
@@ -92,6 +92,7 @@ public final class NodeSerializerImpl implements DeweyIdSerializer {
         }
         writeDeweyID(sink, nextDeweyID, i);
       } else {
+        checkDeweyIdFrameLength(deweyID.length, "DeweyID length");
         sink.writeByte((byte) deweyID.length);
         sink.write(deweyID);
       }
@@ -99,8 +100,22 @@ public final class NodeSerializerImpl implements DeweyIdSerializer {
   }
 
   private static void writeDeweyID(final BytesOut<?> sink, final byte[] deweyID, final int i) {
+    checkDeweyIdFrameLength(i, "DeweyID shared-prefix length");
+    checkDeweyIdFrameLength(deweyID.length - i, "DeweyID suffix length");
     sink.writeByte((byte) i);
     sink.writeByte((byte) (deweyID.length - i));
     sink.write(deweyID, i, deweyID.length - i);
+  }
+
+  /**
+   * The DeweyID delta framing stores lengths as single unsigned bytes; a value past 255 used to
+   * wrap silently and corrupt the record. Extremely deep/wide trees can exceed it, so the limit
+   * must be a loud error until the framing is widened with a format bump.
+   */
+  private static void checkDeweyIdFrameLength(final int length, final String what) {
+    if ((length & ~0xFF) != 0) {
+      throw new IllegalStateException(what + " " + length
+          + " exceeds the 1-byte framing limit (255) — document is too deeply nested for the current format");
+    }
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/node/PooledGrowingSegment.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/PooledGrowingSegment.java
@@ -155,7 +155,7 @@ public final class PooledGrowingSegment {
    */
   public void writeShort(short value) {
     ensureCapacity(position + 2);
-    currentSegment.set(ValueLayout.JAVA_SHORT_UNALIGNED, position, value);
+    currentSegment.set(LE.SHORT, position, value);
     position += 2;
   }
 
@@ -166,7 +166,7 @@ public final class PooledGrowingSegment {
    */
   public void writeInt(int value) {
     ensureCapacity(position + 4);
-    currentSegment.set(ValueLayout.JAVA_INT_UNALIGNED, position, value);
+    currentSegment.set(LE.INT, position, value);
     position += 4;
   }
 
@@ -177,7 +177,7 @@ public final class PooledGrowingSegment {
    */
   public void writeLong(long value) {
     ensureCapacity(position + 8);
-    currentSegment.set(ValueLayout.JAVA_LONG_UNALIGNED, position, value);
+    currentSegment.set(LE.LONG, position, value);
     position += 8;
   }
 
@@ -188,7 +188,7 @@ public final class PooledGrowingSegment {
    */
   public void writeFloat(float value) {
     ensureCapacity(position + 4);
-    currentSegment.set(ValueLayout.JAVA_FLOAT_UNALIGNED, position, value);
+    currentSegment.set(LE.FLOAT, position, value);
     position += 4;
   }
 
@@ -199,7 +199,7 @@ public final class PooledGrowingSegment {
    */
   public void writeDouble(double value) {
     ensureCapacity(position + 8);
-    currentSegment.set(ValueLayout.JAVA_DOUBLE_UNALIGNED, position, value);
+    currentSegment.set(LE.DOUBLE, position, value);
     position += 8;
   }
 
@@ -330,7 +330,7 @@ public final class PooledGrowingSegment {
   public void writeByteAndInt(byte b, int value) {
     ensureCapacity(position + 5);
     currentSegment.set(ValueLayout.JAVA_BYTE, position, b);
-    currentSegment.set(ValueLayout.JAVA_INT_UNALIGNED, position + 1, value);
+    currentSegment.set(LE.INT, position + 1, value);
     position += 5;
   }
 
@@ -344,7 +344,7 @@ public final class PooledGrowingSegment {
   public void writeByteAndLong(byte b, long value) {
     ensureCapacity(position + 9);
     currentSegment.set(ValueLayout.JAVA_BYTE, position, b);
-    currentSegment.set(ValueLayout.JAVA_LONG_UNALIGNED, position + 1, value);
+    currentSegment.set(LE.LONG, position + 1, value);
     position += 9;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/json/NumberNode.java
@@ -29,6 +29,7 @@
 package io.sirix.node.json;
 
 import io.sirix.node.AbstractFlyweightNode;
+import io.sirix.node.LE;
 import io.sirix.utils.ToStringHelper;
 import java.util.Objects;
 import io.sirix.access.ResourceConfiguration;
@@ -294,9 +295,9 @@ public final class NumberNode extends AbstractFlyweightNode implements StructNod
       case 1 -> // Long (zigzag varlong)
           DeltaVarIntCodec.decodeSignedLongFromSegment(segment, pos);
       case 2 -> // Float (4 bytes raw bits, native endian)
-          Float.intBitsToFloat(segment.get(ValueLayout.JAVA_INT_UNALIGNED, pos));
+          Float.intBitsToFloat(segment.get(LE.INT, pos));
       case 3 -> // Double (8 bytes raw bits, native endian)
-          Double.longBitsToDouble(segment.get(ValueLayout.JAVA_LONG_UNALIGNED, pos));
+          Double.longBitsToDouble(segment.get(LE.LONG, pos));
       case 4 -> { // BigDecimal (varint scale + varint byte-length + bytes)
         final int scale = DeltaVarIntCodec.decodeSignedFromSegment(segment, pos);
         final int scaleWidth = DeltaVarIntCodec.readSignedVarintWidth(segment, pos);
@@ -433,13 +434,13 @@ public final class NumberNode extends AbstractFlyweightNode implements StructNod
       case Float floatVal -> {
         target.set(ValueLayout.JAVA_BYTE, pos, (byte) 2);
         pos++;
-        target.set(ValueLayout.JAVA_INT_UNALIGNED, pos, Float.floatToRawIntBits(floatVal));
+        target.set(LE.INT, pos, Float.floatToRawIntBits(floatVal));
         pos += Float.BYTES;
       }
       case Double doubleVal -> {
         target.set(ValueLayout.JAVA_BYTE, pos, (byte) 3);
         pos++;
-        target.set(ValueLayout.JAVA_LONG_UNALIGNED, pos, Double.doubleToRawLongBits(doubleVal));
+        target.set(LE.LONG, pos, Double.doubleToRawLongBits(doubleVal));
         pos += Double.BYTES;
       }
       case BigDecimal bigDecimalVal -> {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/BitmapChunkPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/BitmapChunkPage.java
@@ -445,8 +445,8 @@ public final class BitmapChunkPage implements Page {
     // Revision
     out.writeInt(revision);
 
-    // Index type
-    out.writeByte(indexType.ordinal());
+    // Index type — stable id byte, never the ordinal
+    out.writeByte(indexType.getID());
 
     // Data based on mode
     if (!isDeleted) {
@@ -498,9 +498,8 @@ public final class BitmapChunkPage implements Page {
     // Revision
     int revision = in.readInt();
 
-    // Index type
-    int indexTypeOrdinal = in.readByte() & 0xFF;
-    IndexType indexType = IndexType.values()[indexTypeOrdinal];
+    // Index type — stable id byte, never the ordinal
+    IndexType indexType = IndexType.getType(in.readByte());
 
     // Data based on mode
     Roaring64Bitmap bitmap = null;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/ColumnarPageExtractor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/ColumnarPageExtractor.java
@@ -1,5 +1,6 @@
 package io.sirix.page;
 
+import io.sirix.node.LE;
 import io.sirix.node.DeltaVarIntCodec;
 import io.sirix.node.NodeKind;
 
@@ -300,10 +301,10 @@ public final class ColumnarPageExtractor {
 
         switch (numType) {
           case NUM_TYPE_DOUBLE:
-            numValue = page.get(ValueLayout.JAVA_DOUBLE_UNALIGNED, payloadAbs + 1);
+            numValue = page.get(LE.DOUBLE, payloadAbs + 1);
             break;
           case NUM_TYPE_FLOAT:
-            numValue = page.get(ValueLayout.JAVA_FLOAT_UNALIGNED, payloadAbs + 1);
+            numValue = page.get(LE.FLOAT, payloadAbs + 1);
             break;
           case NUM_TYPE_INTEGER:
             numValue = DeltaVarIntCodec.decodeSignedFromSegment(page, payloadAbs + 1);

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
@@ -103,23 +103,76 @@ public final class HOTIndirectPage implements Page {
   public static final int MAX_NODE_ENTRIES = 32;
 
   /**
-   * Node type enumeration.
+   * Node type enumeration. Each constant carries an explicit stable id byte that is written to
+   * disk — never persist {@link #ordinal()}, so constants can be reordered or inserted without
+   * changing the on-disk meaning.
    */
   public enum NodeType {
     /** 2-16 children, SIMD-searchable partial keys. */
-    SPAN_NODE,
+    SPAN_NODE((byte) 0),
     /** 17-32 children, SIMD-searchable partial keys (same as SpanNode but higher fanout). */
-    MULTI_NODE
+    MULTI_NODE((byte) 1);
+
+    private final byte id;
+
+    NodeType(final byte id) {
+      this.id = id;
+    }
+
+    /** The stable on-disk id byte. */
+    public byte getID() {
+      return id;
+    }
+
+    /**
+     * Resolves the stable on-disk id byte to its constant.
+     *
+     * @throws IllegalStateException if the id is unknown (written by a newer version or corrupt)
+     */
+    public static NodeType fromID(final byte id) {
+      return switch (id) {
+        case 0 -> SPAN_NODE;
+        case 1 -> MULTI_NODE;
+        default -> throw new IllegalStateException(
+            "Unknown HOTIndirectPage.NodeType id: " + id + " (written by a newer version or corrupt)");
+      };
+    }
   }
 
   /**
-   * Layout type for discriminative bit storage.
+   * Layout type for discriminative bit storage. Each constant carries an explicit stable id byte
+   * that is written to disk — never persist {@link #ordinal()}.
    */
   public enum LayoutType {
     /** Single 64-bit mask with initial byte position. */
-    SINGLE_MASK,
+    SINGLE_MASK((byte) 0),
     /** Multiple 8-bit masks per byte. */
-    MULTI_MASK
+    MULTI_MASK((byte) 1);
+
+    private final byte id;
+
+    LayoutType(final byte id) {
+      this.id = id;
+    }
+
+    /** The stable on-disk id byte. */
+    public byte getID() {
+      return id;
+    }
+
+    /**
+     * Resolves the stable on-disk id byte to its constant.
+     *
+     * @throws IllegalStateException if the id is unknown (written by a newer version or corrupt)
+     */
+    public static LayoutType fromID(final byte id) {
+      return switch (id) {
+        case 0 -> SINGLE_MASK;
+        case 1 -> MULTI_MASK;
+        default -> throw new IllegalStateException(
+            "Unknown HOTIndirectPage.LayoutType id: " + id + " (written by a newer version or corrupt)");
+      };
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -28,6 +28,7 @@
 
 package io.sirix.page;
 
+import io.sirix.node.LE;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.cache.Allocators;
 import io.sirix.index.hot.DiscriminativeBitComputer;
@@ -118,7 +119,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * Unaligned short layout for zero-copy deserialization. When slotMemory is a slice, it may not be
    * 2-byte aligned.
    */
-  private static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED = ValueLayout.JAVA_SHORT.withByteAlignment(1);
+  private static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED = LE.SHORT;
 
   /**
    * Unaligned big-endian long layout for zero-allocation lexicographic key comparison.

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -1,5 +1,6 @@
 package io.sirix.page;
 
+import io.sirix.node.LE;
 import io.sirix.utils.ToStringHelper;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.api.StorageEngineReader;
@@ -1510,7 +1511,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     }
     final long[] copy = new long[BITMAP_WORDS];
     for (int i = 0; i < BITMAP_WORDS; i++) {
-      copy[i] = slottedPage.get(ValueLayout.JAVA_LONG_UNALIGNED,
+      copy[i] = slottedPage.get(LE.LONG,
           PageLayout.PRESERVATION_BITMAP_OFF + ((long) i << 3));
     }
     return copy;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -28,6 +28,7 @@
 
 package io.sirix.page;
 
+import io.sirix.node.LE;
 import io.sirix.BinaryEncodingVersion;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.User;
@@ -38,6 +39,7 @@ import io.sirix.index.IndexType;
 import io.sirix.io.bytepipe.ByteHandler;
 import io.sirix.io.bytepipe.ByteHandlerPipeline;
 import io.sirix.io.bytepipe.FFILz4Compressor;
+import io.sirix.io.bytepipe.JavaLz4BlockDecoder;
 import io.sirix.exception.SirixIOException;
 
 import java.lang.foreign.MemorySegment;
@@ -113,7 +115,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> { return deserializeSlottedPage(resourceConfig, source); }
@@ -336,14 +338,17 @@ public enum PageKind {
             source.read(tmpBuf, 0, compressedLen);
             MemorySegment.copy(tmpBuf, 0, compressedIn, ValueLayout.JAVA_BYTE, 0L, compressedLen);
             final FFILz4Compressor lz4 = V1_HEAP_LZ4.get();
-            if (lz4 == null) {
-              throw new SirixIOException("body encoded with LZ4 but FFI LZ4 not available");
-            }
             final MemorySegment blobView = blobStaging.asSlice(0, maxBlobBytes);
-            actualBlobBytes = lz4.decompressSegment(
-                compressedIn.asSlice(0, compressedLen), blobView, compressedLen);
-            if (actualBlobBytes < 0) {
-              throw new SirixIOException("body LZ4 decompress returned " + actualBlobBytes);
+            if (lz4 == null) {
+              // Pure-Java fallback: LZ4-bodied pages stay readable without liblz4.
+              actualBlobBytes = JavaLz4BlockDecoder.decompressSafe(
+                  compressedIn, 0L, compressedLen, blobView, 0L, maxBlobBytes);
+            } else {
+              actualBlobBytes = lz4.decompressSegment(
+                  compressedIn.asSlice(0, compressedLen), blobView, compressedLen);
+              if (actualBlobBytes < 0) {
+                throw new SirixIOException("body LZ4 decompress returned " + actualBlobBytes);
+              }
             }
           } else if (codec == 0) {
             final byte[] rleBuf = V1_HEAP_RLE_SCRATCH.get();
@@ -1141,7 +1146,7 @@ public enum PageKind {
                 }
               } else if (rKind == 2) {
                 // Hash: write 8 zero bytes.
-                slottedPage.set(ValueLayout.JAVA_LONG_UNALIGNED, writePos, 0L);
+                slottedPage.set(LE.LONG, writePos, 0L);
               } else if (rKind == 3) {
                 // Value: zero-fill placeholder; the second-pass injectValueElidedBytes
                 // pass populates [type:1][varint] from the NumberRegion + tag/slotRank.
@@ -1289,7 +1294,7 @@ public enum PageKind {
       keyValueLeafPage.ensureSlottedPage();
 
       sink.writeByte(KEYVALUELEAFPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       final Map<Long, PageReference> references = keyValueLeafPage.getReferencesMap();
 
@@ -1654,7 +1659,7 @@ public enum PageKind {
                     recordBase + 1 + hashFieldIdx) & 0xFF;
                 slotHashOffs[i] = (short) hashOffInData;
                 final long hashAbsOff = recordBase + 1 + fc + hashOffInData;
-                final long h = slottedPage.get(ValueLayout.JAVA_LONG_UNALIGNED, hashAbsOff);
+                final long h = slottedPage.get(LE.LONG, hashAbsOff);
                 if (h == 0L) {
                   zeroHashBitmap[i >>> 3] |= (byte) (1 << (i & 7));
                   zeroHashCount++;
@@ -3199,7 +3204,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3238,7 +3243,7 @@ public enum PageKind {
         final SerializationType type) {
       NamePage namePage = (NamePage) page;
       sink.writeByte(NAMEPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
       Page delegate = namePage.delegate();
 
       PageKind.writeDelegateType(delegate, sink);
@@ -3290,7 +3295,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3308,7 +3313,7 @@ public enum PageKind {
       UberPage uberPage = (UberPage) page;
 
       sink.writeByte(UBERPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
       sink.writeInt(uberPage.getRevisionCount());
       uberPage.setBootstrap(false);
     }
@@ -3321,7 +3326,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfiguration, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3338,7 +3343,7 @@ public enum PageKind {
       IndirectPage indirectPage = (IndirectPage) page;
       Page delegate = indirectPage.delegate();
       sink.writeByte(INDIRECTPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
 
@@ -3353,7 +3358,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfiguration, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3400,7 +3405,7 @@ public enum PageKind {
         final SerializationType type) {
       RevisionRootPage revisionRootPage = (RevisionRootPage) page;
       sink.writeByte(REVISIONROOTPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       Page delegate = revisionRootPage.delegate();
       PageKind.serializeDelegate(sink, delegate, type);
@@ -3458,7 +3463,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3486,7 +3491,7 @@ public enum PageKind {
         final SerializationType type) {
       PathSummaryPage pathSummaryPage = (PathSummaryPage) page;
       sink.writeByte(PATHSUMMARYPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       Page delegate = pathSummaryPage.delegate();
       // Shared helper instead of a hand-rolled (byte) 0 — a non-ReferencesPage4 delegate would
@@ -3514,7 +3519,7 @@ public enum PageKind {
   CASPAGE((byte) 8, CASPage.class) {
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3537,7 +3542,7 @@ public enum PageKind {
       CASPage casPage = (CASPage) page;
       Page delegate = casPage.delegate();
       sink.writeByte(CASPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
       PageKind.serializeDelegate(sink, delegate, type);
@@ -3569,7 +3574,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfiguration, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3588,7 +3593,7 @@ public enum PageKind {
         SerializationType type) {
       OverflowPage overflowPage = (OverflowPage) page;
       sink.writeByte(OVERFLOWPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
       
       // Write byte array directly
       byte[] data = overflowPage.getDataBytes();
@@ -3604,7 +3609,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(ResourceConfiguration resourceConfiguration, BytesIn<?> source,
         SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
       switch (binaryVersion) {
         case V0 -> {
           final Page delegate = PageUtils.createDelegate(source, type);
@@ -3626,7 +3631,7 @@ public enum PageKind {
       PathPage pathPage = (PathPage) page;
       Page delegate = pathPage.delegate();
       sink.writeByte(PATHPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
       PageKind.serializeDelegate(sink, delegate, type);
@@ -3658,7 +3663,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(ResourceConfiguration resourceConfiguration, BytesIn<?> source,
         SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -3677,7 +3682,7 @@ public enum PageKind {
       DeweyIDPage deweyIDPage = (DeweyIDPage) page;
       Page delegate = deweyIDPage.delegate();
       sink.writeByte(DEWEYIDPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
 
@@ -3694,7 +3699,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(ResourceConfiguration resourceConfiguration, BytesIn<?> source,
         SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       // Read header
       final long recordPageKey = Utils.getVarLong(source);
@@ -3764,7 +3769,7 @@ public enum PageKind {
           && hotLeaf.hasDirty();
 
       sink.writeByte(HOT_LEAF_PAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       // Write header
       Utils.putVarLong(sink, hotLeaf.getPageKey());
@@ -3829,7 +3834,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(ResourceConfiguration resourceConfiguration, BytesIn<?> source,
         SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
       
       // Read header
       final long pageKey = Utils.getVarLong(source);
@@ -3947,7 +3952,7 @@ public enum PageKind {
         Page page, SerializationType type) {
       HOTIndirectPage hotIndirect = (HOTIndirectPage) page;
       sink.writeByte(HOT_INDIRECT_PAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
       
       // Write header
       Utils.putVarLong(sink, hotIndirect.getPageKey());
@@ -4045,11 +4050,8 @@ public enum PageKind {
     @Override
     public Page deserializePage(ResourceConfiguration resourceConfiguration, BytesIn<?> source,
         SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      // Honor the binary version byte: silently skipping it meant a future bump would mis-parse
-      // the body instead of failing fast.
-      final byte bitmapChunkVersion = source.readByte();
-      BinaryEncodingVersion.fromByte(bitmapChunkVersion);
-      
+      readVersionAndFlags(source);
+
       // Read page key (stored before calling deserialize)
       final long pageKey = Utils.getVarLong(source);
       
@@ -4070,7 +4072,7 @@ public enum PageKind {
         Page page, SerializationType type) {
       BitmapChunkPage chunkPage = (BitmapChunkPage) page;
       sink.writeByte(BITMAP_CHUNK_PAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
       
       // Write page key
       Utils.putVarLong(sink, chunkPage.getPageKey());
@@ -4094,7 +4096,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -4116,7 +4118,7 @@ public enum PageKind {
       final VectorPage vectorPage = (VectorPage) page;
       final Page delegate = vectorPage.delegate();
       sink.writeByte(VECTORPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
       PageKind.serializeDelegate(sink, delegate, type);
@@ -4142,7 +4144,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -4165,7 +4167,7 @@ public enum PageKind {
       final ProjectionIndexPage projectionPage = (ProjectionIndexPage) page;
       final Page delegate = projectionPage.delegate();
       sink.writeByte(PROJECTIONPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
       PageKind.serializeDelegate(sink, delegate, type);
@@ -4197,7 +4199,7 @@ public enum PageKind {
     @Override
     public Page deserializePage(final ResourceConfiguration resourceConfig, final BytesIn<?> source,
         final SerializationType type, final ByteHandler.DecompressionResult decompressionResult) {
-      final BinaryEncodingVersion binaryVersion = BinaryEncodingVersion.fromByte(source.readByte());
+      final BinaryEncodingVersion binaryVersion = readVersionAndFlags(source);
 
       switch (binaryVersion) {
         case V0 -> {
@@ -4220,7 +4222,7 @@ public enum PageKind {
       final ValidTimeIndexPage validTimePage = (ValidTimeIndexPage) page;
       final Page delegate = validTimePage.delegate();
       sink.writeByte(VALIDTIMEPAGE.id);
-      sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+      writeVersionAndFlags(sink);
 
       PageKind.writeDelegateType(delegate, sink);
       PageKind.serializeDelegate(sink, delegate, type);
@@ -4284,6 +4286,31 @@ public enum PageKind {
       currentMaxLevelsOfIndirectPages.put(i, source.readByte() & 0xFF);
     }
     return currentMaxLevelsOfIndirectPages;
+  }
+
+  /**
+   * Writes the shared page envelope after the kind byte: {@code [binaryVersion u8][flags u8]}.
+   * The flags byte is reserved extension space for every page kind (all bits zero in V0) —
+   * without it, any additive change to a non-KVLP page required a global version bump.
+   */
+  static void writeVersionAndFlags(final BytesOut<?> sink) {
+    sink.writeByte(BinaryEncodingVersion.V0.byteVersion());
+    sink.writeByte((byte) 0);
+  }
+
+  /**
+   * Reads and validates the shared page envelope: the version byte (throws on unknown) and the
+   * reserved flags byte (must be zero in V0 — a nonzero value means a newer writer used an
+   * extension this build does not understand, so misparsing is not an option).
+   */
+  static BinaryEncodingVersion readVersionAndFlags(final BytesIn<?> source) {
+    final BinaryEncodingVersion version = BinaryEncodingVersion.fromByte(source.readByte());
+    final byte flags = source.readByte();
+    if (flags != 0) {
+      throw new IllegalStateException("Unknown page envelope flags 0x" + Integer.toHexString(flags & 0xFF)
+          + " — page written by a newer version");
+    }
+    return version;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -1452,27 +1452,34 @@ public enum PageKind {
      * doesn't pay (e.g. every record has a unique offset table or records
      * are raw slab bytes without offset-table structure).
      *
-     * <p>Wire layout:
+     * <p>Wire layout (the deserializer's two branches in {@code KEYVALUELEAFPAGE.deserializePage}
+     * are the authoritative reader):
      * <pre>
-     *   int[populatedCount] compactDir            // dataLength = ON-DISK length
-     *   int                 onDiskHeapSize        // == Σ on-disk lengths
-     *   byte                templateCount         // 0 = dedup disabled (fall back)
-     *   if templateCount &gt; 0:
-     *     byte              structuralFlags       // bit 0 = hash elision, bit 1 = parentKey column
+     *   byte                templateCount         // 0 = dedup disabled (inline fallback)
+     *   if templateCount &gt; 0 (dedup path):
+     *     byte              structuralFlags       // bit0 hashElision, bit1 parentKeyColumn,
+     *                                             // bit2 pathNodeKeyColumn, bit3 valueElision,
+     *                                             // bit4 nameKeyElision
      *     int               templatePoolBytes
-     *     byte[templatePoolBytes] templatePool
-     *     byte[populatedCount] slotTemplateIds
-     *     if hashElision:
-     *       byte[ceil(N/8)] zeroHashBitmap        // bit i = slot i's hash was stripped
-     *     if parentKeyColumn:
-     *       int             parentKeyColumnLen
-     *       byte[parentKeyColumnLen] parentKeyColumn  // StructuralKeyColumnCodec
      *     int               compressedLen
-     *     byte              codec                 // 0 = ZeroRunByteCodec, 1 = LZ4, 2 = ByteRunCodec, 3 = SirixLZ77Codec
-     *     byte[compressedLen] compressedHeap
-     *   if templateCount == 0:
-     *     byte[onDiskHeapSize] heapBytes          // inline, uncompressed
+     *     byte              codec                 // 0 ZeroRun, 1 LZ4, 2 ByteRun, 3 SirixLZ77
+     *     byte[compressedLen] blob — decompresses to, in order:
+     *       int[populatedCount] compactDir        // BE byte layout; dataLength = ON-DISK length
+     *       byte[templatePoolBytes] templatePool
+     *       byte[populatedCount]    slotTemplateIds
+     *       if hashElision:      byte[ceil(N/8)] zeroHashBitmap
+     *       if parentKeyColumn:  int len + byte[len]   (StructuralKeyColumnCodec)
+     *       if pathNodeKeyColumn:int len + byte[len]
+     *       if valueElision:     int len + section
+     *       if nameKeyElision:   int len + section
+     *       byte[onDiskHeapSize] heap
+     *   if templateCount == 0 (inline path):
+     *     int               compressedLen
+     *     byte              codec
+     *     byte[compressedLen] blob — decompresses to compactDir + heap
      * </pre>
+     * The smallest-of-codecs bake-off covers the whole blob (compactDir included), not just the
+     * heap.
      *
      * @param sink destination byte sink
      * @param slottedPage the slotted-page memory (in-memory format, full offset tables inline)

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -3839,8 +3839,8 @@ public enum PageKind {
       final byte layoutTypeId = source.readByte();
       final int numChildren = source.readInt();
       
-      final HOTIndirectPage.NodeType nodeType = HOTIndirectPage.NodeType.values()[nodeTypeId];
-      final HOTIndirectPage.LayoutType layoutType = HOTIndirectPage.LayoutType.values()[layoutTypeId];
+      final HOTIndirectPage.NodeType nodeType = HOTIndirectPage.NodeType.fromID(nodeTypeId);
+      final HOTIndirectPage.LayoutType layoutType = HOTIndirectPage.LayoutType.fromID(layoutTypeId);
 
       // Read layout-specific discriminative bit data
       final int initialBytePos;
@@ -3953,8 +3953,8 @@ public enum PageKind {
       Utils.putVarLong(sink, hotIndirect.getPageKey());
       sink.writeInt(hotIndirect.getRevision());
       sink.writeByte((byte) hotIndirect.getHeight());
-      sink.writeByte((byte) hotIndirect.getNodeType().ordinal());
-      sink.writeByte((byte) hotIndirect.getLayoutType().ordinal());
+      sink.writeByte(hotIndirect.getNodeType().getID());
+      sink.writeByte(hotIndirect.getLayoutType().getID());
       sink.writeInt(hotIndirect.getNumChildren());
       
       // Write layout-specific discriminative bit data

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
@@ -1,5 +1,6 @@
 package io.sirix.page;
 
+import io.sirix.node.LE;
 import io.sirix.settings.Constants;
 
 import java.lang.foreign.MemorySegment;
@@ -184,14 +185,13 @@ public final class PageLayout {
 
   // ==================== VALUE LAYOUTS ====================
 
-  private static final ValueLayout.OfLong JAVA_LONG_UNALIGNED =
-      ValueLayout.JAVA_LONG_UNALIGNED;
+  // Little-endian pinned (see io.sirix.node.LE): the header/bitmap block is bulk-copied to disk
+  // verbatim, so its scalar byte order IS on-disk format, not an in-memory detail.
+  private static final ValueLayout.OfLong JAVA_LONG_UNALIGNED = LE.LONG;
 
-  private static final ValueLayout.OfInt JAVA_INT_UNALIGNED =
-      ValueLayout.JAVA_INT.withByteAlignment(1);
+  private static final ValueLayout.OfInt JAVA_INT_UNALIGNED = LE.INT;
 
-  private static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED =
-      ValueLayout.JAVA_SHORT.withByteAlignment(1);
+  private static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED = LE.SHORT;
 
   // ==================== STATIC ASSERTIONS ====================
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
@@ -47,6 +47,15 @@ import java.lang.foreign.ValueLayout;
  * [fieldOffsetTable: fieldCount × 1 byte] — O(1) access to any field
  * [data region: varint fields + hash + optional payload]
  * </pre>
+ *
+ * <h2>Header redundancy — retained by design (format decision)</h2>
+ * The header's recordPageKey/revision/indexType duplicate information the reader already knows
+ * from the page's reference, and heapEnd/heapUsed are runtime bump-allocator state. They stay in
+ * the on-disk header deliberately: (1) "in-memory format = on-disk format" means the 160-byte
+ * block is bulk-copied verbatim — stripping fields would reintroduce a per-commit conversion
+ * pass; (2) the redundancy makes every page SELF-DESCRIBING, so recovery/forensic tooling can
+ * interpret a page from its bytes alone and readers can cross-check the header against the
+ * reference (a mismatch is corruption caught early). The cost is 21 bytes per ~64 KiB page.
  */
 public final class PageLayout {
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageLayout.java
@@ -592,13 +592,23 @@ public final class PageLayout {
   /**
    * Write a field offset into a record's offset table.
    *
+   * <p>The table entry is a single unsigned byte, so offsets are limited to 0-255. Current
+   * layouts keep the one unbounded (variable-length value) field last so preceding offsets stay
+   * in range; the guard turns a violation of that invariant into a loud error instead of a
+   * silently truncated offset that corrupts the record.
+   *
    * @param page        the page MemorySegment
    * @param recordBase  absolute byte offset of the record start
    * @param fieldIndex  the field index (0 to fieldCount-1)
    * @param offset      the field offset (0-255) relative to the data region start
+   * @throws IllegalStateException if the offset exceeds the unsigned-byte range of the table entry
    */
   public static void writeFieldOffset(final MemorySegment page, final long recordBase,
       final int fieldIndex, final int offset) {
+    if ((offset & ~0xFF) != 0) {
+      throw new IllegalStateException("Record field offset " + offset + " for field " + fieldIndex
+          + " exceeds the 1-byte offset-table range (0-255)");
+    }
     page.set(ValueLayout.JAVA_BYTE, recordBase + 1 + fieldIndex, (byte) offset);
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionCompact.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionCompact.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.page.pax;
 
+import io.sirix.node.LE;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 
@@ -202,7 +203,7 @@ public final class NumberRegionCompact {
     target.set(ValueLayout.JAVA_BYTE, pos, (byte) bitWidth);
     pos++;
     pos += writeVarintUnsigned(target, pos, count);
-    target.set(ValueLayout.JAVA_LONG_UNALIGNED, pos, minValue);
+    target.set(LE.LONG, pos, minValue);
     pos += 8L;
     final long bodyStart = pos;
     if (bodyBytes > 0L) {
@@ -279,7 +280,7 @@ public final class NumberRegionCompact {
       throw new IllegalStateException("illegal count=" + countLong);
     }
     out.count = (int) countLong;
-    out.minValue = src.get(ValueLayout.JAVA_LONG_UNALIGNED, headerOffset + 2L + varintBytes);
+    out.minValue = src.get(LE.LONG, headerOffset + 2L + varintBytes);
     out.headerBytes = 2 + varintBytes + 8;
     out.bodyOffset = headerOffset + out.headerBytes;
     out.bodyBytes = bodyBytes(out.count, out.bitWidth);
@@ -381,7 +382,7 @@ public final class NumberRegionCompact {
       // Raw 64-bit path: base is 0 (spread overflow => caller forced min=0).
       long off = baseOff;
       for (int i = 0; i < count; i++) {
-        target.set(ValueLayout.JAVA_LONG_UNALIGNED, off, values[i]);
+        target.set(LE.LONG, off, values[i]);
         off += 8L;
       }
       return;
@@ -444,7 +445,7 @@ public final class NumberRegionCompact {
   private static void writeBitPackWord(final MemorySegment target, final long off, final long word) {
     final long size = target.byteSize();
     if (off + 8L <= size) {
-      target.set(ValueLayout.JAVA_LONG_UNALIGNED, off, word);
+      target.set(LE.LONG, off, word);
       return;
     }
     final long remaining = Math.max(0L, size - off);
@@ -472,7 +473,7 @@ public final class NumberRegionCompact {
   private static long bitUnpack(final MemorySegment src, final long baseOff, final int bitWidth,
       final int index) {
     if (bitWidth == 64) {
-      return src.get(ValueLayout.JAVA_LONG_UNALIGNED, baseOff + ((long) index << 3));
+      return src.get(LE.LONG, baseOff + ((long) index << 3));
     }
     final long bitOff = (long) index * (long) bitWidth;
     final long byteOff = baseOff + (bitOff >>> 3);
@@ -498,7 +499,7 @@ public final class NumberRegionCompact {
   private static long readUpToLongLE(final MemorySegment src, final long off) {
     final long size = src.byteSize();
     if (off + 8L <= size) {
-      return src.get(ValueLayout.JAVA_LONG_UNALIGNED, off);
+      return src.get(LE.LONG, off);
     }
     if (off >= size) {
       return 0L;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.page.pax;
 
+import io.sirix.node.LE;
 import jdk.incubator.vector.LongVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
@@ -85,7 +86,7 @@ public final class NumberRegionSimd {
     }
     // Scalar tail.
     for (; i < end; i++) {
-      final long v = payload.get(ValueLayout.JAVA_LONG_UNALIGNED, (long) valueBytesOffset + (long) i * 8L);
+      final long v = payload.get(LE.LONG, (long) valueBytesOffset + (long) i * 8L);
       if (eval(v, op, threshold)) {
         count++;
       }
@@ -166,7 +167,7 @@ public final class NumberRegionSimd {
   private static long readWordSafe(final MemorySegment payload, final long payloadSize,
       final long byteOff) {
     if (byteOff + 8L <= payloadSize) {
-      return payload.get(ValueLayout.JAVA_LONG_UNALIGNED, byteOff);
+      return payload.get(LE.LONG, byteOff);
     }
     long word = 0L;
     final long remaining = Math.max(0L, payloadSize - byteOff);
@@ -234,7 +235,7 @@ public final class NumberRegionSimd {
       count += m1.and(m2).trueCount();
     }
     for (; i < end; i++) {
-      final long v = payload.get(ValueLayout.JAVA_LONG_UNALIGNED,
+      final long v = payload.get(LE.LONG,
           (long) valueBytesOffset + (long) i * 8L);
       if (eval(v, op1, threshold1) && eval(v, op2, threshold2)) {
         count++;
@@ -342,7 +343,7 @@ public final class NumberRegionSimd {
     long max = maxV.reduceLanes(VectorOperators.MAX);
     // Scalar tail.
     for (; i < end; i++) {
-      final long v = payload.get(ValueLayout.JAVA_LONG_UNALIGNED,
+      final long v = payload.get(LE.LONG,
           (long) valueBytesOffset + (long) i * 8L);
       sum += v;
       if (v < min) min = v;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/ObjectKeyNameKeyRegion.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/ObjectKeyNameKeyRegion.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.page.pax;
 
+import io.sirix.node.LE;
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
@@ -100,13 +101,13 @@ public final class ObjectKeyNameKeyRegion {
     seg.set(ValueLayout.JAVA_BYTE, 0L, (byte) numUnique);
     long off = 1;
     for (int i = 0; i < numUnique; i++) {
-      seg.set(ValueLayout.JAVA_INT_UNALIGNED, off, dict[i]);
+      seg.set(LE.INT, off, dict[i]);
       off += 4;
     }
-    seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, off, (short) count);
+    seg.set(LE.SHORT, off, (short) count);
     off += 2;
     for (int i = 0; i < 16; i++) {
-      seg.set(ValueLayout.JAVA_LONG_UNALIGNED, off, bitmap[i]);
+      seg.set(LE.LONG, off, bitmap[i]);
       off += 8;
     }
     MemorySegment.copy(dictIds, 0, seg, ValueLayout.JAVA_BYTE, off, count);

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/PathNodeKeyRegion.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/PathNodeKeyRegion.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.page.pax;
 
+import io.sirix.node.LE;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
@@ -106,13 +107,13 @@ public final class PathNodeKeyRegion {
     seg.set(ValueLayout.JAVA_BYTE, 0L, (byte) numUnique);
     long off = 1;
     for (int i = 0; i < numUnique; i++) {
-      seg.set(ValueLayout.JAVA_INT_UNALIGNED, off, dictScratch[i]);
+      seg.set(LE.INT, off, dictScratch[i]);
       off += 4;
     }
-    seg.set(ValueLayout.JAVA_SHORT_UNALIGNED, off, (short) count);
+    seg.set(LE.SHORT, off, (short) count);
     off += 2;
     for (int i = 0; i < 16; i++) {
-      seg.set(ValueLayout.JAVA_LONG_UNALIGNED, off, bitmapScratch[i]);
+      seg.set(LE.LONG, off, bitmapScratch[i]);
       off += 8;
     }
     MemorySegment.copy(dictIdsScratch, 0, seg, ValueLayout.JAVA_BYTE, off, count);

--- a/bundles/sirix-core/src/test/java/io/sirix/format/GoldenCompositePageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/format/GoldenCompositePageTest.java
@@ -1,0 +1,141 @@
+package io.sirix.format;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.Holder;
+import io.sirix.XmlTestHelper;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.exception.SirixException;
+import io.sirix.index.IndexType;
+import io.sirix.node.Bytes;
+import io.sirix.node.BytesOut;
+import io.sirix.node.SirixDeweyID;
+import io.sirix.node.xml.ElementNode;
+import io.sirix.page.HOTLeafPage;
+import io.sirix.page.KeyValueLeafPage;
+import io.sirix.page.PagePersister;
+import io.sirix.page.SerializationType;
+import io.sirix.settings.Constants;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+
+import static io.sirix.cache.LinuxMemorySegmentAllocator.SIXTYFOUR_KB;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Golden byte-pins for COMPOSITE pages — a populated {@link KeyValueLeafPage} (record heap,
+ * compact directory, structural encoders, PAX assembly) and a populated {@link HOTLeafPage}.
+ * Together with {@link GoldenFormatTest} (headers, envelopes, single records, codecs, id
+ * registries) this pins whole-page composition: any byte-level change to the serialization
+ * pipeline fails here and must be shipped as a conscious format bump.
+ */
+public final class GoldenCompositePageTest {
+
+  private Holder holder;
+  private StorageEngineReader storageEngineReader;
+  private Arena arena;
+
+  @Before
+  public void setUp() throws SirixException {
+    XmlTestHelper.closeEverything();
+    XmlTestHelper.deleteEverything();
+    XmlTestHelper.createTestDocument();
+    holder = Holder.generateDeweyIDResourceSession();
+    storageEngineReader = holder.getResourceSession().createStorageEngineReader();
+    arena = Arena.ofConfined();
+  }
+
+  @After
+  public void tearDown() throws SirixException {
+    storageEngineReader.close();
+    holder.close();
+    XmlTestHelper.closeEverything();
+    XmlTestHelper.deleteEverything();
+    arena.close();
+  }
+
+  private static final String GOLDEN_KVLP =
+      "01000000010000000100000000000000000100000002005600000056000000010000000000000000"
+          + "00030000000000000000000000000000000000000000000000000000000000000000000000000000"
+          + "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
+          + "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
+          + "000000000000000000020000003a0000000100110000005700000003fd554000001d010400f12901"
+          + "0f000102030405060708090a0b131415000001000309071919030c0e0a01000f1d506d3cfcc7dd02"
+          + "0002b10102c70101000105071717011d00f001c0f638d2d64b9c6b020002af0102c5010000000000"
+          + "000000000000000000";
+
+  private static final String GOLDEN_HOT_LEAF =
+      "0c00000101000000050000030000002f00000000000000100000001f0000000500616c7068610700"
+          + "76616c75652d31040062657461070076616c75652d32050067616d6d61070076616c75652d33";
+
+  @Test
+  public void keyValueLeafPageBytesArePinned() throws IOException {
+    final var config = storageEngineReader.getResourceSession().getResourceConfig();
+    final KeyValueLeafPage page = new KeyValueLeafPage(0L, IndexType.DOCUMENT, config,
+        storageEngineReader.getRevisionNumber(), arena.allocate(SIXTYFOUR_KB), null);
+    try {
+      page.setRecord(elementNode(config, 0L, 3L, 4L));
+      page.setRecord(elementNode(config, 1L, 4L, 3L));
+
+      final BytesOut<?> data = Bytes.elasticOffHeapByteBuffer();
+      new PagePersister().serializePage(config, data, page, SerializationType.DATA);
+      assertGolden("kvlp", GOLDEN_KVLP, hex(data.toByteArray()));
+    } finally {
+      page.close();
+    }
+  }
+
+  @Test
+  public void hotLeafPageBytesArePinned() throws IOException {
+    final var config = storageEngineReader.getResourceSession().getResourceConfig();
+    final MemorySegment slotMemory = arena.allocate(SIXTYFOUR_KB);
+    final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.PATH, slotMemory, null,
+        new int[HOTLeafPage.MAX_ENTRIES], 0, 0);
+    try {
+      page.put("alpha".getBytes(StandardCharsets.UTF_8), "value-1".getBytes(StandardCharsets.UTF_8));
+      page.put("beta".getBytes(StandardCharsets.UTF_8), "value-2".getBytes(StandardCharsets.UTF_8));
+      page.put("gamma".getBytes(StandardCharsets.UTF_8), "value-3".getBytes(StandardCharsets.UTF_8));
+
+      final BytesOut<?> data = Bytes.elasticOffHeapByteBuffer();
+      new PagePersister().serializePage(config, data, page, SerializationType.DATA);
+      assertGolden("hot-leaf", GOLDEN_HOT_LEAF, hex(data.toByteArray()));
+    } finally {
+      page.close();
+    }
+  }
+
+  private static ElementNode elementNode(final io.sirix.access.ResourceConfiguration config, final long nodeKey,
+      final long leftSibling, final long rightSibling) {
+    final LongArrayList attributeKeys = new LongArrayList();
+    attributeKeys.add(88L);
+    final LongArrayList namespaceKeys = new LongArrayList();
+    namespaceKeys.add(99L);
+    final ElementNode node = new ElementNode(nodeKey, 1L, Constants.NULL_REVISION_NUMBER, 0, rightSibling,
+        leftSibling, 12L, 12L, config.storeChildCount() ? 1L : 0L, 0L, 0L, 1L, 6, 7, 5, config.nodeHashFunction,
+        SirixDeweyID.newRootID(), attributeKeys, namespaceKeys, new QNm("a", "b", "c"));
+    node.setHash(node.computeHash(Bytes.elasticOffHeapByteBuffer()));
+    return node;
+  }
+
+  private static void assertGolden(final String what, final String expected, final String actual) {
+    if ("TBD".equals(expected)) {
+      System.out.println("GOLDEN[" + what + "]=" + actual);
+      throw new AssertionError("Golden constant for " + what + " not yet recorded; actual printed above");
+    }
+    assertEquals(what, expected, actual);
+  }
+
+  private static String hex(final byte[] bytes) {
+    final StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (final byte b : bytes) {
+      sb.append(Character.forDigit((b >>> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+    }
+    return sb.toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/format/GoldenFormatTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/format/GoldenFormatTest.java
@@ -1,0 +1,251 @@
+package io.sirix.format;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.index.IndexType;
+import io.sirix.io.Superblock;
+import io.sirix.io.bytepipe.FFILz4Compressor;
+import io.sirix.io.bytepipe.JavaLz4BlockDecoder;
+import io.sirix.node.Bytes;
+import io.sirix.node.BytesOut;
+import io.sirix.node.DeltaVarIntCodec;
+import io.sirix.node.NodeKind;
+import io.sirix.node.RevisionReferencesNode;
+import io.sirix.page.PageKind;
+import io.sirix.page.PagePersister;
+import io.sirix.page.SerializationType;
+import io.sirix.page.UberPage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Golden-file tests: pin the EXACT bytes of representative serialized structures so that any
+ * accidental change to the binary format fails CI instead of silently breaking every existing
+ * resource. A legitimate format change must update these constants consciously — together with a
+ * {@code BinaryEncodingVersion}/superblock-version bump and a migration note in
+ * {@code docs/DISK_FORMAT.md}.
+ */
+public final class GoldenFormatTest {
+
+  private StorageEngineWriter storageEngineWriter;
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    storageEngineWriter = database.beginResourceSession(JsonTestHelper.RESOURCE).createStorageEngineWriter();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  // ==================== golden constants ====================
+
+  private static final String GOLDEN_SUPERBLOCK_DATA =
+      "53495249584442210000000000000000040302010010000000100000000000000030000000000000"
+          + "000000000000000000000000000000008b366a74bdb5c9f2";
+  private static final String GOLDEN_SUPERBLOCK_REVISIONS =
+      "53495249584442210000000001000000040302012000000000000000000000000010000000000000"
+          + "000000000000000000000000000000005cf2431e4f70b533";
+  private static final String GOLDEN_UBER_PAGE = "03000001000000";
+  private static final String GOLDEN_REVISION_REFERENCES_NODE = "230003000000030000000700000004010000";
+  private static final String GOLDEN_VARINTS = "0001fe01d804808080808040ffffffffffffffff7f0300959aef3a";
+  private static final String GOLDEN_ROARING64 =
+      "01020000000000000000020002000000000100040000000000000000000000000000000000040000"
+          + "00000001000000010000000000000001000000fe02000000010202000000010064000102010000000"
+          + "00002000000000000000000000001000000";
+
+  /** Stable id registries — changing any value is an on-disk format break. */
+  private static final String GOLDEN_PAGE_KIND_IDS =
+      "KEYVALUELEAFPAGE=1,NAMEPAGE=2,UBERPAGE=3,INDIRECTPAGE=4,REVISIONROOTPAGE=5,PATHSUMMARYPAGE=6,"
+          + "CASPAGE=8,OVERFLOWPAGE=9,PATHPAGE=10,DEWEYIDPAGE=11,HOT_LEAF_PAGE=12,HOT_INDIRECT_PAGE=13,"
+          + "BITMAP_CHUNK_PAGE=14,VECTORPAGE=15,PROJECTIONPAGE=16,VALIDTIMEPAGE=17";
+
+  private static final String GOLDEN_INDEX_TYPE_IDS =
+      "REVISIONS=0,DOCUMENT=1,CHANGED_NODES=2,RECORD_TO_REVISIONS=3,PATH_SUMMARY=4,PATH=5,CAS=6,"
+          + "NAME=7,DEWEYID_TO_RECORDID=8,VECTOR=9,PROJECTION=10,VALIDTIME=11";
+
+  // ==================== cases ====================
+
+  @Test
+  public void superblockBytesArePinned() {
+    final String dataHex = hex(Superblock.build(Superblock.ROLE_DATA));
+    final String revisionsHex = hex(Superblock.build(Superblock.ROLE_REVISIONS));
+    assertGolden("superblock-data", GOLDEN_SUPERBLOCK_DATA, dataHex);
+    assertGolden("superblock-revisions", GOLDEN_SUPERBLOCK_REVISIONS, revisionsHex);
+  }
+
+  @Test
+  public void uberPageBytesArePinned() throws IOException {
+    final var config = storageEngineWriter.getResourceSession().getResourceConfig();
+    final UberPage uberPage = new UberPage();
+    final BytesOut<?> sink = Bytes.elasticOffHeapByteBuffer();
+    new PagePersister().serializePage(config, sink, uberPage, SerializationType.DATA);
+    assertGolden("uber-page", GOLDEN_UBER_PAGE, hex(sink));
+  }
+
+  @Test
+  public void revisionReferencesNodeBytesArePinned() {
+    final var config = storageEngineWriter.getResourceSession().getResourceConfig();
+    final var node = new RevisionReferencesNode(42, new int[] {3, 7, 260});
+    final NodeKind kind = (NodeKind) node.getKind();
+    final BytesOut<?> sink = Bytes.elasticOffHeapByteBuffer();
+    sink.writeByte(kind.getId());
+    kind.serialize(sink, node, config);
+    assertGolden("revision-references-node", GOLDEN_REVISION_REFERENCES_NODE, hex(sink));
+  }
+
+  @Test
+  public void deltaVarIntEncodingsArePinned() {
+    final BytesOut<?> sink = Bytes.elasticOffHeapByteBuffer();
+    DeltaVarIntCodec.encodeSigned(sink, 0);
+    DeltaVarIntCodec.encodeSigned(sink, -1);
+    DeltaVarIntCodec.encodeSigned(sink, 127);
+    DeltaVarIntCodec.encodeSigned(sink, 300);
+    DeltaVarIntCodec.encodeSignedLong(sink, 1L << 40);
+    DeltaVarIntCodec.encodeSignedLong(sink, Long.MIN_VALUE / 2);
+    DeltaVarIntCodec.encodeDelta(sink, 1001, 1000);
+    DeltaVarIntCodec.encodeDelta(sink, io.sirix.settings.Fixed.NULL_NODE_KEY.getStandardProperty(), 1000);
+    DeltaVarIntCodec.encodeAbsolute(sink, 123456789L);
+    assertGolden("varints", GOLDEN_VARINTS, hex(sink));
+  }
+
+  @Test
+  public void roaring64SerializationIsPinned() throws IOException {
+    // Third-party format coupling: NamePage and node-reference sets embed Roaring64Bitmap's
+    // portable serialization. If the library ever changes its wire format, this fails.
+    final Roaring64Bitmap bitmap = new Roaring64Bitmap();
+    bitmap.addLong(1L);
+    bitmap.addLong(100L);
+    bitmap.addLong(1L << 40);
+    bitmap.runOptimize();
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    bitmap.serialize(new DataOutputStream(bos));
+    assertGolden("roaring64", GOLDEN_ROARING64, hex(bos.toByteArray()));
+  }
+
+  @Test
+  public void lz4BlockDecoderDecodesHandcraftedBlock() {
+    // [token lit=4|match=4] "abcd" [dist=4 LE] → "abcd" + 8-byte overlapping match; final token 0x00.
+    final byte[] block = {0x44, 'a', 'b', 'c', 'd', 0x04, 0x00, 0x00};
+    try (Arena arena = Arena.ofConfined()) {
+      final MemorySegment src = arena.allocate(block.length);
+      MemorySegment.copy(block, 0, src, ValueLayout.JAVA_BYTE, 0, block.length);
+      final MemorySegment dst = arena.allocate(64);
+      final int n = JavaLz4BlockDecoder.decompressSafe(src, 0, block.length, dst, 0, 64);
+      final byte[] out = new byte[n];
+      MemorySegment.copy(dst, ValueLayout.JAVA_BYTE, 0, out, 0, n);
+      assertEquals("abcdabcdabcd", new String(out, StandardCharsets.US_ASCII));
+    }
+  }
+
+  @Test
+  public void lz4BlockDecoderMatchesNativeCompressor() {
+    // When liblz4 is present, prove the pure-Java decoder consumes real native-compressed
+    // blocks — the exact bytes an LZ4-capable host persists and an LZ4-less host must read.
+    final FFILz4Compressor lz4 = new FFILz4Compressor();
+    final byte[] input = new byte[8192];
+    for (int i = 0; i < input.length; i++) {
+      input[i] = (byte) ((i * 31 + (i >>> 5)) & 0x3F); // repetitive → compressible
+    }
+    try (Arena arena = Arena.ofConfined()) {
+      final MemorySegment src = arena.allocate(input.length);
+      MemorySegment.copy(input, 0, src, ValueLayout.JAVA_BYTE, 0, input.length);
+      final MemorySegment compressed = arena.allocate(lz4.compressBound(input.length));
+      final int compressedLen;
+      try {
+        compressedLen = lz4.compressSegment(src, compressed);
+      } catch (UnsupportedOperationException nativeUnavailable) {
+        return; // no liblz4 on this host — the handcrafted-block test still covers the decoder
+      }
+      final MemorySegment out = arena.allocate(input.length);
+      final int n = JavaLz4BlockDecoder.decompressSafe(compressed, 0, compressedLen, out, 0, input.length);
+      assertEquals(input.length, n);
+      final byte[] roundTripped = new byte[n];
+      MemorySegment.copy(out, ValueLayout.JAVA_BYTE, 0, roundTripped, 0, n);
+      assertArrayEquals(input, roundTripped);
+    }
+  }
+
+  @Test
+  public void pageKindIdsArePinned() {
+    final StringJoiner joiner = new StringJoiner(",");
+    for (final PageKind kind : PageKind.values()) {
+      joiner.add(kind.name() + "=" + (kind.getID() & 0xFF));
+    }
+    assertEquals(GOLDEN_PAGE_KIND_IDS, joiner.toString());
+  }
+
+  @Test
+  public void nodeKindIdsArePinned() {
+    final StringJoiner joiner = new StringJoiner(",");
+    for (final NodeKind kind : NodeKind.values()) {
+      joiner.add(kind.name() + "=" + kind.getId());
+    }
+    assertGolden("node-kind-ids", GOLDEN_NODE_KIND_IDS, joiner.toString());
+  }
+
+  private static final String GOLDEN_NODE_KIND_IDS =
+      "ELEMENT=1,ATTRIBUTE=2,NAMESPACE=13,TEXT=3,PROCESSING_INSTRUCTION=7,COMMENT=8,XML_DOCUMENT=9,"
+          + "WHITESPACE=4,DELETE=5,NULL=6,DUMB=20,ATOMIC=15,PATH=16,CASRB=17,PATHRB=18,NAMERB=19,"
+          + "RB_NODE_VALUE=55,DEWEYIDMAPPING=23,OBJECT=24,ARRAY=25,OBJECT_NAMED_BOOLEAN=48,"
+          + "OBJECT_NAMED_NUMBER=49,OBJECT_NAMED_STRING=50,OBJECT_NAMED_NULL=51,OBJECT_NAMED_OBJECT=52,"
+          + "OBJECT_NAMED_ARRAY=53,STRING_VALUE=30,BOOLEAN_VALUE=27,NUMBER_VALUE=28,NULL_VALUE=29,"
+          + "JSON_DOCUMENT=31,HASH_ENTRY=32,HASH_NAME_COUNT_TO_NAME_ENTRY=33,DEWEY_ID_NODE=34,"
+          + "REVISION_REFERENCES_NODE=35,PROJECTION_INDEX_LEAF=44,VECTOR_NODE=56,VECTOR_INDEX_METADATA=58,"
+          + "UNKNOWN=22";
+
+  @Test
+  public void indexTypeIdsArePinned() {
+    final StringJoiner joiner = new StringJoiner(",");
+    for (final IndexType type : IndexType.values()) {
+      joiner.add(type.name() + "=" + type.getID());
+    }
+    assertEquals(GOLDEN_INDEX_TYPE_IDS, joiner.toString());
+  }
+
+  // ==================== helpers ====================
+
+  private static void assertGolden(final String what, final String expected, final String actual) {
+    if ("TBD".equals(expected)) {
+      System.out.println("GOLDEN[" + what + "]=" + actual);
+      throw new AssertionError("Golden constant for " + what + " not yet recorded; actual printed above");
+    }
+    assertEquals(what, expected, actual);
+  }
+
+  private static String hex(final BytesOut<?> sink) {
+    return hex(sink.toByteArray());
+  }
+
+  private static String hex(final ByteBuffer buf) {
+    final byte[] bytes = new byte[buf.remaining()];
+    buf.duplicate().get(bytes);
+    return hex(bytes);
+  }
+
+  private static String hex(final byte[] bytes) {
+    final StringBuilder sb = new StringBuilder(bytes.length * 2);
+    for (final byte b : bytes) {
+      sb.append(Character.forDigit((b >>> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+    }
+    return sb.toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexDenseCompositeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexDenseCompositeTest.java
@@ -235,9 +235,9 @@ public final class ProjectionIndexDenseCompositeTest {
         "cardinality above the limit must bail");
     // Tail-less (malformed) leaf — no presence info, must fail closed.
     final byte[] full = payloads.get(0);
-    final int tailLen = (full[full.length - 8] & 0xFF) | ((full[full.length - 7] & 0xFF) << 8)
-        | ((full[full.length - 6] & 0xFF) << 16) | ((full[full.length - 5] & 0xFF) << 24);
-    final byte[] truncated = Arrays.copyOf(full, full.length - 8 - tailLen);
+    final int tailLen = (full[full.length - 9] & 0xFF) | ((full[full.length - 8] & 0xFF) << 8)
+        | ((full[full.length - 7] & 0xFF) << 16) | ((full[full.length - 6] & 0xFF) << 24);
+    final byte[] truncated = Arrays.copyOf(full, full.length - 9 - tailLen);
     assertNull(ProjectionIndexByteScan.distinctPresentStrings(List.of(truncated), 1, 1024));
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
@@ -73,10 +73,10 @@ public final class ProjectionIndexIntegralityPersistenceTest {
     return (b[off] & 0xFF) | ((b[off + 1] & 0xFF) << 8) | ((b[off + 2] & 0xFF) << 16) | ((b[off + 3] & 0xFF) << 24);
   }
 
-  /** Strip the mandatory presence tail — a corrupt/truncated payload. */
+  /** Strip the mandatory presence tail (9-byte footer: tailLen + version + magic) — a corrupt/truncated payload. */
   private static byte[] stripTail(final byte[] payload) {
-    final int tailLen = intLE(payload, payload.length - 8);
-    return Arrays.copyOf(payload, payload.length - 8 - tailLen);
+    final int tailLen = intLE(payload, payload.length - 9);
+    return Arrays.copyOf(payload, payload.length - 9 - tailLen);
   }
 
   // ==================== leaf round-trip ====================

--- a/bundles/sirix-core/src/test/java/io/sirix/io/StorageBackendInteropTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/StorageBackendInteropTest.java
@@ -1,0 +1,200 @@
+package io.sirix.io;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.json.objectvalue.StringValue;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.exception.SirixIOException;
+import io.sirix.exception.SirixUsageException;
+import io.sirix.service.json.serialize.JsonSerializer;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Cross-backend format checks: `docs/DISK_FORMAT.md` §4 claims FILE_CHANNEL (default) and
+ * MEMORY_MAPPED share ONE on-disk format. This test proves it end-to-end — a resource written
+ * by either backend opens, verifies (superblock incl. resource UUID, page checksums), reads
+ * identically, and accepts further commits under the other backend. It also proves the
+ * resource-UUID cross-link catches wrong-file mixups on the real open path, and that the
+ * unavailable/removed backends (FILE, IO_URING, S3) fail fast with actionable errors instead of
+ * misreading anything.
+ */
+public final class StorageBackendInteropTest {
+
+  private static final String RESOURCE = "interop-resource";
+  private static final String JSON = "{\"name\":\"sirix\",\"backends\":[\"fc\",\"mm\"],\"n\":42}";
+
+  @TempDir
+  private Path tempDir;
+
+  @BeforeEach
+  @AfterEach
+  public void cleanState() throws IOException {
+    Databases.clearGlobalCaches();
+    if (Files.exists(tempDir)) {
+      try (Stream<Path> paths = Files.walk(tempDir)) {
+        paths.sorted(Comparator.reverseOrder()).filter(p -> !p.equals(tempDir)).forEach(p -> p.toFile().delete());
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Resource written via FILE_CHANNEL opens and grows via MEMORY_MAPPED")
+  public void fileChannelResourceOpensViaMemoryMapped() throws IOException {
+    writtenWithOpensWith(StorageType.FILE_CHANNEL, StorageType.MEMORY_MAPPED);
+  }
+
+  @Test
+  @DisplayName("Resource written via MEMORY_MAPPED opens and grows via FILE_CHANNEL")
+  public void memoryMappedResourceOpensViaFileChannel() throws IOException {
+    writtenWithOpensWith(StorageType.MEMORY_MAPPED, StorageType.FILE_CHANNEL);
+  }
+
+  private void writtenWithOpensWith(final StorageType writer, final StorageType reader) throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(tempDir));
+    final String goldenJson;
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(tempDir)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE).storageType(writer).build());
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE);
+          final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(JSON), JsonNodeTrx.Commit.NO);
+        wtx.commit();
+      }
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        goldenJson = serialize(session);
+      }
+    }
+
+    // Cold "process": swap the persisted backend in ressetting.obj — the files themselves are
+    // the shared format and must be bit-compatible.
+    Databases.clearGlobalCaches();
+    swapPersistedBackend(writer, reader);
+
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(tempDir)) {
+      try (final JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        assertEquals(reader, session.getResourceConfig().storageType,
+            "test wiring: the persisted backend swap must be in effect");
+        assertEquals(goldenJson, serialize(session),
+            "revision 1 must read back byte-identically under " + reader);
+        try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.moveToDocumentRoot();
+          wtx.moveToFirstChild();
+          wtx.insertObjectRecordAsFirstChild("addedBy", new StringValue(reader.name()));
+          wtx.commit();
+        }
+        assertEquals(2, session.getMostRecentRevisionNumber(),
+            "the other backend must be able to COMMIT on top of the shared format");
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Resource-UUID cross-link rejects a swapped-in foreign data file on both backends")
+  public void foreignDataFileFailsUuidCheck() throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(tempDir));
+    try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(tempDir)) {
+      for (final String name : new String[] {"res-a", "res-b"}) {
+        db.createResource(ResourceConfiguration.newBuilder(name).storageType(StorageType.FILE_CHANNEL).build());
+        try (final JsonResourceSession session = db.beginResourceSession(name);
+            final JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(JSON), JsonNodeTrx.Commit.NO);
+          wtx.commit();
+        }
+      }
+    }
+
+    Databases.clearGlobalCaches();
+    final Path dataA = findFile("res-a", "sirix.data");
+    final Path dataB = findFile("res-b", "sirix.data");
+    Files.copy(dataB, dataA, StandardCopyOption.REPLACE_EXISTING);
+
+    for (final StorageType backend : new StorageType[] {StorageType.FILE_CHANNEL, StorageType.MEMORY_MAPPED}) {
+      Databases.clearGlobalCaches();
+      swapPersistedBackendOf("res-a", backend);
+      try (final Database<JsonResourceSession> db = Databases.openJsonDatabase(tempDir)) {
+        try (final JsonResourceSession session = db.beginResourceSession("res-a")) {
+          serialize(session);
+          fail("opening res-a with res-b's data file must fail the UUID cross-check under " + backend);
+        } catch (final SirixIOException | SirixUsageException e) {
+          assertTrue(messageChain(e).contains("resource UUID mismatch"),
+              backend + ": expected a resource-UUID mismatch error but got: " + messageChain(e));
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("Removed/absent backends fail fast with actionable errors")
+  public void unavailableBackendsFailFast() {
+    final ResourceConfiguration config = ResourceConfiguration.newBuilder("unused").build();
+    final UnsupportedOperationException file =
+        assertThrows(UnsupportedOperationException.class, () -> StorageType.FILE.getInstance(config));
+    assertTrue(file.getMessage().contains("FILE_CHANNEL"));
+    final SirixIOException iouring =
+        assertThrows(SirixIOException.class, () -> StorageType.IO_URING.getInstance(config));
+    assertTrue(iouring.getMessage().contains("io_uring"));
+    final SirixIOException s3 = assertThrows(SirixIOException.class, () -> StorageType.S3.getInstance(config));
+    assertTrue(s3.getMessage().contains("S3"));
+  }
+
+  // ==================== helpers ====================
+
+  private static String serialize(final JsonResourceSession session) throws IOException {
+    final StringWriter writer = new StringWriter();
+    final JsonSerializer serializer = new JsonSerializer.Builder(session, writer).build();
+    serializer.call();
+    return writer.toString();
+  }
+
+  private void swapPersistedBackend(final StorageType from, final StorageType to) throws IOException {
+    final Path config = findFile(RESOURCE, "ressetting.obj");
+    final String json = Files.readString(config);
+    assertTrue(json.contains("\"" + from.name() + "\""), "config must persist the writer backend");
+    Files.writeString(config, json.replace("\"" + from.name() + "\"", "\"" + to.name() + "\""));
+  }
+
+  private void swapPersistedBackendOf(final String resource, final StorageType to) throws IOException {
+    final Path config = findFile(resource, "ressetting.obj");
+    final String json = Files.readString(config)
+        .replace("\"" + StorageType.FILE_CHANNEL.name() + "\"", "\"" + to.name() + "\"")
+        .replace("\"" + StorageType.MEMORY_MAPPED.name() + "\"", "\"" + to.name() + "\"");
+    Files.writeString(config, json);
+  }
+
+  private Path findFile(final String resource, final String fileName) throws IOException {
+    try (Stream<Path> paths = Files.walk(tempDir)) {
+      return paths.filter(p -> p.getFileName().toString().equals(fileName)
+              && p.toString().contains(resource))
+          .findFirst()
+          .orElseThrow(() -> new AssertionError(fileName + " not found for resource " + resource));
+    }
+  }
+
+  private static String messageChain(final Throwable throwable) {
+    final StringBuilder sb = new StringBuilder();
+    for (Throwable t = throwable; t != null; t = t.getCause()) {
+      sb.append(t.getMessage()).append(" | ");
+    }
+    return sb.toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/io/SuperblockResourceUuidTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/SuperblockResourceUuidTest.java
@@ -1,0 +1,59 @@
+package io.sirix.io;
+
+import io.sirix.exception.SirixIOException;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The superblock's resource UUID cross-links the binary files to their resource-settings JSON:
+ * a matching pair validates, a mismatched pair (files restored from a different resource's
+ * backup) fails fast, and a zero UUID on either side (legacy file or legacy config) skips the
+ * cross-check.
+ */
+public final class SuperblockResourceUuidTest {
+
+  private static final long MSB = 0x0011223344556677L;
+  private static final long LSB = 0x8899AABBCCDDEEFFL;
+
+  @Test
+  public void matchingUuidValidates() {
+    final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA, MSB, LSB);
+    Superblock.validate(sb, Superblock.ROLE_DATA, "sirix.data", MSB, LSB);
+  }
+
+  @Test
+  public void mismatchedUuidFailsFast() {
+    final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA, MSB, LSB);
+    final SirixIOException e = assertThrows(SirixIOException.class,
+        () -> Superblock.validate(sb, Superblock.ROLE_DATA, "sirix.data", MSB, LSB + 1));
+    assertTrue(e.getMessage().contains("resource UUID mismatch"));
+  }
+
+  @Test
+  public void zeroStoredUuidIsLegacyAndSkipsCheck() {
+    final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA);
+    Superblock.validate(sb, Superblock.ROLE_DATA, "sirix.data", MSB, LSB);
+  }
+
+  @Test
+  public void zeroExpectedUuidIsLegacyAndSkipsCheck() {
+    final ByteBuffer sb = Superblock.build(Superblock.ROLE_REVISIONS, MSB, LSB);
+    Superblock.validate(sb, Superblock.ROLE_REVISIONS, "sirix.revisions", 0L, 0L);
+  }
+
+  @Test
+  public void uuidIsCoveredByTheHeaderChecksum() {
+    final ByteBuffer sb = Superblock.build(Superblock.ROLE_DATA, MSB, LSB);
+    final ByteBuffer corrupted = ByteBuffer.allocate(Superblock.BYTES);
+    corrupted.put(sb.duplicate());
+    corrupted.put(40, (byte) (corrupted.get(40) ^ 0x01)); // flip a UUID bit
+    corrupted.flip();
+    final SirixIOException e = assertThrows(SirixIOException.class,
+        () -> Superblock.validate(corrupted, Superblock.ROLE_DATA, "sirix.data", 0L, 0L));
+    assertTrue(e.getMessage().contains("checksum"));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/node/NameRBNodeEncodingTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/node/NameRBNodeEncodingTest.java
@@ -1,0 +1,60 @@
+package io.sirix.node;
+
+import io.brackit.query.atomic.QNm;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.index.redblacktree.RBNodeKey;
+import io.sirix.node.delegates.NodeDelegate;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Round-trips a NAMERB (name red-black index) node with non-ASCII names to pin the on-disk
+ * string encoding to UTF-8 — the serializer must never fall back to the platform-default
+ * charset, or names corrupt on any JVM whose default is not UTF-8.
+ */
+public final class NameRBNodeEncodingTest {
+
+  private StorageEngineWriter storageEngineWriter;
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    storageEngineWriter = database.beginResourceSession(JsonTestHelper.RESOURCE).createStorageEngineWriter();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  public void nonAsciiNameRoundTripsAsUtf8() {
+    final ResourceConfiguration config = storageEngineWriter.getResourceSession().getResourceConfig();
+    final QNm name = new QNm("https://example.org/ünïcode", "präfix", "地方élément");
+    final NodeDelegate nodeDelegate = new NodeDelegate(7, 3, config.nodeHashFunction, 0, 0, (byte[]) null);
+    final RBNodeKey<QNm> node = new RBNodeKey<>(name, 42, nodeDelegate);
+    node.setLeftChildKey(11);
+    node.setRightChildKey(13);
+    node.setChanged(true);
+
+    final BytesOut<?> data = Bytes.elasticOffHeapByteBuffer();
+    NodeKind.NAMERB.serialize(data, node, config);
+
+    @SuppressWarnings("unchecked")
+    final RBNodeKey<QNm> deserialized =
+        (RBNodeKey<QNm>) NodeKind.NAMERB.deserialize(data.asBytesIn(), node.getNodeKey(), null, config);
+
+    assertEquals(name, deserialized.getKey());
+    assertEquals(42, deserialized.getValueNodeKey());
+    assertEquals(11, deserialized.getLeftChildKey());
+    assertEquals(13, deserialized.getRightChildKey());
+    assertTrue(deserialized.isChanged());
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/node/StableIdEncodingTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/node/StableIdEncodingTest.java
@@ -1,0 +1,66 @@
+package io.sirix.node;
+
+import io.sirix.index.IndexType;
+import io.sirix.page.HOTIndirectPage;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Pins the stable on-disk id contracts: every persisted enum id must round-trip through its
+ * lookup, unknown ids must fail fast with a descriptive error (never NPE/AIOOBE or a silently
+ * wrong constant), and the id assignments themselves must not drift — a change here is an
+ * on-disk format break.
+ */
+public final class StableIdEncodingTest {
+
+  @Test
+  public void everyNodeKindIdRoundTrips() {
+    for (final NodeKind kind : NodeKind.values()) {
+      assertSame(kind, NodeKind.getKind(kind.getId()));
+    }
+  }
+
+  @Test
+  public void unknownNodeKindIdFailsFast() {
+    final IllegalStateException inRange =
+        assertThrows(IllegalStateException.class, () -> NodeKind.getKind((byte) 100));
+    assertTrue(inRange.getMessage().contains("100"));
+    // Ids >= 128 arrive as negative bytes; before the guard this was an AIOOBE.
+    assertThrows(IllegalStateException.class, () -> NodeKind.getKind((byte) 0xFE));
+  }
+
+  @Test
+  public void hotIndirectNodeTypeIdsAreStable() {
+    assertEquals(0, HOTIndirectPage.NodeType.SPAN_NODE.getID());
+    assertEquals(1, HOTIndirectPage.NodeType.MULTI_NODE.getID());
+    for (final HOTIndirectPage.NodeType type : HOTIndirectPage.NodeType.values()) {
+      assertSame(type, HOTIndirectPage.NodeType.fromID(type.getID()));
+    }
+    assertThrows(IllegalStateException.class, () -> HOTIndirectPage.NodeType.fromID((byte) 2));
+    assertThrows(IllegalStateException.class, () -> HOTIndirectPage.NodeType.fromID((byte) -1));
+  }
+
+  @Test
+  public void hotIndirectLayoutTypeIdsAreStable() {
+    assertEquals(0, HOTIndirectPage.LayoutType.SINGLE_MASK.getID());
+    assertEquals(1, HOTIndirectPage.LayoutType.MULTI_MASK.getID());
+    for (final HOTIndirectPage.LayoutType type : HOTIndirectPage.LayoutType.values()) {
+      assertSame(type, HOTIndirectPage.LayoutType.fromID(type.getID()));
+    }
+    assertThrows(IllegalStateException.class, () -> HOTIndirectPage.LayoutType.fromID((byte) 2));
+    assertThrows(IllegalStateException.class, () -> HOTIndirectPage.LayoutType.fromID((byte) -1));
+  }
+
+  @Test
+  public void everyIndexTypeIdRoundTrips() {
+    for (final IndexType type : IndexType.values()) {
+      assertSame(type, IndexType.getType(type.getID()));
+    }
+    assertThrows(IllegalStateException.class, () -> IndexType.getType((byte) 120));
+    assertThrows(IllegalStateException.class, () -> IndexType.getType((byte) -1));
+  }
+}

--- a/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
+++ b/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
@@ -1,0 +1,145 @@
+# Binary Encoding Future-Proofing Audit
+
+Scope: the complete persisted format — file headers, page envelope, page bodies, node records,
+secondary indexes, codecs, and configuration — audited for evolvability (can V1 be introduced
+without breaking V0 files?), portability (endianness, native libraries, JVM/platform behavior),
+and fail-fast behavior on unknown/foreign input. All references verified against this tree.
+
+Overall verdict: **the versioning skeleton is in place and mostly sound** (superblocks, per-page
+kind + version bytes, explicit stable kind ids, checksummed roots, fail-fast on unknown
+versions), but a handful of encodings bypass it — two enum-ordinal encodings, a
+platform-charset bug, native-endian scalars, and unversioned node-record layouts — and there is
+no test harness that pins the format. Ranked findings below; SEV-1 items should be fixed before
+the V0 freeze (`docs/DISK_FORMAT.md` §5).
+
+## What is already future-proof (verified)
+
+- **File identity**: 64-byte superblock in both `sirix.data` and `sirix.revisions` — magic,
+  layout version, file role, endianness check, XXH3 checksum — validated at storage open in
+  both backends (`io/Superblock.java`, `FileChannelStorage`, `MMStorage`). Unknown layout
+  version, foreign endianness, wrong role, and torn header all fail fast with actionable
+  messages.
+- **Page envelope**: every page serializes as `[pageKind u8][binaryVersion u8][body]`. All 16
+  active kinds write and validate the version byte via `BinaryEncodingVersion.fromByte`, which
+  throws on an unknown value; `PageKind.getKind(byte)` throws on an unknown kind id
+  (`PageKind.java:5162-5168`). No silent misparse at the envelope level.
+- **Stable id registries**: page-kind ids are explicit constructor-assigned bytes with a
+  retired-id gap (7), never ordinals (`PageKind.java:93-4196`). Node-kind ids are likewise
+  explicit and sparse (`NodeKind.java`), `IndexType` has explicit id bytes, and the KVLP
+  offset-table template pool self-describes `fieldCount` alongside `kindId` precisely so a
+  future kind-id reuse doesn't need a migration (`OffsetTableTemplatePool.java:29-35`).
+- **Body codec identification**: the KVLP body carries an explicit per-page codec id byte
+  (0 = ZeroRun RLE, 1 = LZ4, 2 = ByteRun, 3 = SirixLZ77); the writer runs a smallest-wins
+  bake-off and records the winner, the reader dispatches on the id. FSST presence is a header
+  flag bit with the symbol table embedded in the page.
+- **Integrity chain**: page XXH3 in the parent `PageReference` (Merkle-style), checksummed
+  superblocks, beacon slots with XXH3 trailers, checksummed 32-byte revision records, and the
+  RevisionRootPage covered via the revision record's 4th field — with a legacy discriminator
+  (`hash == 0`) that keeps beta1 resources readable.
+- **No JVM-unstable serialization**: no `ObjectOutputStream` in persisted data, no
+  `String.hashCode` on disk, node hashes are pinned XXH3, map-backed metadata serializes in
+  deterministic indexed/bitmap order, varints are byte-oriented (endian-free), DeweyIDs use a
+  deterministic bit-prefix code.
+- **Graceful degradation where limits bind**: template pool caps at 255 and falls back to the
+  inline layout; fragment count > 255 throws at write time (not read time); 3-byte
+  `dataLength` has an explicit write-side guard; LZ4 decompression is size-bounded against
+  allocation bombs.
+- **Newer structures already carry their own versions**: VECTOR_NODE / VECTOR_INDEX_METADATA
+  write and check a per-record version byte; projection-index metadata has magic `PIXM` plus a
+  version byte and degrades to rebuild (correct for a derived index).
+
+## SEV-1 — encodings that bypass the versioning discipline (fix before freeze)
+
+1. **Enum-ordinal on-disk encodings.** `HOTIndirectPage.NodeType` and `LayoutType` are
+   persisted as `.ordinal()` and read via `values()[id]` (`PageKind.java:3956-3957`,
+   `:3838-3843`); `BitmapChunkPage` persists `indexType.ordinal()` and reads
+   `IndexType.values()[ordinal]` (`BitmapChunkPage.java:449`, `:503`) — bypassing the stable
+   `IndexType.getID()` byte used everywhere else (including HOT leaf pages). Reordering or
+   inserting an enum constant silently corrupts existing pages, and an out-of-range id throws
+   `ArrayIndexOutOfBoundsException` instead of a versioned error. Fix: write stable id bytes
+   with a lookup that throws a named error, exactly like `PageKind`/`IndexType` already do.
+2. **Platform-default charset in a persisted path.** The NAMERB (name red-black index node)
+   serializer calls `getBytes()` with no charset (`NodeKind.java:865-871`) while its
+   deserializer decodes explicit UTF-8 (`:846-847`). Under any JVM where the default charset
+   is not UTF-8 (`-Dfile.encoding`, pre-JEP-400 runtimes), non-ASCII names corrupt on
+   round-trip. This is the only charset-less `getBytes()` in the persisted store path. Fix:
+   `getBytes(Constants.DEFAULT_ENCODING)`.
+3. **Unknown node-kind id fails as NPE/AIOOBE, not a versioned error.**
+   `NodeKind.getKind(byte)` indexes a 128-slot array with no null/range check
+   (`NodeKind.java:2085-2087`), so a record written by a newer version (or a corrupt kind
+   byte) dies with an opaque `NullPointerException` in `NodeSerializerImpl` or
+   `ArrayIndexOutOfBoundsException` for ids ≥ 128 — while the flyweight path already throws a
+   clean `IllegalArgumentException` (`FlyweightNodeFactory.java:90-91`). Fix: null/range-check
+   with a "node kind N not supported by this version" error.
+4. **Node-record layouts are unversioned and unskippable.** Core node kinds' layouts are
+   implied solely by `(binaryVersion, nodeKind)`; `NodeFieldLayout` field counts are exact
+   with no reserved slot, and no deserializer branches on `BinaryEncodingVersion` yet. Adding
+   one field to one node type today means either a new kind id or a global V1 with full
+   dispatch plumbing that doesn't exist. Acceptable pre-freeze, but the freeze decision should
+   pick the evolution mechanism (per-record version byte like VECTOR_NODE, reserved
+   flags/fields, or committed global-version dispatch) — silence is the only wrong option.
+
+## SEV-2 — portability and hard ceilings (decide before freeze)
+
+5. **Native-endian scalars** (already checklist item 1 in `DISK_FORMAT.md` §5, confirmed):
+   `MemorySegmentBytesIn`/`GrowingMemorySegment` use unaligned *native-order* layouts, the
+   KVLP 160-byte header+bitmap is bulk-copied raw, and beacon/page-record length prefixes are
+   platform order — while LZ77/PAX/superblock/revision records are pinned LE and `compactDir`
+   is BE. Three conventions coexist; the superblock endian check makes foreign-endian opens
+   fail fast (mismatch-safe) but files are not portable. Pin everything LE before freeze.
+6. **Native-LZ4 body pages hard-fail without `liblz4`.** Codec id 1 is only decodable when the
+   FFI LZ4 probe succeeds (`PageKind.java:338-341` throws otherwise), and an outer FFILz4
+   `ByteHandlerPipeline` has the same property. A resource written on an LZ4-capable host is
+   unreadable on a host without the native library even though pure-Java codecs exist. Either
+   ship a pure-Java LZ4-block decoder fallback (the wire format is documented and
+   `SirixLZ77Codec` is already an LZ4-block clone — likely reusable as the decoder) or
+   document the dependency as a format requirement.
+7. **`int`-narrowed child/descendant counts.** Structural serializers cast
+   `getChildCount()`/`getDescendantCount()` from `long` to `int` and decode 32-bit
+   (`NodeKind.java:187,191` and peers), overflowing beyond ~2.1 B descendants — while another
+   path writes the same quantity as a full `long` (`:2191`). Varints make widening cheap:
+   encode the `long` now, before freeze, since the delta encoding means small values cost the
+   same bytes.
+8. **Hash-function identity is no longer validated.** The persisted `hashFunction` config
+   field is read and explicitly skipped (`ResourceConfiguration.java:730-733`); XXH3 is
+   hard-coded. Changing the node-hash function later would be undetectable — old resources
+   would re-verify against the wrong function with no mismatch error. Re-persist (or fold into
+   the binary version) the hash identity before freeze.
+
+## SEV-3 — hardening gaps
+
+9. **No golden-file format tests.** There are no checked-in binary fixtures or byte-exact
+   serialization tests; round-trip tests pass even when the format silently changes. At freeze,
+   add golden fixtures (a small committed resource + expected bytes/checksums per page kind) so
+   any accidental format change fails CI.
+10. **Config↔binary identity gap.** `ressetting.obj` is unchecksummed, unversioned JSON, yet it
+    is the sole source of pipeline/compression identity; the superblock's 16 reserved UUID
+    bytes are unused, so config and data file are not cross-linked (checklist item 5 covers the
+    UUID; consider also checksumming the JSON). Field-order validation in
+    `ResourceConfiguration.deserialize` uses `assert` (`:695` ff.), a no-op in production.
+11. **No reserved bytes outside KVLP.** Only the KVLP header carries flags + 8 reserved bytes;
+    UberPage/IndirectPage/RevisionRootPage/NamePage/etc. have none, and `RevisionRootPage`
+    hard-codes 11 delegate references — any additive change is a global version bump. Likewise
+    the 32-byte revision record has no remaining reserved field and its stride is not recorded
+    in the superblock geometry.
+12. **Unversioned magics.** `ProjectionIndexLeafCodec` (`PIXC`) and the `PIX1` presence-tail
+    footer carry magic but no version byte — a future layout change needs a new magic rather
+    than a version bump. Index-definition files (`indexes/<revision>.xml`) have no
+    magic/version/checksum.
+13. **Small unguarded limits.** Per-field offset-table entries are a single unchecked byte
+    (`PageLayout.java:589,602`) — an offset > 255 silently truncates, held off only by the
+    convention that the variable-length field is last; DeweyID delta framing caps at 255 bytes
+    (`NodeSerializerImpl.java:53-69`); HOT keys/values cap at 64 KiB (u16). Add write-side
+    guards that throw, mirroring the existing `dataLength`/fragment-count guards.
+14. **Third-party format coupling.** NamePage and node-reference sets embed
+    `Roaring64Bitmap.serialize` bytes — a documented stable format, but on-disk compatibility
+    is now coupled to that library's format stability; pin the portable format version in a
+    comment/test.
+
+## Suggested order of work
+
+Fix 1-3 now (small, mechanical, and each is a latent corruption or crash). Decide 4-8 as part
+of the `DISK_FORMAT.md` §5 pre-freeze checklist — items 5 (endianness) and 6 (LZ4
+portability) change bytes on disk and are free only while there are no deployed users. Item 9
+(golden files) should land together with the freeze itself, as it is what makes the freeze
+enforceable.

--- a/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
+++ b/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
@@ -6,9 +6,11 @@
 > decode fallback, long counts, hash-identity persistence), and SEV-3 items 9–13 (golden
 > tests in `io.sirix.format.GoldenFormatTest`, config validation, reserved envelope flags
 > byte + superblock stride, PIXC/PIX1 versions, DeweyID/offset-table guards) are done; item
-> 14 (Roaring format coupling) is pinned by a golden test. Still open by design: superblock
-> resource-UUID plumbing and whole-page composite golden fixtures — tracked in
-> `DISK_FORMAT.md` §5. The findings below are retained as the audit record.
+> 14 (Roaring format coupling) is pinned by a golden test. The final hardening pass closed
+> the rest: resource-UUID cross-linking (superblock ⇄ `ressetting.obj`), composite-page
+> golden fixtures (`GoldenCompositePageTest`), and verified crash-gate coverage of write
+> loss/reordering and writer/truncate recovery. **No open items remain** — `DISK_FORMAT.md`
+> §5 is a closed decisions log. The findings below are retained as the audit record.
 
 Scope: the complete persisted format — file headers, page envelope, page bodies, node records,
 secondary indexes, codecs, and configuration — audited for evolvability (can V1 be introduced

--- a/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
+++ b/docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md
@@ -1,5 +1,15 @@
 # Binary Encoding Future-Proofing Audit
 
+> **Status update (2026-07): all fixable findings below are FIXED on this branch.**
+> SEV-1 items 1–3 (stable ids, UTF-8 pin, fail-fast kind lookup), item 4's evolution
+> mechanism (documented in `DISK_FORMAT.md` §2), SEV-2 items 5–8 (LE pin, pure-Java LZ4
+> decode fallback, long counts, hash-identity persistence), and SEV-3 items 9–13 (golden
+> tests in `io.sirix.format.GoldenFormatTest`, config validation, reserved envelope flags
+> byte + superblock stride, PIXC/PIX1 versions, DeweyID/offset-table guards) are done; item
+> 14 (Roaring format coupling) is pinned by a golden test. Still open by design: superblock
+> resource-UUID plumbing and whole-page composite golden fixtures — tracked in
+> `DISK_FORMAT.md` §5. The findings below are retained as the audit record.
+
 Scope: the complete persisted format — file headers, page envelope, page bodies, node records,
 secondary indexes, codecs, and configuration — audited for evolvability (can V1 be introduced
 without breaking V0 files?), portability (endianness, native libraries, JVM/platform behavior),

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -1,10 +1,15 @@
 # SirixDB On-Disk Format (V0)
 
-Status: **pre-freeze**. We are at `BinaryEncodingVersion.V0` (pages) and superblock
-`LAYOUT_VERSION = 0` (files) with no external users — breaking changes are still free and there
-is exactly ONE format: V0. This document is the contract for what V0 *is* (§1–§4, verified
-against the code) and the ranked checklist of what must be decided **before** the format
-freezes (§5). Once V0 ships to users, every change here costs a migration.
+Status: **V0 contract complete — no open format work items.** We are at
+`BinaryEncodingVersion.V0` (pages) and superblock `LAYOUT_VERSION = 0` (files). Every
+pre-freeze checklist item has been resolved (implemented or explicitly decided — see §5's
+decisions log), and the byte-level contract is pinned by golden tests
+(`io.sirix.format.GoldenFormatTest`, `io.sirix.format.GoldenCompositePageTest`): an accidental
+change to any pinned structure fails CI. From here, ANY change to the bytes in this document is
+a conscious format bump — `BinaryEncodingVersion` (page bodies/records), the page-envelope
+flags byte (additive page features), `LAYOUT_VERSION` (file layout), or a sub-structure version
+byte (PIXM/PIXC/PIX1, per-record versions) — accompanied by an update to the golden constants
+and a migration note here.
 
 ## 1. Files
 
@@ -17,9 +22,12 @@ A resource directory contains:
 | resource settings JSON | Format identity: `binaryVersion`, byte-pipeline classes, `storageType`, `hashAlgorithm`, `verifyChecksumsOnRead` |
 
 Both binary files open with the 64-byte superblock (magic, layout version, endianness check,
-file role, XXH3 checksum — see below); the *rest* of the format identity — compression
-pipeline, hash algorithm, binary encoding version — lives only in the JSON, which carries no
-header or checksum of its own (§5.5).
+file role, geometry, resource UUID, XXH3 checksum — see below); the *rest* of the format
+identity — compression pipeline, hash-function id, binary encoding version — lives in the JSON,
+whose parse is strictly validated (unexpected/misordered fields throw) and which is
+cross-linked to the binary files by the **resource UUID**: the JSON persists it, both
+superblocks embed it, and opening a data file with a different resource's settings (wrong-backup
+restore) fails fast. A zero UUID on either side (legacy dev files) skips the cross-check.
 
 ### sirix.data (FILE_CHANNEL, the default)
 
@@ -201,26 +209,39 @@ and record offset-table guards throw instead of truncating**; **long child/desce
 **golden byte-pinning tests** (`io.sirix.format.GoldenFormatTest` — superblocks, page
 envelope, node record, varints, Roaring64 coupling, id registries).
 
-Remaining before freeze:
+Closed in the final hardening pass — every former checklist item is either implemented or
+explicitly decided; **nothing remains open**:
 
-1. **Block-aligned page records** (SEV-2, only if O_DIRECT is on the roadmap): byte-granular
-   `[u32 len][payload]` records with 8-byte alignment are hostile to direct I/O and fixed-frame
-   buffer managers. Decide: pad data pages to a block multiple, or commit to mmap/pread.
-2. **Per-block string dictionaries / wider FSST** (compression): strings dominate the residual
-   size (generic LZ4 buys only −16% for +7% read latency); slots into the existing PAX-region
-   + structuralFlags extension points without a format break.
-3. **KVLP hygiene** (SEV-3): drop the 8 stale runtime header bytes + the duplicated
-   pageKey/revision/indexType; fix the `writeEncodedBody` javadoc drift and the stale
-   "verified after decompression" comments.
-4. **Resource UUID** in the superblock's reserved field (plumbing from ResourceConfiguration) —
-   cross-links `ressetting.obj` (pipeline/hash identity, still unchecksummed JSON) to the data
-   file.
-5. **fsync-ORDER validation** (dm-flakey/trace-replay): the SIGKILL gate validates write order
-   only — it never reorders or drops writes that the page cache already accepted, so a missing
-   or misplaced fsync barrier would still pass it.
-6. **Crash-recovery truncate path is not exercised by the read-only gate verifier**: the gate
-   only reopens readers, so the commit-lock-file truncation (`truncateTo`) never runs — extend
-   the gate to reopen a writer per iteration.
-7. **Golden fixtures for composite pages** (KVLP with records/PAX, HOT leaf/indirect): the
-   golden suite pins headers, envelopes, records, and codecs; a committed full-resource fixture
-   would extend the pin to whole-page composition.
+- **Resource UUID** — implemented. Generated per resource, persisted in `ressetting.obj`
+  (`resourceUuid`), embedded in both superblocks (bytes [40, 56), checksum-covered), validated
+  at storage open in both backends; zero on either side = legacy, cross-check skipped
+  (`SuperblockResourceUuidTest`).
+- **fsync-order/write-loss validation** — covered. `PowerLossSimulationTest` (opt-in
+  `-Dsirix.crash.run=true`) records every channel write and `force()` barrier of real commits,
+  then materializes post-power-loss states where unforced writes are lost, applied, or torn in
+  any combination/order — exactly the model a missing fsync barrier fails — with a
+  seeded-corruption self-test proving the oracle is sharp. Gate run green in this tree.
+- **Writer-reopen / truncate-recovery coverage** — covered. Both the SIGKILL gate
+  (`CrashRecoveryInjectionTest`) and the power-loss gate verify the crashed resource ACCEPTS A
+  WRITER again: `beginNodeTrx` runs the `.commit`-marker truncate-recovery path, the recovery
+  commit succeeds, and every pre-crash revision stays intact. Gates run green in this tree.
+- **Golden fixtures for composite pages** — implemented.
+  `io.sirix.format.GoldenCompositePageTest` byte-pins a populated KeyValueLeafPage (records,
+  compact directory, structural encoders, codec bake-off) and a populated HOTLeafPage,
+  deterministic across independent runs.
+- **KVLP header redundancy** — DECIDED: retained. The header's pageKey/revision/indexType
+  duplication and the heapEnd/heapUsed runtime fields stay on disk: the 160-byte block is
+  bulk-copied verbatim ("in-memory format = on-disk format" — stripping fields would
+  reintroduce a commit-time conversion pass), and the redundancy makes pages self-describing
+  for recovery/forensics plus cross-checkable against the parent reference. Cost: 21 bytes per
+  ~64 KiB page. The `writeEncodedBody` javadoc and the stale "verified after decompression"
+  comments are fixed.
+- **Block-aligned page records** — DECIDED: V0 commits to pread/mmap with byte-granular
+  8-byte-aligned `[u32 len][payload]` records. O_DIRECT/fixed-frame buffer management is not a
+  V0 target; adopting it later is a file-layout change and therefore a superblock
+  `LAYOUT_VERSION` bump (the version machinery for exactly this is in place), not a latent
+  incompatibility.
+- **Per-block string dictionaries / wider FSST** — reclassified: this is a compression
+  *performance* roadmap item, not a format gap. It slots into the existing PAX-region +
+  structuralFlags + envelope-flags extension points without a format break, so nothing about
+  V0's future-proofness depends on it. Tracked in `ROADMAP.md`.

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -16,8 +16,10 @@ A resource directory contains:
 | `data/sirix.revisions` | Fixed-slot revision index: 32-byte records (`IOStorage.revisionsFileOffset`) |
 | resource settings JSON | Format identity: `binaryVersion`, byte-pipeline classes, `storageType`, `hashAlgorithm`, `verifyChecksumsOnRead` |
 
-Neither binary file carries a magic number, version, or endianness marker — identity lives only
-in the JSON (§5.6).
+Both binary files open with the 64-byte superblock (magic, layout version, endianness check,
+file role, XXH3 checksum — see below); the *rest* of the format identity — compression
+pipeline, hash algorithm, binary encoding version — lives only in the JSON, which carries no
+header or checksum of its own (§5.5).
 
 ### sirix.data (FILE_CHANNEL, the default)
 
@@ -106,7 +108,8 @@ unambiguously means "legacy".)
 
 Every page serializes as `[pageKind u8][binaryVersion u8][body]`. Kind ids: 1 KVLP, 2 NAME,
 3 UBER, 4 INDIRECT, 5 REVISION_ROOT, 6 PATH_SUMMARY, 8 CAS, 9 OVERFLOW, 10 PATH, 11 DEWEYID,
-12 HOT_LEAF, 13 HOT_INDIRECT, 14 BITMAP_CHUNK, 15 VECTOR, 16 PROJECTION (7 retired/reserved).
+12 HOT_LEAF, 13 HOT_INDIRECT, 14 BITMAP_CHUNK, 15 VECTOR, 16 PROJECTION, 17 VALID_TIME
+(7 retired/reserved).
 
 - **UberPage** body: `[i32 revisionCount]` — 6 bytes total, no checksum (§5.3).
 - **RevisionRootPage**: delegate refs + revision, maxNodeKeys, commit timestamp/message, user.

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -70,7 +70,8 @@ and the next commit is no longer an unopenable state (regression-tested by
 ### sirix.revisions
 
 ```
-0      : SUPERBLOCK (64 B, role = revisions)
+0      : SUPERBLOCK (64 B, role = revisions; slot-size field = 32, the record stride —
+         persisted geometry, validated at open against this build's record size)
 64     : reserved (sparse zeros) up to 4096
 4096 + 32*revision : [u64 dataFileOffsetOfRevisionRootPage][u64 epochMillis]
                      [u64 recordChecksum][u64 revisionRootPageHash]      (little-endian)
@@ -96,22 +97,42 @@ unambiguously means "legacy".)
 
 ### Endianness
 
-- Superblock, beacon XXH3 trailers, and revision records: pinned **little-endian**.
-- Page-record length prefixes and `BytesOut` payload primitives: platform order — the
-  superblock's endianness check makes a foreign-endian open fail fast instead of misread
-  (full LE pinning is checklist item 1).
-- Inside page payloads: `compactDir` and in-blob column length prefixes big-endian; the three
-  body codecs and all PAX regions pinned little-endian.
+The format is **fully little-endian pinned** (checklist item 1 — done). Every multi-byte scalar
+that reaches disk goes through an explicitly LE-ordered accessor:
+
+- Superblock, beacon XXH3 trailers, revision records, beacon/page-record length prefixes:
+  pinned LE (`ByteOrder.LITTLE_ENDIAN` buffers / `MMFileReader.LAYOUT_INT`).
+- `BytesOut`/`BytesIn` payload primitives, the KVLP header+bitmap block, PAX regions,
+  flyweight field access, and the FFILz4 frame header: pinned LE via `io.sirix.node.LE`
+  layouts (`ByteArrayBytesIn` already decoded LE byte-shifts).
+- Deliberate exceptions (byte-shift-encoded, endian-independent): `compactDir` and in-blob
+  column length prefixes use big-endian *byte layout* via explicit shifts; HOT discriminative
+  keys use BE loads for lexicographic `compareUnsigned` — both are defined byte sequences, not
+  host-order dependent.
+- The superblock's endianness check remains as a fail-fast guard for headers written by
+  pre-pin dev builds on BE hosts (none exist in practice).
 - The legacy big-endian FILE backend is removed; `StorageType.FILE` fails fast.
 
 ## 2. Pages
 
-Every page serializes as `[pageKind u8][binaryVersion u8][body]`. Kind ids: 1 KVLP, 2 NAME,
+Every page serializes as `[pageKind u8][binaryVersion u8][flags u8][body]`
+(`PageKind.writeVersionAndFlags` / `readVersionAndFlags`). The flags byte is reserved
+extension space for **every** page kind — all bits zero in V0, and a reader rejects nonzero
+flags as "written by a newer version" instead of misparsing. Kind ids: 1 KVLP, 2 NAME,
 3 UBER, 4 INDIRECT, 5 REVISION_ROOT, 6 PATH_SUMMARY, 8 CAS, 9 OVERFLOW, 10 PATH, 11 DEWEYID,
 12 HOT_LEAF, 13 HOT_INDIRECT, 14 BITMAP_CHUNK, 15 VECTOR, 16 PROJECTION, 17 VALID_TIME
 (7 retired/reserved).
 
-- **UberPage** body: `[i32 revisionCount]` — 6 bytes total, no checksum (§5.3).
+**Format evolution mechanism (decided):** the unit of node-record/page-body evolution is a
+`BinaryEncodingVersion` bump — every node/page (de)serializer receives the
+`ResourceConfiguration`, which carries the resource's persisted `binaryEncoding`, and the
+per-page version byte fails fast on unknown values. Node kinds that need to evolve
+independently of the global version carry a per-record version byte (the VECTOR_NODE /
+VECTOR_INDEX_METADATA pattern); sub-structures with their own magic carry their own version
+byte (PIXC/PIX1, PIXM). Enum-typed bytes on disk are always explicit stable ids with
+fail-fast lookups, never ordinals.
+
+- **UberPage** body: `[i32 revisionCount]` — 7 bytes total incl. envelope, no checksum (§5.3).
 - **RevisionRootPage**: delegate refs + revision, maxNodeKeys, commit timestamp/message, user.
 - **KeyValueLeafPage** (the data page): 1024 implicit-keyed slots
   (`nodeKey = recordPageKey << 10 | slot`), 160-byte header+slot-bitmap, then a
@@ -166,26 +187,40 @@ helper; PageReference hashes as `[u8 flag][8 B]` instead of `[i32 len][8 B]`; th
 first-offset quirk and the 256-byte RevisionRootPage alignment are gone (8-byte alignment for
 all data pages, data starts exactly at `DATA_REGION_START`).
 
+Done since the audit (see `docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md` for the full list):
+**full little-endian pin** (was item 1 — all scalar IO via `io.sirix.node.LE`); **reserved
+flags byte in every page envelope** (additive changes no longer force a global version bump);
+**revisions record stride persisted in the superblock** and validated at open; **stable id
+bytes replace every enum-ordinal on disk** (HOT node/layout types, BitmapChunkPage index
+type); **fail-fast unknown node-kind/page-flags/version errors**; **pure-Java LZ4 block
+decoder** (`JavaLz4BlockDecoder` — LZ4-bodied pages and FFILz4-pipeline resources are readable
+without `liblz4`; writes fall back to stored-uncompressed frames); **hash-function identity
+persisted + validated** (`ressetting.obj` `hashFunction` = "XX3"); **config field validation
+throws in production** (was `assert`); **PIXC/PIX1 carry version bytes**; **DeweyID framing
+and record offset-table guards throw instead of truncating**; **long child/descendant counts**;
+**golden byte-pinning tests** (`io.sirix.format.GoldenFormatTest` — superblocks, page
+envelope, node record, varints, Roaring64 coupling, id registries).
+
 Remaining before freeze:
 
-1. **Full endianness pin** (SEV-2): the superblock's endianness check gates foreign-endian
-   hosts (fail-fast), and all NEW structures (superblock, beacon trailers, revision records)
-   are pinned little-endian — but page-record length prefixes and `BytesOut` payload
-   primitives are still platform-order, and the KVLP body mixes BE `compactDir` with LE
-   codecs/PAX. Pinning everything LE makes files portable instead of merely mismatch-safe.
-2. **Block-aligned page records** (SEV-2, only if O_DIRECT is on the roadmap): byte-granular
+1. **Block-aligned page records** (SEV-2, only if O_DIRECT is on the roadmap): byte-granular
    `[u32 len][payload]` records with 8-byte alignment are hostile to direct I/O and fixed-frame
    buffer managers. Decide: pad data pages to a block multiple, or commit to mmap/pread.
-3. **Per-block string dictionaries / wider FSST** (compression): strings dominate the residual
+2. **Per-block string dictionaries / wider FSST** (compression): strings dominate the residual
    size (generic LZ4 buys only −16% for +7% read latency); slots into the existing PAX-region
    + structuralFlags extension points without a format break.
-4. **KVLP hygiene** (SEV-3): drop the 8 stale runtime header bytes + the duplicated
+3. **KVLP hygiene** (SEV-3): drop the 8 stale runtime header bytes + the duplicated
    pageKey/revision/indexType; fix the `writeEncodedBody` javadoc drift and the stale
    "verified after decompression" comments.
-5. **Resource UUID** in the superblock's reserved field (plumbing from ResourceConfiguration).
-6. **fsync-ORDER validation** (dm-flakey/trace-replay): the SIGKILL gate validates write order
+4. **Resource UUID** in the superblock's reserved field (plumbing from ResourceConfiguration) —
+   cross-links `ressetting.obj` (pipeline/hash identity, still unchecksummed JSON) to the data
+   file.
+5. **fsync-ORDER validation** (dm-flakey/trace-replay): the SIGKILL gate validates write order
    only — it never reorders or drops writes that the page cache already accepted, so a missing
    or misplaced fsync barrier would still pass it.
-7. **Crash-recovery truncate path is not exercised by the read-only gate verifier**: the gate
+6. **Crash-recovery truncate path is not exercised by the read-only gate verifier**: the gate
    only reopens readers, so the commit-lock-file truncation (`truncateTo`) never runs — extend
    the gate to reopen a writer per iteration.
+7. **Golden fixtures for composite pages** (KVLP with records/PAX, HOT leaf/indirect): the
+   golden suite pins headers, envelopes, records, and codecs; a committed full-resource fixture
+   would extend the pin to whole-page composition.

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -177,9 +177,17 @@ PAX-region + `structuralFlags` extension points without a format break.
 
 ## 4. Storage backends
 
-`FILE_CHANNEL` (default) and `MEMORY_MAPPED` share one on-disk format. The legacy `FILE`
-backend is removed (`StorageType.FILE` throws with a pointer to FILE_CHANNEL). `IO_URING`/`S3`
-resolve enterprise providers via SPI and fail fast when absent.
+`FILE_CHANNEL` (default) and `MEMORY_MAPPED` share one on-disk format — MEMORY_MAPPED writes
+through the same `FileChannelWriter` (superblock + UUID stamping included) and both backends
+run the same superblock validation (magic/version/endianness/role/geometry/UUID) at open. This
+is proven end-to-end by `io.sirix.io.StorageBackendInteropTest`: a resource written by either
+backend reads back byte-identically AND accepts further commits under the other, and a
+swapped-in foreign data file fails the resource-UUID cross-check under both. `IN_MEMORY`
+(RAMStorage) persists nothing and is exercised by `StorageTest` alongside the file-backed
+backends. The legacy `FILE` backend is removed (`StorageType.FILE` throws with a pointer to
+FILE_CHANNEL — it wrote an incompatible layout under the same version); `IO_URING`/`S3`
+resolve enterprise providers via SPI and fail fast with actionable errors when absent (also
+covered by the interop test).
 
 ## 5. PRE-FREEZE CHECKLIST (ranked; decide before first user data)
 


### PR DESCRIPTION
## What does this PR do?

Audits the on-disk binary encoding for future-proofness and closes every finding, completing the V0 format contract with no open work items:

- **Audit**: full ranked audit of the persisted format in `docs/BINARY_ENCODING_FUTURE_PROOFING_AUDIT.md` (file headers, page envelope, node records, indexes, codecs, config).
- **Correctness fixes**: enum-ordinal encodings replaced with stable id bytes (HOTIndirectPage node/layout types, BitmapChunkPage index type); NAMERB serializer pinned to UTF-8; `NodeKind.getKind` fails fast on unknown ids instead of NPE/AIOOBE; child/descendant counts widened to long varints (wire-compatible).
- **Portability**: all on-disk scalars pinned little-endian via `io.sirix.node.LE` (byte-identical on LE hosts); pure-Java LZ4 block decoder (`JavaLz4BlockDecoder`) so LZ4-compressed data reads without `liblz4` (writes degrade to stored-uncompressed frames).
- **Evolvability**: reserved flags byte in every page envelope (`[kind][version][flags]`); version bytes for the PIXC codec and PIX1 presence-tail footer; revisions record stride + resource UUID persisted in the superblock; hash-function identity persisted and validated; production-grade config field validation (was `assert`).
- **Cross-linking**: per-resource UUID in `ressetting.obj` and both superblocks — restoring settings from the wrong backup fails fast on both storage backends.
- **Enforcement**: golden byte-pinning tests (`GoldenFormatTest`, `GoldenCompositePageTest`) covering superblocks, page envelope, node records, varints, composite KVLP/HOT pages, Roaring64 coupling, and all stable-id registries; cross-backend interop test (`StorageBackendInteropTest`) proving FILE_CHANNEL and MEMORY_MAPPED share one on-disk format.
- **Docs**: `docs/DISK_FORMAT.md` updated to a complete V0 contract with a closed decisions log (block alignment, KVLP header redundancy, FSST reclassified to `ROADMAP.md`).

## Related issue

No issue — initiated from a format future-proofness review while the format is pre-freeze with no deployed users, so byte-layout corrections are still free.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [x] `./gradlew build` passes locally (JDK 25)
- [x] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: the relevant invariant in
      [`docs/formal-verification.md`](../docs/formal-verification.md) is still upheld (and updated/added if needed)
- [x] Updated documentation (README / docs) where relevant
- [x] No unrelated formatting churn (run Spotless / the `pre-commit` hook)

## Notes for reviewers

- All byte-level changes are wire-compatible on little-endian hosts except the deliberate pre-freeze format changes: page-envelope flags byte, PIXC/PIX1 version bytes, superblock stride/UUID fields — all legal per the pre-freeze policy (no deployed users) and validated with legacy-leniency (zero UUID/stride accepted).
- Both opt-in crash gates (`CrashRecoveryInjectionTest` SIGKILL loop, `PowerLossSimulationTest` write-loss/reorder simulation incl. oracle self-test) were run green on this branch.
- The golden constants are the format freeze anchor: any future intentional format change must update them alongside a version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgciWvEey2Rdy4qmLErCoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgciWvEey2Rdy4qmLErCoZ)_