### PR TITLE
Fix cross-platform golden-byte flake from the sticky-codec election

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -4933,6 +4933,22 @@ public enum PageKind {
   private static final ThreadLocal<int[]> STICKY_CODEC =
       ThreadLocal.withInitial(() -> new int[3]);
 
+  /**
+   * Reset the current thread's sticky-codec election so its next
+   * {@link #STICKY_WARMUP_PAGES} page bodies run the full bake-off (exhaustive
+   * pick-smallest). Golden-byte tests MUST call this before serializing: the election
+   * makes stored bytes a function of per-thread serialization history (see
+   * {@link #emitSmallestBody}), so a page serialized after unrelated work on the same
+   * thread may be encoded with the elected codec instead of the smallest one — which is
+   * exactly the run-to-run variance a golden comparison has to neutralize.
+   */
+  public static void resetStickyCodecElectionForCurrentThread() {
+    final int[] sticky = STICKY_CODEC.get();
+    sticky[0] = 0;
+    sticky[1] = 0;
+    sticky[2] = 0;
+  }
+
   /** Per-thread scratch for {@link ByteRunCodec} output. */
   private static final ThreadLocal<byte[]> V1_HEAP_V2_SCRATCH =
       ThreadLocal.withInitial(() -> new byte[128 * 1024]);

--- a/bundles/sirix-core/src/test/java/io/sirix/format/GoldenCompositePageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/format/GoldenCompositePageTest.java
@@ -12,6 +12,7 @@ import io.sirix.node.SirixDeweyID;
 import io.sirix.node.xml.ElementNode;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.page.KeyValueLeafPage;
+import io.sirix.page.PageKind;
 import io.sirix.page.PagePersister;
 import io.sirix.page.SerializationType;
 import io.sirix.settings.Constants;
@@ -82,6 +83,12 @@ public final class GoldenCompositePageTest {
     try {
       page.setRecord(elementNode(config, 0L, 3L, 4L));
       page.setRecord(elementNode(config, 1L, 4L, 3L));
+
+      // Golden bytes require the exhaustive pick-smallest codec choice. Earlier tests in
+      // the same JVM fork may have driven this thread's sticky-codec election past its
+      // warmup with a different winner, making the emitted codec (and thus the bytes)
+      // history-dependent — the exact cross-platform flake this reset prevents.
+      PageKind.resetStickyCodecElectionForCurrentThread();
 
       final BytesOut<?> data = Bytes.elasticOffHeapByteBuffer();
       new PagePersister().serializePage(config, data, page, SerializationType.DATA);


### PR DESCRIPTION
## What does this PR do?

Fixes the `main` CI failure introduced by #1131: `GoldenCompositePageTest.keyValueLeafPageBytesArePinned` failed on the macOS and Windows cross-platform jobs (1 of 9368 tests; the Linux jobs passed by scheduling luck). Root cause: the sticky-winner codec election makes a page's emitted codec a function of per-thread serialization history — when earlier tests in the same JVM fork drove the thread past the election warmup with an elected winner, the golden page was encoded with that winner instead of the exhaustive pick-smallest choice the pinned bytes assume. This is exactly the determinism caveat documented with the election, materializing as a cross-platform flake.

Fix: `PageKind.resetStickyCodecElectionForCurrentThread()` (test hook, documented) + a call in the golden test before serializing, restoring the exhaustive bake-off for the pinned page regardless of prior same-thread work.

## Related issue

Follow-up to #1131 (the failing run: https://github.com/sirixdb/sirix/actions/runs/29867976108).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — targeted verification instead (local wrapper constraint documented in #1131): `PageLayoutFuzzTest` + `KeyValueLeafTest` + `GoldenCompositePageTest` in one JVM (heavy serialization preceding the golden pin — the exact failure ordering) — green.
- [x] Added or updated tests covering the change (the golden test now neutralizes election history by construction)
- [x] Storage-engine invariants unaffected (test-only determinism hook; no wire-format or behavior change)
- [x] No unrelated formatting churn

## Notes for reviewers

Two-line production change (a documented ThreadLocal reset hook), one call site in the test. The alternative — pinning `-Dsirix.codecBakeoff.probeInterval=1` for the whole test JVM — would stop CI from exercising the election at all; the targeted reset keeps it live everywhere else.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PavdHDQDnmk42QwygZE7Bq)_