### PR TITLE
Make the prefetcher close()-drain test deterministic

### DIFF
--- a/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RevisionPrefetcherLifecycleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/axis/temporal/RevisionPrefetcherLifecycleTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Proxy;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntSupplier;
 
 import static org.junit.Assert.assertEquals;
@@ -42,6 +43,13 @@ import static org.junit.Assert.fail;
  * </ul>
  */
 public final class RevisionPrefetcherLifecycleTest {
+
+  /**
+   * Bound on every handshake in {@link #close_doesNotReturnWhileInFlightTasksStillHoldTransactions}.
+   * Each one waits for a step that takes microseconds when it happens at all, so this is a
+   * deadlock backstop generous enough for a saturated CI runner, not a tuning knob.
+   */
+  private static final long HANDSHAKE_TIMEOUT_SECONDS = 20L;
 
   private Holder holder;
 
@@ -160,14 +168,22 @@ public final class RevisionPrefetcherLifecycleTest {
    * it is the baseline. Fire-and-forget: {@code close()} returns while they are still parked, and
    * the recorded count is above the baseline by exactly the number in flight.
    *
+   * <p>Both hand-offs are latch handshakes rather than timing assumptions. The consumer waits for
+   * {@code closeAllowed} before closing, because a {@code close()} that wins the race publishes its
+   * flag first and every remaining task then short-circuits ahead of its open — nothing is in
+   * flight and the two behaviours become indistinguishable. The harness in turn waits for the
+   * prefetcher to report itself closed before releasing the parked tasks, so the release can never
+   * precede the flag either.
+   *
    * <p>Consumer calls live on one thread, honouring the single-consumer contract; the test thread
-   * only operates the latch.
+   * only operates the latches.
    */
   @Test
   public void close_doesNotReturnWhileInFlightTasksStillHoldTransactions() throws Exception {
     final XmlResourceSession real = holder.getResourceSession();
     final int baseline = real.activeTrxCount();
     final CountDownLatch parked = new CountDownLatch(1);
+    final CountDownLatch closeAllowed = new CountDownLatch(1);
     final CountDownLatch release = new CountDownLatch(1);
 
     @SuppressWarnings("unchecked")
@@ -181,7 +197,7 @@ public final class RevisionPrefetcherLifecycleTest {
                 if (revision > 1) {
                   // Open and counted, but the body has not reached its closed-flag checkpoint.
                   parked.countDown();
-                  release.await(20, TimeUnit.SECONDS);
+                  release.await(HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                 }
                 return rtx;
               }
@@ -191,27 +207,62 @@ public final class RevisionPrefetcherLifecycleTest {
     final RevisionPrefetcher<XmlNodeReadOnlyTrx, XmlNodeTrx> prefetcher =
         new RevisionPrefetcher<>(blocking, 0L, ascendingRevisions(new AtomicInteger()), 4);
     final AtomicInteger countRecordedRightAfterClose = new AtomicInteger(-1);
+    final AtomicReference<Throwable> consumerFailure = new AtomicReference<>();
     final Thread consumer = new Thread(() -> {
-      final RtxResult<XmlNodeReadOnlyTrx> first = prefetcher.poll();
-      if (first != null) {
-        first.rtx.close();
+      try {
+        final RtxResult<XmlNodeReadOnlyTrx> first = prefetcher.poll();
+        if (first != null) {
+          first.rtx.close();
+        }
+        if (!closeAllowed.await(HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          throw new IllegalStateException("no prefetch task parked within "
+              + HANDSHAKE_TIMEOUT_SECONDS + "s");
+        }
+        prefetcher.close();
+        countRecordedRightAfterClose.set(real.activeTrxCount());
+      } catch (final InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        consumerFailure.set(interrupted);
+      } catch (final RuntimeException failure) {
+        consumerFailure.set(failure);
       }
-      prefetcher.close();
-      countRecordedRightAfterClose.set(real.activeTrxCount());
     }, "prefetch-consumer");
     consumer.start();
 
     assertTrue("a prefetch task must park inside the open, holding an rtx",
-        parked.await(20, TimeUnit.SECONDS));
-    // Long enough for the consumer to get from poll() to close() — microseconds of work. A
-    // fire-and-forget close() has therefore already recorded its count by the time we release.
+        parked.await(HANDSHAKE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    closeAllowed.countDown();
+    assertTrue("the consumer must reach close() while a task is still parked",
+        awaitClosed(prefetcher));
+    // close() has published its flag and is now either draining or — fire-and-forget — already
+    // back in the consumer. The tasks are still parked either way, so give the latter time to
+    // record its above-baseline count before we let them go.
     Thread.sleep(300);
     release.countDown();
     consumer.join(60_000);
     assertFalse("consumer thread must finish", consumer.isAlive());
+    assertNull("consumer thread must not fail: " + consumerFailure.get(), consumerFailure.get());
 
     assertEquals("close() must not return while in-flight tasks still hold open transactions",
         baseline, countRecordedRightAfterClose.get());
+  }
+
+  /**
+   * Spin until the prefetcher reports itself closed, i.e. {@link RevisionPrefetcher#close()} has
+   * published its flag and is past the point of no return, whether or not it has returned yet.
+   *
+   * @return {@code false} if the flag was not observed within {@link #HANDSHAKE_TIMEOUT_SECONDS}
+   */
+  private static boolean awaitClosed(final RevisionPrefetcher<?, ?> prefetcher)
+      throws InterruptedException {
+    final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(HANDSHAKE_TIMEOUT_SECONDS);
+    while (!prefetcher.isClosed()) {
+      if (System.nanoTime() - deadline >= 0L) {
+        return false;
+      }
+      Thread.sleep(1L);
+    }
+    return true;
   }
 
   @Test


### PR DESCRIPTION
## What does this PR do?

Fixes the CI failure in [run 30334189487](https://github.com/sirixdb/sirix/actions/runs/30334189487), where `Test sirix-core` failed with:

```
RevisionPrefetcherLifecycleTest > close_doesNotReturnWhileInFlightTasksStillHoldTransactions
java.lang.AssertionError: a prefetch task must park inside the open, holding an rtx
```

The failure was on the harness's setup latch, not on the contract assertion — the test never reached the state it wanted to measure.

**Root cause — a race in the test, not in `RevisionPrefetcher`.** The consumer thread called `poll()` and `close()` back to back. `close()` publishes `closed = true`, and every prefetch body checks that flag *before* calling `beginNodeReadOnlyTrx` (cancellation checkpoint #1, `RevisionPrefetcher.java:158`). The test document has three revisions, so revisions 2 and 3 are the only tasks that park. When their virtual threads had not been scheduled by the time `close()` published the flag, both short-circuited without ever opening a trx — nothing parked, and `parked.await(20s)` expired. That window is microseconds of consumer work against thread scheduling on a runner with 12 parallel jobs, which is why it passes locally and flakes in CI.

**The fix** adds the handshake the test's own javadoc already assumed ("a proxy session opens the REAL rtx and then parks … so the task is provably holding an open, counted transaction while `close()` runs"):

- The consumer waits on a new `closeAllowed` latch before calling `close()`; the harness releases it only once a task has actually parked.
- The harness waits for `prefetcher.isClosed()` before releasing the parked tasks, so the release can never precede the flag. This also replaces the previous "sleep 300ms and hope the consumer got from `poll()` to `close()`" assumption with an observed state; the remaining 300ms sleep now only gives a fire-and-forget `close()` time to record its above-baseline count.
- Consumer-thread exceptions are captured and asserted instead of surfacing only as the `-1` sentinel count.

Production code is unchanged — the diff is one test file.

## Related issue

No issue; this is a direct fix for the failing scheduled CI run linked above.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Performance improvement
- [ ] Documentation only

## Checklist

- [x] Added or updated tests covering the change (the change *is* the test)
- [x] No unrelated formatting churn
- [ ] `./gradlew build` passes locally (JDK 25) — ran the affected module's test task, `:sirix-core:test --tests io.sirix.axis.temporal.RevisionPrefetcherLifecycleTest`, rather than a full build; leaving the full run to CI
- [ ] For behavioral changes to the storage engine: n/a — no production code touched
- [ ] Updated documentation — n/a

## Notes for reviewers

Verified in both directions, since a test that only ever passes proves nothing:

- As committed: green.
- With `close()` temporarily reverted to fire-and-forget (early return before the drain join): fails on the contract assertion — `expected:<1> but was:<3>`, the baseline plus the two parked rtxs — not on a latch timeout. So the test still pins the synchronous-release contract from `RevisionPrefetcher.close()`, and now fails for the right reason when that contract breaks.

The three latch waits share one `HANDSHAKE_TIMEOUT_SECONDS = 20` bound. Each guards a step that takes microseconds when it happens at all, so it is a deadlock backstop sized for a saturated runner, not a timing assumption the test depends on.

---
_Generated by [Claude Code](https://claude.ai/code/session_0144wbptK412oPDuNdNv2gr3)_