### PR TITLE
Add delta-of-delta codec for temporal number columns

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -2786,6 +2786,10 @@ public enum PageKind {
       final byte[] booleanPayload = regionTable.payload(RegionTable.KIND_BOOLEAN);
 
       NumberRegion.Header numberHeader = null;
+      // Non-null only when the number region is delta-encoded: all values are
+      // bulk-decoded once here (O(n)) so per-slot access is O(1) instead of the
+      // O(index) delta prefix-sum that would make this loop O(n²).
+      long[] numberValues = null;
       StringRegion.Header stringHeader = null;
       BooleanRegion.Header booleanHeader = null;
 
@@ -2829,6 +2833,15 @@ public enum PageKind {
                 numberRanks = VALUE_RANK_COUNTER.get();
                 numberRanks.clear();
                 numberRanks.defaultReturnValue(0);
+                if (NumberRegion.isDelta(numberHeader.encodingKind)) {
+                  long[] scratch = NUMBER_VALUES_SCRATCH.get();
+                  if (scratch.length < numberHeader.count) {
+                    scratch = new long[numberHeader.count];
+                    NUMBER_VALUES_SCRATCH.set(scratch);
+                  }
+                  NumberRegion.decodeAllValues(numberPayload, numberHeader, scratch);
+                  numberValues = scratch;
+                }
               }
               final int tag = lookupTagForSlot(slottedPage, slot, recordBase, fcRead,
                   numberHeader.tagKind == NumberRegion.TAG_KIND_PATH_NODE, pageKeyBase);
@@ -2845,7 +2858,9 @@ public enum PageKind {
                     "value-elision: NUMBER slot rank out of bounds at slot " + slot
                         + ": absIdx=" + absIdx + " count=" + numberHeader.count);
               }
-              final long longVal = NumberRegion.decodeValueAt(numberPayload, numberHeader, absIdx);
+              final long longVal = numberValues != null
+                  ? numberValues[absIdx]
+                  : NumberRegion.decodeValueAt(numberPayload, numberHeader, absIdx);
               slottedPage.set(ValueLayout.JAVA_BYTE, valueAbsOff, typeByte);
               final int actualWidth;
               if (typeByte == NUMBER_TYPE_INTEGER) {
@@ -4647,6 +4662,16 @@ public enum PageKind {
    */
   private static final ThreadLocal<NumberRegion.Header> NUMBER_HEADER_SCRATCH =
       ThreadLocal.withInitial(NumberRegion.Header::new);
+
+  /**
+   * Per-thread scratch holding all number values decoded once for a
+   * delta-encoded ({@link NumberRegion#ENC_DELTA_ZM}) region. Delta random
+   * access is O(index), so the per-slot rehydration loop bulk-decodes the whole
+   * region up front (O(n)) and indexes this array instead of paying O(n²).
+   * Grows on demand; other encodings never touch it.
+   */
+  private static final ThreadLocal<long[]> NUMBER_VALUES_SCRATCH =
+      ThreadLocal.withInitial(() -> new long[PageLayout.SLOT_COUNT]);
 
   /**
    * Per-thread Long2IntOpenHashMap-equivalent scratch for tag → slotRank-counter

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegion.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegion.java
@@ -59,6 +59,20 @@ public final class NumberRegion {
   public static final byte ENC_COMPACT_ZM = 4;
 
   /**
+   * Value-bytes encoded via {@link NumberRegionDelta} (delta-of-delta / zig-zag
+   * bit-pack). Outer tag dict + zone maps are laid out exactly like
+   * {@link #ENC_COMPACT_ZM} (no outer {@code valueBase}/{@code valueBitWidth} —
+   * those live in the nested delta header). Chosen automatically when it
+   * produces a strictly smaller value region than FOR+BP, which is the case for
+   * temporal columns (commit timestamps, valid-time, monotonic ids).
+   *
+   * <p>Delta decode is sequential, so payloads under this encoding are excluded
+   * from the SIMD scan kernels (they fall back to the scalar
+   * {@link #decodeValueAt} / {@link #decodeAllValues} loop).
+   */
+  public static final byte ENC_DELTA_ZM = 5;
+
+  /**
    * Write {@link #ENC_COMPACT_ZM} instead of {@link #ENC_BIT_PACKED_ZM} on the
    * bit-packed path when enabled. Off by default because the compact codec
    * adds ~2-7 bytes/region of framing overhead (version + varint) without a
@@ -88,6 +102,37 @@ public final class NumberRegion {
   }
 
   /**
+   * Enable/disable the delta-of-delta ({@link #ENC_DELTA_ZM}) write path. When
+   * enabled (the default) the encoder emits delta whenever it yields a strictly
+   * smaller value region than FOR+BP; when disabled the encoder never writes
+   * delta (readers still decode existing delta payloads). Toggled without a
+   * class reload for A/B tests.
+   */
+  private static volatile Boolean DELTA_WRITE_OVERRIDE = null;
+
+  /** Test hook: force-enable/disable delta-ZM writes without restarting the JVM. */
+  public static void setDeltaWriteEnabled(final boolean enabled) {
+    DELTA_WRITE_OVERRIDE = enabled;
+  }
+
+  /** Test hook: clear the override and fall back to the default (enabled). */
+  public static void clearDeltaWriteOverride() {
+    DELTA_WRITE_OVERRIDE = null;
+  }
+
+  private static boolean deltaWriteEnabled() {
+    final Boolean ov = DELTA_WRITE_OVERRIDE;
+    if (ov != null) {
+      return ov;
+    }
+    // Default ON — the size bake-off only picks delta when it actually wins.
+    return !Boolean.getBoolean("sirix.numberRegion.deltaWrite.disabled");
+  }
+
+  /** Minimum value count before delta is even considered (avoids churn on tiny pages). */
+  private static final int MIN_DELTA_COUNT = 3;
+
+  /**
    * {@code tagKind} classifier for the region's tag dictionary. Determines the
    * semantic interpretation of {@link Header#dict}:
    *
@@ -110,17 +155,26 @@ public final class NumberRegion {
   }
 
   /**
-   * @return the "plain vs bit-packed" flag without the zone-map bit. Treats
-   *         {@link #ENC_COMPACT_ZM} as bit-packed (the compact codec is a
-   *         bit-packed encoding under the hood, just with embedded header).
+   * @return true iff the value bytes are FOR + bit-packed and directly
+   *         random-accessible / SIMD-scannable. {@link #ENC_COMPACT_ZM} counts
+   *         (bit-packed under an embedded header); {@link #ENC_DELTA_ZM} does
+   *         <em>not</em> — delta is sequential and must never be routed through
+   *         a FOR unpack loop.
    */
   public static boolean isBitPacked(final byte encodingKind) {
-    return (encodingKind & 1) != 0 || encodingKind == ENC_COMPACT_ZM;
+    return encodingKind == ENC_BIT_PACKED
+        || encodingKind == ENC_BIT_PACKED_ZM
+        || encodingKind == ENC_COMPACT_ZM;
   }
 
   /** @return true iff {@code encodingKind == ENC_COMPACT_ZM}. */
   public static boolean isCompact(final byte encodingKind) {
     return encodingKind == ENC_COMPACT_ZM;
+  }
+
+  /** @return true iff {@code encodingKind == ENC_DELTA_ZM} (delta-of-delta). */
+  public static boolean isDelta(final byte encodingKind) {
+    return encodingKind == ENC_DELTA_ZM;
   }
 
   private NumberRegion() {}
@@ -157,6 +211,12 @@ public final class NumberRegion {
     public long[] tagMax;
     public int valueBytesOffset;
     public int valueBytesLength;
+    /**
+     * Nested delta header. Populated only for {@link #ENC_DELTA_ZM}; null
+     * otherwise. Carries {@code firstValue}/{@code firstDelta}/{@code bodyOffset}
+     * needed to replay the delta prefix sum.
+     */
+    public NumberRegionDelta.Header deltaHeader;
 
     public Header parseInto(final byte[] payload) {
       final ByteBuffer bb = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
@@ -165,9 +225,9 @@ public final class NumberRegion {
       count = bb.getInt();
       valueMin = bb.getLong();
       valueMax = bb.getLong();
-      if (encodingKind == ENC_COMPACT_ZM) {
-        // Compact-ZM: no outer valueBase/valueBitWidth — those live inside
-        // the nested compact header which precedes the body.
+      if (encodingKind == ENC_COMPACT_ZM || encodingKind == ENC_DELTA_ZM) {
+        // Compact-ZM / Delta-ZM: no outer valueBase/valueBitWidth — those live
+        // inside the nested codec header which precedes the body.
         valueBase = 0L;
         valueBitWidth = 0;
       } else {
@@ -204,7 +264,22 @@ public final class NumberRegion {
         valueBitWidth = compactH.bitWidth;
         valueBytesOffset = (int) compactH.bodyOffset;
         valueBytesLength = (int) compactH.bodyBytes;
+        deltaHeader = null; // defensive: never leave a stale delta header on a reused Header
+      } else if (encodingKind == ENC_DELTA_ZM) {
+        // Parse the nested delta header. valueBytesOffset points at the delta
+        // body; decode goes through NumberRegionDelta, not the FOR unpack path.
+        final int deltaHeaderOff = bb.position();
+        final MemorySegment segView = MemorySegment.ofArray(payload);
+        if (deltaHeader == null) {
+          deltaHeader = new NumberRegionDelta.Header();
+        }
+        NumberRegionDelta.readHeader(segView, deltaHeaderOff, deltaHeader);
+        valueBase = 0L;
+        valueBitWidth = deltaHeader.bitWidth;
+        valueBytesOffset = (int) deltaHeader.bodyOffset;
+        valueBytesLength = (int) deltaHeader.bodyBytes;
       } else {
+        deltaHeader = null;
         valueBytesOffset = bb.position();
         valueBytesLength = bitsToBytes((long) count * (isBitPacked(encodingKind) ? valueBitWidth : 64));
       }
@@ -310,6 +385,34 @@ public final class NumberRegion {
     }
     final long spread = count == 0 ? 0 : (max - min);
     final boolean bitPacked = count > 0 && spread >= 0 && spread < (1L << 48);
+
+    // Delta-of-delta bake-off. Two conditions must both hold:
+    //   1. Structure: the delta-of-delta residual width is *strictly* narrower
+    //      than the FOR/plain per-value width. This is what separates a genuine
+    //      temporal column (near-constant stride ⇒ tiny residuals) from random
+    //      data, where delta-of-delta is as wide or wider. Without it a wide
+    //      random column would switch to delta to shave a few header bytes —
+    //      a bad trade, since delta forfeits SIMD scans and O(1) random access.
+    //   2. Size: the delta value region is actually smaller (guards the small-
+    //      count case where the two 8-byte anchors outweigh the width saving).
+    // The outer header (dict, tag directory, zone maps) is identical across
+    // ENC_BIT_PACKED_ZM/ENC_DELTA_ZM, so only the value regions are compared:
+    // FOR+BP writes 9 outer bytes (valueBase + width) plus the packed body;
+    // delta writes its self-describing nested payload.
+    if (deltaWriteEnabled() && count >= MIN_DELTA_COUNT) {
+      final int forBitWidth = bitPacked ? Math.max(1, 64 - Long.numberOfLeadingZeros(spread)) : 64;
+      final int deltaBitWidth = NumberRegionDelta.computeBitWidth(sortedValues, count);
+      if (deltaBitWidth < forBitWidth) {
+        final long forValueRegionBytes = 9L + bitsToBytes((long) count * forBitWidth);
+        final long deltaRegionBytes = NumberRegionDelta.headerBytes(count)
+            + NumberRegionDelta.bodyBytes(count, deltaBitWidth);
+        if (deltaRegionBytes < forValueRegionBytes) {
+          return encodeDeltaZM(sortedValues, count, dict, dictSize, tagStart, tagCount,
+              tagMin, tagMax, min, max, tagKind);
+        }
+      }
+    }
+
     if (bitPacked && compactWriteEnabled()) {
       return encodeCompactZM(sortedValues, count, dict, dictSize, tagStart, tagCount,
           tagMin, tagMax, min, max, tagKind);
@@ -416,10 +519,63 @@ public final class NumberRegion {
     return trimmed;
   }
 
+  /**
+   * Build an {@link #ENC_DELTA_ZM} payload. Outer layout matches
+   * {@link #encodeCompactZM} (no outer {@code valueBase}/{@code valueBitWidth});
+   * the value region is a {@link NumberRegionDelta} payload with its own
+   * header (version, ddBitWidth, varint count, first value, first delta,
+   * bit-packed residuals).
+   */
+  private static byte[] encodeDeltaZM(final long[] sortedValues, final int count,
+      final int[] dict, final int dictSize, final int[] tagStart, final int[] tagCount,
+      final long[] tagMin, final long[] tagMax, final long min, final long max,
+      final byte tagKind) {
+    final int outerHeaderBytes = 1 /* encodingKind */ + 1 /* tagKind */ + 4 /* count */
+        + 8 /* valueMin */ + 8 /* valueMax */ + 4 /* dictSize */
+        + (4 * dictSize)   // dict
+        + (4 * dictSize)   // tagStart
+        + (4 * dictSize);  // tagCount
+    final int zoneMapBytes = (8 + 8) * dictSize;
+    final long deltaSize = NumberRegionDelta.maxEncodedSize(sortedValues, count);
+    final int totalBytes = outerHeaderBytes + zoneMapBytes + (int) deltaSize;
+    final byte[] out = new byte[totalBytes];
+    final ByteBuffer bb = ByteBuffer.wrap(out).order(ByteOrder.LITTLE_ENDIAN);
+    bb.put(ENC_DELTA_ZM);
+    bb.put(tagKind);
+    bb.putInt(count);
+    bb.putLong(min);
+    bb.putLong(max);
+    bb.putInt(dictSize);
+    for (int i = 0; i < dictSize; i++) bb.putInt(dict[i]);
+    for (int i = 0; i < dictSize; i++) bb.putInt(tagStart[i]);
+    for (int i = 0; i < dictSize; i++) bb.putInt(tagCount[i]);
+    for (int i = 0; i < dictSize; i++) bb.putLong(tagMin[i]);
+    for (int i = 0; i < dictSize; i++) bb.putLong(tagMax[i]);
+
+    final int deltaStart = bb.position();
+    final MemorySegment view = MemorySegment.ofArray(out);
+    final long written = NumberRegionDelta.writeDelta(view, deltaStart, sortedValues, count);
+    final int actualTotal = deltaStart + (int) written;
+    if (actualTotal == out.length) {
+      return out;
+    }
+    final byte[] trimmed = new byte[actualTotal];
+    System.arraycopy(out, 0, trimmed, 0, actualTotal);
+    return trimmed;
+  }
+
   // ───────────────────────────────────────────────────────────── decoding
 
-  /** Decode the value at {@code index} (absolute within the sorted payload). O(1). */
+  /**
+   * Decode the value at {@code index} (absolute within the sorted payload).
+   * O(1) for every encoding except {@link #ENC_DELTA_ZM}, where the sequential
+   * prefix sum makes it O(index) — scan loops over delta payloads should use
+   * {@link #decodeAllValues} instead.
+   */
   public static long decodeValueAt(final byte[] payload, final Header h, final int index) {
+    if (isDelta(h.encodingKind)) {
+      return NumberRegionDelta.readDelta(MemorySegment.ofArray(payload), h.deltaHeader, index);
+    }
     if (!isBitPacked(h.encodingKind)) {
       return readLittleEndianLong(payload, h.valueBytesOffset + (index << 3));
     }
@@ -448,6 +604,11 @@ public final class NumberRegion {
   /** Bulk-decode all values (across all tags) into {@code out}. */
   public static void decodeAllValues(final byte[] payload, final Header h, final long[] out) {
     final int count = h.count;
+    if (isDelta(h.encodingKind)) {
+      // Single sequential prefix sum — the fast path for delta payloads.
+      NumberRegionDelta.decodeAll(MemorySegment.ofArray(payload), h.deltaHeader, out);
+      return;
+    }
     if (!isBitPacked(h.encodingKind)) {
       int off = h.valueBytesOffset;
       for (int i = 0; i < count; i++, off += 8) {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionDelta.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionDelta.java
@@ -1,0 +1,596 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page.pax;
+
+import io.sirix.node.LE;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Delta-of-delta ("DoubleDelta") codec for {@code long[]} sequences over an
+ * off-heap {@link MemorySegment}. Sibling of {@link NumberRegionCompact}: where
+ * that codec removes a shared frame-of-reference base and bit-packs the
+ * residuals, this one removes both the base <em>and the slope</em>, bit-packing
+ * only the change in stride between consecutive values.
+ *
+ * <p>The target workload is temporal columns — commit timestamps, valid-time
+ * bounds, monotonic sequence numbers — where values advance by a near-constant
+ * stride. For a strictly constant stride (e.g. one tick per row) every
+ * delta-of-delta is {@code 0}, the bit width collapses to {@code 0}, and the
+ * body disappears entirely: the whole column reduces to {@code firstValue} +
+ * {@code firstDelta} regardless of length. This is the same family of codec
+ * ClickHouse exposes as {@code DoubleDelta} and Gorilla uses for its timestamp
+ * stream.
+ *
+ * <h2>Wire format</h2>
+ * <pre>
+ * byte    version      // format version, currently VERSION_V1
+ * byte    ddBitWidth   // 0..64; bits per zig-zag(delta-of-delta). 0 ⇒ no body
+ * varint  n            // unsigned: number of values encoded
+ * long    firstValue   // v[0], stored raw LE (0 when n == 0)
+ * long    firstDelta   // v[1]-v[0], stored raw LE signed (0 when n < 2)
+ * byte[]  body          // ceil(max(0,n-2) * ddBitWidth / 8) bytes, bit-packed LE
+ * </pre>
+ *
+ * <p>Decode is a running prefix sum: {@code delta += dd; value += delta}. That
+ * is inherently sequential, so unlike {@link NumberRegionCompact} random access
+ * costs {@code O(index)} ({@link #readDelta}); bulk {@link #decodeAll} is the
+ * fast path and is what scan operators use.
+ *
+ * <h2>Zone maps</h2>
+ * <p>This codec deliberately does <em>not</em> compute or store min/max. In the
+ * PAX layout the enclosing {@link NumberRegion} header already carries the
+ * global and per-tag zone maps (computed from the raw values before any value
+ * codec runs), exactly as it does for {@link NumberRegionCompact}. Duplicating
+ * them here would waste bytes and risk divergence.
+ *
+ * <h2>HFT-grade constraints</h2>
+ * <ul>
+ *   <li>Zero allocation on both encode and decode hot paths.</li>
+ *   <li>All shifts + masks; the only branch in the steady state is the
+ *       word-straddle check inherited from the bit-packing layer.</li>
+ *   <li>Accepts both on-heap-backed and native-backed MemorySegments.</li>
+ *   <li>Operates on {@code long} offsets throughout — no 2 GiB wrap risk.</li>
+ * </ul>
+ */
+public final class NumberRegionDelta {
+
+  /** Current wire format version. Bumped when the on-disk layout changes. */
+  public static final byte VERSION_V1 = 1;
+
+  private NumberRegionDelta() {
+    // utility class
+  }
+
+  // ────────────────────────────────────────────────────────────── size helpers
+
+  /**
+   * Exact byte count required to encode {@code values} with delta-of-delta.
+   *
+   * @param values source values
+   * @param count number of valid entries (0..values.length)
+   * @return byte count the encoding will consume
+   */
+  public static long maxEncodedSize(final long[] values, final int count) {
+    if (values == null) {
+      throw new IllegalArgumentException("values");
+    }
+    if (count < 0 || count > values.length) {
+      throw new IllegalArgumentException("count=" + count + " values.length=" + values.length);
+    }
+    final int bitWidth = computeBitWidth(values, count);
+    return headerBytes(count) + bodyBytes(count, bitWidth);
+  }
+
+  /**
+   * Bytes the fixed header consumes for {@code n == count}: the count field is
+   * varint-encoded, the two anchor longs are always present.
+   */
+  public static long headerBytes(final int count) {
+    if (count < 0) {
+      throw new IllegalArgumentException("count=" + count);
+    }
+    // 1 version + 1 ddBitWidth + varint(count) + 8 firstValue + 8 firstDelta
+    return 1L + 1L + varintSize(count) + 8L + 8L;
+  }
+
+  /**
+   * Exact size of the bit-packed body for {@code count} values at
+   * {@code ddBitWidth} bits. Only {@code max(0, count-2)} residuals are stored
+   * (the first two values are the raw anchors).
+   */
+  public static long bodyBytes(final int count, final int bitWidth) {
+    if (count < 0) {
+      throw new IllegalArgumentException("count=" + count);
+    }
+    if (bitWidth < 0 || bitWidth > 64) {
+      throw new IllegalArgumentException("bitWidth=" + bitWidth);
+    }
+    final int residuals = count > 2 ? count - 2 : 0;
+    if (bitWidth == 0 || residuals == 0) {
+      return 0L;
+    }
+    final long totalBits = (long) residuals * (long) bitWidth;
+    return (totalBits + 7L) >>> 3;
+  }
+
+  /**
+   * Smallest bit width W such that every zig-zag(delta-of-delta) residual fits
+   * in unsigned W bits. Returns 0 when there are fewer than three values, or
+   * when every residual is 0 (constant-stride shortcut — no body needed).
+   *
+   * @param values source array
+   * @param count number of valid entries
+   * @return bit width in {@code [0..64]}
+   */
+  public static int computeBitWidth(final long[] values, final int count) {
+    if (values == null) {
+      throw new IllegalArgumentException("values");
+    }
+    if (count < 0 || count > values.length) {
+      throw new IllegalArgumentException("count=" + count + " values.length=" + values.length);
+    }
+    if (count <= 2) {
+      return 0;
+    }
+    long prevDelta = values[1] - values[0];
+    long maxZigZag = 0L;
+    for (int i = 2; i < count; i++) {
+      final long delta = values[i] - values[i - 1];
+      final long dd = delta - prevDelta;
+      prevDelta = delta;
+      final long zz = zigZagEncode(dd);
+      // Unsigned max: a zig-zag of a large-magnitude dd can set the top bit,
+      // making the value "negative" as a signed long. Compare unsigned so the
+      // widest residual wins regardless of sign.
+      if (Long.compareUnsigned(zz, maxZigZag) > 0) {
+        maxZigZag = zz;
+      }
+    }
+    if (maxZigZag == 0L) {
+      return 0;
+    }
+    return 64 - Long.numberOfLeadingZeros(maxZigZag);
+  }
+
+  // ─────────────────────────────────────────────────────────────── encoding
+
+  /**
+   * Encode {@code count} values from {@code values[0..count)} into
+   * {@code target} starting at {@code offset}.
+   *
+   * @param target destination segment (must have ≥ {@link #maxEncodedSize}
+   *     bytes available at {@code offset})
+   * @param offset byte offset at which to start writing
+   * @param values source values; only the {@code count} prefix is read
+   * @param count number of values to encode
+   * @return total bytes written (header + body)
+   */
+  public static long writeDelta(final MemorySegment target, final long offset,
+      final long[] values, final int count) {
+    if (target == null) {
+      throw new IllegalArgumentException("target");
+    }
+    if (values == null) {
+      throw new IllegalArgumentException("values");
+    }
+    if (count < 0 || count > values.length) {
+      throw new IllegalArgumentException("count=" + count + " values.length=" + values.length);
+    }
+    // Guard against the *actual* header size (the count varint may be up to 5
+    // bytes), so an undersized target fails with IllegalArgumentException here
+    // rather than an IndexOutOfBoundsException from a later store.
+    if (offset < 0 || offset + headerBytes(count) > target.byteSize()) {
+      throw new IllegalArgumentException(
+          "offset=" + offset + " byteSize=" + target.byteSize());
+    }
+
+    final int bitWidth = computeBitWidth(values, count);
+    final long firstValue = count >= 1 ? values[0] : 0L;
+    final long firstDelta = count >= 2 ? values[1] - values[0] : 0L;
+    final long bodyBytes = bodyBytes(count, bitWidth);
+
+    long pos = offset;
+    target.set(ValueLayout.JAVA_BYTE, pos, VERSION_V1);
+    pos++;
+    target.set(ValueLayout.JAVA_BYTE, pos, (byte) bitWidth);
+    pos++;
+    pos += writeVarintUnsigned(target, pos, count);
+    target.set(LE.LONG, pos, firstValue);
+    pos += 8L;
+    target.set(LE.LONG, pos, firstDelta);
+    pos += 8L;
+
+    if (bodyBytes > 0L) {
+      if (pos + bodyBytes > target.byteSize()) {
+        throw new IllegalArgumentException(
+            "target too small: need " + (pos + bodyBytes - offset) + " bytes at offset " + offset);
+      }
+      packResiduals(target, pos, values, count, bitWidth);
+      pos += bodyBytes;
+    }
+    return pos - offset;
+  }
+
+  /**
+   * Bit-pack the {@code count-2} zig-zag(delta-of-delta) residuals starting at
+   * {@code bodyOff}. Recomputes deltas in one pass — no scratch allocation.
+   */
+  private static void packResiduals(final MemorySegment target, final long bodyOff,
+      final long[] values, final int count, final int bitWidth) {
+    long prevDelta = values[1] - values[0];
+    if (bitWidth == 64) {
+      // Every residual is byte-aligned (index*64 bits = index*8 bytes), so a
+      // direct 64-bit store per value avoids the straddle logic — and its
+      // {@code 1L << 64} masking hazard — entirely.
+      long off = bodyOff;
+      for (int i = 2; i < count; i++) {
+        final long delta = values[i] - values[i - 1];
+        target.set(LE.LONG, off, zigZagEncode(delta - prevDelta));
+        prevDelta = delta;
+        off += 8L;
+      }
+      return;
+    }
+    // Widths ≤ 63 ⇒ the low-part slice is at most 63 bits, so every
+    // {@code (1L << n) - 1} mask below is well-defined.
+    final long mask = (1L << bitWidth) - 1L;
+    // Buffered LE bit writer. bitWidth ≤ 56 keeps max(bitsInBuf) = 7 + 56 < 64.
+    if (bitWidth <= 56) {
+      long buf = 0L;
+      int bitsInBuf = 0;
+      long writePos = bodyOff;
+      for (int i = 2; i < count; i++) {
+        final long delta = values[i] - values[i - 1];
+        final long zz = zigZagEncode(delta - prevDelta) & mask;
+        prevDelta = delta;
+        buf |= zz << bitsInBuf;
+        bitsInBuf += bitWidth;
+        while (bitsInBuf >= 8) {
+          target.set(ValueLayout.JAVA_BYTE, writePos, (byte) buf);
+          writePos++;
+          buf >>>= 8;
+          bitsInBuf -= 8;
+        }
+      }
+      if (bitsInBuf > 0) {
+        target.set(ValueLayout.JAVA_BYTE, writePos, (byte) buf);
+      }
+      return;
+    }
+    // Widths 57..63: place each residual by read-modify-writing the containing
+    // 64-bit word(s), tolerating straddles across the word boundary.
+    int residualIndex = 0;
+    for (int i = 2; i < count; i++) {
+      final long delta = values[i] - values[i - 1];
+      final long zz = zigZagEncode(delta - prevDelta) & mask;
+      prevDelta = delta;
+      final long bitOff = (long) residualIndex * (long) bitWidth;
+      residualIndex++;
+      final long byteOff = bodyOff + (bitOff >>> 3);
+      final int bitInByte = (int) (bitOff & 7L);
+      final int bitsFromLo = Math.min(bitWidth, 64 - bitInByte);
+      final long loWord = readUpToLongLE(target, byteOff);
+      final long loMask = bitsFromLo == 64 ? ~0L : (((1L << bitsFromLo) - 1L) << bitInByte);
+      final long loShifted = (zz & ((1L << bitsFromLo) - 1L)) << bitInByte;
+      writeWord(target, byteOff, (loWord & ~loMask) | loShifted);
+      if (bitsFromLo < bitWidth) {
+        final int remaining = bitWidth - bitsFromLo;
+        final long hiMask = (1L << remaining) - 1L;
+        final long hiWord = readUpToLongLE(target, byteOff + 8L);
+        final long hiValBits = (zz >>> bitsFromLo) & hiMask;
+        writeWordPartial(target, byteOff + 8L, (hiWord & ~hiMask) | hiValBits,
+            (remaining + 7) >>> 3);
+      }
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────── decoding
+
+  /**
+   * Parsed header describing a delta payload. Reusable across calls to
+   * minimise allocation pressure on scan paths.
+   */
+  public static final class Header {
+    public byte version;
+    /** Bit width per zig-zag residual, 0..64. 0 ⇒ constant stride (no body). */
+    public byte bitWidth;
+    /** Number of encoded values. */
+    public int count;
+    /** First value, {@code v[0]}. */
+    public long firstValue;
+    /** First delta, {@code v[1]-v[0]}. */
+    public long firstDelta;
+    /** Absolute byte offset of the bit-packed body (or end of header when no body). */
+    public long bodyOffset;
+    /** Total bytes consumed by the header. */
+    public int headerBytes;
+    /** Total bytes consumed by the body. */
+    public long bodyBytes;
+
+    /** Clear for reuse. Every field is repopulated on parse. */
+    public Header reset() {
+      version = 0;
+      bitWidth = 0;
+      count = 0;
+      firstValue = 0L;
+      firstDelta = 0L;
+      bodyOffset = 0L;
+      headerBytes = 0;
+      bodyBytes = 0L;
+      return this;
+    }
+  }
+
+  /**
+   * Parse the delta header at {@code headerOffset} into {@code out}.
+   *
+   * @param src source segment
+   * @param headerOffset absolute byte offset of the version byte
+   * @param out header to populate
+   * @return {@code out} for chaining
+   */
+  public static Header readHeader(final MemorySegment src, final long headerOffset, final Header out) {
+    if (src == null || out == null) {
+      throw new IllegalArgumentException("src/out");
+    }
+    out.version = src.get(ValueLayout.JAVA_BYTE, headerOffset);
+    if (out.version != VERSION_V1) {
+      throw new IllegalStateException("unsupported NumberRegionDelta version=" + out.version);
+    }
+    out.bitWidth = src.get(ValueLayout.JAVA_BYTE, headerOffset + 1L);
+    if (out.bitWidth < 0 || out.bitWidth > 64) {
+      throw new IllegalStateException("illegal bitWidth=" + out.bitWidth);
+    }
+    final long varintPacked = readVarintUnsignedPacked(src, headerOffset + 2L);
+    final long countLong = varintPacked & 0xFFFFFFFFL;
+    final int varintBytes = (int) (varintPacked >>> 32);
+    if (countLong < 0L || countLong > (long) Integer.MAX_VALUE) {
+      throw new IllegalStateException("illegal count=" + countLong);
+    }
+    out.count = (int) countLong;
+    long pos = headerOffset + 2L + varintBytes;
+    out.firstValue = src.get(LE.LONG, pos);
+    pos += 8L;
+    out.firstDelta = src.get(LE.LONG, pos);
+    pos += 8L;
+    out.headerBytes = (int) (pos - headerOffset);
+    out.bodyOffset = pos;
+    out.bodyBytes = bodyBytes(out.count, out.bitWidth);
+    return out;
+  }
+
+  /**
+   * Bulk decode into a caller-supplied buffer. Writes exactly
+   * {@code header.count} values starting at {@code out[0]}. This is the fast
+   * path — a single sequential prefix-sum over the residuals.
+   *
+   * @param src source segment
+   * @param header parsed header
+   * @param out destination array, {@code out.length >= header.count}
+   */
+  public static void decodeAll(final MemorySegment src, final Header header, final long[] out) {
+    if (src == null || header == null || out == null) {
+      throw new IllegalArgumentException("src/header/out");
+    }
+    final int n = header.count;
+    if (out.length < n) {
+      throw new IllegalArgumentException("out too small: " + out.length + " < " + n);
+    }
+    if (n == 0) {
+      return;
+    }
+    long value = header.firstValue;
+    out[0] = value;
+    if (n == 1) {
+      return;
+    }
+    long delta = header.firstDelta;
+    value += delta;
+    out[1] = value;
+    if (n == 2) {
+      return;
+    }
+    final int bitWidth = header.bitWidth;
+    if (bitWidth == 0) {
+      // Constant stride — every delta-of-delta is 0.
+      for (int i = 2; i < n; i++) {
+        value += delta;
+        out[i] = value;
+      }
+      return;
+    }
+    final long bodyOff = header.bodyOffset;
+    for (int i = 2; i < n; i++) {
+      final long dd = zigZagDecode(bitUnpack(src, bodyOff, bitWidth, i - 2));
+      delta += dd;
+      value += delta;
+      out[i] = value;
+    }
+  }
+
+  /**
+   * Convenience bulk-decode that parses the header first. Prefer
+   * {@link #decodeAll(MemorySegment, Header, long[])} in hot code.
+   */
+  public static void decodeAll(final MemorySegment src, final long headerOffset, final long[] out) {
+    final Header h = new Header();
+    readHeader(src, headerOffset, h);
+    decodeAll(src, h, out);
+  }
+
+  /**
+   * Random-access read of the value at {@code index}. Unlike
+   * {@link NumberRegionCompact#readCompact}, delta-of-delta has no closed-form
+   * random access: this replays the prefix sum from the start and therefore
+   * costs {@code O(index)}. Provided for correctness and point probes; scan
+   * loops must use {@link #decodeAll}.
+   *
+   * @param src source segment
+   * @param header parsed header
+   * @param index 0-based index into the logical sequence
+   * @return value stored at {@code index}
+   */
+  public static long readDelta(final MemorySegment src, final Header header, final int index) {
+    if (src == null || header == null) {
+      throw new IllegalArgumentException("src/header");
+    }
+    if (index < 0 || index >= header.count) {
+      throw new IndexOutOfBoundsException("index=" + index + " count=" + header.count);
+    }
+    final long value = header.firstValue;
+    if (index == 0) {
+      return value;
+    }
+    final long firstDelta = header.firstDelta;
+    final int bitWidth = header.bitWidth;
+    if (bitWidth == 0) {
+      // Constant stride: v[i] = firstValue + firstDelta*i. The multiply wraps
+      // in two's-complement identically to i repeated additions — O(1).
+      return value + firstDelta * index;
+    }
+    long delta = firstDelta;
+    long acc = value + delta;
+    final long bodyOff = header.bodyOffset;
+    for (int i = 2; i <= index; i++) {
+      delta += zigZagDecode(bitUnpack(src, bodyOff, bitWidth, i - 2));
+      acc += delta;
+    }
+    return acc;
+  }
+
+  // ───────────────────────────────────────────────────────── zig-zag helpers
+
+  /** Map a signed long to an unsigned long: 0,-1,1,-2,2,… → 0,1,2,3,4,… */
+  static long zigZagEncode(final long v) {
+    return (v << 1) ^ (v >> 63);
+  }
+
+  /** Inverse of {@link #zigZagEncode}. */
+  static long zigZagDecode(final long z) {
+    return (z >>> 1) ^ -(z & 1L);
+  }
+
+  // ─────────────────────────────────────────────────────── bit-pack / unpack
+
+  /**
+   * Unsigned bit-unpack of the residual at {@code residualIndex}. Widths ≤ 56
+   * need a single unaligned 64-bit load; widths 57..64 may straddle two words.
+   */
+  private static long bitUnpack(final MemorySegment src, final long baseOff, final int bitWidth,
+      final int residualIndex) {
+    if (bitWidth == 64) {
+      return src.get(LE.LONG, baseOff + ((long) residualIndex << 3));
+    }
+    final long bitOff = (long) residualIndex * (long) bitWidth;
+    final long byteOff = baseOff + (bitOff >>> 3);
+    final int bitInByte = (int) (bitOff & 7L);
+    final long mask = (1L << bitWidth) - 1L;
+    final long w0 = readUpToLongLE(src, byteOff);
+    long v = (w0 >>> bitInByte) & mask;
+    final int bitsFromW0 = 64 - bitInByte;
+    if (bitsFromW0 < bitWidth) {
+      final int extra = bitWidth - bitsFromW0;
+      final long w1 = readUpToLongLE(src, byteOff + 8L);
+      v |= (w1 & ((1L << extra) - 1L)) << bitsFromW0;
+    }
+    return v;
+  }
+
+  private static void writeWord(final MemorySegment target, final long off, final long word) {
+    final long size = target.byteSize();
+    if (off + 8L <= size) {
+      target.set(LE.LONG, off, word);
+      return;
+    }
+    final long remaining = Math.max(0L, size - off);
+    for (long k = 0L; k < remaining; k++) {
+      target.set(ValueLayout.JAVA_BYTE, off + k, (byte) (word >>> (k << 3)));
+    }
+  }
+
+  private static void writeWordPartial(final MemorySegment target, final long off,
+      final long word, final int bytes) {
+    final long size = target.byteSize();
+    final long limit = Math.min((long) bytes, Math.max(0L, size - off));
+    for (long k = 0L; k < limit; k++) {
+      target.set(ValueLayout.JAVA_BYTE, off + k, (byte) (word >>> (k << 3)));
+    }
+  }
+
+  /**
+   * Read up to 8 little-endian bytes as a {@code long} even if fewer bytes
+   * remain. Bytes past the segment end read as zero; callers mask to bitWidth
+   * and the valid bits of the last residual always lie inside the segment.
+   */
+  private static long readUpToLongLE(final MemorySegment src, final long off) {
+    final long size = src.byteSize();
+    if (off + 8L <= size) {
+      return src.get(LE.LONG, off);
+    }
+    if (off >= size) {
+      return 0L;
+    }
+    long v = 0L;
+    final long remaining = size - off;
+    for (long k = 0L; k < remaining; k++) {
+      v |= ((long) (src.get(ValueLayout.JAVA_BYTE, off + k) & 0xFF)) << (k << 3);
+    }
+    return v;
+  }
+
+  // ───────────────────────────────────────────────────────────────── varint
+
+  private static int writeVarintUnsigned(final MemorySegment target, final long offset,
+      final long value) {
+    long v = value;
+    long pos = offset;
+    while ((v & ~0x7FL) != 0L) {
+      target.set(ValueLayout.JAVA_BYTE, pos, (byte) ((v & 0x7FL) | 0x80L));
+      pos++;
+      v >>>= 7;
+    }
+    target.set(ValueLayout.JAVA_BYTE, pos, (byte) v);
+    return (int) (pos - offset + 1L);
+  }
+
+  private static long readVarintUnsignedPacked(final MemorySegment src, final long offset) {
+    long pos = offset;
+    long result = 0L;
+    int shift = 0;
+    while (true) {
+      final byte b = src.get(ValueLayout.JAVA_BYTE, pos);
+      pos++;
+      result |= ((long) (b & 0x7F)) << shift;
+      if ((b & 0x80) == 0) {
+        break;
+      }
+      shift += 7;
+      if (shift > 63) {
+        throw new IllegalStateException("varint too long at offset=" + offset);
+      }
+    }
+    final int bytes = (int) (pos - offset);
+    return ((long) bytes << 32) | (result & 0xFFFFFFFFL);
+  }
+
+  private static int varintSize(final int unsignedValue) {
+    if (unsignedValue < 0) {
+      return 5;
+    }
+    if (unsignedValue < 1 << 7) {
+      return 1;
+    }
+    if (unsignedValue < 1 << 14) {
+      return 2;
+    }
+    if (unsignedValue < 1 << 21) {
+      return 3;
+    }
+    if (unsignedValue < 1 << 28) {
+      return 4;
+    }
+    return 5;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
@@ -188,6 +188,9 @@ public final class NumberRegionSimd {
    */
   public static long countMatching(final MemorySegment payload, final NumberRegion.Header h,
       final int start, final int end, final VectorOperators.Comparison op, final long threshold) {
+    if (NumberRegion.isDelta(h.encodingKind)) {
+      return -1L; // delta is sequential: caller falls back to scalar decode
+    }
     if (NumberRegion.isBitPacked(h.encodingKind)) {
       return countBitPacked(payload, h.valueBytesOffset, h.valueBase, h.valueBitWidth,
           start, end, op, threshold);
@@ -209,6 +212,9 @@ public final class NumberRegionSimd {
       final int start, final int end,
       final VectorOperators.Comparison op1, final long threshold1,
       final VectorOperators.Comparison op2, final long threshold2) {
+    if (NumberRegion.isDelta(h.encodingKind)) {
+      return -1L; // delta is sequential: caller falls back to scalar decode
+    }
     if (NumberRegion.isBitPacked(h.encodingKind)) {
       return countBitPackedRange(payload, h.valueBytesOffset, h.valueBase, h.valueBitWidth,
           start, end, op1, threshold1, op2, threshold2);
@@ -313,6 +319,9 @@ public final class NumberRegionSimd {
       out[1] = Long.MAX_VALUE;
       out[2] = Long.MIN_VALUE;
       return true;
+    }
+    if (NumberRegion.isDelta(h.encodingKind)) {
+      return false; // delta is sequential: caller falls back to scalar decode
     }
     if (NumberRegion.isBitPacked(h.encodingKind)) {
       return aggregateBitPacked(payload, h.valueBytesOffset, h.valueBase, h.valueBitWidth,

--- a/bundles/sirix-core/src/test/java/io/sirix/page/pax/NumberRegionDeltaTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/pax/NumberRegionDeltaTest.java
@@ -1,0 +1,331 @@
+package io.sirix.page.pax;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.SplittableRandom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the delta-of-delta {@link NumberRegionDelta} codec. Covers the
+ * constant-stride shortcut, monotonic-timestamp workloads, negative/decreasing
+ * sequences, the wide (57..64-bit) straddle path, random stress, native vs
+ * on-heap segments, and the header/size invariants.
+ */
+@DisplayName("NumberRegionDelta")
+final class NumberRegionDeltaTest {
+
+  private static MemorySegment onHeap(final int bytes) {
+    return MemorySegment.ofArray(new byte[bytes]);
+  }
+
+  /** Encode into a fresh segment, decode back, and assert an exact round-trip. */
+  private static void assertRoundTrip(final long[] values, final int count) {
+    final long size = NumberRegionDelta.maxEncodedSize(values, count);
+    final MemorySegment seg = onHeap((int) size + 16 /* slack, must not be needed */);
+
+    final long written = NumberRegionDelta.writeDelta(seg, 0L, values, count);
+    assertEquals(size, written, "writeDelta must consume exactly maxEncodedSize bytes");
+
+    final NumberRegionDelta.Header h = new NumberRegionDelta.Header();
+    NumberRegionDelta.readHeader(seg, 0L, h);
+    assertEquals(count, h.count);
+    assertEquals(written, h.headerBytes + h.bodyBytes,
+        "header + body must account for every written byte");
+
+    final long[] out = new long[Math.max(1, count)];
+    NumberRegionDelta.decodeAll(seg, h, out);
+    for (int i = 0; i < count; i++) {
+      assertEquals(values[i], out[i], "decodeAll mismatch at index " + i);
+    }
+    // readDelta must agree with decodeAll at every index.
+    for (int i = 0; i < count; i++) {
+      assertEquals(values[i], NumberRegionDelta.readDelta(seg, h, i),
+          "readDelta mismatch at index " + i);
+    }
+  }
+
+  @Test
+  @DisplayName("zig-zag encode/decode is an exact inverse")
+  void zigZagInverse() {
+    final long[] probes = { 0, 1, -1, 2, -2, 42, -42, Long.MAX_VALUE, Long.MIN_VALUE,
+        1L << 40, -(1L << 40), Long.MIN_VALUE + 1 };
+    for (final long v : probes) {
+      assertEquals(v, NumberRegionDelta.zigZagDecode(NumberRegionDelta.zigZagEncode(v)),
+          "zig-zag not invertible for " + v);
+    }
+  }
+
+  @Test
+  @DisplayName("empty column round-trips with no body")
+  void empty() {
+    assertRoundTrip(new long[0], 0);
+    assertEquals(0, NumberRegionDelta.computeBitWidth(new long[0], 0));
+  }
+
+  @Test
+  @DisplayName("single and two-value columns round-trip")
+  void singleAndPair() {
+    assertRoundTrip(new long[] { 1234567890123L }, 1);
+    assertRoundTrip(new long[] { 1234567890123L, 1234567890999L }, 2);
+    // Fewer than 3 values ⇒ no residuals ⇒ bit width 0.
+    assertEquals(0, NumberRegionDelta.computeBitWidth(new long[] { 5, 9 }, 2));
+  }
+
+  @Test
+  @DisplayName("constant stride collapses to a zero-width body regardless of length")
+  void constantStride() {
+    final int n = 4096;
+    final long[] values = new long[n];
+    long t = 1_700_000_000_000L;
+    for (int i = 0; i < n; i++, t += 1000L) {
+      values[i] = t;
+    }
+    assertEquals(0, NumberRegionDelta.computeBitWidth(values, n),
+        "constant stride must have bit width 0");
+    // Body is empty: encoded size equals the fixed header only.
+    final long size = NumberRegionDelta.maxEncodedSize(values, n);
+    assertEquals(NumberRegionDelta.headerBytes(n), size,
+        "constant stride must encode to header bytes only");
+    assertRoundTrip(values, n);
+  }
+
+  @Test
+  @DisplayName("constant stride is dramatically smaller than frame-of-reference")
+  void constantStrideBeatsFor() {
+    final int n = 4096;
+    final long[] values = new long[n];
+    long t = 1_700_000_000_000L;
+    for (int i = 0; i < n; i++, t += 60_000L) {
+      values[i] = t;
+    }
+    final long deltaSize = NumberRegionDelta.maxEncodedSize(values, n);
+    final long forSize = NumberRegionCompact.maxEncodedSize(values, n);
+    assertTrue(deltaSize * 8 < forSize,
+        "delta-of-delta (" + deltaSize + " B) should be far below FOR+BP (" + forSize + " B)");
+  }
+
+  @Test
+  @DisplayName("monotonic timestamps with jitter round-trip")
+  void jitteredTimestamps() {
+    final int n = 5000;
+    final long[] values = new long[n];
+    final SplittableRandom rnd = new SplittableRandom(0xC0FFEEL);
+    long t = 1_700_000_000_000L;
+    for (int i = 0; i < n; i++) {
+      t += 1000L + rnd.nextInt(-50, 51); // ~1s stride, ±50ms jitter
+      values[i] = t;
+    }
+    assertRoundTrip(values, n);
+    // Small jitter ⇒ narrow residuals ⇒ still well under raw 8 bytes/value.
+    final long size = NumberRegionDelta.maxEncodedSize(values, n);
+    assertTrue(size < (long) n * 8, "jittered timestamps should beat raw longs: " + size);
+  }
+
+  @Test
+  @DisplayName("strictly decreasing and negative sequences round-trip")
+  void decreasingAndNegative() {
+    final int n = 1000;
+    final long[] values = new long[n];
+    long t = -500L;
+    for (int i = 0; i < n; i++, t -= 37L) {
+      values[i] = t;
+    }
+    assertRoundTrip(values, n);
+  }
+
+  @Test
+  @DisplayName("wide residuals exercise the 57..64-bit straddle path")
+  void wideStraddle() {
+    // Alternating extremes force large-magnitude deltas and delta-of-deltas,
+    // pushing the zig-zag residual width into the 57..64-bit slow path.
+    final long[] values = { 0L, Long.MAX_VALUE, Long.MIN_VALUE, Long.MAX_VALUE,
+        Long.MIN_VALUE, 0L, Long.MAX_VALUE };
+    final int bw = NumberRegionDelta.computeBitWidth(values, values.length);
+    assertTrue(bw > 56, "expected a wide bit width, got " + bw);
+    assertRoundTrip(values, values.length);
+  }
+
+  @Test
+  @DisplayName("every bit width 1..64 round-trips")
+  void allBitWidths() {
+    final SplittableRandom rnd = new SplittableRandom(99L);
+    for (int width = 1; width <= 62; width++) {
+      final int n = 200;
+      final long[] values = new long[n];
+      // Build a sequence whose delta-of-deltas span roughly `width` bits by
+      // adding a bounded random jitter on top of a linear ramp.
+      final long bound = 1L << Math.max(1, width - 2);
+      long v = 0L;
+      long delta = 1000L;
+      for (int i = 0; i < n; i++) {
+        values[i] = v;
+        final long dd = rnd.nextLong(-bound, bound);
+        delta += dd;
+        v += delta;
+      }
+      assertRoundTrip(values, n);
+    }
+  }
+
+  @Test
+  @DisplayName("random stress over native segments round-trips")
+  void randomStressNative() {
+    final SplittableRandom rnd = new SplittableRandom(0xDEADBEEFL);
+    try (Arena arena = Arena.ofConfined()) {
+      for (int iter = 0; iter < 200; iter++) {
+        final int n = rnd.nextInt(0, 400);
+        final long[] values = new long[Math.max(1, n)];
+        for (int i = 0; i < n; i++) {
+          values[i] = rnd.nextLong();
+        }
+        final long size = NumberRegionDelta.maxEncodedSize(values, n);
+        final MemorySegment seg = arena.allocate(size + 8);
+        final long written = NumberRegionDelta.writeDelta(seg, 0L, values, n);
+        assertEquals(size, written);
+
+        final NumberRegionDelta.Header h = new NumberRegionDelta.Header();
+        NumberRegionDelta.readHeader(seg, 0L, h);
+        final long[] out = new long[Math.max(1, n)];
+        NumberRegionDelta.decodeAll(seg, h, out);
+        for (int i = 0; i < n; i++) {
+          assertEquals(values[i], out[i], "iter " + iter + " index " + i);
+        }
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("writing at a non-zero offset leaves surrounding bytes untouched")
+  void nonZeroOffset() {
+    final long[] values = { 10, 20, 31, 43, 56 };
+    final int off = 7;
+    final long size = NumberRegionDelta.maxEncodedSize(values, values.length);
+    final MemorySegment seg = onHeap(off + (int) size + 5);
+    // Poison the whole buffer; only [off, off+size) should change meaning.
+    for (int i = 0; i < seg.byteSize(); i++) {
+      seg.set(java.lang.foreign.ValueLayout.JAVA_BYTE, i, (byte) 0xAB);
+    }
+    final long written = NumberRegionDelta.writeDelta(seg, off, values, values.length);
+    assertEquals(size, written);
+
+    final NumberRegionDelta.Header h = new NumberRegionDelta.Header();
+    NumberRegionDelta.readHeader(seg, off, h);
+    final long[] out = new long[values.length];
+    NumberRegionDelta.decodeAll(seg, h, out);
+    for (int i = 0; i < values.length; i++) {
+      assertEquals(values[i], out[i]);
+    }
+  }
+
+  @Test
+  @DisplayName("header reset clears every field for reuse")
+  void headerReuse() {
+    final long[] a = { 100, 200, 305, 411 };
+    final long[] b = { -5, -4, -3, -2, -1, 0 };
+    final MemorySegment segA = onHeap((int) NumberRegionDelta.maxEncodedSize(a, a.length));
+    final MemorySegment segB = onHeap((int) NumberRegionDelta.maxEncodedSize(b, b.length));
+    NumberRegionDelta.writeDelta(segA, 0L, a, a.length);
+    NumberRegionDelta.writeDelta(segB, 0L, b, b.length);
+
+    final NumberRegionDelta.Header h = new NumberRegionDelta.Header();
+    NumberRegionDelta.readHeader(segA, 0L, h);
+    final long[] outA = new long[a.length];
+    NumberRegionDelta.decodeAll(segA, h, outA);
+
+    h.reset();
+    NumberRegionDelta.readHeader(segB, 0L, h);
+    final long[] outB = new long[b.length];
+    NumberRegionDelta.decodeAll(segB, h, outB);
+    for (int i = 0; i < b.length; i++) {
+      assertEquals(b[i], outB[i]);
+    }
+  }
+
+  // ───────────────────────────── NumberRegion integration (ENC_DELTA_ZM) ─────
+
+  @Test
+  @DisplayName("NumberRegion selects ENC_DELTA_ZM for a monotonic timestamp column")
+  void regionSelectsDeltaForTimestamps() {
+    NumberRegion.clearDeltaWriteOverride();
+    final int n = 512;
+    final long[] values = new long[n];
+    final int[] tags = new int[n];
+    long t = 1_700_000_000_000L;
+    for (int i = 0; i < n; i++, t += 1000L) {
+      values[i] = t;
+      tags[i] = 7; // single field
+    }
+    final byte[] wire = NumberRegion.encode(values, tags, n);
+    final NumberRegion.Header h = new NumberRegion.Header().parseInto(wire);
+    assertEquals(NumberRegion.ENC_DELTA_ZM, h.encodingKind);
+    assertTrue(NumberRegion.isDelta(h.encodingKind));
+    assertTrue(NumberRegion.hasZoneMap(h.encodingKind));
+    // Outer per-tag zone map survives the delta value region.
+    final int tag = NumberRegion.lookupTag(h, 7);
+    assertEquals(values[0], h.tagMin[tag]);
+    assertEquals(values[n - 1], h.tagMax[tag]);
+
+    // Both decode entry points round-trip.
+    final long[] bulk = new long[n];
+    NumberRegion.decodeAllValues(wire, h, bulk);
+    for (int i = 0; i < n; i++) {
+      assertEquals(values[i], bulk[i], "decodeAllValues @" + i);
+      assertEquals(values[i], NumberRegion.decodeValueAt(wire, h, i), "decodeValueAt @" + i);
+    }
+    // Delta must be a large win here vs the raw payload.
+    assertTrue(wire.length < n * 8L, "delta region should be far smaller than raw longs");
+  }
+
+  @Test
+  @DisplayName("NumberRegion keeps FOR+BP for scattered random values")
+  void regionKeepsForForRandom() {
+    NumberRegion.clearDeltaWriteOverride();
+    final SplittableRandom rnd = new SplittableRandom(7L);
+    final int n = 256;
+    final long[] values = new long[n];
+    final int[] tags = new int[n];
+    for (int i = 0; i < n; i++) {
+      values[i] = 1000 + rnd.nextInt(0, 1 << 20); // narrow range ⇒ FOR is tight
+      tags[i] = 3;
+    }
+    final byte[] wire = NumberRegion.encode(values, tags, n);
+    final NumberRegion.Header h = new NumberRegion.Header().parseInto(wire);
+    // Random within a narrow band ⇒ delta-of-delta is wider than FOR residuals,
+    // so the bake-off should not pick delta.
+    assertTrue(NumberRegion.isBitPacked(h.encodingKind),
+        "expected FOR/bit-packed, got kind " + h.encodingKind);
+    for (int i = 0; i < n; i++) {
+      assertEquals(values[i], NumberRegion.decodeValueAt(wire, h, i));
+    }
+  }
+
+  @Test
+  @DisplayName("delta write toggle forces FOR when disabled")
+  void deltaToggleDisables() {
+    try {
+      NumberRegion.setDeltaWriteEnabled(false);
+      final int n = 128;
+      final long[] values = new long[n];
+      final int[] tags = new int[n];
+      long t = 1_700_000_000_000L;
+      for (int i = 0; i < n; i++, t += 1000L) {
+        values[i] = t;
+        tags[i] = 1;
+      }
+      final byte[] wire = NumberRegion.encode(values, tags, n);
+      final NumberRegion.Header h = new NumberRegion.Header().parseInto(wire);
+      assertFalse(NumberRegion.isDelta(h.encodingKind), "delta disabled but region used it");
+      for (int i = 0; i < n; i++) {
+        assertEquals(values[i], NumberRegion.decodeValueAt(wire, h, i));
+      }
+    } finally {
+      NumberRegion.clearDeltaWriteOverride();
+    }
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -2360,6 +2360,26 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     return scratch;
   }
 
+  /**
+   * Tally the {@code n} values of one tag (starting at {@code start}) into
+   * {@code pc}. Delta-encoded regions are bulk-decoded once (O(n)); every other
+   * encoding uses the direct O(1) {@link NumberRegion#decodeValueAt}. Kept
+   * separate so callers stay below the complexity budget.
+   */
+  private static void fillNumberRegionCounts(final byte[] payload, final NumberRegion.Header nh,
+      final int start, final int n, final it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap pc) {
+    final long[] deltaVals = deltaDecodedOrNull(payload, nh);
+    if (deltaVals != null) {
+      for (int i = 0; i < n; i++) {
+        pc.addTo(deltaVals[start + i], 1L);
+      }
+    } else {
+      for (int i = 0; i < n; i++) {
+        pc.addTo(NumberRegion.decodeValueAt(payload, nh, start + i), 1L);
+      }
+    }
+  }
+
   private static boolean tryRegionGroupByPage(final KeyValueLeafPage kv, final int anchorSlotCount,
       final long targetPathNodeKey, final int anchorNameKey, final Object2LongOpenHashMap<String> counts,
       final RegionGroupScratch scratch) {
@@ -2384,13 +2404,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         if (payload == null) return false;
         final it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap pc = scratch.pageCounts;
         pc.clear();
-        final long[] deltaVals = deltaDecodedOrNull(payload, nh);
-        for (int i = 0; i < n; i++) {
-          final long v = deltaVals != null
-              ? deltaVals[start + i]
-              : NumberRegion.decodeValueAt(payload, nh, start + i);
-          pc.addTo(v, 1L);
-        }
+        fillNumberRegionCounts(payload, nh, start, n, pc);
         for (final var e : pc.long2LongEntrySet()) {
           kb.setLength(0);
           kb.append('l').append(e.getLongKey()).append('\u0000');

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -2330,6 +2330,36 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    *
    * @return {@code true} when the page was fully accounted via a region
    */
+  /**
+   * Per-thread scratch for bulk-decoding a delta-encoded ({@link
+   * NumberRegion#ENC_DELTA_ZM}) number region once. Delta random access is
+   * O(index), so the aggregation / group-by fallback loops decode the whole
+   * region up front (O(n)) and index this array — otherwise a per-value
+   * {@link NumberRegion#decodeValueAt} loop would be O(n²). Sized to the max
+   * slots per page; grown defensively. Other encodings never touch it.
+   */
+  private static final ThreadLocal<long[]> NUMBER_DECODE_SCRATCH =
+      ThreadLocal.withInitial(() -> new long[Constants.NDP_NODE_COUNT]);
+
+  /**
+   * When {@code nh} is delta-encoded, returns a per-thread array holding every
+   * value decoded once (so callers index it in O(1)); otherwise returns
+   * {@code null} and callers keep the direct O(1) {@link
+   * NumberRegion#decodeValueAt} path with no bulk decode or allocation.
+   */
+  private static long[] deltaDecodedOrNull(final byte[] payload, final NumberRegion.Header nh) {
+    if (!NumberRegion.isDelta(nh.encodingKind)) {
+      return null;
+    }
+    long[] scratch = NUMBER_DECODE_SCRATCH.get();
+    if (scratch.length < nh.count) {
+      scratch = new long[nh.count];
+      NUMBER_DECODE_SCRATCH.set(scratch);
+    }
+    NumberRegion.decodeAllValues(payload, nh, scratch);
+    return scratch;
+  }
+
   private static boolean tryRegionGroupByPage(final KeyValueLeafPage kv, final int anchorSlotCount,
       final long targetPathNodeKey, final int anchorNameKey, final Object2LongOpenHashMap<String> counts,
       final RegionGroupScratch scratch) {
@@ -2354,8 +2384,12 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         if (payload == null) return false;
         final it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap pc = scratch.pageCounts;
         pc.clear();
+        final long[] deltaVals = deltaDecodedOrNull(payload, nh);
         for (int i = 0; i < n; i++) {
-          pc.addTo(NumberRegion.decodeValueAt(payload, nh, start + i), 1L);
+          final long v = deltaVals != null
+              ? deltaVals[start + i]
+              : NumberRegion.decodeValueAt(payload, nh, start + i);
+          pc.addTo(v, 1L);
         }
         for (final var e : pc.long2LongEntrySet()) {
           kb.setLength(0);
@@ -8055,10 +8089,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
                 acc[4] += tagN;
                 continue;
               }
-              // SIMD fallback: bit-width > 56 or other unsupported encoding.
+              // SIMD fallback: bit-width > 56, or a delta-encoded region (which
+              // is sequential — bulk-decode once so this stays O(n), not O(n²)).
               final byte[] payload = kv.getNumberRegionPayload();
+              final long[] deltaVals = deltaDecodedOrNull(payload, hdr);
               for (int idx = start; idx < end; idx++) {
-                final long v = NumberRegion.decodeValueAt(payload, hdr, idx);
+                final long v = deltaVals != null
+                    ? deltaVals[idx]
+                    : NumberRegion.decodeValueAt(payload, hdr, idx);
                 acc[0]++;
                 acc[1] += v;
                 if (v < acc[2]) acc[2] = v;


### PR DESCRIPTION
## What does this PR do?

Adds `NumberRegionDelta`, a delta-of-delta ("DoubleDelta") codec for `long[]` PAX number regions, and wires it into `NumberRegion` as a new encoding kind `ENC_DELTA_ZM`.

Monotonic / near-constant-stride columns — commit timestamps, valid-time bounds, sequence ids — previously stored frame-of-reference + bit-packed values. They now store the change in stride (delta-of-delta), so a constant stride collapses to a fixed ~20-byte header regardless of row count. This is the ClickHouse `DoubleDelta` family of codec, which Sirix's numeric PAX path was missing.

Selection is a size bake-off with a **structure guard**: delta is chosen only when its delta-of-delta residual width is *strictly narrower* than the FOR/plain per-value width **and** the encoded value region is smaller. Incompressible columns therefore stay on the FOR path and keep their O(1) random access and SIMD scan kernels; only genuinely temporal columns switch to delta.

Because delta decode is sequential (O(index) random access), the three sites that random-access number values bulk-decode a delta region once into a reused scratch to avoid O(n²): page rehydration (`PageKind`) and the vectorized executor's group-by and aggregate fallbacks.

## Related issue

No tracking issue. Follow-up to an internal comparison of DuckDB/ClickHouse storage encodings against Sirix's PAX regions, which identified the absence of a delta-of-delta codec for the temporal/monotonic numeric columns that a versioned store accumulates fastest.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Performance improvement
- [ ] Documentation only

## Checklist

- [ ] `./gradlew build` passes locally (JDK 25) — see reviewer note on the sandbox Gradle constraint; ran targeted module tests instead
- [x] Added or updated tests covering the change
- [x] For behavioral changes to the storage engine: no storage invariant is affected — versioning/COW/page structure are untouched; this only adds a value-region encoding whose decode is an exact round-trip
- [ ] Updated documentation (README / docs) where relevant — none needed (internal on-disk encoding)
- [x] No unrelated formatting churn

## Notes for reviewers

**Changed files**
- `NumberRegionDelta.java` (new) — zero-alloc encode/decode over `MemorySegment`, zig-zag delta-of-delta + bit-packed residuals, constant-stride shortcut, with per-value parity between bulk `decodeAll` and O(index) `readDelta`.
- `NumberRegion.java` — `ENC_DELTA_ZM` encode/decode/parse; `isBitPacked` made explicit to exclude delta; new `isDelta`; the size+structure bake-off; a `deltaWrite` toggle (default on, disable via `-Dsirix.numberRegion.deltaWrite.disabled=true`).
- `NumberRegionSimd.java` — delta payloads return the scalar-fallback sentinel in all three dispatchers.
- `PageKind.java` / `SirixVectorizedExecutor.java` — bulk-decode delta once into a thread-local scratch on the three random-access loops (O(n) not O(n²)).

**Trade-offs**
- A column that switches to delta forfeits the SIMD scan kernels (delta is sequential) — accepted deliberately, since the bake-off only picks delta when it also compresses strictly better, which is the temporal case where the compression win dominates.

**Rollback caveat (worth a conscious call before a release that ships this)**
- Delta is written by default when the bake-off selects it. Forward reads are safe and all legacy encodings still parse, but there is no on-disk format-version gate: an *older* binary reading delta-written data would misinterpret kind 5. The escape hatch is the `sirix.numberRegion.deltaWrite.disabled` system property. If a downgrade path matters, a region format-version bump would be the clean fix.

**Test / environment note**
- The Gradle wrapper pins 9.4.1, whose distribution download is blocked in this CI sandbox, so `./gradlew build` could not run end-to-end here. I verified with local Gradle 8.14.3 against the affected modules: `NumberRegionDeltaTest` (new), `NumberRegionTest`, `NumberRegionSimdTest`, `NumberRegionInvalidationTest`, `ColumnarPageExtractorTest`, the projection-scan suite, and the vectorized-executor group-by/aggregate tests — all green. Please confirm a full `./gradlew build` on JDK 25 in CI.

**Follow-ups (out of scope here)**
- Gorilla/Chimp XOR codec for *double*-valued number columns (this PR covers longs/timestamps).
- Sorted projections so per-tag zone maps prune harder.

---
_Generated by [Claude Code](https://claude.ai/code/session_015F9MQqCHp9UHVer78Dnaws)_