### PR TITLE
Bind projection reads to the caller's transaction (fix concurrent-reader race)

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnScan.java
@@ -4,6 +4,7 @@
 package io.sirix.index.projection;
 
 import io.sirix.index.projection.ProjectionColumnStore.ColumnSlice;
+import io.sirix.index.projection.ProjectionColumnStore.SegmentFetcher;
 import io.sirix.index.projection.ProjectionIndexScan.ColumnPredicate;
 
 import java.util.Arrays;
@@ -44,15 +45,16 @@ public final class ProjectionColumnScan {
    * (numeric/boolean) — callers gate before dispatching.
    */
   public static long conjunctiveCount(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates) {
-    return conjunctiveCount(store, predicates, 0, store.leafCount());
+      final ColumnPredicate[] predicates, final SegmentFetcher fetcher) {
+    return conjunctiveCount(store, predicates, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for the executor's chunked parallel dispatch — scratch is thread-local. */
   public static long conjunctiveCount(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int fromLeaf, final int toLeaf) {
+      final ColumnPredicate[] predicates, final int fromLeaf, final int toLeaf,
+      final SegmentFetcher fetcher) {
     checkPredicates(store, predicates);
-    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates);
+    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates, fetcher);
     final Scratch s = SCRATCH.get();
     long total = 0;
     for (int leaf = fromLeaf; leaf < toLeaf; leaf++) {
@@ -74,20 +76,21 @@ public final class ProjectionColumnScan {
    * presence is ANDed before folding, exactly like the byte kernel.
    */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc) {
-    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.leafCount());
+      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
+      final SegmentFetcher fetcher) {
+    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
       final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
-      final int fromLeaf, final int toLeaf) {
+      final int fromLeaf, final int toLeaf, final SegmentFetcher fetcher) {
     checkPredicates(store, predicates);
     if (store.columnKind(numericColumn) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_LONG");
     }
-    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates);
-    final ColumnSlice[] aggCol = store.column(numericColumn);
+    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates, fetcher);
+    final ColumnSlice[] aggCol = store.column(numericColumn, fetcher);
     final Scratch s = SCRATCH.get();
     for (int leaf = fromLeaf; leaf < toLeaf; leaf++) {
       final int rowCount = evaluateMask(predicates, cols, leaf, store.rowCount(leaf), s.mask);
@@ -133,20 +136,22 @@ public final class ProjectionColumnScan {
    * diagnostic only — served sums fold seed-first through {@link MatchingDoubleCursor}.
    */
   public static void conjunctiveAggregateNumericDouble(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int numericColumn, final double[] acc) {
-    conjunctiveAggregateNumericDouble(store, predicates, numericColumn, acc, 0, store.leafCount());
+      final ColumnPredicate[] predicates, final int numericColumn, final double[] acc,
+      final SegmentFetcher fetcher) {
+    conjunctiveAggregateNumericDouble(store, predicates, numericColumn, acc, 0, store.leafCount(),
+        fetcher);
   }
 
   /** Ranged variant for chunked parallel dispatch (count/min/max are merge-order-insensitive). */
   public static void conjunctiveAggregateNumericDouble(final ProjectionColumnStore store,
       final ColumnPredicate[] predicates, final int numericColumn, final double[] acc,
-      final int fromLeaf, final int toLeaf) {
+      final int fromLeaf, final int toLeaf, final SegmentFetcher fetcher) {
     checkPredicates(store, predicates);
     if (store.columnKind(numericColumn) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_DOUBLE) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_DOUBLE");
     }
-    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates);
-    final ColumnSlice[] aggCol = store.column(numericColumn);
+    final ColumnSlice[][] cols = resolvePredicateColumns(store, predicates, fetcher);
+    final ColumnSlice[] aggCol = store.column(numericColumn, fetcher);
     final Scratch s = SCRATCH.get();
     for (int leaf = fromLeaf; leaf < toLeaf; leaf++) {
       final int rowCount = evaluateMask(predicates, cols, leaf, store.rowCount(leaf), s.mask);
@@ -209,15 +214,15 @@ public final class ProjectionColumnScan {
     private boolean leafLoaded;
 
     public MatchingDoubleCursor(final ProjectionColumnStore store,
-        final ColumnPredicate[] predicates, final int numericColumn) {
+        final ColumnPredicate[] predicates, final int numericColumn, final SegmentFetcher fetcher) {
       checkPredicates(store, predicates);
       if (store.columnKind(numericColumn) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_DOUBLE) {
         throw new IllegalStateException("cursor column " + numericColumn + " is not NUMERIC_DOUBLE");
       }
       this.store = store;
       this.predicates = predicates;
-      this.predicateCols = resolvePredicateColumns(store, predicates);
-      this.aggCol = store.column(numericColumn);
+      this.predicateCols = resolvePredicateColumns(store, predicates, fetcher);
+      this.aggCol = store.column(numericColumn, fetcher);
     }
 
     /** Advance to the next matching cell; {@code false} = stream exhausted. */
@@ -281,10 +286,10 @@ public final class ProjectionColumnScan {
   }
 
   private static ColumnSlice[][] resolvePredicateColumns(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates) {
+      final ColumnPredicate[] predicates, final SegmentFetcher fetcher) {
     final ColumnSlice[][] cols = new ColumnSlice[predicates.length][];
     for (int i = 0; i < predicates.length; i++) {
-      cols[i] = store.column(predicates[i].column);
+      cols[i] = store.column(predicates[i].column, fetcher);
     }
     return cols;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -31,8 +31,14 @@ import java.util.List;
  * path, which surfaces the same corruption through the established fail-soft flow. Decode
  * corruption is PERMANENT for this build and memoized ({@link #columnKnownCorrupt(int)}),
  * so later touches fail fast without re-fetching; fetch-level failures (a session closing
- * mid-read, transient I/O) are NOT memoized — the next query retries with re-bound
- * sources (see {@link #rebindFetcher(SegmentFetcher)}).
+ * mid-read, transient I/O) are NOT memoized — the next query retries with the CALLER's own
+ * live {@link SegmentFetcher}, threaded into every fill call.
+ *
+ * <p><b>Session binding.</b> The store holds NO session-bound source: the decoded column
+ * state (slices, raw bytes) is immutable and shared, and a not-yet-filled column's source is
+ * a per-call {@link SegmentFetcher} argument built from the CALLING reader's own live
+ * transaction — so two concurrent readers sharing this cached store never overwrite each
+ * other's I/O binding.
  */
 public final class ProjectionColumnStore {
 
@@ -58,13 +64,6 @@ public final class ProjectionColumnStore {
   }
 
   private final List<LeafDirectory> directories;
-  /**
-   * Re-bindable segment source. The store outlives the session that built it (it lives in
-   * the catalog's static decode cache), so the catalog re-binds this to the CURRENT
-   * caller's session on every cache lookup — a fill never depends on the builder session
-   * still being open.
-   */
-  private volatile SegmentFetcher fetcher;
   private final byte[] columnKinds;
 
   /** Lazily filled per column; slot = decoded slices for every leaf, ascending leafIndex. */
@@ -85,12 +84,11 @@ public final class ProjectionColumnStore {
    */
   private final byte[] corruptColumns;
 
-  public ProjectionColumnStore(final List<LeafDirectory> directories, final SegmentFetcher fetcher) {
-    if (directories == null || fetcher == null) {
-      throw new IllegalArgumentException("directories and fetcher must not be null");
+  public ProjectionColumnStore(final List<LeafDirectory> directories) {
+    if (directories == null) {
+      throw new IllegalArgumentException("directories must not be null");
     }
     this.directories = List.copyOf(directories);
-    this.fetcher = fetcher;
     if (this.directories.isEmpty()) {
       this.columnKinds = new byte[0];
     } else {
@@ -104,14 +102,6 @@ public final class ProjectionColumnStore {
     this.columns = new ColumnSlice[columnKinds.length][];
     this.columnBytes = new byte[columnKinds.length][][];
     this.corruptColumns = new byte[columnKinds.length];
-  }
-
-  /** Re-bind the segment source to a live session's fetcher (see the field contract). */
-  public void rebindFetcher(final SegmentFetcher fetcher) {
-    if (fetcher == null) {
-      throw new IllegalArgumentException("fetcher must not be null");
-    }
-    this.fetcher = fetcher;
   }
 
   /** Whether a fill of {@code col} hit permanent decode corruption (memoized fail-fast). */
@@ -149,11 +139,11 @@ public final class ProjectionColumnStore {
 
   /**
    * The column's slices across all leaves (ascending leafIndex), fetching + decoding its
-   * BODY segments on first touch.
+   * BODY segments on first touch through the CALLER's own live {@code fetcher}.
    *
    * @throws IllegalStateException on missing/corrupt segments or a non-sliceable column
    */
-  public ColumnSlice[] column(final int col) {
+  public ColumnSlice[] column(final int col, final SegmentFetcher fetcher) {
     if (!columnSliceable(col)) {
       throw new IllegalStateException("Column " + col + " is not sliceable (kind="
           + (col >= 0 && col < columnKinds.length ? columnKinds[col] : -1) + ")");
@@ -169,7 +159,7 @@ public final class ProjectionColumnStore {
     // Fill OUTSIDE the monitor: the fetch+decode is the store's only I/O and must not
     // serialize other columns (or evidence readers) behind it. A same-column race does the
     // work twice with identical results — first publish wins.
-    slices = fillColumn(col);
+    slices = fillColumn(col, fetcher);
     synchronized (this) {
       final ColumnSlice[] existing = columns[col];
       if (existing != null) {
@@ -183,10 +173,10 @@ public final class ProjectionColumnStore {
     return slices;
   }
 
-  private ColumnSlice[] fillColumn(final int col) {
+  private ColumnSlice[] fillColumn(final int col, final SegmentFetcher fetcher) {
     // Bytes-first: the raw-segment cache does the fetch + verification; slice decode is a
     // pure in-memory transform over the already-verified bytes.
-    final byte[][] segments = columnBytes(col);
+    final byte[][] segments = columnBytes(col, fetcher);
     final int n = directories.size();
     final ColumnSlice[] slices = new ColumnSlice[n];
     try {
@@ -203,12 +193,13 @@ public final class ProjectionColumnStore {
 
   /**
    * The column's VERIFIED raw BODY segment bytes across all leaves (ascending leafIndex),
-   * fetching them on first touch — the fused fold kernels' substrate. Same laziness,
-   * threading, and failure contract as {@link #column(int)}.
+   * fetching them on first touch through the CALLER's own live {@code fetcher} — the fused
+   * fold kernels' substrate. Same laziness, threading, and failure contract as
+   * {@link #column(int, SegmentFetcher)}.
    *
    * @throws IllegalStateException on missing/corrupt segments or a non-sliceable column
    */
-  public byte[][] columnBytes(final int col) {
+  public byte[][] columnBytes(final int col, final SegmentFetcher fetcher) {
     if (!columnSliceable(col)) {
       throw new IllegalStateException("Column " + col + " is not sliceable (kind="
           + (col >= 0 && col < columnKinds.length ? columnKinds[col] : -1) + ")");
@@ -221,7 +212,7 @@ public final class ProjectionColumnStore {
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
-    segments = fetchColumnBytes(col);
+    segments = fetchColumnBytes(col, fetcher);
     synchronized (this) {
       final byte[][] existing = columnBytes[col];
       if (existing != null) {
@@ -234,7 +225,7 @@ public final class ProjectionColumnStore {
     return segments;
   }
 
-  private byte[][] fetchColumnBytes(final int col) {
+  private byte[][] fetchColumnBytes(final int col, final SegmentFetcher fetcher) {
     final int n = directories.size();
     final int bodyId = ProjectionIndexSegmentCodec.bodySegmentId(col);
     // Leaf order IS file order to within noise: the builder persists leaves 1..N in one
@@ -249,7 +240,7 @@ public final class ProjectionColumnStore {
       segments = fetcher.fetchAll(offsets);
     } catch (final RuntimeException fetchFailed) {
       // Fetch-level failure (session closed mid-read, transient I/O): NOT memoized —
-      // the next query retries against a re-bound live fetcher.
+      // the next query retries against the caller's own live fetcher.
       throw new IllegalStateException("Segment fetch failed for column " + col + ": "
           + fetchFailed.getMessage(), fetchFailed);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -155,7 +155,8 @@ public final class ProjectionIndexCatalog {
         if (handle.columnStoreOrNull() != null) {
           bytes += handle.projectedWeightBytes();
         } else {
-          for (final byte[] payload : handle.leafPayloads()) {
+          // Eager handle: leaves are pre-materialized, so no materializer is needed.
+          for (final byte[] payload : handle.leafPayloads(null)) {
             bytes += payload == null ? 0 : payload.length;
           }
         }
@@ -445,15 +446,10 @@ public final class ProjectionIndexCatalog {
       if (handle == NOT_USABLE) {
         return null;
       }
-      final ProjectionColumnStore store = handle.columnStoreOrNull();
-      if (store != null) {
-        // A column-lazy handle outlives the session that built it (this cache is static),
-        // so its fills must never depend on that session still being open: re-bind the
-        // fetch/materialize closures to the CURRENT caller's live session on every hit.
-        // Any live session serves — the build revision's pages are immutable.
-        handle.rebindLazySources(segmentFetcher(session, revision),
-            leafMaterializer(session, revision, def.getID(), store.leafCount()));
-      }
+      // The cached handle is SHARED and stores nothing session-lifecycle-scoped: a column-
+      // lazy handle's fills bind to the CALLER's own live session because the caller threads
+      // its own fetcher/materializer (built via segmentFetcher/leafMaterializer) into every
+      // fill call — so concurrent readers on the same build revision never interfere.
       return handle;
     } catch (final RuntimeException e) {
       // Transient failure (session closing mid-read, I/O error): logged,
@@ -582,19 +578,19 @@ public final class ProjectionIndexCatalog {
         }
       }
     }
-    final ProjectionColumnStore store =
-        new ProjectionColumnStore(live, segmentFetcher(session, revision));
+    // The shared store carries only immutable descriptor state; every fill binds to the
+    // CALLER's own live fetcher, threaded in per call — nothing session-scoped is stored.
+    final ProjectionColumnStore store = new ProjectionColumnStore(live);
     return ProjectionIndexRegistry.Handle.columnLazy(metadata.rootPath(), metadata.buildRevision(),
-        metadata.fieldNames(), store,
-        leafMaterializer(session, revision, def.getID(), leafCount), projectedBytes);
+        metadata.fieldNames(), store, def.getID(), projectedBytes);
   }
 
   /**
    * Segment fetcher bound to one session+revision: one fresh read transaction per column
-   * fill (batched). Rebuilt-and-rebound on every {@link #load} hit — see
-   * {@link ProjectionIndexRegistry.Handle#rebindLazySources}.
+   * fill (batched). Built by a CALLER from its OWN live session and threaded into the shared
+   * handle's fill calls — the handle never stores it.
    */
-  private static ProjectionColumnStore.SegmentFetcher segmentFetcher(
+  public static ProjectionColumnStore.SegmentFetcher segmentFetcher(
       final JsonResourceSession session, final int revision) {
     return offsets -> {
       try (JsonNodeReadOnlyTrx fetchRtx = session.beginNodeReadOnlyTrx(revision)) {
@@ -606,8 +602,12 @@ public final class ProjectionIndexCatalog {
     };
   }
 
-  /** Whole-leaf materializer bound to one session+revision — same rebind contract. */
-  private static Supplier<List<byte[]>> leafMaterializer(final JsonResourceSession session,
+  /**
+   * Whole-leaf materializer bound to one session+revision — built by a CALLER from its OWN
+   * live session and threaded into {@link ProjectionIndexRegistry.Handle#leafPayloads} on
+   * demand; the handle never stores it.
+   */
+  public static Supplier<List<byte[]>> leafMaterializer(final JsonResourceSession session,
       final int revision, final int defId, final int leafCount) {
     return () -> {
       try (JsonNodeReadOnlyTrx matRtx = session.beginNodeReadOnlyTrx(revision)) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -60,18 +60,18 @@ public final class ProjectionIndexRegistry {
     private volatile List<byte[]> leafPayloads;
     /**
      * Column-sliced view (P5b stage 2) — non-null marks a COLUMN-LAZY handle: constructed
-     * from descriptors only; {@link #leafPayloads()} materializes whole raw leaves on first
+     * from descriptors only; {@link #leafPayloads} materializes whole raw leaves on first
      * whole-leaf consumer, while column-scoped kernels and gates read {@link #columnStore}
      * slices and never trigger that materialization.
      */
     private final ProjectionColumnStore columnStore;
     /**
-     * Whole-leaf materializer of a column-lazy handle. Re-bindable for the same reason as
-     * {@link ProjectionColumnStore#rebindFetcher}: the handle lives in the catalog's static
-     * decode cache and outlives the session that built it, so the catalog re-binds this to
-     * the current caller's session on every cache lookup.
+     * Catalog index-definition id of a column-lazy handle (immutable identity, {@code -1} for
+     * eager/bench handles). NOT session-scoped: the caller uses it to build a whole-leaf
+     * materializer bound to ITS OWN live session and threads that into
+     * {@link #leafPayloads(Supplier)} — the handle stores nothing session-lifecycle-scoped.
      */
-    private volatile Supplier<List<byte[]>> materializer;
+    private final int defId;
     /** Guards materialization only — never the gate caches, which use {@code this}. */
     private final Object materializeLock = new Object();
     /**
@@ -162,13 +162,12 @@ public final class ProjectionIndexRegistry {
       this.leafPayloads = Objects.requireNonNull(leafPayloads, "leafPayloads");
       this.integralityEvidence = numericNonIntegral == null ? null : numericNonIntegral.clone();
       this.columnStore = null;
-      this.materializer = null;
+      this.defId = -1;
       this.projectedWeightBytes = 0L;
     }
 
     private Handle(final String rootPath, final int validFromRevision, final String[] fieldNames,
-        final ProjectionColumnStore columnStore,
-        final Supplier<List<byte[]>> materializer,
+        final ProjectionColumnStore columnStore, final int defId,
         final long projectedWeightBytes) {
       this.rootPath = rootPath;
       this.validFromRevision = validFromRevision;
@@ -176,42 +175,38 @@ public final class ProjectionIndexRegistry {
       this.leafPayloads = null;
       this.integralityEvidence = null;
       this.columnStore = Objects.requireNonNull(columnStore, "columnStore");
-      this.materializer = Objects.requireNonNull(materializer, "materializer");
+      this.defId = defId;
       this.projectedWeightBytes = projectedWeightBytes;
     }
 
     /**
      * Column-lazy handle (P5b stage 2): built from one descriptor walk; segment bytes are
-     * fetched per COLUMN by the kernels/gates, and whole raw leaves only materialize when a
-     * whole-leaf consumer (group-by, string predicates, canonical dicts) first asks.
+     * fetched per COLUMN by the kernels/gates through the CALLER's own live fetcher, and whole
+     * raw leaves only materialize when a whole-leaf consumer (group-by, string predicates,
+     * canonical dicts) first asks, through the CALLER's own materializer. {@code defId} is the
+     * immutable catalog definition id the caller uses to build that session-bound materializer.
      */
     public static Handle columnLazy(final String rootPath, final int validFromRevision,
-        final String[] fieldNames, final ProjectionColumnStore columnStore,
-        final Supplier<List<byte[]>> materializer,
+        final String[] fieldNames, final ProjectionColumnStore columnStore, final int defId,
         final long projectedWeightBytes) {
-      return new Handle(rootPath, validFromRevision, fieldNames, columnStore, materializer,
+      return new Handle(rootPath, validFromRevision, fieldNames, columnStore, defId,
           projectedWeightBytes);
+    }
+
+    /** Catalog definition id of a column-lazy handle ({@code -1} for eager/bench handles). */
+    public int defId() {
+      return defId;
+    }
+
+    /** Leaf count without materializing (descriptor truth for lazy; list size for eager). */
+    public int leafCount() {
+      return columnStore != null ? columnStore.leafCount()
+          : (leafPayloads == null ? 0 : leafPayloads.size());
     }
 
     /** Non-null on a column-lazy handle. */
     public ProjectionColumnStore columnStoreOrNull() {
       return columnStore;
-    }
-
-    /**
-     * Re-bind a column-lazy handle's segment fetcher and whole-leaf materializer to a LIVE
-     * session's closures (no-op for eager handles). The catalog calls this on every decode-
-     * cache hit so a handle built by a since-closed session keeps working: any live session
-     * serves, because the build revision's pages are immutable. Concurrent lookups re-bind
-     * to their own sessions — last write wins and every candidate is equally valid.
-     */
-    public void rebindLazySources(final ProjectionColumnStore.SegmentFetcher fetcher,
-        final Supplier<List<byte[]>> materializer) {
-      if (columnStore == null) {
-        return;
-      }
-      columnStore.rebindFetcher(fetcher);
-      this.materializer = Objects.requireNonNull(materializer, "materializer");
     }
 
     /**
@@ -223,7 +218,7 @@ public final class ProjectionIndexRegistry {
       if (columnStore != null) {
         return columnStore.columnKind(col);
       }
-      final List<byte[]> leaves = leafPayloads();
+      final List<byte[]> leaves = materializedLeaves();
       return leaves.isEmpty() ? ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
           : leaves.get(0)[24 + col];
     }
@@ -259,16 +254,9 @@ public final class ProjectionIndexRegistry {
       if (evidence != null) {
         return evidence;
       }
-      // Materialize + probe OUTSIDE the monitor (may be a multi-leaf hydrate on a lazy
-      // handle); a duplicate probe on a race is idempotent and the first publish wins.
-      final List<byte[]> leaves;
-      try {
-        leaves = leafPayloads();
-      } catch (final IllegalStateException materializeFailed) {
-        // Transient (dead-session window, I/O): report unknown WITHOUT caching so the
-        // next query — with re-bound sources — can still resolve real evidence.
-        return INTEGRALITY_UNKNOWN;
-      }
+      // Eager-handle path only (lazy handles resolve numeric integrality from column slices
+      // via sliceEvidence): the leaves are already materialized, so this never does I/O.
+      final List<byte[]> leaves = materializedLeaves();
       final boolean[] probed = ProjectionIndexByteScan.probeNumericNonIntegral(leaves);
       final boolean[] resolved = probed == null ? INTEGRALITY_UNKNOWN : probed;
       synchronized (this) {
@@ -287,12 +275,13 @@ public final class ProjectionIndexRegistry {
      * a fractional value. Used to gate value-exact fast paths (aggregates);
      * unknown provenance returns {@code false}.
      */
-    public boolean numericColumnIsIntegral(final int col) {
+    public boolean numericColumnIsIntegral(final int col,
+        final ProjectionColumnStore.SegmentFetcher fetcher) {
       if (columnStore != null && columnStore.columnSliceable(col)) {
         // Column-lazy fast path: flag truth from the column's own BODY slices — same
         // evidentiary weight as the whole-leaf probe (segment truth, hash-verified at
-        // slice decode), touching ONLY this column's segments.
-        return !columnFlagAny(col, ProjectionIndexLeafPage.COLUMN_FLAG_NON_INTEGRAL);
+        // slice decode), touching ONLY this column's segments through the caller's fetcher.
+        return !columnFlagAny(col, ProjectionIndexLeafPage.COLUMN_FLAG_NON_INTEGRAL, fetcher);
       }
       final boolean[] evidence = integralityEvidence();
       return evidence != INTEGRALITY_UNKNOWN && col >= 0 && col < evidence.length
@@ -311,7 +300,7 @@ public final class ProjectionIndexRegistry {
 
     private volatile byte[] sliceEvidence;
 
-    private byte sliceEvidence(final int col) {
+    private byte sliceEvidence(final int col, final ProjectionColumnStore.SegmentFetcher fetcher) {
       final byte[] ev = sliceEvidence;
       if (ev != null && ev[col] != 0) {
         return ev[col];
@@ -320,7 +309,7 @@ public final class ProjectionIndexRegistry {
       // derivation writes identical bits.
       byte bits = (byte) (EV_RESOLVED | EV_PURE_ALL);
       try {
-        for (final ProjectionColumnStore.ColumnSlice slice : columnStore.column(col)) {
+        for (final ProjectionColumnStore.ColumnSlice slice : columnStore.column(col, fetcher)) {
           final byte f = slice.flags();
           if ((f & ProjectionIndexLeafPage.COLUMN_FLAG_UNREPRESENTABLE) != 0) {
             bits |= EV_UNREP_ANY;
@@ -358,8 +347,9 @@ public final class ProjectionIndexRegistry {
      * serving; positive-sighting consumers must not route through here (see
      * {@link #numericColumnKnownNonIntegral}).
      */
-    private boolean columnFlagAny(final int col, final byte bit) {
-      final byte ev = sliceEvidence(col);
+    private boolean columnFlagAny(final int col, final byte bit,
+        final ProjectionColumnStore.SegmentFetcher fetcher) {
+      final byte ev = sliceEvidence(col, fetcher);
       if ((ev & EV_CORRUPT) != 0) {
         return true; // fail closed — gate callers treat "poisoned" as decline
       }
@@ -370,8 +360,9 @@ public final class ProjectionIndexRegistry {
     }
 
     /** {@code true} iff EVERY slice of sliceable column {@code col} carries {@code bit}; corrupt → false. */
-    private boolean columnFlagAll(final int col, final byte bit) {
-      final byte ev = sliceEvidence(col);
+    private boolean columnFlagAll(final int col, final byte bit,
+        final ProjectionColumnStore.SegmentFetcher fetcher) {
+      final byte ev = sliceEvidence(col, fetcher);
       // Only the purity bit is queried through the ALL direction today.
       return (ev & EV_CORRUPT) == 0 && (ev & EV_PURE_ALL) != 0;
     }
@@ -393,21 +384,16 @@ public final class ProjectionIndexRegistry {
      * space and surfaces {@code Dbl}, so digit-and-type parity holds). Unknown provenance
      * returns {@code false}.
      */
-    public boolean doubleColumnPureSource(final int col) {
+    public boolean doubleColumnPureSource(final int col,
+        final ProjectionColumnStore.SegmentFetcher fetcher) {
       if (columnStore != null && columnStore.columnSliceable(col)) {
         return columnStore.columnKind(col) == ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_DOUBLE
-            && columnFlagAll(col, ProjectionIndexLeafPage.COLUMN_FLAG_PURE_DOUBLE_SOURCE);
+            && columnFlagAll(col, ProjectionIndexLeafPage.COLUMN_FLAG_PURE_DOUBLE_SOURCE, fetcher);
       }
       boolean[] evidence = pureDoubleEvidence;
       if (evidence == null) {
-        // Materialize + probe outside the monitor; transient materialize failure reports
-        // impure WITHOUT caching (same contract as integralityEvidence()).
-        final List<byte[]> leaves;
-        try {
-          leaves = leafPayloads();
-        } catch (final IllegalStateException materializeFailed) {
-          return false;
-        }
+        // Eager-handle path only: the leaves are already materialized, so no I/O here.
+        final List<byte[]> leaves = materializedLeaves();
         final boolean[] probed = ProjectionIndexByteScan.probeDoublePureSource(leaves);
         final boolean[] resolved = probed == null ? PURITY_UNKNOWN : probed;
         synchronized (this) {
@@ -422,12 +408,13 @@ public final class ProjectionIndexRegistry {
     }
 
     /** {@code true} iff a non-integral value was POSITIVELY seen in the column. */
-    public boolean numericColumnKnownNonIntegral(final int col) {
+    public boolean numericColumnKnownNonIntegral(final int col,
+        final ProjectionColumnStore.SegmentFetcher fetcher) {
       if (columnStore != null && columnStore.columnSliceable(col)) {
         // "Known" requires an actual sighting: corrupt/unavailable evidence is UNKNOWN,
         // never a fabricated positive. Exactness still holds — serving that would read
         // the corrupt column fails its own fill and declines through the fail-soft flow.
-        final byte ev = sliceEvidence(col);
+        final byte ev = sliceEvidence(col, fetcher);
         return (ev & EV_CORRUPT) == 0 && (ev & EV_NONINT_ANY) != 0;
       }
       final boolean[] evidence = integralityEvidence();
@@ -443,21 +430,24 @@ public final class ProjectionIndexRegistry {
      * fall back (typed scan kernels / generic pipeline). Probe runs once per
      * handle and is cached.
      */
-    public boolean columnSparseClean(final int col) {
+    public boolean columnSparseClean(final int col,
+        final ProjectionColumnStore.SegmentFetcher fetcher,
+        final Supplier<List<byte[]>> materializer) {
       if (col < 0) return false;
       if (columnStore != null && columnStore.columnSliceable(col)) {
         // BODY segments always carry presence; slice decode validated structure and
         // hash, so the eager probe's invalid-tail arm cannot occur here — sparse-clean
         // reduces to the unrepresentable check (same fail-closed direction).
-        return !columnFlagAny(col, ProjectionIndexLeafPage.COLUMN_FLAG_UNREPRESENTABLE);
+        return !columnFlagAny(col, ProjectionIndexLeafPage.COLUMN_FLAG_UNREPRESENTABLE, fetcher);
       }
       byte[] status = sparseStatus;
       if (status == null) {
-        // Materialize + probe outside the monitor; transient materialize failure declines
-        // WITHOUT caching (same contract as integralityEvidence()).
+        // Whole-leaf path (eager handle, or a lazy handle's non-sliceable string column):
+        // materialize + probe outside the monitor through the caller's own materializer;
+        // transient materialize failure declines WITHOUT caching.
         final List<byte[]> leaves;
         try {
-          leaves = leafPayloads();
+          leaves = leafPayloads(materializer);
         } catch (final IllegalStateException materializeFailed) {
           return false;
         }
@@ -478,15 +468,18 @@ public final class ProjectionIndexRegistry {
     }
 
     /**
-     * Whole raw leaves — materializing a column-lazy handle on first call. Guarded by the
-     * dedicated {@link #materializeLock} (NOT {@code this}) so a multi-second hydrate never
-     * blocks the gate caches; waiters genuinely need the result, so blocking them is the
-     * cheapest correct choice (a CAS race would duplicate the full hydrate I/O).
+     * Whole raw leaves — materializing a column-lazy handle on first call through the
+     * CALLER's own live {@code materializer} (built from the caller's session). Guarded by
+     * the dedicated {@link #materializeLock} (NOT {@code this}) so a multi-second hydrate
+     * never blocks the gate caches; waiters genuinely need the result, so blocking them is
+     * the cheapest correct choice (a CAS race would duplicate the full hydrate I/O). Once
+     * materialized the immutable list is cached and shared — the {@code materializer} is not
+     * consulted again, so eager (pre-materialized) handles accept a {@code null} one.
      *
      * @throws IllegalStateException when a lazy handle's materializer fails (dead-session
      *         window, truncated/corrupt store) — callers decline to the generic pipeline
      */
-    public List<byte[]> leafPayloads() {
+    public List<byte[]> leafPayloads(final Supplier<List<byte[]>> materializer) {
       List<byte[]> leaves = leafPayloads;
       if (leaves != null) {
         return leaves;
@@ -494,11 +487,27 @@ public final class ProjectionIndexRegistry {
       synchronized (materializeLock) {
         leaves = leafPayloads;
         if (leaves == null) {
-          leaves = Objects.requireNonNull(materializer.get(), "materializer returned null");
+          leaves = Objects.requireNonNull(
+              Objects.requireNonNull(materializer, "materializer").get(),
+              "materializer returned null");
           leafPayloads = leaves;
         }
         return leaves;
       }
+    }
+
+    /**
+     * Whole raw leaves of an ALREADY-materialized handle (eager handles, or a lazy handle a
+     * prior consumer already hydrated). Does NO I/O and never needs a session-bound source.
+     *
+     * @throws IllegalStateException if the handle is a not-yet-materialized lazy handle
+     */
+    private List<byte[]> materializedLeaves() {
+      final List<byte[]> leaves = leafPayloads;
+      if (leaves == null) {
+        throw new IllegalStateException("whole-leaf access on a non-materialized column-lazy handle");
+      }
+      return leaves;
     }
 
     /** @return index of {@code name} in {@link #fieldNames}, or {@code -1}. */
@@ -523,7 +532,7 @@ public final class ProjectionIndexRegistry {
      * to {@code probeLeaves} leaves) on first call per column.
      */
     public byte[][] canonicalDict(final int groupColumn,
-        final int probeLeaves, final int cardLimit) {
+        final int probeLeaves, final int cardLimit, final Supplier<List<byte[]>> materializer) {
       if (groupColumn < 0) return null;
       byte[][][] cache = canonicalDicts;
       if (cache != null && groupColumn < cache.length) {
@@ -535,7 +544,8 @@ public final class ProjectionIndexRegistry {
       // publish under the monitor to avoid lost wake-ups.
       final byte[][] probed;
       try {
-        probed = ProjectionIndexByteScan.probeCanonicalDict(leafPayloads(), groupColumn, probeLeaves, cardLimit);
+        probed = ProjectionIndexByteScan.probeCanonicalDict(leafPayloads(materializer), groupColumn,
+            probeLeaves, cardLimit);
       } catch (final IllegalStateException materializeFailed) {
         // Transient lazy-handle materialize failure: decline dense group-by for THIS call
         // without caching ineligibility — the next query retries with re-bound sources.
@@ -1014,8 +1024,10 @@ public final class ProjectionIndexRegistry {
       // (see SirixVectorizedExecutor.DENSE_GROUPBY_ENABLED javadoc). Flip
       // on for workloads with larger STRING_DICT cardinality or non-C2
       // JIT where the hashmap path isn't as heavily intrinsified.
+      // Pre-warm runs on eager installed handles whose leaves are already materialized,
+      // so no materializer is needed for the canonical-dict probe.
       final byte[][] canonical = PREWARM_DENSE_GROUPBY_ENABLED
-          ? handle.canonicalDict(stringDictCol, 16, 256)
+          ? handle.canonicalDict(stringDictCol, 16, 256, null)
           : null;
       if (canonical != null) {
         final long[] denseCounts = new long[canonical.length];

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionSegmentFoldScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionSegmentFoldScan.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.index.projection;
 
+import io.sirix.index.projection.ProjectionColumnStore.SegmentFetcher;
 import io.sirix.index.projection.ProjectionIndexScan.ColumnPredicate;
 import io.sirix.index.projection.ProjectionIndexScan.PredicateTree;
 
@@ -135,7 +136,7 @@ public final class ProjectionSegmentFoldScan {
    *         established fail-soft flow
    */
   public static boolean eligible(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int aggColOrNegative) {
+      final ColumnPredicate[] predicates, final int aggColOrNegative, final SegmentFetcher fetcher) {
     for (final ColumnPredicate p : predicates) {
       if (p.stringLitBytes != null || !store.columnSliceable(p.column)) {
         return false;
@@ -155,7 +156,7 @@ public final class ProjectionSegmentFoldScan {
       if (!numericKind) {
         continue;
       }
-      final byte[][] segments = store.columnBytes(col);
+      final byte[][] segments = store.columnBytes(col, fetcher);
       for (int leaf = 0; leaf < segments.length; leaf++) {
         final int rowCount = store.rowCount(leaf);
         if (rowCount <= 0) {
@@ -172,14 +173,15 @@ public final class ProjectionSegmentFoldScan {
 
   /** Conjunctive count folded straight from segment bytes. */
   public static long conjunctiveCount(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates) {
-    return conjunctiveCount(store, predicates, 0, store.leafCount());
+      final ColumnPredicate[] predicates, final SegmentFetcher fetcher) {
+    return conjunctiveCount(store, predicates, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for the executor's chunked parallel dispatch — scratch is thread-local. */
   public static long conjunctiveCount(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int fromLeaf, final int toLeaf) {
-    final byte[][][] predBytes = resolvePredicateBytes(store, predicates);
+      final ColumnPredicate[] predicates, final int fromLeaf, final int toLeaf,
+      final SegmentFetcher fetcher) {
+    final byte[][][] predBytes = resolvePredicateBytes(store, predicates, fetcher);
     final boolean[] predNumeric = predicateNumeric(store, predicates);
     final Stream[] streams = newStreams(predicates.length);
     final Scratch s = SCRATCH.get();
@@ -212,20 +214,21 @@ public final class ProjectionSegmentFoldScan {
    * {@code {0, 0, Long.MAX_VALUE, Long.MIN_VALUE}}.
    */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc) {
-    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.leafCount());
+      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
+      final SegmentFetcher fetcher) {
+    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
       final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
-      final int fromLeaf, final int toLeaf) {
+      final int fromLeaf, final int toLeaf, final SegmentFetcher fetcher) {
     if (store.columnKind(numericColumn) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_LONG");
     }
-    final byte[][][] predBytes = resolvePredicateBytes(store, predicates);
+    final byte[][][] predBytes = resolvePredicateBytes(store, predicates, fetcher);
     final boolean[] predNumeric = predicateNumeric(store, predicates);
-    final byte[][] aggBytes = store.columnBytes(numericColumn);
+    final byte[][] aggBytes = store.columnBytes(numericColumn, fetcher);
     final Stream[] streams = newStreams(predicates.length);
     final Stream aggStream = new Stream();
     final Scratch s = SCRATCH.get();
@@ -301,8 +304,8 @@ public final class ProjectionSegmentFoldScan {
 
   /** {@link #eligible} for a predicate tree — same gates, over the tree's leaves. */
   public static boolean eligibleTree(final ProjectionColumnStore store, final PredicateTree tree,
-      final int aggColOrNegative) {
-    return eligible(store, tree.leaves, aggColOrNegative);
+      final int aggColOrNegative, final SegmentFetcher fetcher) {
+    return eligible(store, tree.leaves, aggColOrNegative, fetcher);
   }
 
   /**
@@ -310,15 +313,16 @@ public final class ProjectionSegmentFoldScan {
    * segment bytes. Leaf masks encode missing ⇒ {@code false}; combinators are word-wise
    * intersection/union — see the tree type's semantics contract.
    */
-  public static long treeCount(final ProjectionColumnStore store, final PredicateTree tree) {
-    return treeCount(store, tree, 0, store.leafCount());
+  public static long treeCount(final ProjectionColumnStore store, final PredicateTree tree,
+      final SegmentFetcher fetcher) {
+    return treeCount(store, tree, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static long treeCount(final ProjectionColumnStore store, final PredicateTree tree,
-      final int fromLeaf, final int toLeaf) {
+      final int fromLeaf, final int toLeaf, final SegmentFetcher fetcher) {
     final ColumnPredicate[] leaves = tree.leaves;
-    final byte[][][] leafBytes = resolvePredicateBytes(store, leaves);
+    final byte[][][] leafBytes = resolvePredicateBytes(store, leaves, fetcher);
     final boolean[] leafNumeric = predicateNumeric(store, leaves);
     final Stream[] streams = newStreams(leaves.length);
     final boolean[] leafLive = new boolean[leaves.length];
@@ -350,21 +354,22 @@ public final class ProjectionSegmentFoldScan {
    * {@code acc = [count, sum, min, max]}, aggregate-column presence ANDed before folding.
    */
   public static void treeAggregateNumeric(final ProjectionColumnStore store,
-      final PredicateTree tree, final int numericColumn, final long[] acc) {
-    treeAggregateNumeric(store, tree, numericColumn, acc, 0, store.leafCount());
+      final PredicateTree tree, final int numericColumn, final long[] acc,
+      final SegmentFetcher fetcher) {
+    treeAggregateNumeric(store, tree, numericColumn, acc, 0, store.leafCount(), fetcher);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static void treeAggregateNumeric(final ProjectionColumnStore store,
       final PredicateTree tree, final int numericColumn, final long[] acc,
-      final int fromLeaf, final int toLeaf) {
+      final int fromLeaf, final int toLeaf, final SegmentFetcher fetcher) {
     if (store.columnKind(numericColumn) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_LONG");
     }
     final ColumnPredicate[] leaves = tree.leaves;
-    final byte[][][] leafBytes = resolvePredicateBytes(store, leaves);
+    final byte[][][] leafBytes = resolvePredicateBytes(store, leaves, fetcher);
     final boolean[] leafNumeric = predicateNumeric(store, leaves);
-    final byte[][] aggBytes = store.columnBytes(numericColumn);
+    final byte[][] aggBytes = store.columnBytes(numericColumn, fetcher);
     final Stream[] streams = newStreams(leaves.length);
     final boolean[] leafLive = new boolean[leaves.length];
     final Stream aggStream = new Stream();
@@ -531,7 +536,7 @@ public final class ProjectionSegmentFoldScan {
   }
 
   private static byte[][][] resolvePredicateBytes(final ProjectionColumnStore store,
-      final ColumnPredicate[] predicates) {
+      final ColumnPredicate[] predicates, final SegmentFetcher fetcher) {
     if (predicates == null) {
       throw new IllegalArgumentException("predicates must not be null");
     }
@@ -541,7 +546,7 @@ public final class ProjectionSegmentFoldScan {
       if (p.stringLitBytes != null) {
         throw new IllegalStateException("String predicates are not foldable");
       }
-      bytes[i] = store.columnBytes(p.column);
+      bytes[i] = store.columnBytes(p.column, fetcher);
     }
     return bytes;
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
@@ -3,6 +3,7 @@
  */
 package io.sirix.index.projection;
 
+import io.sirix.index.projection.ProjectionColumnStore.SegmentFetcher;
 import io.sirix.index.projection.ProjectionIndexHOTStorage.LeafDirectory;
 import io.sirix.index.projection.ProjectionIndexScan.ColumnPredicate;
 import io.sirix.index.projection.ProjectionIndexScan.Op;
@@ -39,7 +40,8 @@ final class ProjectionColumnScanParityTest {
       ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT,
   };
 
-  private record Fixture(ProjectionColumnStore store, List<byte[]> rawLeaves) {
+  private record Fixture(ProjectionColumnStore store, List<byte[]> rawLeaves,
+      SegmentFetcher fetcher) {
   }
 
   /** Build a randomized multi-leaf store + the equivalent raw payload list. */
@@ -107,14 +109,15 @@ final class ProjectionColumnScanParityTest {
       }
       directories.add(new LeafDirectory(leaf + 1, encoded.descriptor(), ids, offsets));
     }
-    final ProjectionColumnStore store = new ProjectionColumnStore(directories, wanted -> {
+    final SegmentFetcher fetcher = wanted -> {
       final byte[][] out = new byte[wanted.length][];
       for (int i = 0; i < wanted.length; i++) {
         out[i] = segmentsByOffset.get(wanted[i]);
       }
       return out;
-    });
-    return new Fixture(store, rawLeaves);
+    };
+    final ProjectionColumnStore store = new ProjectionColumnStore(directories);
+    return new Fixture(store, rawLeaves, fetcher);
   }
 
   private static List<ColumnPredicate[]> predicateShapes() {
@@ -154,7 +157,7 @@ final class ProjectionColumnScanParityTest {
           continue;
         }
         assertEquals(ProjectionIndexScan.conjunctiveCount(fx.rawLeaves(), preds),
-            ProjectionColumnScan.conjunctiveCount(fx.store(), preds),
+            ProjectionColumnScan.conjunctiveCount(fx.store(), preds, fx.fetcher()),
             "count parity seed=" + seed + " preds=" + preds.length + " op=" + preds[0].op);
       }
     }
@@ -168,7 +171,7 @@ final class ProjectionColumnScanParityTest {
         final long[] expected = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
         ProjectionIndexByteScan.conjunctiveAggregateNumeric(fx.rawLeaves(), preds, 0, expected);
         final long[] actual = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionColumnScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual);
+        ProjectionColumnScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual, fx.fetcher());
         for (int i = 0; i < 4; i++) {
           assertEquals(expected[i], actual[i], "long agg[" + i + "] seed=" + seed);
         }
@@ -185,31 +188,31 @@ final class ProjectionColumnScanParityTest {
       final Fixture fx = buildFixture(seed, 7, seed % 2 == 0);
       final int leafCount = fx.store().leafCount();
       for (final ColumnPredicate[] preds : predicateShapes()) {
-        if (!ProjectionSegmentFoldScan.eligible(fx.store(), preds, 0)) {
+        if (!ProjectionSegmentFoldScan.eligible(fx.store(), preds, 0, fx.fetcher())) {
           continue;
         }
         final long expectedCount = preds.length == 0
             ? ProjectionIndexScan.countRows(fx.rawLeaves())
             : ProjectionIndexScan.conjunctiveCount(fx.rawLeaves(), preds);
-        assertEquals(expectedCount, ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds),
+        assertEquals(expectedCount, ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, fx.fetcher()),
             "fused count parity seed=" + seed + " preds=" + preds.length);
         // Ranged split — the executor's chunked parallel dispatch shape.
         final int mid = leafCount / 2;
         assertEquals(expectedCount,
-            ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, 0, mid)
-                + ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, mid, leafCount),
+            ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, 0, mid, fx.fetcher())
+                + ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, mid, leafCount, fx.fetcher()),
             "fused ranged count parity seed=" + seed);
         final long[] expected = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
         ProjectionIndexByteScan.conjunctiveAggregateNumeric(fx.rawLeaves(), preds, 0, expected);
         final long[] actual = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual, fx.fetcher());
         for (int i = 0; i < 4; i++) {
           assertEquals(expected[i], actual[i], "fused long agg[" + i + "] seed=" + seed);
         }
         final long[] left = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, left, 0, mid);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, left, 0, mid, fx.fetcher());
         final long[] right = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, right, mid, leafCount);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, right, mid, leafCount, fx.fetcher());
         assertEquals(expected[0], left[0] + right[0], "fused ranged agg count seed=" + seed);
         assertEquals(expected[1], left[1] + right[1], "fused ranged agg sum seed=" + seed);
         assertEquals(expected[2], Math.min(left[2], right[2]), "fused ranged agg min seed=" + seed);
@@ -227,25 +230,25 @@ final class ProjectionColumnScanParityTest {
       final Fixture fx = buildFixture(seed, 6, false, true);
       final int leafCount = fx.store().leafCount();
       for (final ColumnPredicate[] preds : predicateShapes()) {
-        if (!ProjectionSegmentFoldScan.eligible(fx.store(), preds, 0)) {
+        if (!ProjectionSegmentFoldScan.eligible(fx.store(), preds, 0, fx.fetcher())) {
           continue;
         }
         final long expectedCount = preds.length == 0
             ? ProjectionIndexScan.countRows(fx.rawLeaves())
             : ProjectionIndexScan.conjunctiveCount(fx.rawLeaves(), preds);
-        assertEquals(expectedCount, ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds),
+        assertEquals(expectedCount, ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, fx.fetcher()),
             "dense count parity seed=" + seed + " preds=" + preds.length);
         final long[] expected = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
         ProjectionIndexByteScan.conjunctiveAggregateNumeric(fx.rawLeaves(), preds, 0, expected);
         final long[] actual = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, actual, fx.fetcher());
         for (int i = 0; i < 4; i++) {
           assertEquals(expected[i], actual[i], "dense long agg[" + i + "] seed=" + seed);
         }
         final int mid = leafCount / 2;
         assertEquals(expectedCount,
-            ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, 0, mid)
-                + ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, mid, leafCount),
+            ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, 0, mid, fx.fetcher())
+                + ProjectionSegmentFoldScan.conjunctiveCount(fx.store(), preds, mid, leafCount, fx.fetcher()),
             "dense ranged count parity seed=" + seed);
       }
     }
@@ -261,21 +264,21 @@ final class ProjectionColumnScanParityTest {
       final Fixture fx = buildFixture(seed, 6, seed % 2 == 0);
       for (int trial = 0; trial < 12; trial++) {
         final ProjectionIndexScan.PredicateTree tree = randomTree(rnd);
-        if (!ProjectionSegmentFoldScan.eligibleTree(fx.store(), tree, 0)) {
+        if (!ProjectionSegmentFoldScan.eligibleTree(fx.store(), tree, 0, fx.fetcher())) {
           continue;
         }
-        final long expectedCount = naiveTreeCount(fx.store(), tree);
-        assertEquals(expectedCount, ProjectionSegmentFoldScan.treeCount(fx.store(), tree),
+        final long expectedCount = naiveTreeCount(fx.store(), tree, fx.fetcher());
+        assertEquals(expectedCount, ProjectionSegmentFoldScan.treeCount(fx.store(), tree, fx.fetcher()),
             "tree count parity seed=" + seed + " trial=" + trial);
         final int leafCount = fx.store().leafCount();
         final int mid = leafCount / 2;
         assertEquals(expectedCount,
-            ProjectionSegmentFoldScan.treeCount(fx.store(), tree, 0, mid)
-                + ProjectionSegmentFoldScan.treeCount(fx.store(), tree, mid, leafCount),
+            ProjectionSegmentFoldScan.treeCount(fx.store(), tree, 0, mid, fx.fetcher())
+                + ProjectionSegmentFoldScan.treeCount(fx.store(), tree, mid, leafCount, fx.fetcher()),
             "tree ranged count parity seed=" + seed + " trial=" + trial);
-        final long[] expected = naiveTreeAggregate(fx.store(), tree, 0);
+        final long[] expected = naiveTreeAggregate(fx.store(), tree, 0, fx.fetcher());
         final long[] actual = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.treeAggregateNumeric(fx.store(), tree, 0, actual);
+        ProjectionSegmentFoldScan.treeAggregateNumeric(fx.store(), tree, 0, actual, fx.fetcher());
         for (int i = 0; i < 4; i++) {
           assertEquals(expected[i], actual[i],
               "tree agg[" + i + "] seed=" + seed + " trial=" + trial);
@@ -322,12 +325,12 @@ final class ProjectionColumnScanParityTest {
 
   /** Row-at-a-time oracle over decoded slices — independent of the mask algebra. */
   private static long naiveTreeCount(final ProjectionColumnStore store,
-      final ProjectionIndexScan.PredicateTree tree) {
+      final ProjectionIndexScan.PredicateTree tree, final SegmentFetcher fetcher) {
     long total = 0;
     for (int leaf = 0; leaf < store.leafCount(); leaf++) {
       final int rows = store.rowCount(leaf);
       for (int r = 0; r < rows; r++) {
-        if (naiveTreeRow(store, tree, leaf, r)) {
+        if (naiveTreeRow(store, tree, leaf, r, fetcher)) {
           total++;
         }
       }
@@ -336,13 +339,13 @@ final class ProjectionColumnScanParityTest {
   }
 
   private static long[] naiveTreeAggregate(final ProjectionColumnStore store,
-      final ProjectionIndexScan.PredicateTree tree, final int aggCol) {
+      final ProjectionIndexScan.PredicateTree tree, final int aggCol, final SegmentFetcher fetcher) {
     final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
     for (int leaf = 0; leaf < store.leafCount(); leaf++) {
       final int rows = store.rowCount(leaf);
-      final ProjectionColumnStore.ColumnSlice agg = store.column(aggCol)[leaf];
+      final ProjectionColumnStore.ColumnSlice agg = store.column(aggCol, fetcher)[leaf];
       for (int r = 0; r < rows; r++) {
-        if (!naiveTreeRow(store, tree, leaf, r)) {
+        if (!naiveTreeRow(store, tree, leaf, r, fetcher)) {
           continue;
         }
         if ((agg.presenceWords()[r >>> 6] & (1L << (r & 63))) == 0) {
@@ -359,12 +362,13 @@ final class ProjectionColumnScanParityTest {
   }
 
   private static boolean naiveTreeRow(final ProjectionColumnStore store,
-      final ProjectionIndexScan.PredicateTree tree, final int leaf, final int r) {
+      final ProjectionIndexScan.PredicateTree tree, final int leaf, final int r,
+      final SegmentFetcher fetcher) {
     final boolean[] stack = new boolean[ProjectionIndexScan.PredicateTree.MAX_LEAVES];
     int depth = 0;
     for (final byte insn : tree.program) {
       if (insn >= 0) {
-        stack[depth++] = naiveLeafRow(store, tree.leaves[insn], leaf, r);
+        stack[depth++] = naiveLeafRow(store, tree.leaves[insn], leaf, r, fetcher);
       } else if (insn == ProjectionIndexScan.PredicateTree.OP_AND) {
         depth--;
         stack[depth - 1] = stack[depth - 1] && stack[depth];
@@ -377,8 +381,8 @@ final class ProjectionColumnScanParityTest {
   }
 
   private static boolean naiveLeafRow(final ProjectionColumnStore store, final ColumnPredicate p,
-      final int leaf, final int r) {
-    final ProjectionColumnStore.ColumnSlice slice = store.column(p.column)[leaf];
+      final int leaf, final int r, final SegmentFetcher fetcher) {
+    final ProjectionColumnStore.ColumnSlice slice = store.column(p.column, fetcher)[leaf];
     if ((slice.presenceWords()[r >>> 6] & (1L << (r & 63))) == 0) {
       return false; // missing ⇒ predicate false, the interpreter's general-comparison rule
     }
@@ -435,26 +439,27 @@ final class ProjectionColumnScanParityTest {
       nextOffset += 1 + encoded.segments()[i].length;
     }
     final ProjectionColumnStore store = new ProjectionColumnStore(
-        List.of(new LeafDirectory(1, encoded.descriptor(), ids, offsets)), wanted -> {
-          final byte[][] out = new byte[wanted.length][];
-          for (int i = 0; i < wanted.length; i++) {
-            out[i] = segmentsByOffset.get(wanted[i]);
-          }
-          return out;
-        });
+        List.of(new LeafDirectory(1, encoded.descriptor(), ids, offsets)));
+    final SegmentFetcher fetcher = wanted -> {
+      final byte[][] out = new byte[wanted.length][];
+      for (int i = 0; i < wanted.length; i++) {
+        out[i] = segmentsByOffset.get(wanted[i]);
+      }
+      return out;
+    };
     final ColumnPredicate[] longAndBool =
         { ColumnPredicate.numeric(0, Op.GT, 99L), ColumnPredicate.booleanEq(2, true) };
-    assertTrue(ProjectionSegmentFoldScan.eligible(store, longAndBool, 0),
+    assertTrue(ProjectionSegmentFoldScan.eligible(store, longAndBool, 0, fetcher),
         "plain-FOR long/boolean streams must be fold-eligible");
     final ColumnPredicate[] doublePred =
         { ColumnPredicate.numeric(1, Op.GT, ProjectionDoubleEncoding.encode(25.0)) };
-    assertFalse(ProjectionSegmentFoldScan.eligible(store, doublePred, -1),
+    assertFalse(ProjectionSegmentFoldScan.eligible(store, doublePred, -1, fetcher),
         "an ALP-escaped double stream must route to the slice kernels");
     assertEquals(ProjectionIndexScan.conjunctiveCount(List.of(raw), doublePred),
-        ProjectionColumnScan.conjunctiveCount(store, doublePred),
+        ProjectionColumnScan.conjunctiveCount(store, doublePred, fetcher),
         "the slice path must still serve the ALP column exactly");
     assertEquals(ProjectionIndexScan.conjunctiveCount(List.of(raw), longAndBool),
-        ProjectionSegmentFoldScan.conjunctiveCount(store, longAndBool),
+        ProjectionSegmentFoldScan.conjunctiveCount(store, longAndBool, fetcher),
         "the fused path must serve the eligible shape exactly");
   }
 
@@ -466,7 +471,7 @@ final class ProjectionColumnScanParityTest {
         final double[] expected = { 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
         ProjectionIndexByteScan.conjunctiveAggregateNumericDouble(fx.rawLeaves(), preds, 1, expected);
         final double[] actual = { 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
-        ProjectionColumnScan.conjunctiveAggregateNumericDouble(fx.store(), preds, 1, actual);
+        ProjectionColumnScan.conjunctiveAggregateNumericDouble(fx.store(), preds, 1, actual, fx.fetcher());
         for (int i = 0; i < 4; i++) {
           assertEquals(Double.doubleToRawLongBits(expected[i]), Double.doubleToRawLongBits(actual[i]),
               "double agg[" + i + "] seed=" + seed + " (bitwise, ±0.0 included)");
@@ -476,7 +481,7 @@ final class ProjectionColumnScanParityTest {
         final ProjectionIndexByteScan.MatchingDoubleCursor byteCursor =
             new ProjectionIndexByteScan.MatchingDoubleCursor(fx.rawLeaves(), preds, 1);
         final ProjectionColumnScan.MatchingDoubleCursor colCursor =
-            new ProjectionColumnScan.MatchingDoubleCursor(fx.store(), preds, 1);
+            new ProjectionColumnScan.MatchingDoubleCursor(fx.store(), preds, 1, fx.fetcher());
         while (true) {
           final boolean a = byteCursor.advance();
           final boolean b = colCursor.advance();
@@ -523,12 +528,12 @@ final class ProjectionColumnScanParityTest {
   @Test
   void stringPredicatesAndColumnsAreRejected() {
     final Fixture fx = buildFixture(17, 3, false);
-    assertThrows(IllegalStateException.class, () -> fx.store().column(3),
+    assertThrows(IllegalStateException.class, () -> fx.store().column(3, fx.fetcher()),
         "string columns must not slice");
     final ColumnPredicate[] stringPred =
         { ColumnPredicate.stringEq(3, "s1".getBytes(StandardCharsets.UTF_8)) };
     assertThrows(IllegalStateException.class,
-        () -> ProjectionColumnScan.conjunctiveCount(fx.store(), stringPred),
+        () -> ProjectionColumnScan.conjunctiveCount(fx.store(), stringPred, fx.fetcher()),
         "string predicates must be rejected loudly (callers gate and fall back)");
   }
 
@@ -537,25 +542,26 @@ final class ProjectionColumnScanParityTest {
     final Fixture good = buildFixture(29, 3, false);
     // Rebuild with a fetcher that corrupts one BODY byte — hash verification must throw.
     final Fixture tampered = buildFixture(29, 3, false);
-    final ProjectionColumnStore corrupt = new ProjectionColumnStore(
-        directoriesOf(tampered), offsets -> {
-          final byte[][] out = new byte[offsets.length][];
-          for (int i = 0; i < offsets.length; i++) {
-            final byte[] viaGood = fetchFrom(good, offsets[i]);
-            out[i] = viaGood == null ? null : viaGood.clone();
-            if (i == 1 && out[i] != null && out[i].length > 8) {
-              out[i][8] ^= 0x40;
-            }
-          }
-          return out;
-        });
-    assertThrows(IllegalStateException.class, () -> corrupt.column(0),
+    final ProjectionColumnStore corrupt = new ProjectionColumnStore(directoriesOf(tampered));
+    // A fetcher that corrupts one BODY byte — hash verification must throw when threaded in.
+    final SegmentFetcher corruptFetcher = offsets -> {
+      final byte[][] out = new byte[offsets.length][];
+      for (int i = 0; i < offsets.length; i++) {
+        final byte[] viaGood = fetchFrom(good, offsets[i]);
+        out[i] = viaGood == null ? null : viaGood.clone();
+        if (i == 1 && out[i] != null && out[i].length > 8) {
+          out[i][8] ^= 0x40;
+        }
+      }
+      return out;
+    };
+    assertThrows(IllegalStateException.class, () -> corrupt.column(0, corruptFetcher),
         "hash mismatch must reject, never serve tampered bytes");
-    assertThrows(IllegalStateException.class, () -> corrupt.columnBytes(0),
+    assertThrows(IllegalStateException.class, () -> corrupt.columnBytes(0, corruptFetcher),
         "the byte-level cache must reject tampered bytes identically");
     assertThrows(IllegalStateException.class,
         () -> ProjectionSegmentFoldScan.conjunctiveCount(corrupt,
-            new ColumnPredicate[] { ColumnPredicate.numeric(0, Op.GT, -1L) }),
+            new ColumnPredicate[] { ColumnPredicate.numeric(0, Op.GT, -1L) }, corruptFetcher),
         "the fused kernels must never fold unverified bytes");
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexIntegralityPersistenceTest.java
@@ -139,10 +139,10 @@ public final class ProjectionIndexIntegralityPersistenceTest {
     final List<byte[]> leaves = List.of(leaf(100, false).serialize(), leaf(80, true).serialize());
     final ProjectionIndexRegistry.Handle handle =
         new ProjectionIndexRegistry.Handle(FIELD_NAMES, leaves);
-    assertTrue(handle.numericColumnIsIntegral(0), "age column must stay aggregate-servable after re-open");
-    assertFalse(handle.numericColumnIsIntegral(2), "amount column saw truncated values");
-    assertTrue(handle.numericColumnKnownNonIntegral(2));
-    assertFalse(handle.numericColumnKnownNonIntegral(0));
+    assertTrue(handle.numericColumnIsIntegral(0, null), "age column must stay aggregate-servable after re-open");
+    assertFalse(handle.numericColumnIsIntegral(2, null), "amount column saw truncated values");
+    assertTrue(handle.numericColumnKnownNonIntegral(2, null));
+    assertFalse(handle.numericColumnKnownNonIntegral(0, null));
   }
 
   @Test
@@ -150,8 +150,8 @@ public final class ProjectionIndexIntegralityPersistenceTest {
     final byte[] tailed = leaf(100, false).serialize();
     final ProjectionIndexRegistry.Handle handle =
         new ProjectionIndexRegistry.Handle(FIELD_NAMES, List.of(tailed, stripTail(tailed)));
-    assertFalse(handle.numericColumnIsIntegral(0), "a malformed leaf must resolve the handle to UNKNOWN");
-    assertFalse(handle.numericColumnKnownNonIntegral(0));
+    assertFalse(handle.numericColumnIsIntegral(0, null), "a malformed leaf must resolve the handle to UNKNOWN");
+    assertFalse(handle.numericColumnKnownNonIntegral(0, null));
   }
 
   @Test
@@ -161,7 +161,7 @@ public final class ProjectionIndexIntegralityPersistenceTest {
     final List<byte[]> leaves = List.of(leaf(100, false).serialize());
     final ProjectionIndexRegistry.Handle handle =
         new ProjectionIndexRegistry.Handle(FIELD_NAMES, leaves, new boolean[] {false, false, true});
-    assertTrue(handle.numericColumnIsIntegral(0));
-    assertFalse(handle.numericColumnIsIntegral(2));
+    assertTrue(handle.numericColumnIsIntegral(0, null));
+    assertFalse(handle.numericColumnIsIntegral(2, null));
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexRegistryTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionIndexRegistryTest.java
@@ -77,7 +77,7 @@ final class ProjectionIndexRegistryTest {
 
     final ProjectionIndexRegistry.Handle handle = ProjectionIndexRegistry.lookup("res-A", new String[0]);
     assertNotNull(handle);
-    assertEquals(2, handle.leafPayloads().size());
+    assertEquals(2, handle.leafPayloads(null).size());
     assertEquals(0, handle.columnOf("age"));
     assertEquals(1, handle.columnOf("active"));
     assertEquals(2, handle.columnOf("dept"));
@@ -134,7 +134,7 @@ final class ProjectionIndexRegistryTest {
     ProjectionIndexRegistry.installWildcard("res-empty", new String[] {"age"}, List.of());
     final ProjectionIndexRegistry.Handle h = ProjectionIndexRegistry.lookup("res-empty", new String[0]);
     assertNotNull(h);
-    assertEquals(0, h.leafPayloads().size());
+    assertEquals(0, h.leafPayloads(null).size());
   }
 
   /**
@@ -184,10 +184,10 @@ final class ProjectionIndexRegistryTest {
     leaves.add(buildLeaf(100L, 32));
     final ProjectionIndexRegistry.Handle h = new ProjectionIndexRegistry.Handle(
         new String[] {"age", "active", "dept"}, leaves);
-    final byte[][] first = h.canonicalDict(2, 16, 256);
+    final byte[][] first = h.canonicalDict(2, 16, 256, null);
     assertNotNull(first);
     assertEquals(3, first.length);  // {Eng, Sales, Ops}
-    final byte[][] second = h.canonicalDict(2, 16, 256);
+    final byte[][] second = h.canonicalDict(2, 16, 256, null);
     // Same reference — cache hit.
     assertSame(first, second);
   }
@@ -201,9 +201,9 @@ final class ProjectionIndexRegistryTest {
     final List<byte[]> leaves = List.of(buildLeaf(0L, 8));
     final ProjectionIndexRegistry.Handle h = new ProjectionIndexRegistry.Handle(
         new String[] {"age", "active", "dept"}, leaves);
-    assertNull(h.canonicalDict(0, 16, 256));
+    assertNull(h.canonicalDict(0, 16, 256, null));
     // Second call — ineligible sentinel cached; still null.
-    assertNull(h.canonicalDict(0, 16, 256));
+    assertNull(h.canonicalDict(0, 16, 256, null));
   }
 
   /**
@@ -227,7 +227,7 @@ final class ProjectionIndexRegistryTest {
     final ProjectionIndexRegistry.Handle h = new ProjectionIndexRegistry.Handle(
         new String[] {"age", "active", "dept"}, leaves);
     // Limit 5, actual cardinality 10 → null.
-    assertNull(h.canonicalDict(2, 16, 5));
+    assertNull(h.canonicalDict(2, 16, 5, null));
   }
 
   /**
@@ -238,7 +238,7 @@ final class ProjectionIndexRegistryTest {
     final List<byte[]> leaves = List.of(buildLeaf(0L, 8));
     final ProjectionIndexRegistry.Handle h = new ProjectionIndexRegistry.Handle(
         new String[] {"age", "active", "dept"}, leaves);
-    assertNull(h.canonicalDict(-1, 16, 256));
+    assertNull(h.canonicalDict(-1, 16, 256, null));
     // Placate unused-import check.
     assertFalse(false);
   }
@@ -286,7 +286,7 @@ final class ProjectionIndexRegistryTest {
     ProjectionIndexRegistry.installWildcard("res-multi",
         new String[] {"age", "active", "dept"}, replacement);
     assertEquals(1, ProjectionIndexRegistry.lookupExactFields("res-multi",
-        new String[] {"age", "active", "dept"}).leafPayloads().size());
+        new String[] {"age", "active", "dept"}).leafPayloads(null).size());
 
     // uninstallWildcard removes exactly one entry.
     ProjectionIndexRegistry.uninstallWildcard("res-multi", new String[] {"age", "active", "dept"});

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -88,6 +88,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -718,7 +719,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     // every leaf and never hold unrepresentable values (null/object/array/
     // kind mismatch) — otherwise missing-vs-default and null-vs-missing are
     // indistinguishable in the columnar layout. Fail closed to the scan path.
-    if (!handle.columnSparseClean(groupColumn)) return null;
+    if (!handle.columnSparseClean(groupColumn, columnFetcher(), leafMaterializer(handle))) {
+      return null;
+    }
     final ProjectionIndexScan.ColumnPredicate[] emptyPreds = new ProjectionIndexScan.ColumnPredicate[0];
     final long[] missing = new long[1];
     final Object2LongOpenHashMap<String> agg;
@@ -963,22 +966,26 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     final ProjectionIndexRegistry.Handle handle = lookupProjection(sourcePath, required);
     if (handle == null) return null;
     final ProjectionColumnStore store = handle.columnStoreOrNull();
+    // Session-bound sources built from THIS executor's own live session, threaded into the
+    // shared handle's fill calls (no session-scoped state on the cached handle).
+    final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+    final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
     final int col = handle.columnOf(field);
     if (col < 0) return null;
     // One kind-check path for both handle tiers; columnKindOf never materializes a
     // column-lazy handle (descriptor truth).
-    if (store != null ? store.leafCount() == 0 : handle.leafPayloads().isEmpty()) return null;
+    if (handle.leafCount() == 0) return null;
     if (handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG) return null;
     // Value-exact gate: the builder truncates non-integral numbers into the
     // NUMERIC_LONG column (Number#longValue). Serve aggregates only when the
     // column is PROVABLY integral; unknown provenance falls back. On a lazy
     // handle these gates read the column's OWN slices — no materialization.
-    if (!handle.numericColumnIsIntegral(col)) {
+    if (!handle.numericColumnIsIntegral(col, fetcher)) {
       return null;
     }
     // Sparse-evidence gate: without per-row presence, MISSING rows would fold
     // their phantom default 0 into count/min/max (sum survives by luck).
-    if (!handle.columnSparseClean(col)) {
+    if (!handle.columnSparseClean(col, fetcher, materializer)) {
       return null;
     }
     final ProjectionIndexScan.ColumnPredicate[] preds;
@@ -990,13 +997,13 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (extracted == null) {
         // Not a pure conjunction — AND/OR trees serve through the fold kernels' tree
         // path (P5b stage 6); anything else (NOT, unsupported leaves) falls back.
-        return tryTreeAggregate(cp, handle, store, col);
+        return tryTreeAggregate(cp, handle, store, col, fetcher);
       }
       preds = fuseRangePredicates(extracted);
     }
     if (store != null && predsSliceable(store, preds)) {
       try {
-        return sliceAggregateParallel(store, preds, col);
+        return sliceAggregateParallel(store, preds, col, fetcher);
       } catch (final IllegalStateException ise) {
         // Corrupt/missing slices — fall through to the eager path, which re-surfaces
         // the condition through the established fail-soft flow.
@@ -1047,32 +1054,37 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    */
   private record DoubleAggServing(ProjectionIndexRegistry.Handle handle, int col,
       ProjectionIndexScan.ColumnPredicate[] preds, ProjectionColumnStore sliceStore,
-      boolean pure) {
+      boolean pure, ProjectionColumnStore.SegmentFetcher fetcher,
+      Supplier<List<byte[]>> materializer) {
     List<byte[]> leafPayloads() {
-      return handle.leafPayloads();
+      return handle.leafPayloads(materializer);
     }
   }
 
   /** Pre-fill every needed column on the calling thread (one I/O batch each, outside the fan-out). */
   private static void prefillColumns(final ProjectionColumnStore store,
-      final ProjectionIndexScan.ColumnPredicate[] preds, final int aggColOrNegative) {
+      final ProjectionIndexScan.ColumnPredicate[] preds, final int aggColOrNegative,
+      final ProjectionColumnStore.SegmentFetcher fetcher) {
     for (final ProjectionIndexScan.ColumnPredicate p : preds) {
-      store.column(p.column);
+      store.column(p.column, fetcher);
     }
     if (aggColOrNegative >= 0) {
-      store.column(aggColOrNegative);
+      store.column(aggColOrNegative, fetcher);
     }
   }
 
   /** Chunked parallel slice count — mirrors {@link #parallelConjunctiveCount}'s dispatch shape. */
   private long sliceCountParallel(final ProjectionColumnStore store,
-      final ProjectionIndexScan.ColumnPredicate[] preds) {
+      final ProjectionIndexScan.ColumnPredicate[] preds,
+      final ProjectionColumnStore.SegmentFetcher fetcher) {
     final int leafCount = store.leafCount();
     // Fold-during-decode first (P5b stage 4): counts stream straight from the verified
     // segment bytes — no slice arrays. ALP/reserved width escapes route to the slice path.
-    if (ProjectionSegmentFoldScan.eligible(store, preds, -1)) {
+    // eligible() pre-fills the involved columns on the calling thread through this reader's
+    // own fetcher, so the parallel ranged calls below hit cached bytes.
+    if (ProjectionSegmentFoldScan.eligible(store, preds, -1, fetcher)) {
       if (leafCount < 64) {
-        return ProjectionSegmentFoldScan.conjunctiveCount(store, preds);
+        return ProjectionSegmentFoldScan.conjunctiveCount(store, preds, fetcher);
       }
       final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
       final long[] perThread = new long[eff];
@@ -1081,7 +1093,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         final int from = idx * chunkSize;
         final int to = Math.min(from + chunkSize, leafCount);
         if (from >= to) return;
-        perThread[idx] = ProjectionSegmentFoldScan.conjunctiveCount(store, preds, from, to);
+        perThread[idx] = ProjectionSegmentFoldScan.conjunctiveCount(store, preds, from, to, fetcher);
       });
       long total = 0;
       for (final long t : perThread) {
@@ -1089,9 +1101,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       }
       return total;
     }
-    prefillColumns(store, preds, -1);
+    prefillColumns(store, preds, -1, fetcher);
     if (leafCount < 64) {
-      return ProjectionColumnScan.conjunctiveCount(store, preds);
+      return ProjectionColumnScan.conjunctiveCount(store, preds, fetcher);
     }
     final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
     final long[] perThread = new long[eff];
@@ -1100,7 +1112,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       final int from = idx * chunkSize;
       final int to = Math.min(from + chunkSize, leafCount);
       if (from >= to) return;
-      perThread[idx] = ProjectionColumnScan.conjunctiveCount(store, preds, from, to);
+      perThread[idx] = ProjectionColumnScan.conjunctiveCount(store, preds, from, to, fetcher);
     });
     long total = 0;
     for (final long t : perThread) {
@@ -1111,13 +1123,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
 
   /** Chunked parallel slice long-aggregate; exact integer merges. */
   private long[] sliceAggregateParallel(final ProjectionColumnStore store,
-      final ProjectionIndexScan.ColumnPredicate[] preds, final int col) {
+      final ProjectionIndexScan.ColumnPredicate[] preds, final int col,
+      final ProjectionColumnStore.SegmentFetcher fetcher) {
     final int leafCount = store.leafCount();
     // Fold-during-decode first (P5b stage 4) — same merge shape, byte substrate.
-    if (ProjectionSegmentFoldScan.eligible(store, preds, col)) {
+    if (ProjectionSegmentFoldScan.eligible(store, preds, col, fetcher)) {
       if (leafCount < 64) {
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, fetcher);
         return acc;
       }
       final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
@@ -1128,15 +1141,16 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         final int to = Math.min(from + chunkSize, leafCount);
         if (from >= to) return;
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, from, to);
+        ProjectionSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, from, to,
+            fetcher);
         perThread[idx] = acc;
       });
       return mergeLongAgg(perThread);
     }
-    prefillColumns(store, preds, col);
+    prefillColumns(store, preds, col, fetcher);
     if (leafCount < 64) {
       final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-      ProjectionColumnScan.conjunctiveAggregateNumeric(store, preds, col, acc);
+      ProjectionColumnScan.conjunctiveAggregateNumeric(store, preds, col, acc, fetcher);
       return acc;
     }
     final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
@@ -1147,7 +1161,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       final int to = Math.min(from + chunkSize, leafCount);
       if (from >= to) return;
       final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-      ProjectionColumnScan.conjunctiveAggregateNumeric(store, preds, col, acc, from, to);
+      ProjectionColumnScan.conjunctiveAggregateNumeric(store, preds, col, acc, from, to, fetcher);
       perThread[idx] = acc;
     });
     return mergeLongAgg(perThread);
@@ -1168,12 +1182,13 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
 
   /** Chunked parallel slice double stats (count/min/max order-insensitive; sum diagnostic). */
   private double[] sliceDoubleStatsParallel(final ProjectionColumnStore store,
-      final ProjectionIndexScan.ColumnPredicate[] preds, final int col) {
+      final ProjectionIndexScan.ColumnPredicate[] preds, final int col,
+      final ProjectionColumnStore.SegmentFetcher fetcher) {
     final int leafCount = store.leafCount();
-    prefillColumns(store, preds, col);
+    prefillColumns(store, preds, col, fetcher);
     if (leafCount < 64) {
       final double[] acc = { 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
-      ProjectionColumnScan.conjunctiveAggregateNumericDouble(store, preds, col, acc);
+      ProjectionColumnScan.conjunctiveAggregateNumericDouble(store, preds, col, acc, fetcher);
       return acc;
     }
     final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
@@ -1184,7 +1199,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       final int to = Math.min(from + chunkSize, leafCount);
       if (from >= to) return;
       final double[] acc = { 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
-      ProjectionColumnScan.conjunctiveAggregateNumericDouble(store, preds, col, acc, from, to);
+      ProjectionColumnScan.conjunctiveAggregateNumericDouble(store, preds, col, acc, from, to,
+          fetcher);
       perThread[idx] = acc;
     });
     final double[] merged = { 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
@@ -1203,9 +1219,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    * (dead-session window before the catalog's next rebind, truncated/corrupt store) —
    * callers decline serving and the generic pipeline answers.
    */
-  private static List<byte[]> leafPayloadsOrNull(final ProjectionIndexRegistry.Handle handle) {
+  private List<byte[]> leafPayloadsOrNull(final ProjectionIndexRegistry.Handle handle) {
     try {
-      return handle.leafPayloads();
+      return handle.leafPayloads(leafMaterializer(handle));
     } catch (final IllegalStateException materializeFailed) {
       return null;
     }
@@ -1241,15 +1257,17 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     final ProjectionColumnStore store = handle.columnStoreOrNull();
     final int col = handle.columnOf(field);
     if (col < 0) return null;
-    if (store != null ? store.leafCount() == 0 : handle.leafPayloads().isEmpty()) return null;
+    final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+    final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
+    if (handle.leafCount() == 0) return null;
     if (handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_DOUBLE) return null;
-    if (!handle.numericColumnIsIntegral(col)) {
+    if (!handle.numericColumnIsIntegral(col, fetcher)) {
       return null; // not provably value-exact — fail closed
     }
-    if (!handle.columnSparseClean(col)) {
+    if (!handle.columnSparseClean(col, fetcher, materializer)) {
       return null;
     }
-    final boolean pure = needsPurity && handle.doubleColumnPureSource(col);
+    final boolean pure = needsPurity && handle.doubleColumnPureSource(col, fetcher);
     if (needsPurity && !pure) {
       return null;
     }
@@ -1264,7 +1282,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     }
     final ProjectionColumnStore sliceStore =
         store != null && predsSliceable(store, preds) ? store : null;
-    return new DoubleAggServing(handle, col, preds, sliceStore, pure);
+    return new DoubleAggServing(handle, col, preds, sliceStore, pure, fetcher, materializer);
   }
 
   /**
@@ -1277,7 +1295,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
   private double[] doubleKernelStats(final DoubleAggServing s) {
     if (s.sliceStore() != null) {
       try {
-        return sliceDoubleStatsParallel(s.sliceStore(), s.preds(), s.col());
+        return sliceDoubleStatsParallel(s.sliceStore(), s.preds(), s.col(), s.fetcher());
       } catch (final IllegalStateException ise) {
         // Corrupt/missing slices — fall through to the eager kernels (same fallback the
         // long path gets), not the row-at-a-time interpreter.
@@ -1336,7 +1354,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     if (s.sliceStore() != null) {
       try {
         final ProjectionColumnScan.MatchingDoubleCursor cursor =
-            new ProjectionColumnScan.MatchingDoubleCursor(s.sliceStore(), s.preds(), s.col());
+            new ProjectionColumnScan.MatchingDoubleCursor(s.sliceStore(), s.preds(), s.col(),
+                s.fetcher());
         while (cursor.advance()) {
           final double v = cursor.value();
           sum = count == 0 ? v : sum + v;
@@ -1424,6 +1443,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     final ProjectionIndexRegistry.Handle handle =
         lookupProjection(sourcePath, requiredFields(groupFields, cp));
     if (handle == null) return null;
+    final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+    final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
     final List<byte[]> leafPayloads = leafPayloadsOrNull(handle);
     if (leafPayloads == null || leafPayloads.isEmpty()) return null;
     final int[] cols = new int[groupFields.length];
@@ -1437,7 +1458,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       // segment from presence bitmaps; without them (or with null/complex
       // values poisoning the column) the typed slot-walk kernel is the
       // correct fallback.
-      if (!handle.columnSparseClean(col)) {
+      if (!handle.columnSparseClean(col, fetcher, materializer)) {
         return null;
       }
       cols[i] = col;
@@ -1465,7 +1486,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         boolean denseEligible = true;
         long cellCount = 1L;
         for (int i = 0; i < cols.length; i++) {
-          canon[i] = handle.canonicalDict(cols[i], DENSE_GROUPBY_PROBE_LEAVES, DENSE_GROUPBY_CARD_LIMIT);
+          canon[i] = handle.canonicalDict(cols[i], DENSE_GROUPBY_PROBE_LEAVES,
+              DENSE_GROUPBY_CARD_LIMIT, materializer);
           if (canon[i] == null) {
             denseEligible = false;
             break;
@@ -3577,10 +3599,11 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
           + " fields=" + Arrays.toString(cp.fieldNames));
       return null;
     }
+    final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
     final ProjectionIndexScan.ColumnPredicate[] extracted = extractConjunctivePredicates(cp, handle);
     if (extracted == null) {
       // Not a pure conjunction — AND/OR trees serve through the fold kernels (stage 6).
-      final Long treeCount = tryTreeCount(cp, handle);
+      final Long treeCount = tryTreeCount(cp, handle, fetcher);
       if (treeCount == null && PROJ_DIAG) System.err.println("[proj] unsupported shape");
       return treeCount;
     }
@@ -3600,11 +3623,11 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         }
         return rows;
       }
-      return ProjectionIndexByteScan.countRows(handle.leafPayloads());
+      return ProjectionIndexByteScan.countRows(handle.leafPayloads(leafMaterializer(handle)));
     }
     if (store != null && predsSliceable(store, preds)) {
       try {
-        return sliceCountParallel(store, preds);
+        return sliceCountParallel(store, preds, fetcher);
       } catch (final IllegalStateException ise) {
         // Corrupt/missing slices — eager path re-surfaces through fail-soft.
       }
@@ -3783,9 +3806,11 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       final ProjectionIndexScan.ColumnPredicate[] preds,
       final int groupColumn,
       final long[] missingOut) {
-    final List<byte[]> leafPayloads = handle.leafPayloads();
+    final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
+    final List<byte[]> leafPayloads = handle.leafPayloads(materializer);
     final byte[][] canonicalDict = DENSE_GROUPBY_ENABLED
-        ? handle.canonicalDict(groupColumn, DENSE_GROUPBY_PROBE_LEAVES, DENSE_GROUPBY_CARD_LIMIT)
+        ? handle.canonicalDict(groupColumn, DENSE_GROUPBY_PROBE_LEAVES, DENSE_GROUPBY_CARD_LIMIT,
+            materializer)
         : null;
     if (canonicalDict != null) {
       return parallelConjunctiveCountByGroupDense(leafPayloads, preds, groupColumn, canonicalDict, missingOut);
@@ -3995,7 +4020,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     final int groupColumn = handle.columnOf(groupField);
     if (groupColumn < 0) return null;
     // Sparse-evidence gate — see tryProjectionIndexGroupByCountOnly.
-    if (!handle.columnSparseClean(groupColumn)) return null;
+    if (!handle.columnSparseClean(groupColumn, columnFetcher(), leafMaterializer(handle))) {
+      return null;
+    }
     final ProjectionIndexScan.ColumnPredicate[] extracted = extractConjunctivePredicates(cp, handle);
     if (extracted == null) return null;
     // iter#07 range fusion — same policy as tryProjectionIndexFastPath.
@@ -4157,7 +4184,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    * stack, no recursion, no boxing. {@code null} signals "unsupported
    * shape; fall back to the generic path".
    */
-  private static ProjectionIndexScan.ColumnPredicate[] extractConjunctivePredicates(
+  private ProjectionIndexScan.ColumnPredicate[] extractConjunctivePredicates(
       final CompiledPredicate cp, final ProjectionIndexRegistry.Handle handle) {
     // Collect leaf node indices via a flat conjunction walk. Stack + out
     // arrays are sized to the full node count — bounded by the predicate's
@@ -4203,7 +4230,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    * double columns). {@code null} = not servable — callers fall back. Shared by the flat
    * conjunctive extractor and the AND/OR tree extractor so the gates can never diverge.
    */
-  private static ProjectionIndexScan.ColumnPredicate convertPredicateLeaf(
+  private ProjectionIndexScan.ColumnPredicate convertPredicateLeaf(
       final CompiledPredicate cp, final int n, final ProjectionIndexRegistry.Handle handle) {
     {
       final byte op = cp.ops[n];
@@ -4211,12 +4238,16 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (fi < 0 || fi >= cp.fieldNames.length) return null;
       final int column = handle.columnOf(cp.fieldNames[fi]);
       if (column < 0) return null; // field not in index — should have been filtered by covers()
+      // Session-bound sources built from THIS executor's own live session, threaded into the
+      // shared handle's gate/fill calls.
+      final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+      final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
       // Sparse-evidence gate: a predicate over a column without per-row
       // presence data (legacy v1 leaves) or with unrepresentable values
       // (null/object/array/kind mismatch) would evaluate against stored
       // DEFAULTS — e.g. `x < 40` matching every missing row via the phantom
       // 0. Fail closed; the scan-path kernels handle missing correctly.
-      if (!handle.columnSparseClean(column)) return null;
+      if (!handle.columnSparseClean(column, fetcher, materializer)) return null;
       // NUMERIC_DOUBLE columns store the order-preserving transform: literals must be
       // transformed at plan time (comparing untransformed literals against transformed cells
       // silently returns wrong rows), and only provably value-exact columns may serve
@@ -4258,7 +4289,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
           final ProjectionIndexScan.Op translated = translateCmpOp(cp.cmpOp[n]);
           if (translated == null) return null;
           if (doubleColumn) {
-            if (!handle.numericColumnIsIntegral(column)) return null; // value-exact gate
+            if (!handle.numericColumnIsIntegral(column, fetcher)) return null; // value-exact gate
             final double asDouble = (double) cp.longLit[n];
             if ((long) asDouble != cp.longLit[n]) return null; // literal beyond 2^53 — inexact
             pred = ProjectionIndexScan.ColumnPredicate.numeric(column, translated,
@@ -4269,7 +4300,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
             // e.g. `score > 2` would match 2.5 stored as 2 incorrectly. Unknown
             // provenance keeps the legacy behavior (no regression for re-encoded
             // handles); known-clean columns are exact.
-            if (handle.numericColumnKnownNonIntegral(column)) return null;
+            if (handle.numericColumnKnownNonIntegral(column, fetcher)) return null;
             pred = ProjectionIndexScan.ColumnPredicate.numeric(column, translated, cp.longLit[n]);
           }
         }
@@ -4277,7 +4308,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
           if (doubleColumn) {
             // Native double comparison: transform the literal, keep the operator — no
             // threshold rewrite needed (the transform is order-isomorphic).
-            if (!handle.numericColumnIsIntegral(column)) return null; // value-exact gate
+            if (!handle.numericColumnIsIntegral(column, fetcher)) return null; // value-exact gate
             if (Double.isNaN(cp.dblLit[n])) return null;
             final ProjectionIndexScan.Op translated = translateCmpOp(cp.cmpOp[n]);
             if (translated == null) return null;
@@ -4289,7 +4320,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
             // unknown provenance fails closed, the column stores truncated
             // doubles otherwise). The threshold is rewritten into exact long
             // space (x > 9.99 ⟺ x >= 10) — see rewriteFpCmpForIntegralColumn.
-            if (!handle.numericColumnIsIntegral(column)) return null;
+            if (!handle.numericColumnIsIntegral(column, fetcher)) return null;
             pred = rewriteFpCmpForIntegralColumn(column, cp.cmpOp[n], cp.dblLit[n]);
             if (pred == null) return null;
           }
@@ -4301,7 +4332,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
             // with the original operator is exact parity, even for decimals that are not
             // binary-representable. The long-space arm below would compare untransformed
             // integers against transformed cells (silent wrong rows).
-            if (!handle.numericColumnIsIntegral(column)) return null; // value-exact gate
+            if (!handle.numericColumnIsIntegral(column, fetcher)) return null; // value-exact gate
             final ProjectionIndexScan.Op translatedDec = translateCmpOp(cp.cmpOp[n]);
             if (translatedDec == null || cp.decLit[n] == null) return null;
             final double promoted = cp.decLit[n].doubleValue();
@@ -4312,7 +4343,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
           // Exact-decimal threshold on a NUMERIC_LONG column: the compile
           // step already collapsed the decimal comparison into a pure
           // long-space arm — translate it. Same integrality gate as FP_CMP.
-          if (!handle.numericColumnIsIntegral(column)) return null;
+          if (!handle.numericColumnIsIntegral(column, fetcher)) return null;
           pred = switch (cp.decLongArm[n]) {
             case CompiledPredicate.DEC_ARM_GE ->
                 ProjectionIndexScan.ColumnPredicate.numeric(column, ProjectionIndexScan.Op.GE, cp.decLongLit[n]);
@@ -4356,7 +4387,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    * conjunctions are expected to have been taken by {@link #extractConjunctivePredicates}
    * first; this is the OR-bearing general case. {@code null} = fall back.
    */
-  private static ProjectionIndexScan.PredicateTree extractPredicateTree(
+  private ProjectionIndexScan.PredicateTree extractPredicateTree(
       final CompiledPredicate cp, final ProjectionIndexRegistry.Handle handle) {
     final ArrayList<ProjectionIndexScan.ColumnPredicate> leaves = new ArrayList<>();
     final byte[] program = new byte[2 * cp.ops.length];
@@ -4370,7 +4401,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
   }
 
   /** Recursive postfix emitter for {@link #extractPredicateTree}; {@code false} = unsupported shape. */
-  private static boolean emitTreeNode(final CompiledPredicate cp, final int n,
+  private boolean emitTreeNode(final CompiledPredicate cp, final int n,
       final ProjectionIndexRegistry.Handle handle,
       final ArrayList<ProjectionIndexScan.ColumnPredicate> leaves, final byte[] program,
       final int[] pc) {
@@ -4414,7 +4445,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
 
   /** OR-tree count serving (stage 6): fold kernels only — the generic pipeline is the fallback. */
   private Long tryTreeCount(final CompiledPredicate cp,
-      final ProjectionIndexRegistry.Handle handle) {
+      final ProjectionIndexRegistry.Handle handle,
+      final ProjectionColumnStore.SegmentFetcher fetcher) {
     final ProjectionColumnStore store = handle.columnStoreOrNull();
     if (store == null || store.leafCount() == 0) {
       return null;
@@ -4424,12 +4456,12 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       return null;
     }
     try {
-      if (!ProjectionSegmentFoldScan.eligibleTree(store, tree, -1)) {
+      if (!ProjectionSegmentFoldScan.eligibleTree(store, tree, -1, fetcher)) {
         return null;
       }
       final int leafCount = store.leafCount();
       if (leafCount < 64) {
-        return ProjectionSegmentFoldScan.treeCount(store, tree);
+        return ProjectionSegmentFoldScan.treeCount(store, tree, fetcher);
       }
       final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
       final long[] perThread = new long[eff];
@@ -4438,7 +4470,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         final int from = idx * chunkSize;
         final int to = Math.min(from + chunkSize, leafCount);
         if (from >= to) return;
-        perThread[idx] = ProjectionSegmentFoldScan.treeCount(store, tree, from, to);
+        perThread[idx] = ProjectionSegmentFoldScan.treeCount(store, tree, from, to, fetcher);
       });
       long total = 0;
       for (final long t : perThread) {
@@ -4454,7 +4486,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
   /** OR-tree long-aggregate serving (stage 6) — same contract as {@link #tryTreeCount}. */
   private long[] tryTreeAggregate(final CompiledPredicate cp,
       final ProjectionIndexRegistry.Handle handle, final ProjectionColumnStore store,
-      final int col) {
+      final int col, final ProjectionColumnStore.SegmentFetcher fetcher) {
     if (store == null || store.leafCount() == 0) {
       return null;
     }
@@ -4463,13 +4495,13 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       return null;
     }
     try {
-      if (!ProjectionSegmentFoldScan.eligibleTree(store, tree, col)) {
+      if (!ProjectionSegmentFoldScan.eligibleTree(store, tree, col, fetcher)) {
         return null;
       }
       final int leafCount = store.leafCount();
       if (leafCount < 64) {
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.treeAggregateNumeric(store, tree, col, acc);
+        ProjectionSegmentFoldScan.treeAggregateNumeric(store, tree, col, acc, fetcher);
         return acc;
       }
       final int eff = Math.min(threads, Math.max(1, (leafCount + 63) / 64));
@@ -4480,7 +4512,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         final int to = Math.min(from + chunkSize, leafCount);
         if (from >= to) return;
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionSegmentFoldScan.treeAggregateNumeric(store, tree, col, acc, from, to);
+        ProjectionSegmentFoldScan.treeAggregateNumeric(store, tree, col, acc, from, to, fetcher);
         perThread[idx] = acc;
       });
       return mergeLongAgg(perThread);
@@ -4548,6 +4580,31 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     }
     return ProjectionIndexRegistry.lookupCovering(projectionRegistryKey, sourcePath, requiredFields,
         revision);
+  }
+
+  /**
+   * A {@link ProjectionColumnStore.SegmentFetcher} bound to THIS executor's OWN live session
+   * and revision — threaded into a SHARED column-lazy handle's per-column fill calls so every
+   * fill reads through this reader's own transaction, never a since-closed sibling's. Cheap
+   * (a closure); a caller builds one per query and reuses it across the query's fill calls.
+   */
+  private ProjectionColumnStore.SegmentFetcher columnFetcher() {
+    return ProjectionIndexCatalog.segmentFetcher(session, revision);
+  }
+
+  /**
+   * A whole-leaf materializer bound to THIS executor's OWN live session and revision, or
+   * {@code null} for an eager handle whose leaves are already resident (the materializer is
+   * never consulted then). Threaded into {@link ProjectionIndexRegistry.Handle#leafPayloads}
+   * so a lazy handle's hydrate uses this reader's own transaction.
+   */
+  private Supplier<List<byte[]>> leafMaterializer(final ProjectionIndexRegistry.Handle handle) {
+    final ProjectionColumnStore store = handle.columnStoreOrNull();
+    if (store == null) {
+      return null;
+    }
+    return ProjectionIndexCatalog.leafMaterializer(session, revision, handle.defId(),
+        store.leafCount());
   }
 
   /** The write transaction's index controller (wtx mode only). */
@@ -6194,7 +6251,9 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     if (groupColumn < 0) return null;
     // Sparse-evidence gate: without presence data, rows MISSING the field
     // would contribute the "" default as a phantom distinct value.
-    if (!handle.columnSparseClean(groupColumn)) return null;
+    if (!handle.columnSparseClean(groupColumn, columnFetcher(), leafMaterializer(handle))) {
+      return null;
+    }
     // Dictionary-union fast path: with the column sparse-clean, every
     // non-empty dict entry was interned by a real present row, so the
     // distinct set is the union of the per-leaf dictionaries — no per-row
@@ -6619,12 +6678,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (handle == null) {
         return null;
       }
+      final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+      final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
       final int[] groupCols = new int[keyCount];
       for (int g = 0; g < keyCount; g++) {
         final int col = handle.columnOf(groupFields[g]);
         if (col < 0
             || handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_STRING_DICT
-            || !handle.columnSparseClean(col)) {
+            || !handle.columnSparseClean(col, fetcher, materializer)) {
           return null;
         }
         groupCols[g] = col;
@@ -6642,7 +6703,8 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         final int col = handle.columnOf(distinctFields.get(i));
         if (col < 0
             || handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
-            || !handle.numericColumnIsIntegral(col) || !handle.columnSparseClean(col)) {
+            || !handle.numericColumnIsIntegral(col, fetcher)
+            || !handle.columnSparseClean(col, fetcher, materializer)) {
           return null;
         }
         aggCols[i] = col;
@@ -6816,12 +6878,15 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (handle == null) {
         return null;
       }
+      final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+      final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
       final int[] cols = new int[keyCount];
       for (int k = 0; k < keyCount; k++) {
         final int col = handle.columnOf(orderFields[k]);
         if (col < 0
             || handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
-            || !handle.numericColumnIsIntegral(col) || !handle.columnSparseClean(col)) {
+            || !handle.numericColumnIsIntegral(col, fetcher)
+            || !handle.columnSparseClean(col, fetcher, materializer)) {
           return null;
         }
         cols[k] = col;
@@ -7042,12 +7107,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (handle == null) {
         return null;
       }
+      final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+      final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
       final int n = fields.length;
       final int[] cols = new int[n];
       final byte[] kinds = new byte[n];
       for (int i = 0; i < n; i++) {
         final int col = handle.columnOf(fields[i]);
-        if (col < 0 || !handle.columnSparseClean(col)) {
+        if (col < 0 || !handle.columnSparseClean(col, fetcher, materializer)) {
           return null;
         }
         final byte kind = handle.columnKindOf(col);
@@ -7058,14 +7125,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
           case ProjectionIndexLeafPage.COLUMN_KIND_BOOLEAN:
             break;
           case ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG:
-            if (!handle.numericColumnIsIntegral(col)) {
+            if (!handle.numericColumnIsIntegral(col, fetcher)) {
               return null; // value-exact gate, same as aggregate serving
             }
             break;
           case ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_DOUBLE:
             // Dbl(decode(bits)) reproduces the interpreter's deref ONLY when every stored
             // value came from a real Double/Float source (same gate as double aggregates).
-            if (!handle.doubleColumnPureSource(col)) {
+            if (!handle.doubleColumnPureSource(col, fetcher)) {
               return null;
             }
             break;
@@ -7229,12 +7296,15 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (handle == null) {
         return null;
       }
+      final ProjectionColumnStore.SegmentFetcher fetcher = columnFetcher();
+      final Supplier<List<byte[]>> materializer = leafMaterializer(handle);
       final int[] cols = new int[fields.length];
       for (int i = 0; i < fields.length; i++) {
         final int col = handle.columnOf(fields[i]);
         if (col < 0
             || handle.columnKindOf(col) != ProjectionIndexLeafPage.COLUMN_KIND_NUMERIC_LONG
-            || !handle.numericColumnIsIntegral(col) || !handle.columnSparseClean(col)) {
+            || !handle.numericColumnIsIntegral(col, fetcher)
+            || !handle.columnSparseClean(col, fetcher, materializer)) {
           return null; // value-exact gate, same as plain aggregate serving
         }
         cols[i] = col;

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionColdHydrateBenchTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionColdHydrateBenchTest.java
@@ -92,7 +92,8 @@ public final class ProjectionColdHydrateBenchTest extends AbstractJsonTest {
       final long hydrateMs = (System.nanoTime() - t) / 1_000_000;
       Assertions.assertNotNull(handle);
       System.out.println("[coldbench] hydrate_cold_ms=" + hydrateMs
-          + " leaves=" + handle.leafPayloads().size());
+          + " leaves=" + handle.leafPayloads(ProjectionIndexCatalog.leafMaterializer(
+              session, revision, handle.defId(), handle.leafCount())).size());
       // Hydrate again with everything OS/page warm to isolate steady re-decode cost.
       ProjectionIndexCatalog.clearCache();
       t = System.nanoTime();

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -4,6 +4,7 @@ import io.brackit.query.Query;
 import io.brackit.query.compiler.translator.SequentialPipelineStrategy;
 import io.sirix.JsonTestHelper;
 import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.ProjectionColumnStore;
 import io.sirix.index.projection.ProjectionIndexByteScan;
 import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.index.projection.ProjectionIndexRegistry;
@@ -94,7 +95,9 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       Assertions.assertTrue(ProjectionIndexCatalog.dataCacheSize() > 0,
           "the handle load must hydrate — proving the accessor distinguishes the tiers");
       Assertions.assertEquals(fromDescriptors,
-          ProjectionIndexByteScan.countRows(handle.leafPayloads()),
+          ProjectionIndexByteScan.countRows(handle.leafPayloads(
+              ProjectionIndexCatalog.leafMaterializer(session, revision, handle.defId(),
+                  handle.leafCount()))),
           "descriptor-tier and hydrate-tier counts must agree");
     }
   }
@@ -231,15 +234,23 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
           sessionB, resourceKey, revision, new String[] { "[]" }, new String[] { "age" });
       Assertions.assertSame(built, cached, "the decode cache must return the same handle");
       final int ageCol = cached.columnOf("age");
-      Assertions.assertTrue(cached.numericColumnIsIntegral(ageCol),
-          "the gate's column fill must succeed through the re-bound fetcher");
-      Assertions.assertTrue(cached.columnSparseClean(ageCol),
-          "slice evidence must resolve through the re-bound fetcher");
+      // Session B threads ITS OWN live fetcher/materializer into the shared cached handle's
+      // fills — the handle stores nothing session-scoped, so a closed origin session cannot
+      // poison serving.
+      final ProjectionColumnStore.SegmentFetcher fetcher =
+          ProjectionIndexCatalog.segmentFetcher(sessionB, revision);
+      final java.util.function.Supplier<java.util.List<byte[]>> materializer =
+          ProjectionIndexCatalog.leafMaterializer(sessionB, revision, cached.defId(),
+              cached.columnStoreOrNull().leafCount());
+      Assertions.assertTrue(cached.numericColumnIsIntegral(ageCol, fetcher),
+          "the gate's column fill must succeed through session B's own fetcher");
+      Assertions.assertTrue(cached.columnSparseClean(ageCol, fetcher, materializer),
+          "slice evidence must resolve through session B's own fetcher");
       Assertions.assertEquals(cached.columnStoreOrNull().leafCount(),
-          cached.columnStoreOrNull().column(ageCol).length,
-          "the column fill must decode every leaf's slice through the re-bound fetcher");
-      Assertions.assertEquals(5L, ProjectionIndexByteScan.countRows(cached.leafPayloads()),
-          "whole-leaf materialization must succeed through the re-bound materializer");
+          cached.columnStoreOrNull().column(ageCol, fetcher).length,
+          "the column fill must decode every leaf's slice through session B's own fetcher");
+      Assertions.assertEquals(5L, ProjectionIndexByteScan.countRows(cached.leafPayloads(materializer)),
+          "whole-leaf materialization must succeed through session B's own materializer");
     }
   }
 

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexStressTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexStressTest.java
@@ -300,7 +300,8 @@ public final class ProjectionIndexStressTest extends AbstractJsonTest {
           .openProjectionIndex(rtx.getStorageEngineReader(), SOURCE_PATH, new String[] { "age" });
       Assertions.assertNotNull(handle, "the maintained projection must still be served");
       int rows = 0;
-      for (final byte[] leaf : handle.leafPayloads()) {
+      for (final byte[] leaf : handle.leafPayloads(ProjectionIndexCatalog.leafMaterializer(
+          session, revision, handle.defId(), handle.leafCount()))) {
         rows += ProjectionIndexLeafPage.deserialize(leaf).getRowCount();
       }
       return rows;

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexWtxServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexWtxServingTest.java
@@ -7,6 +7,7 @@ import io.sirix.access.Databases;
 import io.sirix.api.Database;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.index.projection.ProjectionIndexLeafPage;
 import io.sirix.index.projection.ProjectionIndexRegistry;
 import io.sirix.node.NodeKind;
@@ -275,7 +276,8 @@ public final class ProjectionIndexWtxServingTest extends AbstractJsonTest {
           .openProjectionIndex(rtx.getStorageEngineReader(), SOURCE_PATH, new String[] { "age" });
       Assertions.assertNotNull(handle, "the maintained projection must still be served");
       int rows = 0;
-      for (final byte[] leaf : handle.leafPayloads()) {
+      for (final byte[] leaf : handle.leafPayloads(ProjectionIndexCatalog.leafMaterializer(
+          session, mostRecent, handle.defId(), handle.leafCount()))) {
         rows += ProjectionIndexLeafPage.deserialize(leaf).getRowCount();
       }
       return rows;


### PR DESCRIPTION
## What does this PR do?

`ProjectionIndexCatalog` caches decoded projection handles in a process-global cache. On every cache hit it rebound the **shared** handle's lazy I/O sources (segment fetcher + whole-leaf materializer) to the *calling reader's* short-lived session, last-writer-wins. Two concurrent readers serving the same revision shared one handle and overwrote each other's binding, so one reader's column fill could run through another reader's session — which that reader then closed, yielding a use-after-close and the intermittent "concurrent reader observed an inconsistency" failure in `ProjectionIndexStressTest.concurrentReadersServeConsistentRevisionsDuringMaintenance`.

The fix removes all session-lifecycle-scoped state from the cached handle; **a reader stays bound to its own transaction**:

- `ProjectionColumnStore` drops its mutable fetcher field and `rebindFetcher`; the fetcher is now a parameter of `column(col, fetcher)` / `columnBytes(col, fetcher)`.
- `Handle` drops `rebindLazySources` and the rebindable materializer; it keeps only immutable identity (adding a `final defId`) and content-addressed derived caches. Fill-triggering methods take the caller's fetcher/materializer; `leafPayloads` takes the materializer and tolerates `null` once materialized.
- `ProjectionIndexCatalog.load` no longer rebinds; `segmentFetcher`/`leafMaterializer` become the way a caller builds sources from its *own* session.
- The column/fold scans and `SirixVectorizedExecutor` thread a fetcher/materializer built from their own session/revision into every fill.

The decoded state (column slices, raw segment bytes, materialized leaves) stays **shared and immutable**; concurrent first-touch fills are content-addressed and the synchronized publish is unchanged, so results are identical and no reader ever drives I/O through another reader's transaction.

## Related issue

Closes #1133.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] `./gradlew build` passes locally (JDK 25) — full `sirix-core` + `sirix-query` suites green (10,442 tests, 0 failures); `ProjectionIndexStressTest` green 6× pinned to 2 CPUs
- [x] Added or updated tests covering the change — projection serving/parity/stress suites updated to the new signatures; `ProjectionIndexCatalogServingTest` still pins the cross-session invariant
- [x] For behavioral changes to the storage engine: read-path only; decoded-state and publish invariants unchanged
- [ ] Updated documentation (README / docs) where relevant: n/a
- [x] No unrelated formatting churn

## Notes for reviewers

Two independent adversarial reviews (concurrency correctness; API-threading/regressions) found no defect. Key verified properties: no `JsonResourceSession`/`NodeReadOnlyTrx`/closure survives on any cached object; the `null`-fetcher paths are provably eager-only (no NPE); the synchronized clone-and-swap publish and fail-soft memo are unchanged; and the new async risk is absent — the parallel path joins all futures before returning, and although a `SirixVectorizedExecutor` is shared across concurrent queries, each query threads its own fresh fetcher and the cached handle stores none, so no cross-binding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PavdHDQDnmk42QwygZE7Bq)_