### PR TITLE
Fix Windows sharing-violation flake when racing opens replace dbsetting.obj

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/access/DatabaseConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/DatabaseConfiguration.java
@@ -41,6 +41,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -48,6 +49,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.LockSupport;
 
 import static io.sirix.utils.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -381,6 +383,51 @@ public final class DatabaseConfiguration {
   private static final int DESERIALIZE_CACHE_MAX_ENTRIES = 1_024;
 
   /**
+   * Id minting on open atomically replaces {@code dbsetting.obj} while other threads deserialize the
+   * same file outside the global open lock. On Windows a reader that opens the file mid-replace — or
+   * the replace that runs while a reader still holds the old file open — fails with a transient
+   * sharing violation ("The process cannot access the file because it is being used by another
+   * process"). The lock is released within microseconds, so a short bounded retry turns the race
+   * into a clean operation. POSIX has no such semantics: the first attempt always succeeds there and
+   * this retry code is never reached.
+   */
+  private static final int CONFIG_IO_MAX_ATTEMPTS = 64;
+
+  /** Spin for the first handful of attempts, then nap briefly — the whole budget stays near 10 ms. */
+  private static void pauseForConfigContention(final int attempt) {
+    if (attempt < 16) {
+      Thread.onSpinWait();
+    } else {
+      LockSupport.parkNanos(200_000L); // 0.2 ms
+    }
+  }
+
+  /**
+   * Atomically replaces {@code configFile} with {@code tmpFile}, retrying the transient Windows
+   * sharing violation a concurrent reader can raise. A non-transient failure (e.g. a genuinely
+   * unwritable directory) exhausts the bounded retries and is rethrown to the caller unchanged.
+   */
+  private static void moveIntoPlace(final Path tmpFile, final Path configFile) throws IOException {
+    IOException lastError = null;
+    for (int attempt = 0; attempt < CONFIG_IO_MAX_ATTEMPTS; attempt++) {
+      try {
+        try {
+          Files.move(tmpFile, configFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (final AtomicMoveNotSupportedException e) {
+          Files.move(tmpFile, configFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+        return;
+      } catch (final FileSystemException e) {
+        // Only the OS-level file-system errors (sharing/lock violation on Windows) are worth
+        // retrying; the source temp file is still present, so this is a contention signal.
+        lastError = e;
+        pauseForConfigContention(attempt);
+      }
+    }
+    throw lastError;
+  }
+
+  /**
    * Serializing a {@link DatabaseConfiguration} to a json file.
    *
    * @param config to be serialized
@@ -405,11 +452,7 @@ public final class DatabaseConfiguration {
         jsonWriter.name("maxSegmentAllocationSize").value(config.maxSegmentAllocationSize);
         jsonWriter.endObject();
       }
-      try {
-        Files.move(tmpFile, configFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-      } catch (final AtomicMoveNotSupportedException e) {
-        Files.move(tmpFile, configFile, StandardCopyOption.REPLACE_EXISTING);
-      }
+      moveIntoPlace(tmpFile, configFile);
     } catch (final IOException e) {
       if (tmpFile != null) {
         try {
@@ -436,6 +479,27 @@ public final class DatabaseConfiguration {
     final Path configFile = dbFile.resolve(DatabasePaths.CONFIG_BINARY.getFile());
     final Path cacheKey = configFile.normalize();
 
+    SirixIOException lastError = null;
+    for (int attempt = 0; attempt < CONFIG_IO_MAX_ATTEMPTS; attempt++) {
+      try {
+        return deserializeOnce(dbFile, configFile, cacheKey);
+      } catch (final SirixIOException e) {
+        // A concurrent atomic replace of dbsetting.obj (id minting on open) can make a Windows
+        // reader momentarily observe a sharing violation while the file plainly still exists. That
+        // is transient — retry briefly. A genuinely missing file (database removed) does not come
+        // back here: exists() is false, so we rethrow immediately without spinning.
+        if (!Files.exists(configFile)) {
+          throw e;
+        }
+        lastError = e;
+        pauseForConfigContention(attempt);
+      }
+    }
+    throw lastError;
+  }
+
+  private static DatabaseConfiguration deserializeOnce(final Path dbFile, final Path configFile,
+      final Path cacheKey) {
     final BasicFileAttributes attributes;
     try {
       attributes = Files.readAttributes(configFile, BasicFileAttributes.class);


### PR DESCRIPTION
## What does this PR do?

Fixes the `windows-latest / core` CI lane, which failed on a single test:

```
DatabaseOpenCachingTest > concurrentOpensOfLegacyDatabaseMintSingleId()
  java.io.FileNotFoundException: ...\json-path1\dbsetting.obj
  (The process cannot access the file because it is being used by another process)
```

**Root cause.** That test opens a legacy (id-0) database from 8 threads at once. On open, one thread mints a database id and atomically replaces `dbsetting.obj` via `DatabaseConfiguration.serialize()`, while the other threads concurrently `deserialize()` that same file *outside* the global open lock (`Databases.java:420` — an intentional optimization so a file read + JSON parse does not serialize every open).

On Windows, a reader that opens a file mid-replace — or the replace running while a reader still holds the old handle — raises `ERROR_SHARING_VIOLATION`. POSIX has no such semantics, so this only ever flaked on the Windows lane. The existing write-to-temp + atomic-move design already rules out torn reads; the only remaining gap was this transient OS-level lock, which clears within microseconds.

**The fix.** Both sides of the race now retry the transient violation with a bounded backoff (`Thread.onSpinWait()` for the first 16 attempts, then ~0.2 ms `parkNanos` naps, 64 attempts total — roughly a 10 ms ceiling):

- **Read** (`deserialize`) retries only while the config file still exists; a genuinely removed database (`Files.exists() == false`) rethrows immediately with no spinning, preserving the existing failure semantics for that case. The per-call body moved to a private `deserializeOnce`, unchanged.
- **Replace** (`serialize`, via a new `moveIntoPlace` helper) retries the `FileSystemException` a concurrent reader can raise, and rethrows the last error unchanged once the budget is exhausted.

The retry path is never reached on POSIX, where the first attempt always succeeds, so the Linux/macOS hot paths are unaffected.

## Related issue

No issue — CI failure on `main` (run [30199499807](https://github.com/sirixdb/sirix/actions/runs/30199499807), job `Cross-platform tests (windows-latest / core)`).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [x] `:sirix-core:compileJava` and the affected test class pass locally (JDK 25) — all 5 `DatabaseOpenCachingTest` tests green
- [x] Covered by the existing `DatabaseOpenCachingTest` concurrency tests, which are what caught this
- [x] For behavioral changes to the storage engine: no invariant in `docs/formal-verification.md` is affected — this only makes an existing atomic config replace resilient to a transient Windows lock, with no change to on-disk format or ordering
- [x] No documentation change needed
- [x] No unrelated formatting churn

## Notes for reviewers

- The retry budget is deliberately small and non-blocking-ish: the contention window is a Windows file-lock handoff measured in microseconds, so spinning first and only then parking keeps the worst case near 10 ms while never sleeping on the common (uncontended) path.
- `moveIntoPlace` catches `FileSystemException` rather than plain `IOException` so that only OS-level file-system errors are retried; the `AtomicMoveNotSupportedException` fallback to a non-atomic move is preserved inside the retried block.
- Verification note: the failure mode is Windows-only and cannot be reproduced on the Linux dev container, so the fix is validated by reasoning about `ERROR_SHARING_VIOLATION` plus a green local run confirming no regression. The `windows-latest` lane on this PR is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvWc4hJSbAeJBToh7fwTte)_