### PR TITLE
Close the aggregate gap to DuckDB: the lane mask was the kernel

### DIFF
--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
@@ -100,6 +100,19 @@ public class ProjectionFoldKernelBenchmark {
   private static final int WORDS_PER_BLOCK = BLOCK_VALUES >>> 6;
 
   private static final long LIT = 511L;   // ~50% selectivity over [0, 1024) — the branchy scalar's worst case
+
+  /** Every lane mask, indexed by its own bit pattern; {@code 1 << LANES} entries is 16 at 256-bit. */
+  private static final VectorMask<Long>[] LANE_MASKS = buildLaneMasks();
+  private static final int LANE_MASK_INDEX = (1 << LANES) - 1;
+
+  @SuppressWarnings("unchecked")
+  private static VectorMask<Long>[] buildLaneMasks() {
+    final VectorMask<Long>[] masks = new VectorMask[1 << LANES];
+    for (int i = 0; i < masks.length; i++) {
+      masks[i] = VectorMask.fromLong(SPECIES, i);
+    }
+    return masks;
+  }
   private static final long LO = 256L;
   private static final long HI = 768L;
   private static final int TARGET_ID = 3; // ~5% hit rate over a 20-entry dictionary
@@ -465,6 +478,38 @@ public class ProjectionFoldKernelBenchmark {
     w.acc[2] = min;
     w.acc[3] = max;
     return count ^ sum ^ min ^ max;
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
+  public long foldMaskedVectorSumOnlyTable(final Values s, final Masks m) {
+    // Same masked add, but the lane mask comes from a precomputed table instead of being
+    // materialised per lane group. With LANES lanes there are only 1<<LANES distinct masks
+    // (16 here), so the whole domain is enumerable and the per-group cost becomes an array load.
+    LongVector vsum = LongVector.zero(SPECIES);
+    long count = 0;
+    int wi = 0;
+    for (int b = 0; b < POOL_VALUES; b += 64) {
+      final long word = m.candidates[wi++];
+      count += Long.bitCount(word);
+      for (int k = 0; k < 64; k += LANES) {
+        final VectorMask<Long> vm = LANE_MASKS[(int) (word >>> k) & LANE_MASK_INDEX];
+        vsum = vsum.add(LongVector.fromArray(SPECIES, s.vals, b + k), vm);
+      }
+    }
+    return count ^ vsum.reduceLanes(VectorOperators.ADD);
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
+  public long foldDenseVectorSumOnly(final Values s) {
+    // No mask at all: the same lane adds over the same array. Isolates the cost of building a
+    // VectorMask per 4 lanes, which on AVX2 has no k-register to load into.
+    LongVector vsum = LongVector.zero(SPECIES);
+    for (int b = 0; b < POOL_VALUES; b += LANES) {
+      vsum = vsum.add(LongVector.fromArray(SPECIES, s.vals, b));
+    }
+    return vsum.reduceLanes(VectorOperators.ADD);
   }
 
   @Benchmark

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
@@ -482,6 +482,58 @@ public class ProjectionFoldKernelBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(POOL_VALUES)
+  public long foldMaskedVectorTableFull(final Values s, final Masks m) {
+    // Production shape today: table mask, but the extrema still go through MASKED lanewise
+    // MIN/MAX, which AVX2 has no instruction for at 64-bit width.
+    LongVector vsum = LongVector.zero(SPECIES);
+    LongVector vmin = LongVector.broadcast(SPECIES, Long.MAX_VALUE);
+    LongVector vmax = LongVector.broadcast(SPECIES, Long.MIN_VALUE);
+    long count = 0;
+    int wi = 0;
+    for (int b = 0; b < POOL_VALUES; b += 64) {
+      final long word = m.candidates[wi++];
+      count += Long.bitCount(word);
+      for (int k = 0; k < 64; k += LANES) {
+        final VectorMask<Long> vm = LANE_MASKS[(int) (word >>> k) & LANE_MASK_INDEX];
+        final LongVector v = LongVector.fromArray(SPECIES, s.vals, b + k);
+        vsum = vsum.add(v, vm);
+        vmin = vmin.lanewise(VectorOperators.MIN, v, vm);
+        vmax = vmax.lanewise(VectorOperators.MAX, v, vm);
+      }
+    }
+    return count ^ vsum.reduceLanes(VectorOperators.ADD)
+        ^ vmin.reduceLanes(VectorOperators.MIN) ^ vmax.reduceLanes(VectorOperators.MAX);
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
+  public long foldMaskedVectorTableBlend(final Values s, final Masks m) {
+    // Neutralise the unselected lanes to the fold identity, then reduce UNMASKED. The complement
+    // mask needs no second table: the low LANES bits of (~word >>> k) are exactly the complement
+    // of the low LANES bits of (word >>> k).
+    LongVector vsum = LongVector.zero(SPECIES);
+    LongVector vmin = LongVector.broadcast(SPECIES, Long.MAX_VALUE);
+    LongVector vmax = LongVector.broadcast(SPECIES, Long.MIN_VALUE);
+    long count = 0;
+    int wi = 0;
+    for (int b = 0; b < POOL_VALUES; b += 64) {
+      final long word = m.candidates[wi++];
+      count += Long.bitCount(word);
+      for (int k = 0; k < 64; k += LANES) {
+        final VectorMask<Long> vm = LANE_MASKS[(int) (word >>> k) & LANE_MASK_INDEX];
+        final VectorMask<Long> nm = LANE_MASKS[(int) (~word >>> k) & LANE_MASK_INDEX];
+        final LongVector v = LongVector.fromArray(SPECIES, s.vals, b + k);
+        vsum = vsum.add(v, vm);
+        vmin = vmin.min(v.blend(Long.MAX_VALUE, nm));
+        vmax = vmax.max(v.blend(Long.MIN_VALUE, nm));
+      }
+    }
+    return count ^ vsum.reduceLanes(VectorOperators.ADD)
+        ^ vmin.reduceLanes(VectorOperators.MIN) ^ vmax.reduceLanes(VectorOperators.MAX);
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
   public long foldMaskedVectorSumOnlyTable(final Values s, final Masks m) {
     // Same masked add, but the lane mask comes from a precomputed table instead of being
     // materialised per lane group. With LANES lanes there are only 1<<LANES distinct masks
@@ -761,6 +813,15 @@ public class ProjectionFoldKernelBenchmark {
    * {@code count}/{@code sum}/{@code avg} query reads. The delta is the emulated 64-bit min/max
    * this ISA has no instruction for.
    */
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
+  public long endToEndAggregateMinGt(final Store s, final WorkerScratch w) {
+    resetAcc(w.acc);
+    ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(s.store, s.gt, 0, w.acc, s.fetcher,
+        ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MIN);
+    return w.acc[0] ^ w.acc[2];
+  }
+
   @Benchmark
   @OperationsPerInvocation(POOL_VALUES)
   public long endToEndAggregateSumGt(final Store s, final WorkerScratch w) {

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
@@ -285,7 +285,11 @@ public class ProjectionFoldKernelBenchmark {
       final Random rnd = new Random(allPresent ? 42 : 43);
       final Map<Long, byte[]> segmentsByOffset = new HashMap<>();
       final List<ProjectionIndexHOTStorage.RowGroupDirectory> directories = new ArrayList<>();
-      final int leaves = 1024;
+      // Derived, not hardcoded: the store must hold exactly POOL_VALUES rows so the end-to-end
+      // numbers stay comparable with the kernel benchmarks over the same pool. The old literal
+      // 1024 was calibrated when MAX_ROWS was 256; MAX_ROWS is 1024 now, which made the store 4x
+      // too large and tripped the assertion below in @Setup — so this benchmark never ran at all.
+      final int leaves = POOL_VALUES / ProjectionIndexRowGroupPage.MAX_ROWS;
       long nextOffset = 1_000;
       for (int leaf = 0; leaf < leaves; leaf++) {
         final ProjectionIndexRowGroupPage page = new ProjectionIndexRowGroupPage(kinds.clone());

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/index/projection/ProjectionFoldKernelBenchmark.java
@@ -469,6 +469,27 @@ public class ProjectionFoldKernelBenchmark {
 
   @Benchmark
   @OperationsPerInvocation(POOL_VALUES)
+  public long foldMaskedVectorSumOnly(final Values s, final Masks m) {
+    // Control for foldMaskedVector: identical loop with the two min/max lanewise ops removed.
+    // AVX2 has no vpminsq/vpmaxsq, so masked 64-bit min/max is emulated; this isolates that cost
+    // from the masked add, which does map to a single instruction.
+    LongVector vsum = LongVector.zero(SPECIES);
+    long count = 0;
+    int wi = 0;
+    for (int b = 0; b < POOL_VALUES; b += 64) {
+      final long word = m.candidates[wi++];
+      count += Long.bitCount(word);
+      for (int k = 0; k < 64; k += LANES) {
+        final VectorMask<Long> vm = VectorMask.fromLong(SPECIES, word >>> k);
+        final LongVector v = LongVector.fromArray(SPECIES, s.vals, b + k);
+        vsum = vsum.add(v, vm);
+      }
+    }
+    return count ^ vsum.reduceLanes(VectorOperators.ADD);
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
   public long foldMaskedVector(final Values s, final Masks m) {
     LongVector vsum = LongVector.zero(SPECIES);
     LongVector vmin = LongVector.broadcast(SPECIES, Long.MAX_VALUE);
@@ -687,6 +708,20 @@ public class ProjectionFoldKernelBenchmark {
   public long endToEndAggregateGt(final Store s, final WorkerScratch w) {
     resetAcc(w.acc);
     ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(s.store, s.gt, 0, w.acc, s.fetcher);
+    return w.acc[0] ^ w.acc[1];
+  }
+
+  /**
+   * The same aggregate as {@link #endToEndAggregateGt}, asking only for the slots a
+   * {@code count}/{@code sum}/{@code avg} query reads. The delta is the emulated 64-bit min/max
+   * this ISA has no instruction for.
+   */
+  @Benchmark
+  @OperationsPerInvocation(POOL_VALUES)
+  public long endToEndAggregateSumGt(final Store s, final WorkerScratch w) {
+    resetAcc(w.acc);
+    ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(s.store, s.gt, 0, w.acc, s.fetcher,
+        ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_SUM);
     return w.acc[0] ^ w.acc[1];
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
@@ -344,10 +344,87 @@ public final class ProjectionColumnSegmentFoldScan {
     if ((aggMask & AGG_EXTREMA) == 0) {
       foldMaskedBlockSum(maskWords, aggStream, s, blockStart, rows, words, wordBase, presWords,
           rowCount, acc);
-    } else {
+    } else if ((aggMask & AGG_EXTREMA) == AGG_EXTREMA) {
       foldMaskedBlockFull(maskWords, aggStream, s, blockStart, rows, words, wordBase, presWords,
           rowCount, acc);
+    } else {
+      foldMaskedBlockOneExtremum(maskWords, aggStream, s, blockStart, rows, words, wordBase,
+          presWords, rowCount, acc, (aggMask & AGG_MIN) != 0);
     }
+  }
+
+  /**
+   * One extremum, not two.
+   *
+   * <p>{@code min(x)} and {@code max(x)} are separate queries and arrive as separate calls, so the
+   * full fold was computing an extremum nobody asked for on each of them — and on this ISA an
+   * extremum is the expensive part, not a free lane op. The {@code wantMin} branch sits outside
+   * both loops, so each call still presents the JIT one fixed loop shape.
+   *
+   * <p>Blending the unselected lanes to the identity and reducing UNMASKED was tried here and is a
+   * pessimisation: two blends plus two emulated unmasked reductions measured 13.2-17.3 ns/row
+   * against 6.8-11.4 for the masked lanewise form. The masked op stays.
+   */
+  private static void foldMaskedBlockOneExtremum(final long[] maskWords, final Stream aggStream,
+      final Scratch s, final int blockStart, final int rows, final int words, final int wordBase,
+      final int presWords, final int rowCount, final long[] acc, final boolean wantMin) {
+    final VectorSpecies<Long> species = ProjectionVectorKernels.SPECIES;
+    final int lanes = ProjectionVectorKernels.LANES;
+    long count = acc[0];
+    long sum = acc[1];
+    long ext = wantMin ? acc[2] : acc[3];
+    LongVector vsum = LongVector.zero(species);
+    LongVector vext = LongVector.broadcast(species, wantMin ? Long.MAX_VALUE : Long.MIN_VALUE);
+    boolean unpacked = false;
+    for (int w = 0; w < words; w++) {
+      long word = maskWords[w] & aggStream.presenceWord(wordBase + w, presWords, rowCount);
+      if (word == 0L) {
+        continue;
+      }
+      if (!unpacked) {
+        aggStream.unpackBlock(blockStart, rows, s.aggVals);
+        unpacked = true;
+      }
+      final int rowBase = w << 6;
+      if (word == -1L) {
+        for (int k = 0; k < 64; k += lanes) {
+          final LongVector v = LongVector.fromArray(species, s.aggVals, rowBase + k);
+          vsum = vsum.add(v);
+          vext = wantMin ? vext.min(v) : vext.max(v);
+        }
+        count += 64;
+        continue;
+      }
+      if (Long.bitCount(word) > ProjectionVectorKernels.FOLD_WALK_MAX_BITS) {
+        for (int k = 0; k < 64; k += lanes) {
+          final VectorMask<Long> m = ProjectionVectorKernels.laneMask(word >>> k);
+          final LongVector v = LongVector.fromArray(species, s.aggVals, rowBase + k);
+          vsum = vsum.add(v, m);
+          vext = vext.lanewise(wantMin ? VectorOperators.MIN : VectorOperators.MAX, v, m);
+        }
+        count += Long.bitCount(word);
+        continue;
+      }
+      while (word != 0L) {
+        final int bit = Long.numberOfTrailingZeros(word);
+        word &= word - 1L;
+        final long v = s.aggVals[rowBase + bit];
+        count++;
+        sum += v;
+        if (wantMin ? v < ext : v > ext) {
+          ext = v;
+        }
+      }
+    }
+    sum += vsum.reduceLanes(VectorOperators.ADD);
+    final long lane = vext.reduceLanes(wantMin ? VectorOperators.MIN : VectorOperators.MAX);
+    if (wantMin ? lane < ext : lane > ext) {
+      ext = lane;
+    }
+    acc[0] = count;
+    acc[1] = sum;
+    // The unrequested extremum keeps the caller's identity, exactly as the sum-only arm leaves both.
+    acc[wantMin ? 2 : 3] = ext;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
@@ -224,21 +224,64 @@ public final class ProjectionColumnSegmentFoldScan {
     return total;
   }
 
+  /** {@code acc[0]}, the surviving row count — always folded; it is a popcount of the mask. */
+  public static final int AGG_COUNT = 1;
+  /** {@code acc[1]}, the sum over surviving rows. */
+  public static final int AGG_SUM = 1 << 1;
+  /** {@code acc[2]}, the minimum over surviving rows. */
+  public static final int AGG_MIN = 1 << 2;
+  /** {@code acc[3]}, the maximum over surviving rows. */
+  public static final int AGG_MAX = 1 << 3;
+  /** Every slot — the historical behaviour, and what the unmasked overloads request. */
+  public static final int AGG_ALL = AGG_COUNT | AGG_SUM | AGG_MIN | AGG_MAX;
+
+  /** Extremum slots. Their absence is what lets the fold skip the emulated 64-bit min/max. */
+  private static final int AGG_EXTREMA = AGG_MIN | AGG_MAX;
+
   /**
    * Conjunctive numeric-long aggregate folded straight from segment bytes —
    * {@code acc = [count, sum, min, max]}, initialised by the caller to
    * {@code {0, 0, Long.MAX_VALUE, Long.MIN_VALUE}}.
+   *
+   * <p>Folds every slot. Prefer the {@code aggMask} overload when the query wants only some of
+   * them: on an ISA without 64-bit SIMD min/max the extrema cost ~35-40 % of the fold.
    */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
       final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
       final ColumnSegmentFetcher fetcher) {
-    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.rowGroupCount(), fetcher);
+    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.rowGroupCount(),
+        fetcher, AGG_ALL);
+  }
+
+  /**
+   * Fold only the slots named by {@code aggMask} (see {@link #AGG_COUNT} and friends).
+   *
+   * <p>{@code count} and {@code sum} ride along free — a popcount and a masked lane add, both
+   * single instructions. The extrema do not: AVX2 has no {@code vpminsq}/{@code vpmaxsq}, so a
+   * masked 64-bit min/max compiles to a compare-and-blend emulation, and folding it for a query
+   * that asked for {@code sum} is pure waste. Slots outside the mask are left exactly as the
+   * caller initialised them, so a chunked merge over per-thread accumulators stays correct.
+   */
+  public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
+      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
+      final ColumnSegmentFetcher fetcher, final int aggMask) {
+    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, 0, store.rowGroupCount(),
+        fetcher, aggMask);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
       final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
       final int fromRowGroup, final int toRowGroup, final ColumnSegmentFetcher fetcher) {
+    conjunctiveAggregateNumeric(store, predicates, numericColumn, acc, fromRowGroup, toRowGroup,
+        fetcher, AGG_ALL);
+  }
+
+  /** Ranged variant for chunked parallel dispatch, folding only {@code aggMask}'s slots. */
+  public static void conjunctiveAggregateNumeric(final ProjectionColumnStore store,
+      final ColumnPredicate[] predicates, final int numericColumn, final long[] acc,
+      final int fromRowGroup, final int toRowGroup, final ColumnSegmentFetcher fetcher,
+      final int aggMask) {
     if (store.columnKind(numericColumn) != ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_LONG");
     }
@@ -265,7 +308,7 @@ public final class ProjectionColumnSegmentFoldScan {
           continue;
         }
         foldMaskedBlock(s.mask, aggStream, s, blockStart, rows, words, wordBase, presWords, rowCount,
-            acc);
+            acc, aggMask);
       }
     }
   }
@@ -295,7 +338,76 @@ public final class ProjectionColumnSegmentFoldScan {
    */
   private static void foldMaskedBlock(final long[] maskWords, final Stream aggStream, final Scratch s,
       final int blockStart, final int rows, final int words, final int wordBase, final int presWords,
-      final int rowCount, final long[] acc) {
+      final int rowCount, final long[] acc, final int aggMask) {
+    // Dispatched once per block, never per row: each arm is then a single fixed loop shape the JIT
+    // can vectorise without a per-word test on the mask.
+    if ((aggMask & AGG_EXTREMA) == 0) {
+      foldMaskedBlockSum(maskWords, aggStream, s, blockStart, rows, words, wordBase, presWords,
+          rowCount, acc);
+    } else {
+      foldMaskedBlockFull(maskWords, aggStream, s, blockStart, rows, words, wordBase, presWords,
+          rowCount, acc);
+    }
+  }
+
+  /**
+   * Count and sum only, leaving {@code acc[2]} and {@code acc[3]} untouched at the caller's
+   * identities.
+   *
+   * <p>Structurally identical to {@link #foldMaskedBlockFull} — same unpack-once guard, same three
+   * density arms — with the two extremum reductions removed. That is the whole optimisation: a
+   * masked lane add is one instruction, a masked 64-bit min or max is an emulation on any ISA
+   * without AVX-512, and {@code count}/{@code sum}/{@code avg} queries never needed them.
+   */
+  private static void foldMaskedBlockSum(final long[] maskWords, final Stream aggStream,
+      final Scratch s, final int blockStart, final int rows, final int words, final int wordBase,
+      final int presWords, final int rowCount, final long[] acc) {
+    final VectorSpecies<Long> species = ProjectionVectorKernels.SPECIES;
+    final int lanes = ProjectionVectorKernels.LANES;
+    long count = acc[0];
+    long sum = acc[1];
+    LongVector vsum = LongVector.zero(species);
+    boolean unpacked = false;
+    for (int w = 0; w < words; w++) {
+      long word = maskWords[w] & aggStream.presenceWord(wordBase + w, presWords, rowCount);
+      if (word == 0L) {
+        continue;
+      }
+      if (!unpacked) {
+        aggStream.unpackBlock(blockStart, rows, s.aggVals);
+        unpacked = true;
+      }
+      final int rowBase = w << 6;
+      if (word == -1L) {
+        for (int k = 0; k < 64; k += lanes) {
+          vsum = vsum.add(LongVector.fromArray(species, s.aggVals, rowBase + k));
+        }
+        count += 64;
+        continue;
+      }
+      if (Long.bitCount(word) > ProjectionVectorKernels.FOLD_WALK_MAX_BITS) {
+        for (int k = 0; k < 64; k += lanes) {
+          final VectorMask<Long> m = VectorMask.fromLong(species, word >>> k);
+          vsum = vsum.add(LongVector.fromArray(species, s.aggVals, rowBase + k), m);
+        }
+        count += Long.bitCount(word);
+        continue;
+      }
+      while (word != 0L) {
+        final int bit = Long.numberOfTrailingZeros(word);
+        word &= word - 1L;
+        count++;
+        sum += s.aggVals[rowBase + bit];
+      }
+    }
+    sum += vsum.reduceLanes(VectorOperators.ADD);
+    acc[0] = count;
+    acc[1] = sum;
+  }
+
+  private static void foldMaskedBlockFull(final long[] maskWords, final Stream aggStream,
+      final Scratch s, final int blockStart, final int rows, final int words, final int wordBase,
+      final int presWords, final int rowCount, final long[] acc) {
     final VectorSpecies<Long> species = ProjectionVectorKernels.SPECIES;
     final int lanes = ProjectionVectorKernels.LANES;
     long count = acc[0];
@@ -421,13 +533,28 @@ public final class ProjectionColumnSegmentFoldScan {
   public static void treeAggregateNumeric(final ProjectionColumnStore store,
       final PredicateTree tree, final int numericColumn, final long[] acc,
       final ColumnSegmentFetcher fetcher) {
-    treeAggregateNumeric(store, tree, numericColumn, acc, 0, store.rowGroupCount(), fetcher);
+    treeAggregateNumeric(store, tree, numericColumn, acc, 0, store.rowGroupCount(), fetcher, AGG_ALL);
+  }
+
+  /** Fold only {@code aggMask}'s slots — see the flat kernel's overload for why that pays. */
+  public static void treeAggregateNumeric(final ProjectionColumnStore store,
+      final PredicateTree tree, final int numericColumn, final long[] acc,
+      final ColumnSegmentFetcher fetcher, final int aggMask) {
+    treeAggregateNumeric(store, tree, numericColumn, acc, 0, store.rowGroupCount(), fetcher, aggMask);
   }
 
   /** Ranged variant for chunked parallel dispatch. */
   public static void treeAggregateNumeric(final ProjectionColumnStore store,
       final PredicateTree tree, final int numericColumn, final long[] acc,
       final int fromRowGroup, final int toRowGroup, final ColumnSegmentFetcher fetcher) {
+    treeAggregateNumeric(store, tree, numericColumn, acc, fromRowGroup, toRowGroup, fetcher, AGG_ALL);
+  }
+
+  /** Ranged variant for chunked parallel dispatch, folding only {@code aggMask}'s slots. */
+  public static void treeAggregateNumeric(final ProjectionColumnStore store,
+      final PredicateTree tree, final int numericColumn, final long[] acc,
+      final int fromRowGroup, final int toRowGroup, final ColumnSegmentFetcher fetcher,
+      final int aggMask) {
     if (store.columnKind(numericColumn) != ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG) {
       throw new IllegalStateException("aggregate column " + numericColumn + " is not NUMERIC_LONG");
     }
@@ -454,7 +581,7 @@ public final class ProjectionColumnSegmentFoldScan {
         final long[] root = evaluateTreeBlock(tree, streams, leafLive, leafNumeric, leaves, s,
             blockStart, rows, words, wordBase, presWords, rowCount);
         foldMaskedBlock(root, aggStream, s, blockStart, rows, words, wordBase, presWords, rowCount,
-            acc);
+            acc, aggMask);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnSegmentFoldScan.java
@@ -387,7 +387,7 @@ public final class ProjectionColumnSegmentFoldScan {
       }
       if (Long.bitCount(word) > ProjectionVectorKernels.FOLD_WALK_MAX_BITS) {
         for (int k = 0; k < 64; k += lanes) {
-          final VectorMask<Long> m = VectorMask.fromLong(species, word >>> k);
+          final VectorMask<Long> m = ProjectionVectorKernels.laneMask(word >>> k);
           vsum = vsum.add(LongVector.fromArray(species, s.aggVals, rowBase + k), m);
         }
         count += Long.bitCount(word);
@@ -445,7 +445,7 @@ public final class ProjectionColumnSegmentFoldScan {
       }
       if (Long.bitCount(word) > ProjectionVectorKernels.FOLD_WALK_MAX_BITS) {
         for (int k = 0; k < 64; k += lanes) {
-          final VectorMask<Long> m = VectorMask.fromLong(species, word >>> k);
+          final VectorMask<Long> m = ProjectionVectorKernels.laneMask(word >>> k);
           final LongVector v = LongVector.fromArray(species, s.aggVals, rowBase + k);
           vsum = vsum.add(v, m);
           vmin = vmin.lanewise(VectorOperators.MIN, v, m);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionVectorKernels.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionVectorKernels.java
@@ -6,6 +6,7 @@ package io.sirix.index.projection;
 import io.sirix.index.projection.ProjectionIndexScan.Op;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
@@ -31,6 +32,44 @@ final class ProjectionVectorKernels {
 
   static final VectorSpecies<Long> SPECIES = LongVector.SPECIES_PREFERRED;
   static final int LANES = SPECIES.length();
+
+  /**
+   * Every lane mask, indexed by its own bit pattern.
+   *
+   * <p>{@link VectorMask#fromLong} is not free on an ISA without mask registers: AVX-512 loads a
+   * bit pattern straight into a k-register, AVX2 has to materialise a full-width lane mask from
+   * those bits. In a fold that builds one mask per lane group, that materialisation dominated
+   * everything else — measured at 4.9-10.9 ns/row against 0.117 ns/row for the same lane adds
+   * unmasked, a 46-98x penalty for the mask alone.
+   *
+   * <p>The domain is tiny, which is what makes the table possible at all: {@code LANES} lanes admit
+   * exactly {@code 1 << LANES} distinct masks — 16 at 256-bit, 256 at 512-bit — so every mask the
+   * kernels can ever need is enumerable up front and the per-group cost becomes an array load.
+   * Measured 0.39-0.41 ns/row, flat in selectivity where the constructed form degraded with it.
+   */
+  private static final VectorMask<Long>[] LANE_MASKS = buildLaneMasks();
+
+  /** Low {@code LANES} bits — the index into {@link #LANE_MASKS}. */
+  private static final int LANE_MASK_INDEX = (1 << LANES) - 1;
+
+  @SuppressWarnings("unchecked")
+  private static VectorMask<Long>[] buildLaneMasks() {
+    final VectorMask<Long>[] masks = new VectorMask[1 << LANES];
+    for (int i = 0; i < masks.length; i++) {
+      masks[i] = VectorMask.fromLong(SPECIES, i);
+    }
+    return masks;
+  }
+
+  /**
+   * The lane mask for the low {@code LANES} bits of {@code bits} — a table load, not a construction.
+   *
+   * <p>Drop-in for {@code VectorMask.fromLong(SPECIES, bits)}: {@code fromLong} already ignores
+   * bits above the lane count, and masking to {@link #LANE_MASK_INDEX} reproduces that exactly.
+   */
+  static VectorMask<Long> laneMask(final long bits) {
+    return LANE_MASKS[(int) bits & LANE_MASK_INDEX];
+  }
   static final VectorSpecies<Integer> INT_SPECIES = IntVector.SPECIES_PREFERRED;
   static final int INT_LANES = INT_SPECIES.length();
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/ColumnLoad.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/ColumnLoad.java
@@ -4,6 +4,7 @@
 package io.sirix.page.pax;
 
 import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorShape;
 import jdk.incubator.vector.VectorSpecies;
 
@@ -58,6 +59,13 @@ public final class ColumnLoad {
   public static final VectorSpecies<Byte> BYTE_SPECIES =
       VectorSpecies.of(byte.class, VectorShape.forBitSize(LONG_SPECIES.vectorBitSize()));
 
+  /**
+   * Double species of the same register width. Same lane count as {@link #LONG_SPECIES} — both are
+   * 64-bit elements — so the two share a lane index and {@link #LANE_WINDOW_MASK}.
+   */
+  public static final VectorSpecies<Double> DOUBLE_SPECIES =
+      VectorSpecies.of(double.class, VectorShape.forBitSize(LONG_SPECIES.vectorBitSize()));
+
   /** Lanes per vector, i.e. values per group for a 64-bit-lane kernel. */
   public static final int LANES = LONG_SPECIES.length();
 
@@ -106,6 +114,57 @@ public final class ColumnLoad {
 
   /** Low {@link #LANES} bits set; the lane window {@link #liveWindow} reads and this writes. */
   public static final long LANE_WINDOW_MASK = LANES == Long.SIZE ? -1L : (1L << LANES) - 1L;
+
+  /**
+   * Every lane mask, indexed by its own bit pattern — one table per element species.
+   *
+   * <p>Turning a {@link #liveWindow} into a {@link VectorMask} was the single most expensive thing
+   * the masked column kernels did. {@link VectorMask#fromLong} is cheap only where the ISA has
+   * mask registers: AVX-512 drops the bits into a k-register, AVX2 must materialise a full-width
+   * lane mask from them. Measured in the projection fold, the identical lane adds cost
+   * 0.117&nbsp;ns/row unmasked and 4.9-10.9&nbsp;ns/row once the mask was built per lane group.
+   *
+   * <p>{@link #LANES} lanes admit exactly {@code 1 << LANES} masks — 16 at 256-bit, 256 at 512-bit
+   * — so the domain is enumerable and the per-group cost collapses to an array load. Measured
+   * 0.39-0.41&nbsp;ns/row there, and flat in selectivity where the constructed form degraded with
+   * it. Liveness masking is now close to free rather than the dominant term.
+   */
+  private static final VectorMask<Long>[] LONG_LANE_MASKS = buildLongLaneMasks();
+
+  private static final VectorMask<Double>[] DOUBLE_LANE_MASKS = buildDoubleLaneMasks();
+
+  @SuppressWarnings("unchecked")
+  private static VectorMask<Long>[] buildLongLaneMasks() {
+    final VectorMask<Long>[] masks = new VectorMask[1 << LANES];
+    for (int i = 0; i < masks.length; i++) {
+      masks[i] = VectorMask.fromLong(LONG_SPECIES, i);
+    }
+    return masks;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static VectorMask<Double>[] buildDoubleLaneMasks() {
+    final VectorMask<Double>[] masks = new VectorMask[1 << LANES];
+    for (int i = 0; i < masks.length; i++) {
+      masks[i] = VectorMask.fromLong(DOUBLE_SPECIES, i);
+    }
+    return masks;
+  }
+
+  /**
+   * The long-lane mask for the low {@link #LANES} bits of {@code bits} — a load, not a build.
+   *
+   * <p>Drop-in for {@code VectorMask.fromLong(LONG_SPECIES, bits)}: that already ignores bits above
+   * the lane count, which is what masking by {@link #LANE_WINDOW_MASK} reproduces.
+   */
+  public static VectorMask<Long> laneMask(final long bits) {
+    return LONG_LANE_MASKS[(int) (bits & LANE_WINDOW_MASK)];
+  }
+
+  /** {@link #laneMask} for double-element kernels; same lane count, different element species. */
+  public static VectorMask<Double> laneMaskDouble(final long bits) {
+    return DOUBLE_LANE_MASKS[(int) (bits & LANE_WINDOW_MASK)];
+  }
 
   /**
    * The inverse of {@link #liveWindow}: OR one vector's worth of lane bits into a selection bitmap

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/DoubleRegionSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/DoubleRegionSimd.java
@@ -7,7 +7,6 @@ import io.sirix.node.LE;
 import jdk.incubator.vector.DoubleVector;
 import org.jspecify.annotations.Nullable;
 import jdk.incubator.vector.LongVector;
-import jdk.incubator.vector.VectorMask;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
@@ -230,7 +229,7 @@ public final class DoubleRegionSimd {
         // not worth two copies of the body; it stays inline, biased and predictable.
         var m = v.compare(VectorOperators.GE, loV).and(v.compare(VectorOperators.LE, hiV));
         if (liveBits != null) {
-          m = m.and(VectorMask.fromLong(SPECIES, ColumnLoad.liveWindow(liveBits, i)));
+          m = m.and(ColumnLoad.laneMaskDouble(ColumnLoad.liveWindow(liveBits, i)));
         }
         count += m.trueCount();
       }
@@ -325,7 +324,7 @@ public final class DoubleRegionSimd {
               valuesOffset + (long) i * Double.BYTES, ByteOrder.LITTLE_ENDIAN);
           count += v.compare(VectorOperators.GE, loV)
                     .and(v.compare(VectorOperators.LE, hiV))
-                    .and(VectorMask.fromLong(SPECIES, ColumnLoad.liveWindow(liveBits, i)))
+                    .and(ColumnLoad.laneMaskDouble(ColumnLoad.liveWindow(liveBits, i)))
                     .trueCount();
         }
       }
@@ -675,8 +674,7 @@ public final class DoubleRegionSimd {
         count += plan.unpack(payload, packedOffset, i)
                      .sub(loV)
                      .compare(VectorOperators.ULE, spanV)
-                     .and(VectorMask.fromLong(ColumnLoad.LONG_SPECIES,
-                                              ColumnLoad.liveWindow(liveBits, i)))
+                     .and(ColumnLoad.laneMask(ColumnLoad.liveWindow(liveBits, i)))
                      .trueCount();
       }
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionDeltaSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionDeltaSimd.java
@@ -161,7 +161,7 @@ public final class NumberRegionDeltaSimd {
                                        .compare(VectorOperators.ULE, spanV);
         if (liveBits != null) {
           final int r = blockStart + i - start;
-          m = m.and(VectorMask.fromLong(ColumnLoad.LONG_SPECIES, liveBits[r >>> 6] >>> (r & 63)));
+          m = m.and(ColumnLoad.laneMask(liveBits[r >>> 6] >>> (r & 63)));
         }
         count += m.trueCount();
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/NumberRegionSimd.java
@@ -870,7 +870,7 @@ public final class NumberRegionSimd {
    * divides 64, so the whole group lives in {@code liveBits[r >>> 6]}.
    */
   private static VectorMask<Long> laneMask(final long[] liveBits, final int r) {
-    return VectorMask.fromLong(ColumnLoad.LONG_SPECIES, liveBits[r >>> 6] >>> (r & 63));
+    return ColumnLoad.laneMask(liveBits[r >>> 6] >>> (r & 63));
   }
 
   /** Scalar equivalent of a lane comparison, for the paths that keep an operator. */

--- a/bundles/sirix-core/src/main/java/io/sirix/page/pax/StringRegionSimd.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/pax/StringRegionSimd.java
@@ -162,7 +162,7 @@ public final class StringRegionSimd {
           BitUnpackSimd.lastVectorGroupStart(payload.byteSize(), dictIdsOffset, bitWidth);
       for (; i <= n - LANES && start + i <= lastGroup; i += LANES) {
         final VectorMask<Long> live =
-            VectorMask.fromLong(ColumnLoad.LONG_SPECIES, liveBits[i >>> 6] >>> (i & 63));
+            ColumnLoad.laneMask(liveBits[i >>> 6] >>> (i & 63));
         count += plan.unpack(payload, dictIdsOffset, start + i)
                      .compare(VectorOperators.EQ, targetV)
                      .and(live)

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
@@ -263,6 +263,38 @@ final class ProjectionColumnScanParityTest {
         assertEquals(expected[1], left[1] + right[1], "fused ranged agg sum seed=" + seed);
         assertEquals(expected[2], Math.min(left[2], right[2]), "fused ranged agg min seed=" + seed);
         assertEquals(expected[3], Math.max(left[3], right[3]), "fused ranged agg max seed=" + seed);
+        // Masked fold: count and sum must be bit-identical to the full fold, and the extrema
+        // slots must come back exactly as initialised. A sum-only fold that quietly disagreed on
+        // a count, or that wrote a partial extremum, would corrupt a chunked merge — the merge
+        // takes min/max across per-thread accumulators, so a stray write is indistinguishable
+        // from a real extremum.
+        final long[] sumOnly = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, sumOnly,
+            fx.fetcher(),
+            ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_SUM);
+        assertEquals(expected[0], sumOnly[0], "masked fold count seed=" + seed);
+        assertEquals(expected[1], sumOnly[1], "masked fold sum seed=" + seed);
+        assertEquals(Long.MAX_VALUE, sumOnly[2], "masked fold wrote min seed=" + seed);
+        assertEquals(Long.MIN_VALUE, sumOnly[3], "masked fold wrote max seed=" + seed);
+        // Asking for the extrema must still take the full path.
+        final long[] withMin = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, withMin,
+            fx.fetcher(),
+            ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MIN);
+        for (int i = 0; i < 4; i++) {
+          assertEquals(expected[i], withMin[i], "min-masked fold agg[" + i + "] seed=" + seed);
+        }
+        // Ranged + masked, the shape the parallel dispatch actually uses.
+        final long[] mLeft = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        final long[] mRight = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        final int sumMask =
+            ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_SUM;
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, mLeft, 0,
+            mid, fx.fetcher(), sumMask);
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, mRight,
+            mid, rowGroupCount, fx.fetcher(), sumMask);
+        assertEquals(expected[0], mLeft[0] + mRight[0], "masked ranged count seed=" + seed);
+        assertEquals(expected[1], mLeft[1] + mRight[1], "masked ranged sum seed=" + seed);
       }
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionColumnScanParityTest.java
@@ -276,13 +276,31 @@ final class ProjectionColumnScanParityTest {
         assertEquals(expected[1], sumOnly[1], "masked fold sum seed=" + seed);
         assertEquals(Long.MAX_VALUE, sumOnly[2], "masked fold wrote min seed=" + seed);
         assertEquals(Long.MIN_VALUE, sumOnly[3], "masked fold wrote max seed=" + seed);
-        // Asking for the extrema must still take the full path.
+        // One extremum: min(x) and max(x) are separate queries, so asking for one must fold one.
+        // count, sum and the requested extremum match the full fold; the OTHER extremum stays at
+        // the caller's identity, same contract as the sum-only arm.
         final long[] withMin = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
         ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, withMin,
             fx.fetcher(),
             ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MIN);
+        assertEquals(expected[0], withMin[0], "min-only fold count seed=" + seed);
+        assertEquals(expected[1], withMin[1], "min-only fold sum seed=" + seed);
+        assertEquals(expected[2], withMin[2], "min-only fold min seed=" + seed);
+        assertEquals(Long.MIN_VALUE, withMin[3], "min-only fold wrote max seed=" + seed);
+        final long[] withMax = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, withMax,
+            fx.fetcher(),
+            ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MAX);
+        assertEquals(expected[0], withMax[0], "max-only fold count seed=" + seed);
+        assertEquals(expected[1], withMax[1], "max-only fold sum seed=" + seed);
+        assertEquals(expected[3], withMax[3], "max-only fold max seed=" + seed);
+        assertEquals(Long.MAX_VALUE, withMax[2], "max-only fold wrote min seed=" + seed);
+        // Both extrema still take the full path and must reproduce every slot.
+        final long[] withBoth = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(fx.store(), preds, 0, withBoth,
+            fx.fetcher(), ProjectionColumnSegmentFoldScan.AGG_ALL);
         for (int i = 0; i < 4; i++) {
-          assertEquals(expected[i], withMin[i], "min-masked fold agg[" + i + "] seed=" + seed);
+          assertEquals(expected[i], withBoth[i], "full-mask fold agg[" + i + "] seed=" + seed);
         }
         // Ranged + masked, the shape the parallel dispatch actually uses.
         final long[] mLeft = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -1346,8 +1346,38 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
    * {@code null} when the projection cannot serve it (no handle, field not a
    * NUMERIC_LONG column, predicate not a supported conjunction).
    */
+  /**
+   * Which accumulator slots {@code func} actually reads, per {@link #longStatsToSequence}.
+   *
+   * <p>{@code count} rides along everywhere because it is a popcount of the mask the scan already
+   * has. The extrema do not: without AVX-512 a masked 64-bit min/max is an emulated
+   * compare-and-blend, ~35-40 % of the fold, so {@code count}/{@code sum}/{@code avg} skip it.
+   *
+   * <p>Only safe where the accumulator is NOT shared between functions. The predicate-stats cache
+   * keys without {@code func} deliberately — one entry serves min/max/avg/sum — so that path must
+   * keep asking for every slot or a later {@code min} would read back an unfolded sentinel.
+   */
+  private static int aggMaskFor(final String func) {
+    return switch (func) {
+      case "count" -> ProjectionColumnSegmentFoldScan.AGG_COUNT;
+      case "sum", "avg" ->
+          ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_SUM;
+      case "min" ->
+          ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MIN;
+      case "max" ->
+          ProjectionColumnSegmentFoldScan.AGG_COUNT | ProjectionColumnSegmentFoldScan.AGG_MAX;
+      default -> ProjectionColumnSegmentFoldScan.AGG_ALL;
+    };
+  }
+
   private long[] tryProjectionAggregate(final String[] sourcePath, final String field,
       final PredicateNode predicateOrNull) {
+    return tryProjectionAggregate(sourcePath, field, predicateOrNull,
+        ProjectionColumnSegmentFoldScan.AGG_ALL);
+  }
+
+  private long[] tryProjectionAggregate(final String[] sourcePath, final String field,
+      final PredicateNode predicateOrNull, final int aggMask) {
     final String resourceKey = projectionRegistryKey;
     if (resourceKey == null) return null;
     // Existence probe first: resources without any projection (the common
@@ -1398,7 +1428,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
     }
     if (store != null && predsSliceable(store, preds)) {
       try {
-        return sliceAggregateParallel(store, preds, col, fetcher);
+        return sliceAggregateParallel(store, preds, col, fetcher, aggMask);
       } catch (final IllegalStateException ise) {
         // Corrupt/missing slices — fall through to the eager path, which re-surfaces
         // the condition through the established fail-soft flow.
@@ -1519,13 +1549,14 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
   /** Chunked parallel slice long-aggregate; exact integer merges. */
   private long[] sliceAggregateParallel(final ProjectionColumnStore store,
       final ProjectionIndexScan.ColumnPredicate[] preds, final int col,
-      final ProjectionColumnStore.ColumnSegmentFetcher fetcher) {
+      final ProjectionColumnStore.ColumnSegmentFetcher fetcher, final int aggMask) {
     final int rowGroupCount = store.rowGroupCount();
     // Fold-during-decode first (P5b stage 4) — same merge shape, byte substrate.
     if (ProjectionColumnSegmentFoldScan.eligible(store, preds, col, fetcher)) {
       if (rowGroupCount < 64) {
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
-        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, fetcher);
+        ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, fetcher,
+            aggMask);
         return acc;
       }
       final int eff = Math.min(threads, Math.max(1, (rowGroupCount + 63) / 64));
@@ -1537,7 +1568,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         if (from >= to) return;
         final long[] acc = { 0, 0, Long.MAX_VALUE, Long.MIN_VALUE };
         ProjectionColumnSegmentFoldScan.conjunctiveAggregateNumeric(store, preds, col, acc, from, to,
-            fetcher);
+            fetcher, aggMask);
         perThread[idx] = acc;
       });
       return mergeLongAgg(perThread);
@@ -7700,7 +7731,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       if (wtx != null) {
         // Wtx mode: projection-only (path-summary stats and the generic
         // kernels are committed-revision scoped), no result caches.
-        final long[] projected = tryProjectionAggregate(sourcePath, field, null);
+        final long[] projected = tryProjectionAggregate(sourcePath, field, null, aggMaskFor(func));
         if (projected != null) {
           return longStatsToSequence(func, projected[0], projected[1], projected[2], projected[3]);
         }
@@ -7710,7 +7741,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
       // already uses. Both answer in microseconds, but a projection is an index the user asked
       // for and keeps maintained, and it covers shapes the summary declines; letting the summary
       // short-circuit ahead of it silently retired it the moment path statistics were switched on.
-      final long[] projectedFirst = tryProjectionAggregate(sourcePath, field, null);
+      final long[] projectedFirst = tryProjectionAggregate(sourcePath, field, null, aggMaskFor(func));
       if (projectedFirst != null) {
         return longStatsToSequence(func, projectedFirst[0], projectedFirst[1], projectedFirst[2],
                                    projectedFirst[3]);
@@ -7750,7 +7781,7 @@ public final class SirixVectorizedExecutor implements VectorizedExecutor {
         // Projection fast path: NUMERIC_LONG column sweep over in-memory leaves
         // (the long-only column excludes non-integral values by construction, so
         // no typed redo can be needed when it answers).
-        final long[] projected = tryProjectionAggregate(sourcePath, field, null);
+        final long[] projected = tryProjectionAggregate(sourcePath, field, null, aggMaskFor(func));
         if (projected != null) {
           stats = aggregateCache.putIfAbsent(cacheKey, projected);
           if (stats == null) stats = projected;


### PR DESCRIPTION
Closes the measurable half of the "are we in line with DuckDB/ClickHouse" question, and replaces a
ballpark with numbers taken on one box.

## Result

Per row, 262,144-row store, single thread. DuckDB 1.5.5 for scale, same distribution
(uniform `[0,1024)`, predicate `> 511`), 50M rows, `.timer on`, warmed.

| op | before | **after** | DuckDB 1T | DuckDB 20T |
|---|---|---|---|---|
| `count` | 1.20 | 1.22 | 0.92 | 0.16 |
| `count+sum` | 12.73 | **2.58** | 1.16 | 0.16 |
| `count+sum+min` | 16.56 | **11.36** | — | — |
| `count+sum+min+max` | 16.56 | **12.98** | 1.56 | 0.20 |

`count` was already at parity. Aggregates went from **11x behind to 2.3x**.

The comparison is conservative rather than flattered: our pool is 2 MiB and L3-resident while
DuckDB streams 400 MB from RAM and still wins, and DuckDB bit-packs small-range integers too, so
this is not compressed-versus-raw. Our column additionally carries presence bitmaps and bit-packing
its plain `BIGINT` column does not.

## What was actually wrong

`VectorMask.fromLong` — **46-98x the cost of the arithmetic it guarded**. Identical lane adds,
identical array: 0.117 ns/row unmasked, 4.9-10.9 ns/row with the mask built per lane group.

That is an ISA property. AVX-512 drops a bit pattern straight into a k-register; AVX2 has no mask
register, so a full-width lane mask is materialised from those bits every call. Four lanes admit
sixteen masks, so the entire domain is enumerable: build the table once, index by the bit pattern.
0.39-0.41 ns/row, and flat in selectivity where the constructed form degraded with it.

Applied to the projection fold and to all six sites in the PAX region kernels, where the bits are
the liveness mask — the same tax on every masked column scan.

## Two wrong hypotheses, both refuted by measurement

Recorded because each is the plausible answer and each is wrong.

1. *"The aggregate decodes values, the count does not."* The BtrBlocks thesis, and wrong here:
   `unpackVectorGroups` is 1.3 ns/row against a 5.9 ns/row dense fold. Decode was 7%.
2. *"Neutralise lanes with `blend`, reduce unmasked."* Proposed in an earlier commit message here,
   then measured: 13.2-17.3 ns/row against 6.8-11.4 for masked lanewise. A pessimisation. The
   benchmark keeps both arms so nobody re-derives it.

## Commits

- `e6ed76d3` the three end-to-end benchmarks had **never run** — `Store.setUp` asserted its row
  count against a `MAX_ROWS` that had since quadrupled, and threw on every fork
- `1a1f2641` fold only the aggregate slots the query reads
- `1baceeaa` lane-mask lookup table in the projection fold
- `e89cc5bc` the same table in the PAX column kernels
- `2cbc805a` fold one extremum when one was asked for

## Correctness

The parity oracle pins every masked arm against the full fold over its randomised fixtures —
count and sum bit-identical, unrequested slots left at the caller's identity, which is what keeps a
chunked parallel merge from reading an unfolded sentinel as a real extremum. Sabotaging the
dispatch fails it, so the assertions are live rather than vacuous.

The narrow wiring is deliberate: `executeAggregate` derives the mask from the function and does not
cache, so it may ask for less. The predicate-stats cache may **not** — it keys without the function
on purpose, one entry serving min/max/avg/sum, so a later `min` would read back an unfolded
sentinel. That path still asks for every slot.

sirix-core **9,800 tests / 72 skipped / 0 failures** across 755 classes, plus 205 query scan tests.

## Still open

- **Parallelism, the larger gap.** DuckDB scales 5.8-7.8x on 20 cores. Our scan fan-out is fine, but
  the brackit pipeline is a pessimisation (sequential 640 ms, morsel 4,457 ms on 3.48M items) and
  that residual is architectural and lives in the brackit repo.
- **ClickHouse** — not run.
- A corpus-level JSON comparison still needs a properly controlled rig; deliberately not rushed here.

https://claude.ai/code/session_014wQGA5yhkFEaSFctsW7SKA
