### PR TITLE
Build CAS indexes in one bulk pass instead of n incremental inserts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,16 +105,27 @@ subprojects {
         toolVersion = '0.8.13'
     }
 
+    // Instrument ONLY when coverage is asked for (-Pcoverage). The agent rewrites every loaded class
+    // and adds a probe write per branch; leaving it on by default taxed every `gradlew test` and,
+    // because this block covers all subprojects, ran the JMH benchmarks instrumented — which makes
+    // the very measurements this repo's performance rules depend on meaningless.
+    tasks.withType(Test).configureEach {
+        jacoco.enabled = project.hasProperty('coverage')
+    }
+
     tasks.named('jacocoTestReport') {
         dependsOn tasks.named('test')
         reports {
             xml.required = true
             html.required = true
         }
-        // The generated/vendored trees say nothing about this project's own coverage.
-        classDirectories.setFrom(files(classDirectories.files.collect {
-            fileTree(dir: it, exclude: ['**/generated/**'])
-        }))
+        // The generated/vendored trees say nothing about this project's own coverage. Filtered
+        // lazily: resolving classDirectories.files here would flatten a live FileCollection into a
+        // plain file list, dropping its builtBy wiring to `classes` (and breaking the configuration
+        // cache) — which is what made the explicit dependsOn above necessary in the first place.
+        classDirectories.setFrom(classDirectories.asFileTree.matching {
+            exclude '**/generated/**'
+        })
     }
 
     tasks.withType(KotlinJvmCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
+import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.jetbrains.kotlin.gradle.dsl.jvm.JvmTargetValidationMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -105,12 +106,21 @@ subprojects {
         toolVersion = '0.8.13'
     }
 
-    // Instrument ONLY when coverage is asked for (-Pcoverage). The agent rewrites every loaded class
-    // and adds a probe write per branch; leaving it on by default taxed every `gradlew test` and,
-    // because this block covers all subprojects, ran the JMH benchmarks instrumented — which makes
-    // the very measurements this repo's performance rules depend on meaningless.
-    tasks.withType(Test).configureEach {
-        jacoco.enabled = project.hasProperty('coverage')
+    // Instrument only when coverage is actually going to be consumed. The agent rewrites every
+    // loaded class and adds a probe write per branch, which taxes every `gradlew test` run.
+    //
+    // The trigger is the TASK GRAPH, not just -Pcoverage: sonarqube.yml runs `gradlew build
+    // sonarqube` without any flag, and gating on the flag alone would have left Sonar silently
+    // reporting 0% coverage with no failing task to notice it. Enabling whenever a Jacoco report
+    // (or Sonar) is in the graph keeps CI honest and still leaves a bare `gradlew test`
+    // uninstrumented.
+    gradle.taskGraph.whenReady { graph ->
+        final boolean coverageWanted = project.hasProperty('coverage') || graph.allTasks.any {
+            it instanceof JacocoReport || it.name.toLowerCase().startsWith('sonar')
+        }
+        tasks.withType(Test).configureEach {
+            jacoco.enabled = coverageWanted
+        }
     }
 
     tasks.named('jacocoTestReport') {
@@ -123,7 +133,7 @@ subprojects {
         // lazily: resolving classDirectories.files here would flatten a live FileCollection into a
         // plain file list, dropping its builtBy wiring to `classes` (and breaking the configuration
         // cache) — which is what made the explicit dependsOn above necessary in the first place.
-        classDirectories.setFrom(classDirectories.asFileTree.matching {
+        classDirectories.setFrom(sourceSets.main.output.classesDirs.asFileTree.matching {
             exclude '**/generated/**'
         })
     }

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,24 @@ subprojects {
     apply plugin: 'com.github.ben-manes.versions'
     // Shadow plugin applied selectively in subprojects that need it
     apply plugin: "com.diffplug.spotless"
+    apply plugin: 'jacoco'
+
+    jacoco {
+        // Needs to understand Java 25 class files; the plugin's bundled default lags the toolchain.
+        toolVersion = '0.8.13'
+    }
+
+    tasks.named('jacocoTestReport') {
+        dependsOn tasks.named('test')
+        reports {
+            xml.required = true
+            html.required = true
+        }
+        // The generated/vendored trees say nothing about this project's own coverage.
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: ['**/generated/**'])
+        }))
+    }
 
     tasks.withType(KotlinJvmCompile).configureEach {
         jvmTargetValidationMode.set(JvmTargetValidationMode.WARNING)

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CASDecimalEqualityBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CASDecimalEqualityBenchmark.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.benchmark;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.IndexBackendType;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.IndexController;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.SearchMode;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * What the {@code xs:decimal} key encoding costs a HOT CAS equality lookup, measured against the
+ * types whose bytes are free.
+ *
+ * <h2>Why this exists</h2>
+ * <p>
+ * A trie has nowhere to put type semantics but the <em>encoding</em>. For a type whose natural
+ * bytes already sort correctly — raw UTF-8, a sign-flipped integer, a canonicalized instant — that
+ * costs nothing: {@link io.sirix.index.hot.CASKeySerializer} writes the bytes it would have written
+ * anyway. {@code xs:decimal} is where it stops being free. Arbitrary-precision values do not fit a
+ * fixed-width order-preserving word, so the encoder writes an eight-byte double prefix <em>and</em>
+ * an exact normalized-digit suffix behind it, sign-complemented and terminated, so that
+ * {@code 1.50} and {@code 1.5} share a key while {@code -0.5} still outranks
+ * {@code -0.5000000000000000001}.
+ *
+ * <p>
+ * That suffix is per-probe work: {@link BigDecimal#stripTrailingZeros()},
+ * {@link BigDecimal#toPlainString()}, an ASCII copy. An earlier attempt at exactness made decimal
+ * equality materially slower and was rejected on those grounds, so the current encoding needs a
+ * number rather than an argument — this is that number, and it is the thing to point at if the
+ * encoder is ever changed again.
+ *
+ * <h2>Reading the result</h2>
+ * <p>
+ * The arms are a 2x2: the same literal text is indexed twice, once as {@code xs:decimal} and once
+ * as {@code xs:string}. The string arm is not a separate question — it is the control. It walks the
+ * same document, the same index shape, the same query and the same key <em>width</em>, and its
+ * encoder does nothing but copy bytes. So {@code DEC} minus {@code STR} at a fixed value width is
+ * the decimal encoding's cost, with descent, in-leaf search and posting materialization subtracted
+ * out by construction.
+ *
+ * <p>
+ * The width axis is there because the suffix is the mechanism under suspicion and its cost is
+ * proportional to its length: {@code WIDE} carries 25 significant digits against {@code NARROW}'s
+ * money-shaped two decimal places. Reading the width axis alone would be a trap — a wider value
+ * also gives the trie a longer common prefix to discriminate through, which the string control pays
+ * too. Only the DEC-minus-STR gap, and how that gap moves with width, says anything about the
+ * encoder.
+ *
+ * <p>
+ * Run it:
+ *
+ * <pre>
+ *   ./gradlew :sirix-benchmarks:jmh -Pjmh.includes=CASDecimalEqualityBenchmark \
+ *       -Pjmh.warmupIterations=5 -Pjmh.iterations=10
+ * </pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 10, time = 2)
+public class CASDecimalEqualityBenchmark {
+
+  /** Distinct indexed values — enough that the trie has real depth rather than one leaf. */
+  private static final int DISTINCT_VALUES = 10_000;
+
+  /**
+   * Every value appears twice, so each equality answer is a posting list rather than a singleton. A
+   * benchmark whose answer is empty measures the failure path at full speed and looks excellent, so
+   * {@link #setUp} asserts this exact cardinality before any timing runs.
+   */
+  private static final int POSTINGS_PER_VALUE = 2;
+
+  private static final String VALUE_PATH = "/[]/v";
+
+  private static final String RESOURCE = "cas-decimal-equality";
+
+  /** The literal text the document holds — decimal spellings at two widths. */
+  @Param({"NARROW", "WIDE"})
+  public String width;
+
+  /** The content type that same text is indexed under. {@code STR} is the free-encoding control. */
+  @Param({"DEC", "STR"})
+  public String contentType;
+
+  private File databaseDirectory;
+  private Database<JsonResourceSession> database;
+  private JsonResourceSession session;
+  private JsonNodeReadOnlyTrx rtx;
+  private IndexController<?, ?> controller;
+  private IndexDef indexDef;
+  private Set<String> queriedPaths;
+
+  /** Pre-built so the timed region measures the index, not {@code new BigDecimal(String)}. */
+  private Atomic[] probes;
+
+  private int probeIndex;
+
+  @Setup(Level.Trial)
+  public void setUp() throws IOException {
+    final ValueWidth valueWidth = ValueWidth.valueOf(width);
+    final Encoding encoding = Encoding.valueOf(contentType);
+
+    final String[] values = new String[DISTINCT_VALUES];
+    for (int i = 0; i < DISTINCT_VALUES; i++) {
+      values[i] = valueWidth.literal(i);
+    }
+
+    // createTempDirectory creates the directory; Sirix insists on creating it itself.
+    databaseDirectory = Files.createTempDirectory("sirix-cas-decimal-bench").toFile();
+    Files.delete(databaseDirectory.toPath());
+    Databases.createJsonDatabase(new DatabaseConfiguration(databaseDirectory.toPath()));
+    database = Databases.openJsonDatabase(databaseDirectory.toPath());
+    database.createResource(
+        ResourceConfiguration.newBuilder(RESOURCE).indexBackendType(IndexBackendType.HOT).build());
+
+    queriedPaths = Set.of(VALUE_PATH);
+    indexDef = buildIndex(values, encoding);
+
+    session = database.beginResourceSession(RESOURCE);
+    rtx = session.beginNodeReadOnlyTrx();
+    controller = session.getRtxIndexController(rtx.getRevisionNumber());
+
+    probes = new Atomic[DISTINCT_VALUES];
+    for (int i = 0; i < DISTINCT_VALUES; i++) {
+      probes[i] = encoding.probe(values[i]);
+    }
+    probeIndex = 0;
+
+    // Check every probe once, not a sample: an encoding that resolved 9,999 of 10,000 would pass a
+    // spot check and then be timed largely on its miss path, which is the cheaper one.
+    for (int i = 0; i < DISTINCT_VALUES; i++) {
+      final long cardinality = totalCardinality(probes[i]);
+      if (cardinality != POSTINGS_PER_VALUE) {
+        throw new IllegalStateException(
+            "width=" + width + " contentType=" + contentType + " probe=" + values[i] + " resolved to " + cardinality
+                + " postings, expected " + POSTINGS_PER_VALUE
+                + " — the benchmark would be timing a lookup that does not find its value");
+      }
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() throws IOException {
+    if (rtx != null) {
+      rtx.close();
+    }
+    if (session != null) {
+      session.close();
+    }
+    if (database != null) {
+      database.close();
+    }
+    if (databaseDirectory != null && databaseDirectory.exists()) {
+      Databases.removeDatabase(databaseDirectory.toPath());
+      deleteRecursively(databaseDirectory);
+    }
+  }
+
+  /**
+   * One equality lookup, drained to its postings. Summing the cardinality rather than returning the
+   * iterator keeps the drain from being optimized away and keeps the arms comparable: each must
+   * materialize the same number of node keys.
+   */
+  @Benchmark
+  public long equalityLookup() {
+    final Atomic probe = probes[probeIndex];
+    probeIndex = probeIndex + 1 == DISTINCT_VALUES
+        ? 0
+        : probeIndex + 1;
+    return totalCardinality(probe);
+  }
+
+  private long totalCardinality(final Atomic probe) {
+    final Iterator<NodeReferences> hits = controller.openCASIndex(rtx.getStorageEngineReader(), indexDef,
+        controller.createCASFilter(queriedPaths, probe, SearchMode.EQUAL, new JsonPCRCollector(rtx)));
+    long cardinality = 0;
+    while (hits.hasNext()) {
+      cardinality += hits.next().cardinality();
+    }
+    return cardinality;
+  }
+
+  // ==================== fixture ====================
+
+  /**
+   * How wide the decimal spellings are. Both are valid {@code xs:decimal} lexical forms, so the same
+   * text feeds both encodings unchanged — which is what makes the DEC-minus-STR difference
+   * attributable to the encoder and nothing else.
+   */
+  private enum ValueWidth {
+
+    /** Money-shaped: {@code 0.00} to {@code 99.99}, a short exact suffix. */
+    NARROW {
+      @Override
+      String literal(final int i) {
+        return (i / 100) + "." + (i % 100 < 10
+            ? "0"
+            : "") + (i % 100);
+      }
+    },
+
+    /** 25 significant digits, well past what a {@code double} prefix can discriminate. */
+    WIDE {
+      @Override
+      String literal(final int i) {
+        return "12345678901234." + String.format("%010d", i) + "56789";
+      }
+    };
+
+    abstract String literal(int i);
+  }
+
+  /**
+   * The content type the text is indexed under, and the probe atomic that goes with it. The document
+   * always holds JSON <em>strings</em>, for both: the CAS builder converts to the declared content
+   * type either way, and holding the spelling constant keeps the wide arm from being silently
+   * truncated by JSON number parsing — which would turn the arm that exists to stress the suffix into
+   * one that has no suffix at all.
+   */
+  private enum Encoding {
+
+    /** The subject: an eight-byte double prefix plus an exact normalized-digit suffix. */
+    DEC(Type.DEC) {
+      @Override
+      Atomic probe(final String literal) {
+        return new Dec(new BigDecimal(literal));
+      }
+    },
+
+    /** The control: raw UTF-8, where byte order already is value order and the encoder just copies. */
+    STR(Type.STR) {
+      @Override
+      Atomic probe(final String literal) {
+        return new Str(literal);
+      }
+    };
+
+    private final Type indexType;
+
+    Encoding(final Type indexType) {
+      this.indexType = indexType;
+    }
+
+    Type indexType() {
+      return indexType;
+    }
+
+    abstract Atomic probe(String literal);
+  }
+
+  private IndexDef buildIndex(final String[] values, final Encoding encoding) {
+    try (final var writeSession = database.beginResourceSession(RESOURCE);
+        final JsonNodeTrx trx = writeSession.beginNodeTrx()) {
+      final var wtxController = writeSession.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef def =
+          IndexDefs.createCASIdxDef(false, encoding.indexType(), parsePaths(queriedPaths), 0, IndexDef.DbType.JSON);
+      wtxController.createIndexes(Set.of(def), trx);
+      new JsonShredder.Builder(trx, JsonShredder.createStringReader(json(values)),
+          InsertPosition.AS_FIRST_CHILD).build().call();
+      trx.commit();
+      return def;
+    }
+  }
+
+  /**
+   * The fixture as a JSON array of <code>{"v": "&lt;literal&gt;"}</code>, each literal repeated
+   * {@link #POSTINGS_PER_VALUE} times. Pre-sized because the wide-decimal arm builds roughly 800 kB
+   * of text and growing a {@link StringBuilder} into that is pure setup waste.
+   */
+  private static String json(final String[] values) {
+    final int perEntry = values[0].length() + 16;
+    final StringBuilder sb = new StringBuilder(values.length * POSTINGS_PER_VALUE * perEntry + 2);
+    sb.append('[');
+    for (int copy = 0; copy < POSTINGS_PER_VALUE; copy++) {
+      for (final String value : values) {
+        if (sb.length() > 1) {
+          sb.append(',');
+        }
+        sb.append("{\"v\":\"").append(value).append("\"}");
+      }
+    }
+    return sb.append(']').toString();
+  }
+
+  private static Set<Path<QNm>> parsePaths(final Set<String> paths) {
+    final Set<Path<QNm>> parsed = new HashSet<>(paths.size());
+    for (final String path : paths) {
+      parsed.add(Path.parse(path, PathParser.Type.JSON));
+    }
+    return parsed;
+  }
+
+  private static void deleteRecursively(final File root) throws IOException {
+    if (!root.exists()) {
+      return;
+    }
+    try (final var walk = Files.walk(root.toPath())) {
+      walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+        try {
+          Files.deleteIfExists(path);
+        } catch (final IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      });
+    }
+  }
+}

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CASDecimalEqualityBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CASDecimalEqualityBenchmark.java
@@ -156,8 +156,7 @@ public class CASDecimalEqualityBenchmark {
     Files.delete(databaseDirectory.toPath());
     Databases.createJsonDatabase(new DatabaseConfiguration(databaseDirectory.toPath()));
     database = Databases.openJsonDatabase(databaseDirectory.toPath());
-    database.createResource(
-        ResourceConfiguration.newBuilder(RESOURCE).indexBackendType(IndexBackendType.HOT).build());
+    database.createResource(ResourceConfiguration.newBuilder(RESOURCE).indexBackendType(IndexBackendType.HOT).build());
 
     queriedPaths = Set.of(VALUE_PATH);
     indexDef = buildIndex(values, encoding);
@@ -177,10 +176,9 @@ public class CASDecimalEqualityBenchmark {
     for (int i = 0; i < DISTINCT_VALUES; i++) {
       final long cardinality = totalCardinality(probes[i]);
       if (cardinality != POSTINGS_PER_VALUE) {
-        throw new IllegalStateException(
-            "width=" + width + " contentType=" + contentType + " probe=" + values[i] + " resolved to " + cardinality
-                + " postings, expected " + POSTINGS_PER_VALUE
-                + " — the benchmark would be timing a lookup that does not find its value");
+        throw new IllegalStateException("width=" + width + " contentType=" + contentType + " probe=" + values[i]
+            + " resolved to " + cardinality + " postings, expected " + POSTINGS_PER_VALUE
+            + " — the benchmark would be timing a lookup that does not find its value");
       }
     }
   }

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
@@ -39,40 +39,43 @@ import java.util.concurrent.TimeUnit;
 /**
  * Prices the cursor's page guard against the optimistic stamp that would replace it.
  *
- * <p>De-pinning the cursor — dropping {@code AbstractNodeReadOnlyTrx.currentPageGuard} and making
- * every accessor a snapshot/read/validate/retry against
- * {@link KeyValueLeafPage#readStamp()} — trades one cost for another, and which way the trade goes
- * is an empirical question, not an obvious one:
+ * <p>
+ * De-pinning the cursor — dropping {@code AbstractNodeReadOnlyTrx.currentPageGuard} and making
+ * every accessor a snapshot/read/validate/retry against {@link KeyValueLeafPage#readStamp()} —
+ * trades one cost for another, and which way the trade goes is an empirical question, not an
+ * obvious one:
  *
  * <ul>
- *   <li>What it REMOVES is paid per <em>page switch</em>, not per hop. {@code moveToSingleton} has a
- *       within-page fast path that skips guard management entirely, so a walk that stays inside a
- *       1024-record page pays nothing today. Only a move that crosses a page boundary pays a guard
- *       release plus a {@code tryAcquireGuard} — and both are {@code synchronized} methods over an
- *       {@code AtomicInteger}, so the pair is two monitor acquisitions and two atomics.
- *   <li>What it ADDS is paid per <em>validated read</em>. A stamp proves nothing until it is
- *       validated, and the value it protects must not escape before then, so every accessor that
- *       reads through page memory — the four structural keys, the value, the name — needs its own
- *       validate, and the ones that miss have to redo the work on a re-resolved page.
+ * <li>What it REMOVES is paid per <em>page switch</em>, not per hop. {@code moveToSingleton} has a
+ * within-page fast path that skips guard management entirely, so a walk that stays inside a
+ * 1024-record page pays nothing today. Only a move that crosses a page boundary pays a guard
+ * release plus a {@code tryAcquireGuard} — and both are {@code synchronized} methods over an
+ * {@code AtomicInteger}, so the pair is two monitor acquisitions and two atomics.
+ * <li>What it ADDS is paid per <em>validated read</em>. A stamp proves nothing until it is
+ * validated, and the value it protects must not escape before then, so every accessor that reads
+ * through page memory — the four structural keys, the value, the name — needs its own validate, and
+ * the ones that miss have to redo the work on a re-resolved page.
  * </ul>
  *
- * <p>So the trade is (guard pair per page switch) against (stamp validate x accessors per node), and
+ * <p>
+ * So the trade is (guard pair per page switch) against (stamp validate x accessors per node), and
  * it only pays when a workload switches pages often AND touches few fields per node. The stages
  * below measure each term separately rather than asserting a direction:
  *
  * <ul>
- *   <li>{@link #guardAcquireRelease} — the primitive being removed, on a resident page.
- *   <li>{@link #stampReadValidate} — the primitive being added, on the same page.
- *   <li>{@link #withinPageWalk} — {@code moveTo} over consecutive keys in ONE page: the fast path,
- *       zero guard traffic. The bind floor for this corpus.
- *   <li>{@link #pageSwitchWalk} — the same number of {@code moveTo} calls over the same slots, but
- *       each hop lands on a different page, so every hop pays the guard pair AND the page
- *       re-resolution. The delta over {@link #withinPageWalk} is the whole page-switch cost, of
- *       which the guard is only the {@link #guardAcquireRelease} share — read it as the ceiling on
- *       what de-pinning could possibly recover per hop.
+ * <li>{@link #guardAcquireRelease} — the primitive being removed, on a resident page.
+ * <li>{@link #stampReadValidate} — the primitive being added, on the same page.
+ * <li>{@link #withinPageWalk} — {@code moveTo} over consecutive keys in ONE page: the fast path,
+ * zero guard traffic. The bind floor for this corpus.
+ * <li>{@link #pageSwitchWalk} — the same number of {@code moveTo} calls over the same slots, but
+ * each hop lands on a different page, so every hop pays the guard pair AND the page re-resolution.
+ * The delta over {@link #withinPageWalk} is the whole page-switch cost, of which the guard is only
+ * the {@link #guardAcquireRelease} share — read it as the ceiling on what de-pinning could possibly
+ * recover per hop.
  * </ul>
  *
- * <p>Self-contained: the corpus is shredded into a temp database in {@link #setUp}, so this runs
+ * <p>
+ * Self-contained: the corpus is shredded into a temp database in {@link #setUp}, so this runs
  * anywhere without a prebuilt store. Override with {@code -Dsirix.bench.corpus=/path/to.json}.
  *
  * <pre>
@@ -81,8 +84,9 @@ import java.util.concurrent.TimeUnit;
  *
  * <h2>Measured outcome</h2>
  *
- * <p>movies.json, 540,665 records over 527 record pages, 3 warmup + 5 measurement iterations x 2 s,
- * 1 fork, JDK 25. One run:
+ * <p>
+ * movies.json, 540,665 records over 527 record pages, 3 warmup + 5 measurement iterations x 2 s, 1
+ * fork, JDK 25. One run:
  *
  * <pre>
  *   withinPageWalk        25.9 +- 1.6  ns/hop   the bind floor, zero guard traffic
@@ -91,23 +95,35 @@ import java.util.concurrent.TimeUnit;
  *   stampReadValidate      4.4 +- 0.2  ns/op    the primitive de-pinning adds, per read
  * </pre>
  *
- * <p><b>The trade does not pay.</b> A page switch costs 222.0 ns over the fast path, and the guard
- * pair is 31.6 ns of it — 14 % of the premium, 13 % of the hop. Removing that 31.6 ns per page
- * switch while adding 4.4 ns per validated read breaks even at 7.2 validated reads per page switch.
- * A cursor cannot get near that ratio: a record page holds 1024 records, so a walk with any locality
- * pays the guard once per ~1024 hops and would pay a validate on every accessor of every node. At
- * one validate per node that is 1024 x 4.4 = 4506 ns added against 31.6 ns removed, a ~140x loss.
- * Even in the shape most favourable to de-pinning — {@link #pageSwitchWalk}, a page switch on every
- * single hop — a node touching four structural keys and a value pays 5 x 4.4 = 22 ns to save 31.6,
- * netting 9.6 ns of 247.9, under 4 %. That is the ceiling, and only for a cursor with no locality
- * whatsoever.
+ * <p>
+ * And the contended pair, from the run that added those two stages (4 threads, one page):
  *
- * <p>What the numbers DO indict is the guard's implementation, not its existence: 31.6 ns for an
+ * <pre>
+ *   guardAcquireReleaseContended  907.4 ns/op   29x its own uncontended cost
+ *   stampReadValidateContended      4.8 ns/op   flat, inside measurement error
+ * </pre>
+ *
+ * <p>
+ * <b>The primitive gap is real and the trade still does not pay</b>, because the two costs are not
+ * paid at the same rate. A page switch costs 222.0 ns over the fast path, and the guard pair is
+ * 31.6 ns of it — 14 % of the premium, 13 % of the hop. Removing that 31.6 ns per page switch while
+ * adding 4.4 ns per validated read breaks even at 7.2 validated reads per page switch. A cursor
+ * cannot get near that ratio: a record page holds 1024 records, so a walk with any locality pays
+ * the guard once per ~1024 hops — 0.03 ns/hop amortized, or 0.9 ns/hop even at the contended 907 ns
+ * — and would pay a validate on every accessor of every node, which at three to six accessors is
+ * 13-26 ns/hop added onto a 25.9 ns/hop floor. Contention does not rescue it: it raises what the
+ * guard costs per page switch, not how often a page switch happens. Even in the shape most
+ * favourable to de-pinning — {@link #pageSwitchWalk}, a page switch on every single hop — a node
+ * touching four structural keys and a value pays 5 x 4.4 = 22 ns to save 31.6, netting 9.6 ns of
+ * 247.9, under 4 %. That is the ceiling, and only for a cursor with no locality whatsoever.
+ *
+ * <p>
+ * What the numbers DO indict is the guard's implementation, not its existence: 31.6 ns for an
  * UNCONTENDED acquire/release pair is enormous. {@code tryAcquireGuard} is a {@code synchronized}
  * method delegating to {@code acquireGuard}, itself {@code synchronized} (a nested monitor entry),
  * each around a volatile flags read and an {@code AtomicInteger}; {@code releaseGuard} is a third
- * monitor plus an atomic decrement plus another volatile read. Folding count and flags into one word
- * behind a CAS would recover most of that on this path AND on
+ * monitor plus an atomic decrement plus another volatile read. Folding count and flags into one
+ * word behind a CAS would recover most of that on this path AND on
  * {@code NodeStorageEngineReader.getRecordPage}, which pays the same pair per page resolution —
  * without giving up pinning or putting a retry loop under every accessor.
  */
@@ -115,17 +131,17 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 2)
 @Measurement(iterations = 5, time = 2)
-@Fork(value = 1, jvmArgsAppend = {"-Xmx4g", "--add-modules", "jdk.incubator.vector",
-    "--enable-native-access=ALL-UNNAMED", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
-    "--add-opens", "java.base/java.nio=ALL-UNNAMED"})
+@Fork(value = 1,
+    jvmArgsAppend = {"-Xmx4g", "--add-modules", "jdk.incubator.vector", "--enable-native-access=ALL-UNNAMED",
+        "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED", "--add-opens", "java.base/java.nio=ALL-UNNAMED"})
 @State(Scope.Benchmark)
 public class CursorGuardCostBenchmark {
 
   /**
    * Readers hammering ONE page. Matched to the core count of the box this was measured on (4):
-   * oversubscribing measures the scheduler rather than the protocol, and the protocol is the question.
-   * Raise it on a bigger machine — the gap this is looking for widens with the number of cores that
-   * have to invalidate a shared line.
+   * oversubscribing measures the scheduler rather than the protocol, and the protocol is the
+   * question. Raise it on a bigger machine — the gap this is looking for widens with the number of
+   * cores that have to invalidate a shared line.
    */
   private static final int CONTENDED_THREADS = 4;
 
@@ -149,13 +165,16 @@ public class CursorGuardCostBenchmark {
   /** Keys that change page on EVERY hop, over the same slot numbers as {@link #samePageKeys}. */
   private long[] crossPageKeys;
 
-  /** Repo-relative location of the default corpus; resolved against the working directory's parents. */
+  /**
+   * Repo-relative location of the default corpus; resolved against the working directory's parents.
+   */
   private static final String DEFAULT_CORPUS = "bundles/sirix-core/src/test/resources/json/movies.json";
 
   /**
    * Locate the corpus without assuming where the forked JVM was started.
    *
-   * <p>JMH forks run with the benchmark module as their working directory, not the repo root, so a
+   * <p>
+   * JMH forks run with the benchmark module as their working directory, not the repo root, so a
    * repo-relative default resolves to nothing. Walk up until the path exists.
    *
    * @return the corpus file
@@ -171,9 +190,8 @@ public class CursorGuardCostBenchmark {
         return candidate;
       }
     }
-    throw new IllegalStateException(
-        "cannot find " + DEFAULT_CORPUS + " above " + Paths.get("").toAbsolutePath()
-            + "; pass -Dsirix.bench.corpus=/path/to.json");
+    throw new IllegalStateException("cannot find " + DEFAULT_CORPUS + " above " + Paths.get("").toAbsolutePath()
+        + "; pass -Dsirix.bench.corpus=/path/to.json");
   }
 
   @Setup(Level.Trial)
@@ -239,8 +257,8 @@ public class CursorGuardCostBenchmark {
     }
     page = location.page();
 
-    System.out.printf("%n# maxNodeKey=%,d  pages=%,d  hops=%d  sameHits=%d  crossHits=%d%n",
-                      maxNodeKey, pageCount, HOPS, sameHits, crossHits);
+    System.out.printf("%n# maxNodeKey=%,d  pages=%,d  hops=%d  sameHits=%d  crossHits=%d%n", maxNodeKey, pageCount,
+        HOPS, sameHits, crossHits);
   }
 
   @TearDown(Level.Trial)
@@ -285,8 +303,8 @@ public class CursorGuardCostBenchmark {
    * <p>
    * The uncontended pair above is close to a wash against its stamp counterpart, so it cannot decide
    * anything on its own. A guard is a STORE to a line every reader of the page shares — the atomic
-   * RMW inside a monitor — so it invalidates that line in every other core and the pair serializes.
-   * A stamp read is a plain acquire-load that dirties nothing, so readers of one hot page do not
+   * RMW inside a monitor — so it invalidates that line in every other core and the pair serializes. A
+   * stamp read is a plain acquire-load that dirties nothing, so readers of one hot page do not
    * contend at all. If the de-pinning is worth doing, the difference shows up HERE and only here.
    * </p>
    *

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.benchmark;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.page.NodeStorageEngineReader;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexType;
+import io.sirix.page.KeyValueLeafPage;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import io.sirix.settings.Constants;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Prices the cursor's page guard against the optimistic stamp that would replace it.
+ *
+ * <p>De-pinning the cursor — dropping {@code AbstractNodeReadOnlyTrx.currentPageGuard} and making
+ * every accessor a snapshot/read/validate/retry against
+ * {@link KeyValueLeafPage#readStamp()} — trades one cost for another, and which way the trade goes
+ * is an empirical question, not an obvious one:
+ *
+ * <ul>
+ *   <li>What it REMOVES is paid per <em>page switch</em>, not per hop. {@code moveToSingleton} has a
+ *       within-page fast path that skips guard management entirely, so a walk that stays inside a
+ *       1024-record page pays nothing today. Only a move that crosses a page boundary pays a guard
+ *       release plus a {@code tryAcquireGuard} — and both are {@code synchronized} methods over an
+ *       {@code AtomicInteger}, so the pair is two monitor acquisitions and two atomics.
+ *   <li>What it ADDS is paid per <em>validated read</em>. A stamp proves nothing until it is
+ *       validated, and the value it protects must not escape before then, so every accessor that
+ *       reads through page memory — the four structural keys, the value, the name — needs its own
+ *       validate, and the ones that miss have to redo the work on a re-resolved page.
+ * </ul>
+ *
+ * <p>So the trade is (guard pair per page switch) against (stamp validate x accessors per node), and
+ * it only pays when a workload switches pages often AND touches few fields per node. The stages
+ * below measure each term separately rather than asserting a direction:
+ *
+ * <ul>
+ *   <li>{@link #guardAcquireRelease} — the primitive being removed, on a resident page.
+ *   <li>{@link #stampReadValidate} — the primitive being added, on the same page.
+ *   <li>{@link #withinPageWalk} — {@code moveTo} over consecutive keys in ONE page: the fast path,
+ *       zero guard traffic. The bind floor for this corpus.
+ *   <li>{@link #pageSwitchWalk} — the same number of {@code moveTo} calls over the same slots, but
+ *       each hop lands on a different page, so every hop pays the guard pair AND the page
+ *       re-resolution. The delta over {@link #withinPageWalk} is the whole page-switch cost, of
+ *       which the guard is only the {@link #guardAcquireRelease} share — read it as the ceiling on
+ *       what de-pinning could possibly recover per hop.
+ * </ul>
+ *
+ * <p>Self-contained: the corpus is shredded into a temp database in {@link #setUp}, so this runs
+ * anywhere without a prebuilt store. Override with {@code -Dsirix.bench.corpus=/path/to.json}.
+ *
+ * <pre>
+ *   ./gradlew :sirix-benchmarks:jmh -Pjmh.includes=CursorGuardCostBenchmark
+ * </pre>
+ *
+ * <h2>Measured outcome</h2>
+ *
+ * <p>movies.json, 540,665 records over 527 record pages, 3 warmup + 5 measurement iterations x 2 s,
+ * 1 fork, JDK 25. One run:
+ *
+ * <pre>
+ *   withinPageWalk        25.9 +- 1.6  ns/hop   the bind floor, zero guard traffic
+ *   pageSwitchWalk       247.9 +- 31.5 ns/hop   + guard pair + page re-resolution, EVERY hop
+ *   guardAcquireRelease   31.6 +- 1.4  ns/op    the primitive de-pinning removes
+ *   stampReadValidate      4.4 +- 0.2  ns/op    the primitive de-pinning adds, per read
+ * </pre>
+ *
+ * <p><b>The trade does not pay.</b> A page switch costs 222.0 ns over the fast path, and the guard
+ * pair is 31.6 ns of it — 14 % of the premium, 13 % of the hop. Removing that 31.6 ns per page
+ * switch while adding 4.4 ns per validated read breaks even at 7.2 validated reads per page switch.
+ * A cursor cannot get near that ratio: a record page holds 1024 records, so a walk with any locality
+ * pays the guard once per ~1024 hops and would pay a validate on every accessor of every node. At
+ * one validate per node that is 1024 x 4.4 = 4506 ns added against 31.6 ns removed, a ~140x loss.
+ * Even in the shape most favourable to de-pinning — {@link #pageSwitchWalk}, a page switch on every
+ * single hop — a node touching four structural keys and a value pays 5 x 4.4 = 22 ns to save 31.6,
+ * netting 9.6 ns of 247.9, under 4 %. That is the ceiling, and only for a cursor with no locality
+ * whatsoever.
+ *
+ * <p>What the numbers DO indict is the guard's implementation, not its existence: 31.6 ns for an
+ * UNCONTENDED acquire/release pair is enormous. {@code tryAcquireGuard} is a {@code synchronized}
+ * method delegating to {@code acquireGuard}, itself {@code synchronized} (a nested monitor entry),
+ * each around a volatile flags read and an {@code AtomicInteger}; {@code releaseGuard} is a third
+ * monitor plus an atomic decrement plus another volatile read. Folding count and flags into one word
+ * behind a CAS would recover most of that on this path AND on
+ * {@code NodeStorageEngineReader.getRecordPage}, which pays the same pair per page resolution —
+ * without giving up pinning or putting a retry loop under every accessor.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(value = 1, jvmArgsAppend = {"-Xmx4g", "--add-modules", "jdk.incubator.vector",
+    "--enable-native-access=ALL-UNNAMED", "--add-opens", "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens", "java.base/java.nio=ALL-UNNAMED"})
+@State(Scope.Benchmark)
+public class CursorGuardCostBenchmark {
+
+  /** Records per {@link KeyValueLeafPage}; a key and key+PAGE_SPAN are always on different pages. */
+  private static final int PAGE_SPAN = 1 << Constants.NDP_NODE_COUNT_EXPONENT;
+
+  /** Hops per walk invocation. Fixed so both walks do identical work at different localities. */
+  private static final int HOPS = 4096;
+
+  private Path dbPath;
+  private Database<JsonResourceSession> database;
+  private JsonResourceSession session;
+  private JsonNodeReadOnlyTrx rtx;
+
+  /** A resident page, guarded for the whole trial so the micro stages cannot race an eviction. */
+  private KeyValueLeafPage page;
+
+  /** Keys that all live in ONE page: consecutive slots of {@code basePage}. */
+  private long[] samePageKeys;
+
+  /** Keys that change page on EVERY hop, over the same slot numbers as {@link #samePageKeys}. */
+  private long[] crossPageKeys;
+
+  /** Repo-relative location of the default corpus; resolved against the working directory's parents. */
+  private static final String DEFAULT_CORPUS = "bundles/sirix-core/src/test/resources/json/movies.json";
+
+  /**
+   * Locate the corpus without assuming where the forked JVM was started.
+   *
+   * <p>JMH forks run with the benchmark module as their working directory, not the repo root, so a
+   * repo-relative default resolves to nothing. Walk up until the path exists.
+   *
+   * @return the corpus file
+   */
+  private static Path resolveCorpus() {
+    final String override = System.getProperty("sirix.bench.corpus");
+    if (override != null && !override.isBlank()) {
+      return Paths.get(override);
+    }
+    for (Path dir = Paths.get("").toAbsolutePath(); dir != null; dir = dir.getParent()) {
+      final Path candidate = dir.resolve(DEFAULT_CORPUS);
+      if (Files.isReadable(candidate)) {
+        return candidate;
+      }
+    }
+    throw new IllegalStateException(
+        "cannot find " + DEFAULT_CORPUS + " above " + Paths.get("").toAbsolutePath()
+            + "; pass -Dsirix.bench.corpus=/path/to.json");
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() throws Exception {
+    final Path corpus = resolveCorpus();
+    dbPath = Files.createTempDirectory("cursor-guard-cost");
+    Databases.removeDatabase(dbPath);
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    database = Databases.openJsonDatabase(dbPath);
+    database.createResource(ResourceConfiguration.newBuilder("r").build());
+
+    try (final JsonResourceSession manager = database.beginResourceSession("r");
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      new JsonShredder.Builder(trx, JsonShredder.createFileReader(corpus),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+      trx.commit();
+    }
+
+    session = database.beginResourceSession("r");
+    rtx = session.beginNodeReadOnlyTrx();
+
+    final long maxNodeKey = rtx.getMaxNodeKey();
+    // Page 0 holds the document root and is only partly populated; start at page 1 so every key in
+    // both sets resolves and the two walks do identical work.
+    final int pageCount = (int) (maxNodeKey / PAGE_SPAN);
+    final int usablePages = pageCount - 1;
+    if (usablePages < 8) {
+      throw new IllegalStateException(
+          "corpus spans only " + pageCount + " record pages; need >= 9 to measure a page-switching walk");
+    }
+
+    // Both key sets visit the SAME slot sequence, so the per-slot bind work is identical. They
+    // differ only in the page: samePageKeys stays on page 1 the whole way (the within-page fast
+    // path), crossPageKeys advances the page on every single hop (guard pair + re-resolution).
+    samePageKeys = new long[HOPS];
+    crossPageKeys = new long[HOPS];
+    for (int i = 0; i < HOPS; i++) {
+      final int slot = i % PAGE_SPAN;
+      final int pageIndex = 1 + (i % usablePages);
+      samePageKeys[i] = (long) PAGE_SPAN + slot;
+      crossPageKeys[i] = (long) pageIndex * PAGE_SPAN + slot;
+    }
+
+    // Every key must resolve, or the two walks would compare different amounts of work.
+    int sameHits = 0;
+    int crossHits = 0;
+    for (int i = 0; i < HOPS; i++) {
+      if (rtx.moveTo(samePageKeys[i])) {
+        sameHits++;
+      }
+      if (rtx.moveTo(crossPageKeys[i])) {
+        crossHits++;
+      }
+    }
+
+    // Hold one guard on a resident page for the trial. The micro stages measure an ADDITIONAL
+    // acquire/release pair on top of it, which is exactly what a page switch pays; keeping this one
+    // held just stops the sweeper from reclaiming the page mid-measurement.
+    final var reader = (NodeStorageEngineReader) rtx.getStorageEngineReader();
+    final var location = reader.lookupSlotWithGuard(samePageKeys[0], IndexType.DOCUMENT, -1);
+    if (location == null) {
+      throw new IllegalStateException("no slot for the sampled key " + samePageKeys[0]);
+    }
+    page = location.page();
+
+    System.out.printf("%n# maxNodeKey=%,d  pages=%,d  hops=%d  sameHits=%d  crossHits=%d%n",
+                      maxNodeKey, pageCount, HOPS, sameHits, crossHits);
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    rtx.close();
+    session.close();
+    database.close();
+    Databases.removeDatabase(dbPath);
+  }
+
+  /**
+   * The primitive de-pinning removes: one guard pair on a resident page.
+   *
+   * @return the acquire result, so nothing folds away
+   */
+  @Benchmark
+  public boolean guardAcquireRelease() {
+    final KeyValueLeafPage p = page;
+    final boolean acquired = p.tryAcquireGuard();
+    if (acquired) {
+      p.releaseGuard();
+    }
+    return acquired;
+  }
+
+  /**
+   * The primitive de-pinning adds, once per validated read.
+   *
+   * @return whether the stamp validated, so nothing folds away
+   */
+  @Benchmark
+  public boolean stampReadValidate() {
+    final KeyValueLeafPage p = page;
+    final long stamp = p.readStamp();
+    return p.validateStamp(stamp);
+  }
+
+  /**
+   * The within-page fast path: {@code HOPS} binds with no guard traffic at all.
+   *
+   * @return the number of keys that resolved, so the loop cannot be eliminated
+   */
+  @Benchmark
+  @OperationsPerInvocation(HOPS)
+  public int withinPageWalk() {
+    final JsonNodeReadOnlyTrx cursor = rtx;
+    final long[] keys = samePageKeys;
+    int visited = 0;
+    for (int i = 0; i < HOPS; i++) {
+      if (cursor.moveTo(keys[i])) {
+        visited++;
+      }
+    }
+    return visited;
+  }
+
+  /**
+   * The same binds with a page switch on every hop: guard pair plus page re-resolution per hop.
+   *
+   * @return the number of keys that resolved, so the loop cannot be eliminated
+   */
+  @Benchmark
+  @OperationsPerInvocation(HOPS)
+  public int pageSwitchWalk() {
+    final JsonNodeReadOnlyTrx cursor = rtx;
+    final long[] keys = crossPageKeys;
+    int visited = 0;
+    for (int i = 0; i < HOPS; i++) {
+      if (cursor.moveTo(keys[i])) {
+        visited++;
+      }
+    }
+    return visited;
+  }
+}

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/CursorGuardCostBenchmark.java
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.nio.file.Files;
@@ -119,6 +120,14 @@ import java.util.concurrent.TimeUnit;
     "--add-opens", "java.base/java.nio=ALL-UNNAMED"})
 @State(Scope.Benchmark)
 public class CursorGuardCostBenchmark {
+
+  /**
+   * Readers hammering ONE page. Matched to the core count of the box this was measured on (4):
+   * oversubscribing measures the scheduler rather than the protocol, and the protocol is the question.
+   * Raise it on a bigger machine — the gap this is looking for widens with the number of cores that
+   * have to invalidate a shared line.
+   */
+  private static final int CONTENDED_THREADS = 4;
 
   /** Records per {@link KeyValueLeafPage}; a key and key+PAGE_SPAN are always on different pages. */
   private static final int PAGE_SPAN = 1 << Constants.NDP_NODE_COUNT_EXPONENT;
@@ -265,8 +274,47 @@ public class CursorGuardCostBenchmark {
   @Benchmark
   public boolean stampReadValidate() {
     final KeyValueLeafPage p = page;
+    final long binding = p.readStampBinding();
     final long stamp = p.readStamp();
-    return p.validateStamp(stamp);
+    return p.validateStamp(binding, stamp);
+  }
+
+  /**
+   * The same guard pair under CONTENTION, which is the case the whole de-pinning rests on.
+   *
+   * <p>
+   * The uncontended pair above is close to a wash against its stamp counterpart, so it cannot decide
+   * anything on its own. A guard is a STORE to a line every reader of the page shares — the atomic
+   * RMW inside a monitor — so it invalidates that line in every other core and the pair serializes.
+   * A stamp read is a plain acquire-load that dirties nothing, so readers of one hot page do not
+   * contend at all. If the de-pinning is worth doing, the difference shows up HERE and only here.
+   * </p>
+   *
+   * @return the acquire result, so nothing folds away
+   */
+  @Benchmark
+  @Threads(CONTENDED_THREADS)
+  public boolean guardAcquireReleaseContended() {
+    final KeyValueLeafPage p = page;
+    final boolean acquired = p.tryAcquireGuard();
+    if (acquired) {
+      p.releaseGuard();
+    }
+    return acquired;
+  }
+
+  /**
+   * The stamp equivalent under the same contention. Same page, same thread count, no shared store.
+   *
+   * @return whether the stamp validated, so nothing folds away
+   */
+  @Benchmark
+  @Threads(CONTENDED_THREADS)
+  public boolean stampReadValidateContended() {
+    final KeyValueLeafPage p = page;
+    final long binding = p.readStampBinding();
+    final long stamp = p.readStamp();
+    return p.validateStamp(binding, stamp);
   }
 
   /**

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026, Sirix Contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <organization> nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.sirix.benchmark;
+
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.page.HOTTrieReader;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.api.Database;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.SearchMode;
+import io.sirix.index.hot.CASKeySerializer;
+import io.sirix.index.hot.HOTIndexReader;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import io.sirix.page.PageReference;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.brackit.query.util.path.Path.parse;
+
+/**
+ * In-memory HOT read cost, measured the way it should be measured.
+ *
+ * <p>
+ * This replaces a hand-rolled {@code System.nanoTime} best-of-N harness that produced misleading
+ * numbers: running several timing loops over the same code inside one JVM polluted the JIT profile
+ * badly enough that its own end-to-end figure came out 17x worse than a dedicated run of the same
+ * code. Every stage below therefore gets its own {@link Fork}ed JVM, real warmup, and a
+ * {@link Blackhole} so nothing is folded away.
+ *
+ * <p>
+ * The stages isolate where the cost of a point lookup actually sits, so an optimization can be
+ * attributed rather than guessed at:
+ * </p>
+ * <ul>
+ * <li>{@link #serializeKey} — CAS key encoding alone.</li>
+ * <li>{@link #descendToLeaf} — the PEXT-routed descent, the part directly comparable to a
+ * main-memory trie lookup.</li>
+ * <li>{@link #lowerBoundSeek} — the descent plus the full lower-bound machinery (landing verify,
+ * successor peek, lex re-descent on a miss).</li>
+ * <li>{@link #pointGet} — the whole public lookup, including chunk reassembly into
+ * {@code NodeReferences}, which a single-value trie lookup does not have to do.</li>
+ * </ul>
+ *
+ * <p>
+ * Everything is resident: the index is built in {@code @Setup} and every stage is driven over the
+ * same shuffled key set, so no stage pays I/O.
+ * </p>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@Fork(2)
+@State(Scope.Benchmark)
+public class HotInMemoryReadBenchmark {
+
+  private Path dbPath;
+  private Database<JsonResourceSession> database;
+  private JsonResourceSession session;
+  private io.sirix.api.json.JsonNodeReadOnlyTrx rtx;
+  private HOTIndexReader<CASValue> reader;
+  private HOTTrieReader trieReader;
+  private PageReference rootRef;
+
+  private CASValue[] probes;
+  private byte[][] seekKeys;
+  private final byte[] scratch = new byte[512];
+  private int cursor;
+
+  @Setup(Level.Trial)
+  public void setUp() throws Exception {
+    final Path corpus = Paths.get(System.getProperty("sirix.bench.corpus",
+        "bundles/sirix-core/src/test/resources/json/movies.json"));
+    dbPath = Files.createTempDirectory("hot-inmem-read");
+    Databases.removeDatabase(dbPath);
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    database = Databases.openJsonDatabase(dbPath);
+    database.createResource(ResourceConfiguration.newBuilder("r").build());
+
+    final IndexDef casDef;
+    try (final JsonResourceSession manager = database.beginResourceSession("r");
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final var ic = manager.getWtxIndexController(trx.getRevisionNumber());
+      casDef = IndexDefs.createCASIdxDef(false, Type.STR,
+          Collections.singleton(parse("/[]/title", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON);
+      new JsonShredder.Builder(trx, JsonShredder.createFileReader(corpus), InsertPosition.AS_FIRST_CHILD)
+          .commitAfterwards().build().call();
+      ic.createIndexes(Set.of(casDef), trx);
+      trx.commit();
+    }
+
+    session = database.beginResourceSession("r");
+    rtx = session.beginNodeReadOnlyTrx();
+    reader = HOTIndexReader.create(rtx.getStorageEngineReader(), CASKeySerializer.INSTANCE, casDef.getType(), casDef.getID());
+
+    final List<CASValue> keys = new ArrayList<>();
+    for (final Iterator<Map.Entry<CASValue, ?>> it = cast(reader.iterator()); it.hasNext();) {
+      keys.add(it.next().getKey());
+    }
+    // Fixed seed: a stable, cache-unfriendly access order that does not vary run to run.
+    Collections.shuffle(keys, new Random(0x5EED));
+    probes = keys.toArray(new CASValue[0]);
+
+    seekKeys = new byte[probes.length][];
+    for (int i = 0; i < probes.length; i++) {
+      final int n = CASKeySerializer.INSTANCE.serialize(probes[i], scratch, 0);
+      final byte[] composite = new byte[n + 4];
+      System.arraycopy(scratch, 0, composite, 0, n);
+      seekKeys[i] = composite;
+    }
+
+    rootRef = reader.getRootReference();
+    trieReader = new HOTTrieReader(rtx.getStorageEngineReader());
+
+    // Touch every entry once so the whole index is resident before measurement starts.
+    for (final CASValue p : probes) {
+      if (reader.get(p, SearchMode.EQUAL) == null) {
+        throw new IllegalStateException("probe set does not round-trip: " + p);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Iterator<Map.Entry<CASValue, ?>> cast(final Iterator<?> it) {
+    return (Iterator<Map.Entry<CASValue, ?>>) it;
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    if (trieReader != null) {
+      trieReader.close();
+    }
+    if (rtx != null) {
+      rtx.close();
+    }
+    if (session != null) {
+      session.close();
+    }
+    if (database != null) {
+      database.close();
+    }
+  }
+
+  private int next() {
+    final int i = cursor;
+    cursor = i + 1 == probes.length
+        ? 0
+        : i + 1;
+    return i;
+  }
+
+  @Benchmark
+  public void serializeKey(final Blackhole bh) {
+    bh.consume(CASKeySerializer.INSTANCE.serialize(probes[next()], scratch, 0));
+  }
+
+  @Benchmark
+  public void descendToLeaf(final Blackhole bh) {
+    bh.consume(trieReader.navigateToLeaf(rootRef, seekKeys[next()]));
+  }
+
+  @Benchmark
+  public void lowerBoundSeek(final Blackhole bh) {
+    bh.consume(trieReader.lowerBound(rootRef, seekKeys[next()]));
+  }
+
+  @Benchmark
+  public void pointGet(final Blackhole bh) {
+    bh.consume(reader.get(probes[next()], SearchMode.EQUAL));
+  }
+}

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
@@ -143,13 +143,13 @@ import static io.brackit.query.util.path.Path.parse;
  *
  * <p>
  * <b>The 64-entry row is a miss row for {@link #pointGet} ONLY</b>, and the second column is the
- * trap. {@code maxEntries=64} builds {@code highestOneBit(64/8) = 8} sets of
- * {@link HOTLookupCache} WAYS, i.e. 64 slots, and {@link #HOT_KEY_COUNT} is 32 — so the
- * whole hot set stays resident and 66.1 ns is a HIT measurement, statistically indistinguishable
- * from the 66.8 ns above it, as the numbers themselves show. Making {@code pointGetHotKeys} miss
- * needs a table smaller than its working set, which the constructor floors at one 8-way set; a
- * separate row would have to state both the size and the key count to mean anything. Do not read
- * this column as the cost of a miss on a hot key.
+ * trap. {@code maxEntries=64} builds {@code highestOneBit(64/8) = 8} sets of {@link HOTLookupCache}
+ * WAYS, i.e. 64 slots, and {@link #HOT_KEY_COUNT} is 32 — so the whole hot set stays resident and
+ * 66.1 ns is a HIT measurement, statistically indistinguishable from the 66.8 ns above it, as the
+ * numbers themselves show. Making {@code pointGetHotKeys} miss needs a table smaller than its
+ * working set, which the constructor floors at one 8-way set; a separate row would have to state
+ * both the size and the key count to mean anything. Do not read this column as the cost of a miss
+ * on a hot key.
  * </p>
  */
 @BenchmarkMode(Mode.AverageTime)
@@ -326,9 +326,9 @@ public class HotInMemoryReadBenchmark {
    * HIT-path measurement at EVERY cache size the table in the class javadoc lists — including the
    * 64-entry row, which is a miss row for {@code pointGet} alone. Its working set is
    * {@link #HOT_KEY_COUNT} keys against a table the constructor never builds smaller than one
-   * {@code WAYS}-way set, so the whole set stays resident; turning this stage into a miss
-   * measurement takes a table smaller than {@link #HOT_KEY_COUNT}, not merely one below the corpus
-   * size. See the class javadoc for the sizing of all stages at once.
+   * {@code WAYS}-way set, so the whole set stays resident; turning this stage into a miss measurement
+   * takes a table smaller than {@link #HOT_KEY_COUNT}, not merely one below the corpus size. See the
+   * class javadoc for the sizing of all stages at once.
    * </p>
    */
   @Benchmark

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
@@ -31,6 +31,7 @@ import io.sirix.access.DatabaseConfiguration;
 import io.sirix.access.Databases;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.page.HOTTrieReader;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.api.Database;
@@ -40,6 +41,7 @@ import io.sirix.index.SearchMode;
 import io.sirix.index.hot.CASKeySerializer;
 import io.sirix.index.hot.HOTIndexReader;
 import io.sirix.index.redblacktree.keyvalue.CASValue;
+import io.sirix.page.HOTLeafPage;
 import io.sirix.page.PageReference;
 import io.sirix.service.InsertPosition;
 import io.sirix.service.json.shredder.JsonShredder;
@@ -93,11 +95,21 @@ import static io.brackit.query.util.path.Path.parse;
  * successor peek, lex re-descent on a miss).</li>
  * <li>{@link #pointGet} — the whole public lookup, including chunk reassembly into
  * {@code NodeReferences}, which a single-value trie lookup does not have to do.</li>
+ * <li>{@link #findEntryInLeaf} — the in-leaf binary search alone, on one fixed leaf, with no
+ * descent, no key encoding and no chunk assembly in the frame.</li>
  * </ul>
  *
  * <p>
  * Everything is resident: the index is built in {@code @Setup} and every stage is driven over the
  * same shuffled key set, so no stage pays I/O.
+ * </p>
+ *
+ * <p>
+ * <b>Reading the numbers.</b> The composite stages are only trustworthy as a cross-run comparison
+ * when {@link #serializeKey} — which no leaf-side change can touch — reproduces. It has been
+ * observed to compile two different ways across forks (79 ns vs 190 ns for identical bytecode), and
+ * a fork that lands in the slow mode drags {@link #pointGet} with it. Treat it as this harness's
+ * control: if it moved, the run is not comparable and the narrow stages are the only evidence.
  * </p>
  */
 @BenchmarkMode(Mode.AverageTime)
@@ -111,7 +123,7 @@ public class HotInMemoryReadBenchmark {
   private Path dbPath;
   private Database<JsonResourceSession> database;
   private JsonResourceSession session;
-  private io.sirix.api.json.JsonNodeReadOnlyTrx rtx;
+  private JsonNodeReadOnlyTrx rtx;
   private HOTIndexReader<CASValue> reader;
   private HOTTrieReader trieReader;
   private PageReference rootRef;
@@ -120,6 +132,11 @@ public class HotInMemoryReadBenchmark {
   private byte[][] seekKeys;
   private final byte[] scratch = new byte[512];
   private int cursor;
+
+  /** One resident leaf, and composite keys that all land in it — see {@link #findEntryInLeaf}. */
+  private HOTLeafPage leaf;
+  private byte[][] leafKeys;
+  private int leafCursor;
 
   @Setup(Level.Trial)
   public void setUp() throws Exception {
@@ -172,6 +189,28 @@ public class HotInMemoryReadBenchmark {
         throw new IllegalStateException("probe set does not round-trip: " + p);
       }
     }
+
+    // Sample the leaf the median probe routes to, and take its probe keys from the leaf's own
+    // entries: every one is guaranteed resident and a guaranteed hit, so findEntryInLeaf measures
+    // the full search depth rather than a mix of hits and early-outs.
+    leaf = trieReader.navigateToLeaf(rootRef, seekKeys[seekKeys.length / 2]);
+    if (leaf == null) {
+      throw new IllegalStateException("median probe does not route to a leaf");
+    }
+    final int leafEntries = leaf.getEntryCount();
+    final List<byte[]> resident = new ArrayList<>(leafEntries);
+    for (int i = 0; i < leafEntries; i++) {
+      final byte[] entryKey = leaf.getKey(i);
+      if (entryKey != null) {
+        resident.add(entryKey);
+      }
+    }
+    if (resident.isEmpty()) {
+      throw new IllegalStateException("sampled leaf exposes no keys");
+    }
+    Collections.shuffle(resident, new Random(0x5EED));
+    leafKeys = resident.toArray(new byte[0][]);
+    System.out.println("[setup] sampled leaf: entryCount=" + leafEntries + " probes=" + leafKeys.length);
   }
 
   @SuppressWarnings("unchecked")
@@ -221,5 +260,20 @@ public class HotInMemoryReadBenchmark {
   @Benchmark
   public void pointGet(final Blackhole bh) {
     bh.consume(reader.get(probes[next()], SearchMode.EQUAL));
+  }
+
+  /**
+   * The in-leaf search in isolation: one already-resolved leaf, keys that all belong to it, no
+   * descent and no key encoding in the frame. This is the stage that can attribute a change to
+   * {@code HOTLeafPage}'s comparators, which the composite stages cannot — their variance is larger
+   * than the effect being measured.
+   */
+  @Benchmark
+  public void findEntryInLeaf(final Blackhole bh) {
+    final int i = leafCursor;
+    leafCursor = i + 1 == leafKeys.length
+        ? 0
+        : i + 1;
+    bh.consume(leaf.findEntry(leafKeys[i]));
   }
 }

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
@@ -111,6 +111,14 @@ import static io.brackit.query.util.path.Path.parse;
  * a fork that lands in the slow mode drags {@link #pointGet} with it. Treat it as this harness's
  * control: if it moved, the run is not comparable and the narrow stages are the only evidence.
  * </p>
+ *
+ * <p>
+ * <b>Reference point,</b> movies.json CAS index on {@code /[]/title}, 4 cores, JDK 25, interleaved
+ * A/B against the pre-optimization tree: descendToLeaf 72.6 → 70.9 ns, findEntryInLeaf 66.4 → 54.1,
+ * serializeKey 125.9 → 93.9, pointGet 576.2 → 483.7. The descent stage is the figure comparable to
+ * a main-memory trie lookup; the rest of {@link #pointGet} is key encoding, an in-page binary search
+ * over ~180 entries, and posting-list reassembly, none of which a single-tuple trie lookup performs.
+ * </p>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)

--- a/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
+++ b/bundles/sirix-benchmarks/src/jmh/java/io/sirix/benchmark/HotInMemoryReadBenchmark.java
@@ -35,6 +35,7 @@ import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.api.Database;
+import io.sirix.cache.HOTLookupCache;
 import io.sirix.index.IndexDef;
 import io.sirix.index.IndexDefs;
 import io.sirix.index.SearchMode;
@@ -113,11 +114,42 @@ import static io.brackit.query.util.path.Path.parse;
  * </p>
  *
  * <p>
- * <b>Reference point,</b> movies.json CAS index on {@code /[]/title}, 4 cores, JDK 25, interleaved
- * A/B against the pre-optimization tree: descendToLeaf 72.6 → 70.9 ns, findEntryInLeaf 66.4 → 54.1,
- * serializeKey 125.9 → 93.9, pointGet 576.2 → 483.7. The descent stage is the figure comparable to
- * a main-memory trie lookup; the rest of {@link #pointGet} is key encoding, an in-page binary search
- * over ~180 entries, and posting-list reassembly, none of which a single-tuple trie lookup performs.
+ * <b>Reference point,</b> movies.json CAS index on {@code /[]/title}, 4 cores, JDK 25. Narrow
+ * stages, interleaved A/B against the pre-optimization tree: descendToLeaf 72.6 -> 70.9 ns,
+ * findEntryInLeaf 66.4 -> 54.1, serializeKey 125.9 -> 93.9. The descent stage is the figure
+ * comparable to a main-memory trie lookup; the rest of a point lookup is key encoding, an in-page
+ * binary search over ~180 entries, and posting-list reassembly, none of which a single-tuple trie
+ * lookup performs.
+ *
+ * <p>
+ * The composite stages depend on how the point-lookup cache is sized, so they are only meaningful
+ * with {@code sirix.hotLookupCache.maxEntries} stated. Over a ~33K-key corpus:
+ * </p>
+ *
+ * <pre>
+ * maxEntries      pointGet          pointGetHotKeys
+ * 0 (disabled)    551.9 ns          373.0 ns
+ * 65536           240.2 ns           66.8 ns   (both hit)
+ * 64              661.1 ns           66.1 ns   (pointGet misses; pointGetHotKeys still HITS)
+ * </pre>
+ *
+ * <p>
+ * Read that as: memoizing is worth 2.3x when the working set fits and 5.6x on a small hot set, and
+ * costs about 20% when it never fits. The 64-entry row is the one worth keeping honest — sizing the
+ * cache below the key count is the ONLY way this harness measures what a miss costs, since the
+ * trial warm-up touches every probe and would otherwise leave even {@link #pointGet} a pure hit
+ * workload.
+ * </p>
+ *
+ * <p>
+ * <b>The 64-entry row is a miss row for {@link #pointGet} ONLY</b>, and the second column is the
+ * trap. {@code maxEntries=64} builds {@code highestOneBit(64/8) = 8} sets of
+ * {@link HOTLookupCache} WAYS, i.e. 64 slots, and {@link #HOT_KEY_COUNT} is 32 — so the
+ * whole hot set stays resident and 66.1 ns is a HIT measurement, statistically indistinguishable
+ * from the 66.8 ns above it, as the numbers themselves show. Making {@code pointGetHotKeys} miss
+ * needs a table smaller than its working set, which the constructor floors at one 8-way set; a
+ * separate row would have to state both the size and the key count to mean anything. Do not read
+ * this column as the cost of a miss on a hot key.
  * </p>
  */
 @BenchmarkMode(Mode.AverageTime)
@@ -146,10 +178,22 @@ public class HotInMemoryReadBenchmark {
   private byte[][] leafKeys;
   private int leafCursor;
 
+  /**
+   * Working-set size for {@link #pointGetHotKeys}. Small enough that every key stays memoized, and
+   * small enough that the whole set stays in cache, so the stage measures the hit path rather than
+   * the memory system.
+   */
+  private static final int HOT_KEY_COUNT = 32;
+
+  /** {@link #HOT_KEY_COUNT} clamped to the corpus, which {@code -Dsirix.bench.corpus} can shrink. */
+  private int hotKeyCount;
+
+  private int hotCursor;
+
   @Setup(Level.Trial)
   public void setUp() throws Exception {
-    final Path corpus = Paths.get(System.getProperty("sirix.bench.corpus",
-        "bundles/sirix-core/src/test/resources/json/movies.json"));
+    final Path corpus =
+        Paths.get(System.getProperty("sirix.bench.corpus", "bundles/sirix-core/src/test/resources/json/movies.json"));
     dbPath = Files.createTempDirectory("hot-inmem-read");
     Databases.removeDatabase(dbPath);
     Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
@@ -162,15 +206,16 @@ public class HotInMemoryReadBenchmark {
       final var ic = manager.getWtxIndexController(trx.getRevisionNumber());
       casDef = IndexDefs.createCASIdxDef(false, Type.STR,
           Collections.singleton(parse("/[]/title", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON);
-      new JsonShredder.Builder(trx, JsonShredder.createFileReader(corpus), InsertPosition.AS_FIRST_CHILD)
-          .commitAfterwards().build().call();
+      new JsonShredder.Builder(trx, JsonShredder.createFileReader(corpus),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
       ic.createIndexes(Set.of(casDef), trx);
       trx.commit();
     }
 
     session = database.beginResourceSession("r");
     rtx = session.beginNodeReadOnlyTrx();
-    reader = HOTIndexReader.create(rtx.getStorageEngineReader(), CASKeySerializer.INSTANCE, casDef.getType(), casDef.getID());
+    reader = HOTIndexReader.create(rtx.getStorageEngineReader(), CASKeySerializer.INSTANCE, casDef.getType(),
+        casDef.getID());
 
     final List<CASValue> keys = new ArrayList<>();
     for (final Iterator<Map.Entry<CASValue, ?>> it = cast(reader.iterator()); it.hasNext();) {
@@ -205,6 +250,8 @@ public class HotInMemoryReadBenchmark {
     if (leaf == null) {
       throw new IllegalStateException("median probe does not route to a leaf");
     }
+    hotKeyCount = Math.min(HOT_KEY_COUNT, probes.length);
+
     final int leafEntries = leaf.getEntryCount();
     final List<byte[]> resident = new ArrayList<>(leafEntries);
     for (int i = 0; i < leafEntries; i++) {
@@ -268,6 +315,29 @@ public class HotInMemoryReadBenchmark {
   @Benchmark
   public void pointGet(final Blackhole bh) {
     bh.consume(reader.get(probes[next()], SearchMode.EQUAL));
+  }
+
+  /**
+   * The same lookup over a SMALL key set that fits the memoization cache, so nearly every call is a
+   * cache hit.
+   *
+   * <p>
+   * This is the stage the point-lookup cache exists for, and unlike {@link #pointGet} it is a
+   * HIT-path measurement at EVERY cache size the table in the class javadoc lists — including the
+   * 64-entry row, which is a miss row for {@code pointGet} alone. Its working set is
+   * {@link #HOT_KEY_COUNT} keys against a table the constructor never builds smaller than one
+   * {@code WAYS}-way set, so the whole set stays resident; turning this stage into a miss
+   * measurement takes a table smaller than {@link #HOT_KEY_COUNT}, not merely one below the corpus
+   * size. See the class javadoc for the sizing of all stages at once.
+   * </p>
+   */
+  @Benchmark
+  public void pointGetHotKeys(final Blackhole bh) {
+    final int i = hotCursor;
+    hotCursor = i + 1 == hotKeyCount
+        ? 0
+        : i + 1;
+    bh.consume(reader.get(probes[i], SearchMode.EQUAL));
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/access/EmptyBufferManager.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/EmptyBufferManager.java
@@ -3,6 +3,7 @@ package io.sirix.access;
 import io.sirix.cache.BufferManager;
 import io.sirix.cache.Cache;
 import io.sirix.cache.EmptyCache;
+import io.sirix.cache.HOTLookupCache;
 import io.sirix.cache.NamesCacheKey;
 import io.sirix.cache.PathSummaryCacheKey;
 import io.sirix.cache.PathSummaryData;
@@ -30,6 +31,8 @@ public final class EmptyBufferManager implements BufferManager {
       new EmptyCache<>();
 
   private static final EmptyCache<RBIndexKey, Node> INDEX_CACHE = new EmptyCache<>();
+
+  private static final HOTLookupCache HOT_LOOKUP_CACHE = HOTLookupCache.disabled();
 
   private static final EmptyCache<NamesCacheKey, Names> NAMES_CACHE = new EmptyCache<>();
 
@@ -70,6 +73,11 @@ public final class EmptyBufferManager implements BufferManager {
   @Override
   public Cache<RBIndexKey, Node> getIndexCache() {
     return INDEX_CACHE;
+  }
+
+  @Override
+  public HOTLookupCache getHOTLookupCache() {
+    return HOT_LOOKUP_CACHE;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/ResourceConfiguration.java
@@ -183,18 +183,16 @@ public final class ResourceConfiguration {
   private static final VersioningType VERSIONING = VersioningType.SLIDING_SNAPSHOT;
 
   /**
-   * Type of hashing. Default is {@link HashType#ROLLING} (incremental Merkle-tree
-   * hash maintained on structural mutations). Override at JVM level via
-   * {@code -Dsirix.hashType=NONE} when you want to elide per-record hash bytes
-   * entirely (bench workloads); legacy tests rely on the ROLLING default.
+   * Type of hashing. Default is {@link HashType#ROLLING} (incremental Merkle-tree hash maintained on
+   * structural mutations). Override at JVM level via {@code -Dsirix.hashType=NONE} when you want to
+   * elide per-record hash bytes entirely (bench workloads); legacy tests rely on the ROLLING default.
    *
-   * <p>The per-record hash field is stored as a signed-varint (1 byte for hash=0,
-   * up to 10 for a real 64-bit ROLLING hash) — when the resource is configured
-   * {@code HashType.NONE} the bench writer pays only 1 byte per record for the
-   * field, vs. 8 bytes under the previous fixed-width layout.
+   * <p>
+   * The per-record hash field is stored as a signed-varint (1 byte for hash=0, up to 10 for a real
+   * 64-bit ROLLING hash) — when the resource is configured {@code HashType.NONE} the bench writer
+   * pays only 1 byte per record for the field, vs. 8 bytes under the previous fixed-width layout.
    */
-  private static final HashType HASH_TYPE =
-      HashType.fromString(System.getProperty("sirix.hashType", "ROLLING"));
+  private static final HashType HASH_TYPE = HashType.fromString(System.getProperty("sirix.hashType", "ROLLING"));
 
   /**
    * Versions to restore.
@@ -207,17 +205,17 @@ public final class ResourceConfiguration {
   private static final RecordSerializer NODE_SERIALIZER = new NodeSerializerImpl();
 
   /**
-   * The current binary encoding version. Single version (V0) — the on-disk
-   * format includes a version byte to reserve room for future bumps, but
-   * there are no alternative encodings to select at runtime.
+   * The current binary encoding version. Single version (V0) — the on-disk format includes a version
+   * byte to reserve room for future bumps, but there are no alternative encodings to select at
+   * runtime.
    */
   public static final BinaryEncodingVersion BINARY_ENCODING_VERSION = BinaryEncodingVersion.V1;
 
   /**
    * Stable identifier of the node-hash function baked into the on-disk format (XXH3-64 via
-   * {@code LongHashFunction.xx3()}). Persisted in the resource settings and validated on open so
-   * that a future change of the hash function is detectable instead of silently re-verifying old
-   * resources against the wrong function.
+   * {@code LongHashFunction.xx3()}). Persisted in the resource settings and validated on open so that
+   * a future change of the hash function is detectable instead of silently re-verifying old resources
+   * against the wrong function.
    */
   public static final String NODE_HASH_FUNCTION_ID = "XX3";
 
@@ -270,27 +268,29 @@ public final class ResourceConfiguration {
   public final boolean withPathSummary;
 
   /**
-   * Determines if per-path value statistics (count, nullCount, sum, min, max, HLL) are
-   * maintained on the PathSummary nodes. Requires {@link #withPathSummary} to be true.
-   * When enabled, aggregate queries over unfiltered paths ({@code sum/avg/min/max},
-   * {@code countDistinct}) can short-circuit via the PathSummary without scanning data
-   * pages — typically microseconds instead of seconds.
+   * Determines if per-path value statistics (count, nullCount, sum, min, max, HLL) are maintained on
+   * the PathSummary nodes. Requires {@link #withPathSummary} to be true. When enabled, aggregate
+   * queries over unfiltered paths ({@code sum/avg/min/max}, {@code countDistinct}) can short-circuit
+   * via the PathSummary without scanning data pages — typically microseconds instead of seconds.
    */
   public final boolean withPathStatistics;
 
   /**
    * Selects the hash/descendant-count maintenance mode for AUTO-COMMITTING bulk inserts.
    *
-   * <p>{@code false} (default): incremental per-insert adaptation — the upstream behavior.
-   * Correct for imports that fit within the first auto-commit epoch ({@code maxNodes}); for
-   * larger imports, nodes inserted after the first intermediate commit are unmaintained
-   * (hash 0, descendant counts missing from ancestors).
+   * <p>
+   * {@code false} (default): incremental per-insert adaptation — the upstream behavior. Correct for
+   * imports that fit within the first auto-commit epoch ({@code maxNodes}); for larger imports, nodes
+   * inserted after the first intermediate commit are unmaintained (hash 0, descendant counts missing
+   * from ancestors).
    *
-   * <p>{@code true}: per-insert adaptation is skipped uniformly and ONE postorder repair runs
-   * over the entire imported subtree at the end — correct for any import size, at the cost of
-   * a full subtree walk after the import (which for large files can rival the import itself).
+   * <p>
+   * {@code true}: per-insert adaptation is skipped uniformly and ONE postorder repair runs over the
+   * entire imported subtree at the end — correct for any import size, at the cost of a full subtree
+   * walk after the import (which for large files can rival the import itself).
    *
-   * <p>Non-auto-committing bulk inserts always repair at the end (single-trx scope).
+   * <p>
+   * Non-auto-committing bulk inserts always repair at the end (single-trx scope).
    */
   public final boolean repairBulkInsertHashes;
 
@@ -422,10 +422,9 @@ public final class ResourceConfiguration {
   /**
    * Per-resource identity UUID, generated at resource creation and written into both files'
    * superblocks (reserved bytes [40, 56)). Cross-links the binary files to this settings file:
-   * opening a data file with a different resource's settings — the classic
-   * "restored the JSON from the wrong backup" corruption — fails fast instead of misreading.
-   * {@code null} for resources created before the field existed (their superblock UUID is zero,
-   * accepted as legacy).
+   * opening a data file with a different resource's settings — the classic "restored the JSON from
+   * the wrong backup" corruption — fails fast instead of misreading. {@code null} for resources
+   * created before the field existed (their superblock UUID is zero, accepted as legacy).
    */
   public final UUID resourceUuid;
 
@@ -525,6 +524,24 @@ public final class ResourceConfiguration {
   /**
    * Get the database ID from the parent database configuration.
    *
+   * <p>
+   * Returns {@code 0} when no configuration is attached, and that value is a HAZARD rather than a
+   * neutral default: this id is the leading component of every JVM-global cache key in the engine —
+   * {@code PageReference}, {@code RBIndexKey}, {@code NamesCacheKey}, {@code PathSummaryCacheKey},
+   * {@code RevisionRootPageCacheKey} and the HOT lookup cache. Resource ids restart at 0 in every
+   * database, so two unattached resources collapse onto the same {@code (0, 0, revision, …)} key
+   * space and one is served the other's cached data.
+   * </p>
+   *
+   * <p>
+   * Only the HOT lookup cache currently guards against it ({@code AbstractHOTIndexReader} disables
+   * memoization for id 0). Making the unattached state impossible here is the real fix, but it cannot
+   * be done from this accessor alone: {@link #setDatabaseConfiguration} is package-private and
+   * {@code NodeStorageEngineReaderTest} legitimately builds a configuration without a database, so
+   * throwing breaks callers that never touch a cache. Closing it properly means either widening that
+   * setter and requiring it, or applying the id-0 guard at the other five key sites.
+   * </p>
+   *
    * @return the database ID, or 0 if database configuration not set
    */
   public long getDatabaseId() {
@@ -551,11 +568,11 @@ public final class ResourceConfiguration {
   @Override
   public String toString() {
     return ToStringHelper.of(this)
-                      .add("Resource", resourcePath)
-                      .add("Type", storageType)
-                      .add("Revision", versioningType)
-                      .add("HashKind", hashType)
-                      .toString();
+                         .add("Resource", resourcePath)
+                         .add("Type", storageType)
+                         .add("Revision", versioningType)
+                         .add("HashKind", hashType)
+                         .toString();
   }
 
   /**
@@ -622,8 +639,8 @@ public final class ResourceConfiguration {
       "numbersOfRevisiontoRestore", "byteHandlerClasses", "storageKind", "hashKind", "hashFunction", "compression",
       "pathSummary", "resourceID", "deweyIDsStored", "persistenter", "storeDiffs", "customCommitTimestamps",
       "storeNodeHistory", "storeChildCount", "stringCompressionType", "indexBackendType", "deweyIdSiblingDistance",
-      "verifyChecksumsOnRead", "hashAlgorithm", "validTimeConfig", "validFromPath", "validToPath",
-      "pathStatistics", "repairBulkInsertHashes", "resourceUuid", "regionCompression"};
+      "verifyChecksumsOnRead", "hashAlgorithm", "validTimeConfig", "validFromPath", "validToPath", "pathStatistics",
+      "repairBulkInsertHashes", "resourceUuid", "regionCompression"};
 
   /**
    * Serialize the configuration.
@@ -713,16 +730,16 @@ public final class ResourceConfiguration {
   }
 
   /**
-   * Reads the next field name and fails fast when it is not the expected one. The resource
-   * settings are format identity — a reordered, truncated, or hand-edited file must be a loud
-   * error, never a misparse (this used to be an {@code assert}, a no-op in production).
+   * Reads the next field name and fails fast when it is not the expected one. The resource settings
+   * are format identity — a reordered, truncated, or hand-edited file must be a loud error, never a
+   * misparse (this used to be an {@code assert}, a no-op in production).
    */
   private static void expectField(final JsonReader jsonReader, final String expected, final Path configFile)
       throws IOException {
     final String name = jsonReader.nextName();
     if (!name.equals(expected)) {
-      throw new SirixIOException(configFile + ": malformed resource settings — expected field '" + expected
-          + "' but found '" + name + "'");
+      throw new SirixIOException(
+          configFile + ": malformed resource settings — expected field '" + expected + "' but found '" + name + "'");
     }
   }
 
@@ -784,10 +801,9 @@ public final class ResourceConfiguration {
       // configs stored LongHashFunction.xx3().toString(); both spellings mean XXH3.
       expectField(jsonReader, JSONNAMES[7], configFile);
       final String hashFunctionId = jsonReader.nextString();
-      if (!NODE_HASH_FUNCTION_ID.equals(hashFunctionId)
-          && !hashFunctionId.toLowerCase(Locale.ROOT).contains("xx3")) {
-        throw new SirixIOException(configFile + ": resource was written with node-hash function '"
-            + hashFunctionId + "' but this build only supports '" + NODE_HASH_FUNCTION_ID
+      if (!NODE_HASH_FUNCTION_ID.equals(hashFunctionId) && !hashFunctionId.toLowerCase(Locale.ROOT).contains("xx3")) {
+        throw new SirixIOException(configFile + ": resource was written with node-hash function '" + hashFunctionId
+            + "' but this build only supports '" + NODE_HASH_FUNCTION_ID
             + "' (XXH3-64) — node hashes would not verify");
       }
       // Text compression.
@@ -1009,18 +1025,18 @@ public final class ResourceConfiguration {
     /**
      * Determines if a path summary should be build or not.
      *
-     * <p>On by default, matching {@code BasicJsonDBStore}. It used to default to {@code false}
-     * here, so a resource created straight through this builder silently lost every optimisation
-     * that reads the summary — path-based index selection, the count/sum answers, the scan's
-     * page-skip — while the same resource created through the query store kept them. Two defaults
-     * for the same decision is how a system ends up only being fast in the configuration its
-     * benchmarks happen to use.
+     * <p>
+     * On by default, matching {@code BasicJsonDBStore}. It used to default to {@code false} here, so a
+     * resource created straight through this builder silently lost every optimisation that reads the
+     * summary — path-based index selection, the count/sum answers, the scan's page-skip — while the
+     * same resource created through the query store kept them. Two defaults for the same decision is
+     * how a system ends up only being fast in the configuration its benchmarks happen to use.
      */
     private boolean pathSummary = true;
 
     /**
-     * Determines if per-path value statistics are maintained on PathSummary nodes.
-     * Requires {@link #pathSummary} to be {@code true}.
+     * Determines if per-path value statistics are maintained on PathSummary nodes. Requires
+     * {@link #pathSummary} to be {@code true}.
      */
     private boolean pathStatistics;
 
@@ -1050,9 +1066,9 @@ public final class ResourceConfiguration {
     private StringCompressionType stringCompressionType = StringCompressionType.NONE;
 
     /**
-     * Region wire compression defaults ON: the measured trade (−37% database size for ~13%
-     * ingest) is the right default for a database whose stated goal is small storage, and the
-     * dial exists precisely for resources that want the speed back.
+     * Region wire compression defaults ON: the measured trade (−37% database size for ~13% ingest) is
+     * the right default for a database whose stated goal is small storage, and the dial exists
+     * precisely for resources that want the speed back.
      */
     private RegionCompressionType regionCompressionType = RegionCompressionType.LZ77;
 
@@ -1078,9 +1094,9 @@ public final class ResourceConfiguration {
     private ValidTimeConfig validTimeConfig = null;
 
     /**
-     * Per-resource identity UUID. A fresh random UUID for new resources; overwritten with the
-     * persisted value when deserializing an existing configuration ({@code null} = legacy config
-     * without the field).
+     * Per-resource identity UUID. A fresh random UUID for new resources; overwritten with the persisted
+     * value when deserializing an existing configuration ({@code null} = legacy config without the
+     * field).
      */
     private UUID resourceUuid = UUID.randomUUID();
 
@@ -1118,14 +1134,12 @@ public final class ResourceConfiguration {
         case "lz4":
           if (!FFILz4Compressor.isNativeAvailable()) {
             // Graceful degrade: missing native → uncompressed pages, operator sees a warning.
-            System.err.println(
-                "[sirix] WARN: liblz4 not available, falling back to uncompressed pages.");
+            System.err.println("[sirix] WARN: liblz4 not available, falling back to uncompressed pages.");
             return new ByteHandlerPipeline();
           }
           return new ByteHandlerPipeline(new FFILz4Compressor());
         default:
-          throw new IllegalArgumentException(
-              "Unknown sirix.compression value: '" + choice + "' (expected: none, lz4)");
+          throw new IllegalArgumentException("Unknown sirix.compression value: '" + choice + "' (expected: none, lz4)");
       }
     }
 
@@ -1253,13 +1267,13 @@ public final class ResourceConfiguration {
     }
 
     /**
-     * Determines if per-path value statistics (count, nullCount, sum, min, max, HLL)
-     * are maintained on PathSummary nodes. Requires {@code buildPathSummary(true)}.
+     * Determines if per-path value statistics (count, nullCount, sum, min, max, HLL) are maintained on
+     * PathSummary nodes. Requires {@code buildPathSummary(true)}.
      *
-     * <p>When enabled, aggregate queries ({@code sum/avg/min/max}, {@code countDistinct})
-     * over unfiltered paths short-circuit through the PathSummary — microseconds instead
-     * of a full scan. Costs ~10-20% write-path overhead on top of plain PathSummary
-     * maintenance.
+     * <p>
+     * When enabled, aggregate queries ({@code sum/avg/min/max}, {@code countDistinct}) over unfiltered
+     * paths short-circuit through the PathSummary — microseconds instead of a full scan. Costs ~10-20%
+     * write-path overhead on top of plain PathSummary maintenance.
      *
      * @return reference to the builder object
      * @throws IllegalStateException if enabled without a path summary
@@ -1274,11 +1288,10 @@ public final class ResourceConfiguration {
     }
 
     /**
-     * Opt in to the postorder hash/descendant-count repair at the END of auto-committing bulk
-     * inserts. The repair walks the ENTIRE imported subtree — for large imports that can rival
-     * the import itself — so it defaults to {@code false}: bulk-imported nodes then carry hash 0
-     * in the final revision. Enable for resources where hash integrity over bulk-loaded data
-     * matters more than import speed.
+     * Opt in to the postorder hash/descendant-count repair at the END of auto-committing bulk inserts.
+     * The repair walks the ENTIRE imported subtree — for large imports that can rival the import itself
+     * — so it defaults to {@code false}: bulk-imported nodes then carry hash 0 in the final revision.
+     * Enable for resources where hash integrity over bulk-loaded data matters more than import speed.
      */
     public Builder repairBulkInsertHashes(final boolean repair) {
       this.repairBulkInsertHashes = repair;
@@ -1470,11 +1483,11 @@ public final class ResourceConfiguration {
      * <p>
      * The persistent valid-time interval index and two {@code xs:dateTime} CAS indexes over the
      * valid-time fields are created automatically by the store layers (JSONiq
-     * {@code jn:store}/{@code jn:load} with valid-time options and the REST create handler);
-     * resources created directly through the Java API can create them explicitly via
+     * {@code jn:store}/{@code jn:load} with valid-time options and the REST create handler); resources
+     * created directly through the Java API can create them explicitly via
      * {@code jn:create-valid-time-index}/{@code jn:create-cas-index} or the
-     * {@code io.sirix.query.json.ValidTimeIndexes} helper. Setting this configuration alone does
-     * not create any index.
+     * {@code io.sirix.query.json.ValidTimeIndexes} helper. Setting this configuration alone does not
+     * create any index.
      * </p>
      *
      * @param validTimeConfig the valid time configuration, or null to disable
@@ -1486,9 +1499,9 @@ public final class ResourceConfiguration {
     }
 
     /**
-     * Sets the resource identity UUID. Deserialization passes the persisted value ({@code null}
-     * for legacy configs, which disables the superblock cross-check); new resources keep the
-     * generated random default.
+     * Sets the resource identity UUID. Deserialization passes the persisted value ({@code null} for
+     * legacy configs, which disables the superblock cross-check); new resources keep the generated
+     * random default.
      *
      * @param resourceUuid the persisted UUID, or {@code null} for a legacy configuration
      * @return reference to the builder object
@@ -1507,8 +1520,8 @@ public final class ResourceConfiguration {
      * </p>
      *
      * <p>
-     * See {@link #validTimeConfig(ValidTimeConfig)} for how the valid-time interval index is
-     * created — setting the paths alone does not create any index.
+     * See {@link #validTimeConfig(ValidTimeConfig)} for how the valid-time interval index is created —
+     * setting the paths alone does not create any index.
      * </p>
      *
      * @param validFromPath JSON path to the validFrom field (e.g., "$.validFrom" or "validFrom")
@@ -1543,24 +1556,24 @@ public final class ResourceConfiguration {
     @Override
     public String toString() {
       return ToStringHelper.of(this)
-                        .add("binaryEncodingVersion", binaryEncodingVersion)
-                        .add("Type", type)
-                        .add("RevisionKind", revisionKind)
-                        .add("HashKind", hashType)
-                        .add("HashFunction", hashFunction)
-                        .add("PathSummary", pathSummary)
-                        .add("TextCompression", useTextCompression)
-                        .add("Store diffs", storeDiffs)
-                        .add("Store child count", storeChildCount)
-                        .add("Store node history", storeNodeHistory)
-                        .add("Custom commit timestamps", customCommitTimestamps)
-                        .add("Max number of revisions to restore", maxNumberOfRevisionsToRestore)
-                        .add("Use deweyIDs", useDeweyIDs)
-                        .add("Byte handler pipeline", byteHandler)
-                        .add("Index backend type", indexBackendType)
-                        .add("Verify checksums on read", verifyChecksumsOnRead)
-                        .add("Valid time config", validTimeConfig)
-                        .toString();
+                           .add("binaryEncodingVersion", binaryEncodingVersion)
+                           .add("Type", type)
+                           .add("RevisionKind", revisionKind)
+                           .add("HashKind", hashType)
+                           .add("HashFunction", hashFunction)
+                           .add("PathSummary", pathSummary)
+                           .add("TextCompression", useTextCompression)
+                           .add("Store diffs", storeDiffs)
+                           .add("Store child count", storeChildCount)
+                           .add("Store node history", storeNodeHistory)
+                           .add("Custom commit timestamps", customCommitTimestamps)
+                           .add("Max number of revisions to restore", maxNumberOfRevisionsToRestore)
+                           .add("Use deweyIDs", useDeweyIDs)
+                           .add("Byte handler pipeline", byteHandler)
+                           .add("Index backend type", indexBackendType)
+                           .add("Verify checksums on read", verifyChecksumsOnRead)
+                           .add("Valid time config", validTimeConfig)
+                           .toString();
     }
 
     /**

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -175,14 +175,23 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   final IOStorage storage;
 
   /**
-   * Atomic counter for concurrent generation of node transaction id.
+   * Atomic counter for concurrent generation of transaction ids, shared by node transactions and
+   * storage engine readers/writers alike.
+   *
+   * <p>ONE counter, deliberately: node trx ids key {@link #nodeTrxMap} and
+   * {@link #storageEngineWriterMap}, storage engine ids key {@link #storageEngineReaderMap}, and
+   * close paths cross between them (a node trx closes its storage engine reader; a storage engine
+   * reader consults the node trx bookkeeping). Two independent counters made those two id spaces
+   * collide numerically while meaning different things, so a close could skip its own entry (the
+   * map grew for the session's lifetime) or evict a live, unrelated one. A single monotonic
+   * counter makes an id unique across BOTH spaces, which is what every cross-map lookup here
+   * already assumed. Ids also stay unique in pin diagnostics and logs, where they identify a
+   * transaction, not a slot in some space.
+   *
+   * <p>A read-write node transaction still shares one id with its bound storage engine writer —
+   * that is a single {@code incrementAndGet} used for both, not a collision.
    */
-  private final AtomicInteger nodeTrxIDCounter;
-
-  /**
-   * Atomic counter for concurrent generation of storage engine id.
-   */
-  final AtomicInteger storageEngineIDCounter;
+  private final AtomicInteger trxIDCounter;
 
   /**
    * Per-thread shared read-only transactions for parallel query execution. Key: (threadId, revision)
@@ -258,8 +267,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     storageEngineReaderMap = new ConcurrentHashMap<>();
     storageEngineWriterMap = new ConcurrentHashMap<>();
 
-    nodeTrxIDCounter = new AtomicInteger();
-    storageEngineIDCounter = new AtomicInteger();
+    trxIDCounter = new AtomicInteger();
     commitLock = new ReentrantLock(false);
     sharedTrxMap = new ConcurrentHashMap<>();
 
@@ -755,7 +763,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     // * createStorageEngineReader() uses AtomicInteger for IDs and ConcurrentMap for the
     // bookkeeping — already not synchronized.
     // * getDocumentNode() operates on the just-constructed reader (per-thread ownership).
-    // * nodeTrxIDCounter is an AtomicInteger; nodeTrxMap is a ConcurrentMap.
+    // * trxIDCounter is an AtomicInteger; nodeTrxMap is a ConcurrentMap.
     // Removing the per-session monitor allows N concurrent reader-opens to run in parallel,
     // unblocking the depth-N pipeline in the prefetched temporal axes (and any other caller
     // that opens multiple rtxs back-to-back from concurrent threads).
@@ -763,18 +771,29 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
     final StorageEngineReader storageEngineReader = createStorageEngineReader(revision);
 
-    final Node documentNode = getDocumentNode(storageEngineReader);
+    // Every failure after the reader exists must close it: it holds an epoch ticket, a page
+    // reader and an entry in storageEngineReaderMap, none of which anything else would reclaim
+    // (getDocumentNode already closes on its own failure path — closing twice is idempotent).
+    boolean success = false;
+    try {
+      final Node documentNode = getDocumentNode(storageEngineReader);
 
-    // Create new reader.
-    final R reader = createNodeReadOnlyTrx(nodeTrxIDCounter.incrementAndGet(), storageEngineReader, documentNode);
+      // Create new reader.
+      final R reader = createNodeReadOnlyTrx(trxIDCounter.incrementAndGet(), storageEngineReader, documentNode);
 
-    // Remember reader for debugging and safe close.
-    if (nodeTrxMap.put(reader.getId(), reader) != null) {
-      throw new SirixUsageException(ID_GENERATION_EXCEPTION);
+      // Remember reader for debugging and safe close.
+      if (nodeTrxMap.put(reader.getId(), reader) != null) {
+        throw new SirixUsageException(ID_GENERATION_EXCEPTION);
+      }
+      TransactionMetrics.onReadOnlyTrxOpened();
+
+      success = true;
+      return reader;
+    } finally {
+      if (!success) {
+        storageEngineReader.close();
+      }
     }
-    TransactionMetrics.onReadOnlyTrxOpened();
-
-    return reader;
   }
 
   public abstract R createNodeReadOnlyTrx(int nodeTrxId, StorageEngineReader storageEngineReader, Node documentNode);
@@ -900,7 +919,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     boolean success = false;
     try {
       // Create new storage engine writer (shares the same ID with the node write trx).
-      final int nodeTrxId = nodeTrxIDCounter.incrementAndGet();
+      final int nodeTrxId = trxIDCounter.incrementAndGet();
       final int lastRev = getMostRecentRevisionNumber();
       final StorageEngineWriter storageEngineWriter =
           createPageTransaction(nodeTrxId, lastRev, lastRev, Abort.NO, true);
@@ -1083,33 +1102,45 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   /**
-   * Close a write transaction.
+   * Close a storage engine writer that is NOT bound to a node transaction.
    *
-   * @param transactionID write transaction ID
+   * @param transactionID storage engine writer ID
+   * @param storageEngineWriter the writer being closed; the bookkeeping entry is dropped only if
+   *        the map still maps {@code transactionID} to exactly this instance
    */
   @Override
-  public void closePageWriteTransaction(final Integer transactionID) {
+  public void closePageWriteTransaction(final int transactionID, final StorageEngineWriter storageEngineWriter) {
     assertNotClosed();
 
-    // Remove from internal map.
-    storageEngineReaderMap.remove(transactionID);
+    // Remove from internal map. Identity-scoped: see closePageReadTransaction.
+    storageEngineReaderMap.remove(transactionID, requireNonNull(storageEngineWriter));
 
-    // Make new transactions available.
+    // Make new transactions available. Unconditional — this writer took a permit in
+    // createStorageEngineWriter whether or not its bookkeeping entry is still present.
     LOGGER.trace("Lock unlock (closePageWriteTransaction).");
     writeLock.release();
   }
 
   /**
-   * Close a read transaction.
+   * Close a storage engine reader: drop it from {@link #storageEngineReaderMap}.
    *
-   * @param transactionID read transaction ID
+   * <p>Removal is by (key, value) rather than by key alone. A storage engine reader bound to a
+   * node transaction carries that transaction's id, and while ids are unique session-wide (see
+   * {@link #trxIDCounter}) the two maps are keyed by different populations — so a bare
+   * {@code remove(id)} from a bound reader could only ever be a no-op or, if the id spaces were
+   * ever allowed to overlap again, evict a live foreign reader. Identity removal makes that
+   * structurally impossible and is idempotent, so a double close cannot drop a successor that
+   * reused the id.
+   *
+   * @param transactionID storage engine reader ID
+   * @param storageEngineReader the reader being closed
    */
   @Override
-  public void closePageReadTransaction(final Integer transactionID) {
+  public void closePageReadTransaction(final int transactionID, final StorageEngineReader storageEngineReader) {
     assertNotClosed();
 
     // Remove from internal map.
-    storageEngineReaderMap.remove(transactionID);
+    storageEngineReaderMap.remove(transactionID, requireNonNull(storageEngineReader));
   }
 
   /**
@@ -1203,7 +1234,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   public StorageEngineReader createStorageEngineReader(final int revision) {
     assertAccess(revision);
 
-    final int currentStorageEngineID = storageEngineIDCounter.incrementAndGet();
+    final int currentStorageEngineID = trxIDCounter.incrementAndGet();
     final NodeStorageEngineReader storageEngineReader =
         new NodeStorageEngineReader(currentStorageEngineID, this, lastCommittedUberPage.get(), revision,
             storage.createReader(), bufferManager, new RevisionRootPageReader(), null);
@@ -1232,7 +1263,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
     boolean success = false;
     try {
-      final int currentStorageEngineID = storageEngineIDCounter.incrementAndGet();
+      final int currentStorageEngineID = trxIDCounter.incrementAndGet();
       final int lastRev = getMostRecentRevisionNumber();
       final StorageEngineWriter storageEngineWriter =
           createPageTransaction(currentStorageEngineID, lastRev, lastRev, Abort.NO, false);
@@ -1273,6 +1304,15 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    */
   public int activeTrxCount() {
     return nodeTrxMap.size();
+  }
+
+  /**
+   * Number of storage engine readers/writers this session still tracks as open. Every entry is
+   * dropped when its reader closes, so a workload that opens and closes transactions in a loop
+   * must leave this bounded — it is the direct leak signal for {@link #storageEngineReaderMap}.
+   */
+  public int activeStorageEngineReaderCount() {
+    return storageEngineReaderMap.size();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -178,18 +178,20 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * Atomic counter for concurrent generation of transaction ids, shared by node transactions and
    * storage engine readers/writers alike.
    *
-   * <p>ONE counter, deliberately: node trx ids key {@link #nodeTrxMap} and
+   * <p>
+   * ONE counter, deliberately: node trx ids key {@link #nodeTrxMap} and
    * {@link #storageEngineWriterMap}, storage engine ids key {@link #storageEngineReaderMap}, and
    * close paths cross between them (a node trx closes its storage engine reader; a storage engine
    * reader consults the node trx bookkeeping). Two independent counters made those two id spaces
-   * collide numerically while meaning different things, so a close could skip its own entry (the
-   * map grew for the session's lifetime) or evict a live, unrelated one. A single monotonic
-   * counter makes an id unique across BOTH spaces, which is what every cross-map lookup here
-   * already assumed. Ids also stay unique in pin diagnostics and logs, where they identify a
-   * transaction, not a slot in some space.
+   * collide numerically while meaning different things, so a close could skip its own entry (the map
+   * grew for the session's lifetime) or evict a live, unrelated one. A single monotonic counter makes
+   * an id unique across BOTH spaces, which is what every cross-map lookup here already assumed. Ids
+   * also stay unique in pin diagnostics and logs, where they identify a transaction, not a slot in
+   * some space.
    *
-   * <p>A read-write node transaction still shares one id with its bound storage engine writer —
-   * that is a single {@code incrementAndGet} used for both, not a collision.
+   * <p>
+   * A read-write node transaction still shares one id with its bound storage engine writer — that is
+   * a single {@code incrementAndGet} used for both, not a collision.
    */
   private final AtomicInteger trxIDCounter;
 
@@ -1105,8 +1107,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * Close a storage engine writer that is NOT bound to a node transaction.
    *
    * @param transactionID storage engine writer ID
-   * @param storageEngineWriter the writer being closed; the bookkeeping entry is dropped only if
-   *        the map still maps {@code transactionID} to exactly this instance
+   * @param storageEngineWriter the writer being closed; the bookkeeping entry is dropped only if the
+   *        map still maps {@code transactionID} to exactly this instance
    */
   @Override
   public void closePageWriteTransaction(final int transactionID, final StorageEngineWriter storageEngineWriter) {
@@ -1124,13 +1126,13 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   /**
    * Close a storage engine reader: drop it from {@link #storageEngineReaderMap}.
    *
-   * <p>Removal is by (key, value) rather than by key alone. A storage engine reader bound to a
-   * node transaction carries that transaction's id, and while ids are unique session-wide (see
+   * <p>
+   * Removal is by (key, value) rather than by key alone. A storage engine reader bound to a node
+   * transaction carries that transaction's id, and while ids are unique session-wide (see
    * {@link #trxIDCounter}) the two maps are keyed by different populations — so a bare
-   * {@code remove(id)} from a bound reader could only ever be a no-op or, if the id spaces were
-   * ever allowed to overlap again, evict a live foreign reader. Identity removal makes that
-   * structurally impossible and is idempotent, so a double close cannot drop a successor that
-   * reused the id.
+   * {@code remove(id)} from a bound reader could only ever be a no-op or, if the id spaces were ever
+   * allowed to overlap again, evict a live foreign reader. Identity removal makes that structurally
+   * impossible and is idempotent, so a double close cannot drop a successor that reused the id.
    *
    * @param transactionID storage engine reader ID
    * @param storageEngineReader the reader being closed
@@ -1308,8 +1310,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
   /**
    * Number of storage engine readers/writers this session still tracks as open. Every entry is
-   * dropped when its reader closes, so a workload that opens and closes transactions in a loop
-   * must leave this bounded — it is the direct leak signal for {@link #storageEngineReaderMap}.
+   * dropped when its reader closes, so a workload that opens and closes transactions in a loop must
+   * leave this bounded — it is the direct leak signal for {@link #storageEngineReaderMap}.
    */
   public int activeStorageEngineReaderCount() {
     return storageEngineReaderMap.size();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -130,6 +130,10 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * truncation drop the databaseId slice, {@code Databases.clearGlobalCaches()} (cold-process
    * simulation in tests) drops everything.
    */
+  // FULLY QUALIFIED deliberately, and it must stay that way: io.sirix.cache.Cache is imported in
+  // this file, so a single-type-import of Caffeine's Cache does not compile ("a type with the same
+  // simple name is already defined"). A review flagged this as a CLAUDE.md violation; it is the one
+  // place the rule cannot be followed without renaming one of the two types.
   private static final com.github.benmanes.caffeine.cache.Cache<RevisionInfoKey, RevisionInfo> REVISION_INFO_CACHE =
       com.github.benmanes.caffeine.cache.Caffeine.newBuilder().maximumSize(100_000).build();
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -112,10 +112,10 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   final ConcurrentMap<Integer, StorageEngineWriter> storageEngineWriterMap;
 
   /**
-   * Cache key for {@link #REVISION_INFO_CACHE}: database ids are random positive longs persisted
-   * per database and claimed per directory in-JVM, resource ids are persisted per resource — the
-   * pair is stable and unique, so (databaseId, resourceId, revision) can never be misattributed
-   * across resources.
+   * Cache key for {@link #REVISION_INFO_CACHE}: database ids are random positive longs persisted per
+   * database and claimed per directory in-JVM, resource ids are persisted per resource — the pair is
+   * stable and unique, so (databaseId, resourceId, revision) can never be misattributed across
+   * resources.
    */
   private record RevisionInfoKey(long databaseId, long resourceId, int revision) {
   }
@@ -123,12 +123,12 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   /**
    * GLOBAL cache of (databaseId, resourceId, revision) → {@link RevisionInfo} (author, timestamp,
    * commit message). A committed revision is immutable, so an entry never has to be invalidated by
-   * new commits (they add new keys). The cache is static because REST closes the session per
-   * request — a per-session cache re-read one {@code RevisionRootPage} per revision on EVERY
-   * {@code /history} call; the global cache only pays I/O for revisions not yet seen by this JVM.
-   * Invalidation: resource removal drops the (databaseId, resourceId) slice, database removal and
-   * crash-recovery truncation drop the databaseId slice, {@code Databases.clearGlobalCaches()}
-   * (cold-process simulation in tests) drops everything.
+   * new commits (they add new keys). The cache is static because REST closes the session per request
+   * — a per-session cache re-read one {@code RevisionRootPage} per revision on EVERY {@code /history}
+   * call; the global cache only pays I/O for revisions not yet seen by this JVM. Invalidation:
+   * resource removal drops the (databaseId, resourceId) slice, database removal and crash-recovery
+   * truncation drop the databaseId slice, {@code Databases.clearGlobalCaches()} (cold-process
+   * simulation in tests) drops everything.
    */
   private static final com.github.benmanes.caffeine.cache.Cache<RevisionInfoKey, RevisionInfo> REVISION_INFO_CACHE =
       com.github.benmanes.caffeine.cache.Caffeine.newBuilder().maximumSize(100_000).build();
@@ -185,8 +185,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   final AtomicInteger storageEngineIDCounter;
 
   /**
-   * Per-thread shared read-only transactions for parallel query execution.
-   * Key: (threadId, revision) → one read-only trx per worker thread per revision.
+   * Per-thread shared read-only transactions for parallel query execution. Key: (threadId, revision)
+   * → one read-only trx per worker thread per revision.
    */
   private final ConcurrentHashMap<SharedTrxKey, R> sharedTrxMap;
 
@@ -240,13 +240,14 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * @param uberPage holds a reference to the revision root page tree
    * @param writeLock allow for concurrent writes
    * @param user the user tied to the resource session
-   * @param storageEngineWriterFactory A factory that creates new {@link StorageEngineWriter} instances.
+   * @param storageEngineWriterFactory A factory that creates new {@link StorageEngineWriter}
+   *        instances.
    * @throws SirixException if Sirix encounters an exception
    */
   protected AbstractResourceSession(final ResourceStore<? extends ResourceSession<R, W>> resourceStore,
-      final ResourceConfiguration resourceConf, final BufferManager bufferManager,
-      final IOStorage storage, final UberPage uberPage, final Semaphore writeLock,
-      final @Nullable User user, final StorageEngineWriterFactory storageEngineWriterFactory) {
+      final ResourceConfiguration resourceConf, final BufferManager bufferManager, final IOStorage storage,
+      final UberPage uberPage, final Semaphore writeLock, final @Nullable User user,
+      final StorageEngineWriterFactory storageEngineWriterFactory) {
     this.resourceStore = requireNonNull(resourceStore);
     resourceConfig = requireNonNull(resourceConf);
     this.bufferManager = requireNonNull(bufferManager);
@@ -313,7 +314,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       int bestRevision = -1;
       if (Files.isDirectory(indexesDir)) {
         try (final var children = Files.list(indexesDir)) {
-          for (final var it = children.iterator(); it.hasNext(); ) {
+          for (final var it = children.iterator(); it.hasNext();) {
             final String name = it.next().getFileName().toString();
             if (name.endsWith(".xml")) {
               try {
@@ -362,15 +363,14 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * @return a new {@link StorageEngineWriter} instance
    */
   @Override
-  public StorageEngineWriter createPageTransaction(final int id, final int representRevision,
-      final int storedRevision, final Abort abort, boolean isBoundToNodeTrx) {
+  public StorageEngineWriter createPageTransaction(final int id, final int representRevision, final int storedRevision,
+      final Abort abort, final boolean isBoundToNodeTrx) {
     return createPageTransaction(id, representRevision, storedRevision, abort, isBoundToNodeTrx, null);
   }
 
   @Override
-  public StorageEngineWriter createPageTransaction(final int id, final int representRevision,
-      final int storedRevision, final Abort abort, boolean isBoundToNodeTrx,
-      final @Nullable UberPage pendingBaseUberPage) {
+  public StorageEngineWriter createPageTransaction(final int id, final int representRevision, final int storedRevision,
+      final Abort abort, final boolean isBoundToNodeTrx, final @Nullable UberPage pendingBaseUberPage) {
     checkArgument(id >= 0, "id must be >= 0!");
     checkArgument(representRevision >= 0, "representRevision must be >= 0!");
     checkArgument(storedRevision >= 0, "storedRevision must be >= 0!");
@@ -380,8 +380,9 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     // Pipelined async commits pass the pending (phase-1-complete, canonical in-memory) uber page
     // of the still-hardening revision as the base for the successor epoch; readers keep resolving
     // "latest" through lastCommittedUberPage until the background hardening publishes it.
-    final UberPage lastCommittedUberPage =
-        pendingBaseUberPage != null ? pendingBaseUberPage : this.lastCommittedUberPage.get();
+    final UberPage lastCommittedUberPage = pendingBaseUberPage != null
+        ? pendingBaseUberPage
+        : this.lastCommittedUberPage.get();
     final int lastCommittedRev = lastCommittedUberPage.getRevisionNumber();
 
     // Crash recovery runs BEFORE the writer is constructed, and the ordering is load-bearing.
@@ -421,7 +422,9 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   @Override
   public RevisionRootPage getPendingRevisionRoot(final int revision) {
     final PendingRevisionRoot pending = pendingRevisionRoot;
-    return pending != null && pending.revision() == revision ? pending.rootPage() : null;
+    return pending != null && pending.revision() == revision
+        ? pending.rootPage()
+        : null;
   }
 
   @Override
@@ -440,8 +443,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     storageEngineWriterMap.remove(transactionID);
   }
 
-  private void truncateToLastSuccessfullyCommittedRevisionIfCommitLockFileExists(Writer writer,
-      int lastCommittedRev) {
+  private void truncateToLastSuccessfullyCommittedRevisionIfCommitLockFileExists(final Writer writer,
+      final int lastCommittedRev) {
     if (!Files.exists(getCommitFile())) {
       return;
     }
@@ -452,7 +455,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     // tracking, no retained previous uber page), and its data does not outlive the process, so the
     // marker describes a commit whose pages are gone with it: log and carry on.
     if (!writer.supportsTruncateTo()) {
-      LOGGER.warn("Resource {} has a commit marker from an aborted commit, but {} cannot truncate —"
+      LOGGER.warn(
+          "Resource {} has a commit marker from an aborted commit, but {} cannot truncate —"
               + " skipping crash recovery. Use a persistent StorageType where rollback matters.",
           resourceConfig.getResource(), writer.getClass().getSimpleName());
       return;
@@ -481,10 +485,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     assertAccess(fromRevision);
     assertAccess(toRevision);
 
-    checkArgument(fromRevision > 0 && toRevision > 0,
-                  "Revision numbers must be positive, but got %s and %s.",
-                  fromRevision,
-                  toRevision);
+    checkArgument(fromRevision > 0 && toRevision > 0, "Revision numbers must be positive, but got %s and %s.",
+        fromRevision, toRevision);
 
     // Accept both argument orders (callers like the REST history endpoint naturally pass an
     // ascending [start, end]) and from == to; results are returned newest-first like the other
@@ -510,10 +512,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     assertAccess(fromRevision);
     assertAccess(toRevision);
 
-    checkArgument(fromRevision > 0 && toRevision > 0,
-                  "Revision numbers must be positive, but got %s and %s.",
-                  fromRevision,
-                  toRevision);
+    checkArgument(fromRevision > 0 && toRevision > 0, "Revision numbers must be positive, but got %s and %s.",
+        fromRevision, toRevision);
 
     final int newest = Math.max(fromRevision, toRevision);
     final int oldest = Math.min(fromRevision, toRevision);
@@ -523,13 +523,14 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
   /**
    * Read the commit timestamps (epoch millis) for the inclusive revision range
-   * {@code [oldest, newest]} from the in-memory {@link RevisionIndex} and return them
-   * newest-first. No {@link StorageEngineReader} is opened and no {@code RevisionRootPage} is
-   * read — the timestamps are already resident.
+   * {@code [oldest, newest]} from the in-memory {@link RevisionIndex} and return them newest-first.
+   * No {@link StorageEngineReader} is opened and no {@code RevisionRootPage} is read — the timestamps
+   * are already resident.
    *
-   * <p>If the in-memory index lags the requested range (a fresh process, or out-of-band growth
-   * by another writer), it is resynced once from disk via {@link IOStorage#loadRevisionIndex},
-   * mirroring the storage-open path.
+   * <p>
+   * If the in-memory index lags the requested range (a fresh process, or out-of-band growth by
+   * another writer), it is resynced once from disk via {@link IOStorage#loadRevisionIndex}, mirroring
+   * the storage-open path.
    */
   private long[] historyTimestampsNewestFirst(final int newest, final int oldest) {
     final RevisionIndexHolder holder = storage.getRevisionIndexHolder();
@@ -539,8 +540,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       index = holder.get();
     }
     if (index.size() <= newest) {
-      throw new IllegalStateException("Revision index holds " + index.size()
-          + " entries but revision " + newest + " was requested.");
+      throw new IllegalStateException(
+          "Revision index holds " + index.size() + " entries but revision " + newest + " was requested.");
     }
 
     // RevisionIndex stores timestamps in ascending revision order; reverse in place to honour
@@ -563,7 +564,9 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     }
     // The most recent `revisions` revisions, clamped to the first user revision (1); revision 0
     // is the empty bootstrap and is never reported.
-    final int oldest = revisions >= newest ? 1 : newest - revisions + 1;
+    final int oldest = revisions >= newest
+        ? 1
+        : newest - revisions + 1;
     return buildHistory(newest, oldest);
   }
 
@@ -571,11 +574,11 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * Build the history (newest revision first) for the inclusive revision range
    * {@code [oldest, newest]}.
    *
-   * <p>Already-seen, immutable revisions are served synchronously from
-   * {@link #REVISION_INFO_CACHE} straight into a pre-sized result array — no per-revision
-   * {@link CompletableFuture}, no stream pipeline. Only cache misses (cold revisions) open a
-   * {@link StorageEngineReader}, and those run in parallel so a cold first call still overlaps
-   * its I/O across revisions.
+   * <p>
+   * Already-seen, immutable revisions are served synchronously from {@link #REVISION_INFO_CACHE}
+   * straight into a pre-sized result array — no per-revision {@link CompletableFuture}, no stream
+   * pipeline. Only cache misses (cold revisions) open a {@link StorageEngineReader}, and those run in
+   * parallel so a cold first call still overlaps its I/O across revisions.
    */
   private List<RevisionInfo> buildHistory(final int newest, final int oldest) {
     final int count = newest - oldest + 1;
@@ -593,8 +596,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
         if (misses == null) {
           misses = new ArrayList<>();
         }
-        misses.add(CompletableFuture.runAsync(
-            () -> result[slot] = REVISION_INFO_CACHE.get(cacheKey, this::loadRevisionInfo)));
+        misses.add(
+            CompletableFuture.runAsync(() -> result[slot] = REVISION_INFO_CACHE.get(cacheKey, this::loadRevisionInfo)));
       }
     }
 
@@ -607,18 +610,16 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
 
   /**
    * Cold-path loader for one revision's {@link RevisionInfo}: reads the commit credentials and
-   * timestamp directly through a {@link StorageEngineReader}, bypassing the full
-   * node-transaction machinery (node cursor, item list, per-trx wiring) that
-   * {@code beginNodeReadOnlyTrx} sets up.
+   * timestamp directly through a {@link StorageEngineReader}, bypassing the full node-transaction
+   * machinery (node cursor, item list, per-trx wiring) that {@code beginNodeReadOnlyTrx} sets up.
    */
   private RevisionInfo loadRevisionInfo(final RevisionInfoKey key) {
     final int revision = key.revision();
     try (final StorageEngineReader reader = createStorageEngineReader(revision)) {
       final CommitCredentials commitCredentials = reader.getCommitCredentials();
-      return new RevisionInfo(commitCredentials.getUser(),
-                              revision,
-                              Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
-                              commitCredentials.getMessage());
+      return new RevisionInfo(commitCredentials.getUser(), revision,
+          Instant.ofEpochMilli(reader.getActualRevisionRootPage().getRevisionTimestamp()),
+          commitCredentials.getMessage());
     }
   }
 
@@ -674,10 +675,10 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   /**
-   * Read {@code nodeKey} at {@code revision} through a lightweight {@link StorageEngineReader}
-   * (no {@link io.sirix.api.NodeReadOnlyTrx} wrapper, document-node fetch, or trx bookkeeping) and
-   * hand it to {@code visitor} if the record exists in that revision. The reader stays open for
-   * the duration of the callback so the record remains valid.
+   * Read {@code nodeKey} at {@code revision} through a lightweight {@link StorageEngineReader} (no
+   * {@link NodeReadOnlyTrx} wrapper, document-node fetch, or trx bookkeeping) and hand it to
+   * {@code visitor} if the record exists in that revision. The reader stays open for the duration of
+   * the callback so the record remains valid.
    */
   private void visitRecord(final long nodeKey, final int revision, final RecordHistoryVisitor visitor) {
     try (final StorageEngineReader reader = createStorageEngineReader(revision)) {
@@ -704,7 +705,9 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       final int[] changeRevisions = getRecordChangeRevisions(nodeKey);
       for (int i = 0; i < changeRevisions.length; i++) {
         final int fromRevision = changeRevisions[i];
-        final int toRevision = (i + 1 < changeRevisions.length) ? changeRevisions[i + 1] - 1 : maxRevision;
+        final int toRevision = (i + 1 < changeRevisions.length)
+            ? changeRevisions[i + 1] - 1
+            : maxRevision;
         visitRun(nodeKey, fromRevision, toRevision, visitor);
       }
     } else {
@@ -748,11 +751,11 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   @Override
   public R beginNodeReadOnlyTrx(final int revision) {
     // Read-only opens have no shared-state concurrency concerns:
-    //  * assertAccess() reads a volatile and a volatile-published epoch — thread-safe.
-    //  * createStorageEngineReader() uses AtomicInteger for IDs and ConcurrentMap for the
-    //    bookkeeping — already not synchronized.
-    //  * getDocumentNode() operates on the just-constructed reader (per-thread ownership).
-    //  * nodeTrxIDCounter is an AtomicInteger; nodeTrxMap is a ConcurrentMap.
+    // * assertAccess() reads a volatile and a volatile-published epoch — thread-safe.
+    // * createStorageEngineReader() uses AtomicInteger for IDs and ConcurrentMap for the
+    // bookkeeping — already not synchronized.
+    // * getDocumentNode() operates on the just-constructed reader (per-thread ownership).
+    // * nodeTrxIDCounter is an AtomicInteger; nodeTrxMap is a ConcurrentMap.
     // Removing the per-session monitor allows N concurrent reader-opens to run in parallel,
     // unblocking the depth-N pipeline in the prefetched temporal axes (and any other caller
     // that opens multiple rtxs back-to-back from concurrent threads).
@@ -780,7 +783,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       Duration autoCommitDelay, Node documentNode, AfterCommitState afterCommitState);
 
   static Node getDocumentNode(final StorageEngineReader storageEngineReader) {
-    final Node node = storageEngineReader.getRecord(Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), IndexType.DOCUMENT, -1);
+    final Node node =
+        storageEngineReader.getRecord(Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), IndexType.DOCUMENT, -1);
     if (node == null) {
       storageEngineReader.close();
       throw new IllegalStateException("Node couldn't be fetched from persistent storage!");
@@ -814,8 +818,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   @Override
-  public W beginNodeTrx(final int maxNodeCount, final int maxTime,
-      final TimeUnit timeUnit) {
+  public W beginNodeTrx(final int maxNodeCount, final int maxTime, final TimeUnit timeUnit) {
     return beginNodeTrx(maxNodeCount, maxTime, timeUnit, AfterCommitState.KEEP_OPEN);
   }
 
@@ -830,14 +833,13 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   @Override
-  public W beginNodeTrx(final int maxTime, final TimeUnit timeUnit,
-      final AfterCommitState afterCommitState) {
+  public W beginNodeTrx(final int maxTime, final TimeUnit timeUnit, final AfterCommitState afterCommitState) {
     return beginNodeTrx(0, maxTime, timeUnit, afterCommitState);
   }
 
   @Override
-  public synchronized W beginNodeTrx(final int maxNodeCount, final int maxTime,
-      final TimeUnit timeUnit, final AfterCommitState afterCommitState) {
+  public synchronized W beginNodeTrx(final int maxNodeCount, final int maxTime, final TimeUnit timeUnit,
+      final AfterCommitState afterCommitState) {
     // Checks.
     assertAccess(getMostRecentRevisionNumber());
     if (maxNodeCount < 0 || maxTime < 0) {
@@ -866,15 +868,13 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
         || afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
       final StorageType storageType = getResourceConfig().getStorageType();
       final boolean supportedBackend = storageType == StorageType.FILE_CHANNEL
-          || (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH
-              && storageType == StorageType.MEMORY_MAPPED);
+          || (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH && storageType == StorageType.MEMORY_MAPPED);
       if (!supportedBackend) {
-        throw new IllegalArgumentException(
-            afterCommitState + " requires the FILE_CHANNEL"
-                + (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH
-                    ? " or MEMORY_MAPPED"
-                    : "")
-                + " storage backend; got " + storageType);
+        throw new IllegalArgumentException(afterCommitState + " requires the FILE_CHANNEL"
+            + (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH
+                ? " or MEMORY_MAPPED"
+                : "")
+            + " storage backend; got " + storageType);
       }
       if (maxTime > 0) {
         throw new IllegalArgumentException(
@@ -902,18 +902,20 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       // Create new storage engine writer (shares the same ID with the node write trx).
       final int nodeTrxId = nodeTrxIDCounter.incrementAndGet();
       final int lastRev = getMostRecentRevisionNumber();
-      final StorageEngineWriter storageEngineWriter = createPageTransaction(nodeTrxId, lastRev, lastRev, Abort.NO, true);
+      final StorageEngineWriter storageEngineWriter =
+          createPageTransaction(nodeTrxId, lastRev, lastRev, Abort.NO, true);
 
       final Node documentNode = getDocumentNode(storageEngineWriter);
 
       // Create new node write transaction.
       final var autoCommitDelay = Duration.of(maxTime, timeUnit.toChronoUnit());
-      final W wtx =
-          createNodeReadWriteTrx(nodeTrxId, storageEngineWriter, maxNodeCount, autoCommitDelay, documentNode, afterCommitState);
+      final W wtx = createNodeReadWriteTrx(nodeTrxId, storageEngineWriter, maxNodeCount, autoCommitDelay, documentNode,
+          afterCommitState);
 
       // Remember node transaction for debugging and safe close.
       // noinspection unchecked
-      if (nodeTrxMap.put(nodeTrxId, (R) wtx) != null || storageEngineWriterMap.put(nodeTrxId, storageEngineWriter) != null) {
+      if (nodeTrxMap.put(nodeTrxId, (R) wtx) != null
+          || storageEngineWriterMap.put(nodeTrxId, storageEngineWriter) != null) {
         // Clean up: remove any entries we just inserted, then close resources.
         nodeTrxMap.remove(nodeTrxId);
         storageEngineWriterMap.remove(nodeTrxId);
@@ -1030,8 +1032,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
    * @param storageEngineWriter storage engine writer
    */
   @Override
-  public void setNodePageWriteTransaction(final int transactionID,
-      final StorageEngineWriter storageEngineWriter) {
+  public void setNodePageWriteTransaction(final int transactionID, final StorageEngineWriter storageEngineWriter) {
     assertNotClosed();
     storageEngineWriterMap.put(transactionID, storageEngineWriter);
   }
@@ -1233,7 +1234,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
     try {
       final int currentStorageEngineID = storageEngineIDCounter.incrementAndGet();
       final int lastRev = getMostRecentRevisionNumber();
-      final StorageEngineWriter storageEngineWriter = createPageTransaction(currentStorageEngineID, lastRev, lastRev, Abort.NO, false);
+      final StorageEngineWriter storageEngineWriter =
+          createPageTransaction(currentStorageEngineID, lastRev, lastRev, Abort.NO, false);
 
       // Remember storage engine writer for debugging and safe close.
       if (storageEngineReaderMap.put(currentStorageEngineID, storageEngineWriter) != null) {
@@ -1266,8 +1268,8 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   }
 
   /**
-   * Number of currently-open read-only or read-write node transactions on this session.
-   * Useful for diagnostics and for asserting the absence of resource leaks in tests.
+   * Number of currently-open read-only or read-write node transactions on this session. Useful for
+   * diagnostics and for asserting the absence of resource leaks in tests.
    */
   public int activeTrxCount() {
     return nodeTrxMap.size();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
@@ -42,25 +42,25 @@ public interface InternalResourceSession<R extends NodeReadOnlyTrx & NodeCursor,
   /**
    * Variant for pipelined async commits: bases the new page transaction on the given PENDING
    * (phase-1-complete, not yet hardened) uber page instead of {@code lastCommittedUberPage}, and
-   * skips the crash-recovery truncate check (the commit marker legitimately exists while the
-   * previous epoch hardens in the background). Pass {@code null} for the default behavior.
+   * skips the crash-recovery truncate check (the commit marker legitimately exists while the previous
+   * epoch hardens in the background). Pass {@code null} for the default behavior.
    */
   StorageEngineWriter createPageTransaction(int trxID, int revision, int i, Abort no, boolean isBoundToNodeTrx,
       UberPage pendingBaseUberPage);
 
   /**
-   * Remove a node-bound page write transaction from the session's map WITHOUT closing it — used
-   * by pipelined async commits, where the superseded page transaction is closed by the background
+   * Remove a node-bound page write transaction from the session's map WITHOUT closing it — used by
+   * pipelined async commits, where the superseded page transaction is closed by the background
    * hardening thread after the beacon write.
    */
   void detachNodePageWriteTransaction(int transactionID);
 
   /**
    * Pipelined async commits: register / resolve / clear the PENDING revision root — the
-   * phase-1-complete, canonical in-memory root of a revision whose hardening is still running in
-   * the background. Readers of the pending revision (only the successor epoch can reach it)
-   * resolve it from here, since neither the revisions-file record nor
-   * {@code lastCommittedUberPage} exist for it yet. Depth-1 pipeline ⇒ at most one pending entry.
+   * phase-1-complete, canonical in-memory root of a revision whose hardening is still running in the
+   * background. Readers of the pending revision (only the successor epoch can reach it) resolve it
+   * from here, since neither the revisions-file record nor {@code lastCommittedUberPage} exist for it
+   * yet. Depth-1 pipeline ⇒ at most one pending entry.
    */
   void putPendingRevisionRoot(int revision, RevisionRootPage rootPage);
 
@@ -81,8 +81,8 @@ public interface InternalResourceSession<R extends NodeReadOnlyTrx & NodeCursor,
   void closeReadTransaction(int trxId);
 
   /**
-   * Drop a storage engine reader from the session's bookkeeping. The reader instance is passed so
-   * the entry is removed only if it is still mapped to exactly that instance.
+   * Drop a storage engine reader from the session's bookkeeping. The reader instance is passed so the
+   * entry is removed only if it is still mapped to exactly that instance.
    */
   void closePageReadTransaction(int trxId, StorageEngineReader storageEngineReader);
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/InternalResourceSession.java
@@ -5,6 +5,7 @@ import io.sirix.api.NodeCursor;
 import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.api.NodeTrx;
 import io.sirix.api.ResourceSession;
+import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.io.Reader;
 import io.sirix.page.RevisionRootPage;
@@ -79,9 +80,17 @@ public interface InternalResourceSession<R extends NodeReadOnlyTrx & NodeCursor,
 
   void closeReadTransaction(int trxId);
 
-  void closePageReadTransaction(Integer trxId);
+  /**
+   * Drop a storage engine reader from the session's bookkeeping. The reader instance is passed so
+   * the entry is removed only if it is still mapped to exactly that instance.
+   */
+  void closePageReadTransaction(int trxId, StorageEngineReader storageEngineReader);
 
-  void closePageWriteTransaction(Integer transactionID);
+  /**
+   * Drop a storage engine writer that is not bound to a node transaction from the session's
+   * bookkeeping and release the write lock it holds.
+   */
+  void closePageWriteTransaction(int transactionID, StorageEngineWriter storageEngineWriter);
 
   /**
    * Get the revision epoch tracker for MVCC-aware eviction.

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
@@ -301,7 +301,18 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * @param round how many consecutive torn rounds this is, including the current one
    */
   public void recoverTorn(final int round) {
-    reader.recoverTorn(round, "HOT range cursor");
+    recoverTorn(round, "HOT range cursor");
+  }
+
+  /**
+   * As {@link #recoverTorn(int)}, but naming the caller so an exhaustion diagnostic identifies which
+   * scan path was thrashing rather than reporting every consumer as "HOT range cursor".
+   *
+   * @param round how many consecutive torn rounds this is, including the current one
+   * @param operation the caller's name, for the exhaustion diagnostic
+   */
+  public void recoverTorn(final int round, final String operation) {
+    reader.recoverTorn(round, operation);
     currentLeaf = reader.currentLeafPage();
   }
 
@@ -465,6 +476,7 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * against the stale copy stays valid against the fresh one. Callers re-read from
    * {@link #currentLeafPage()} — the reload creates a NEW page object.
    */
+  @Deprecated
   public void refreshLeaf() {
     recoverTorn(1);
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
@@ -52,7 +52,8 @@ import java.util.Objects;
  * </p>
  * <ul>
  * <li>No sibling pointers (COW-compatible)</li>
- * <li>Guard management for page lifetime</li>
+ * <li>Optimistic stamp validation — leaves stay evictable, every positioning decision is confirmed
+ * against the FrameSlotAllocator's per-slot seqlock version before it takes effect</li>
  * <li>Zero-copy key/value access via MemorySegment</li>
  * <li>Implements AutoCloseable for proper cleanup</li>
  * </ul>
@@ -102,8 +103,8 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
 
   private final HOTTrieReader reader;
   private final PageReference rootRef;
-  private final byte[] fromKey;
-  private final byte[] toKey;
+  private final byte @Nullable [] fromKey;
+  private final byte @Nullable [] toKey;
 
   // Current position
   private HOTLeafPage currentLeaf;
@@ -138,14 +139,29 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
   private static final boolean EARLY_EXIT_PAST_UPPER_BOUND = !Boolean.getBoolean("sirix.hot.range.scanToEnd");
 
   /**
+   * Bound on consecutive torn-read recovery rounds. Each round re-reads a freshly reloaded copy of
+   * the same immutable content, so every round races eviction independently — exhausting this many
+   * implies pathological allocator thrashing, not a logic error.
+   */
+  private static final int MAX_TORN_ROUNDS = 64;
+
+  // Verdicts computed by one batch of unpinned-leaf reads in advanceToValid(), applied only after
+  // the batch passes stamp validation.
+  private static final int VERDICT_ADVANCE_LEAF = 0;
+  private static final int VERDICT_EXIT_SCAN = 1;
+  private static final int VERDICT_SKIP_LEAF = 2;
+  private static final int VERDICT_SKIP_ENTRY = 3;
+  private static final int VERDICT_EMIT = 4;
+
+  /**
    * Create a new range cursor.
    *
    * @param reader the keyed trie reader
    * @param rootRef the root page reference
-   * @param fromKey the start key (inclusive)
-   * @param toKey the end key (inclusive)
+   * @param fromKey the start key (inclusive), or {@code null} to start at the leftmost leaf
+   * @param toKey the end key (inclusive), or {@code null} for an unbounded upper end
    */
-  HOTRangeCursor(HOTTrieReader reader, PageReference rootRef, byte[] fromKey, byte[] toKey) {
+  HOTRangeCursor(HOTTrieReader reader, PageReference rootRef, byte @Nullable [] fromKey, byte @Nullable [] toKey) {
     this.reader = Objects.requireNonNull(reader);
     this.rootRef = Objects.requireNonNull(rootRef);
     this.fromKey = fromKey;
@@ -198,70 +214,102 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * directly from the positional state.
    */
   private void advanceToValid() {
+    int tornRounds = 0;
     while (!exhausted) {
-      // Check if we've exhausted the current leaf
-      if (currentIndex >= currentLeaf.getEntryCount()) {
-        // Advance to next leaf
-        if (!advanceToNextLeaf()) {
-          exhausted = true;
-          positionedValid = false;
-          nextEntry = null;
-          return;
-        }
-        continue;
-      }
-
-      // Whole-leaf skip. Entries WITHIN a leaf are sorted, so one comparison against each end
-      // rules out every entry in it. This is what keeps "scan to the end of the trie" affordable:
-      // a bounded scan still touches each page once, but does no per-entry work on the pages that
-      // cannot contribute.
-      if (currentIndex == 0 && leafCannotContainInRangeKeys()) {
-        if (EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(0, toKey) > 0) {
-          exhausted = true;
-          positionedValid = false;
-          nextEntry = null;
-          return;
-        }
-        currentIndex = currentLeaf.getEntryCount();
-        continue;
-      }
-
-      // Check if current entry is within range — zero-alloc comparison against the pre-supplied
-      // bounds. The previous impl materialised a {@link MemorySegment} via {@code getKeySlice} +
-      // {@code MemorySegment.ofArray(toKey)} on every call (3 heap allocs per iteration); this
-      // path reads the key bytes straight from the HOT leaf's on/off-heap storage.
-      //
-      // An out-of-range key SKIPS the entry by default only under scanToEnd. Tries built by the
-      // branch-guarded writer (AbstractHOTIndexWriter.branchIfEscapesRoutedLeaf) visit leaves in
-      // lex order — validated by HOTBinnaConformanceTest and the validator's I12
-      // (subtree-ranges-disjoint) invariant — so the first key past {@code toKey} proves no
-      // further in-range keys exist and the scan can end there (the default fast path below).
-      //
-      // Resources built BEFORE that guard existed may hold a mask that misses a discriminating
-      // bit, letting one leaf carry two disjoint key ranges and making leaf visit order
-      // non-lex-monotonic. On those, ending at the first key past {@code toKey} would drop
-      // in-range keys in later-visited leaves; -Dsirix.hot.range.scanToEnd=true disables the
-      // early exit and runs the scan to the end of the trie instead. Whole leaves are skipped
-      // cheaply above, so the residual cost is page touches, not per-entry work.
-      if (isOutOfRange(currentIndex)) {
-        if (EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(currentIndex, toKey) > 0) {
-          // Default: stop at the first key past the upper bound. Sound on tries built by the
-          // branch-guarded writer; pre-guard resources opt out via
+      // Classify the current position from ONE batch of unpinned-leaf reads, then validate the
+      // stamp BEFORE the classification takes effect. Every cursor-state mutation below the read
+      // block is therefore derived from proven-stable bytes — which is also why torn recovery
+      // never rewinds: currentIndex only ever moves on validated decisions, so it stays correct
+      // across a leaf reload (content per PageReference is immutable).
+      final int verdict;
+      int entryCount = 0;
+      try {
+        entryCount = currentLeaf.getEntryCount();
+        if (currentIndex >= entryCount) {
+          // Current leaf exhausted.
+          verdict = VERDICT_ADVANCE_LEAF;
+        } else if (currentIndex == 0 && leafCannotContainInRangeKeys(entryCount)) {
+          // Whole-leaf skip. Entries WITHIN a leaf are sorted, so one comparison against each end
+          // rules out every entry in it. This is what keeps "scan to the end of the trie"
+          // affordable: a bounded scan still touches each page once, but does no per-entry work
+          // on the pages that cannot contribute. Ending the scan outright at the first leaf past
+          // {@code toKey} is sound on tries built by the branch-guarded writer
+          // (AbstractHOTIndexWriter.branchIfEscapesRoutedLeaf) — leaf visit order is lex-monotonic
+          // there; pre-guard resources opt out via -Dsirix.hot.range.scanToEnd=true.
+          verdict = EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(0, toKey) > 0
+              ? VERDICT_EXIT_SCAN
+              : VERDICT_SKIP_LEAF;
+        } else if (isOutOfRange(currentIndex)) {
+          // Per-entry range check — zero-alloc comparison against the pre-supplied bounds,
+          // reading the key bytes straight from the HOT leaf's on/off-heap storage. Same
+          // early-exit-vs-skip split as the whole-leaf case above: the first key past
+          // {@code toKey} ends the scan on lex-monotonic tries, and merely skips under
           // -Dsirix.hot.range.scanToEnd=true.
+          verdict =
+              EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(currentIndex, toKey) > 0
+                  ? VERDICT_EXIT_SCAN
+                  : VERDICT_SKIP_ENTRY;
+        } else {
+          verdict = VERDICT_EMIT;
+        }
+      } catch (RuntimeException e) {
+        if (reader.validateCurrentLeaf()) {
+          throw e; // stable bytes — genuine corruption, not a torn read
+        }
+        recoverTornLeaf(++tornRounds);
+        continue;
+      }
+      if (!reader.validateCurrentLeaf()) {
+        recoverTornLeaf(++tornRounds);
+        continue;
+      }
+      tornRounds = 0;
+      switch (verdict) {
+        case VERDICT_ADVANCE_LEAF -> {
+          if (!advanceToNextLeaf()) {
+            exhausted = true;
+            positionedValid = false;
+            nextEntry = null;
+            return;
+          }
+        }
+        case VERDICT_EXIT_SCAN -> {
           exhausted = true;
           positionedValid = false;
           nextEntry = null;
           return;
         }
-        currentIndex++;
-        continue;
+        case VERDICT_SKIP_LEAF -> currentIndex = entryCount;
+        case VERDICT_SKIP_ENTRY -> currentIndex++;
+        default -> {
+          // Valid entry found — expose via positional accessors.
+          positionedValid = true;
+          nextEntry = null;
+          return;
+        }
       }
-
-      // Valid entry found — expose via positional accessors.
-      positionedValid = true;
-      nextEntry = null;
-      return;
     }
+  }
+
+  /**
+   * Recover from a failed stamp validation: reload the current leaf through its {@link PageReference}
+   * and re-adopt the fresh copy at the SAME position — content per reference is immutable, so
+   * {@link #currentIndex} stays correct.
+   *
+   * @param round the number of consecutive torn rounds including this one, for the retry bound
+   */
+  private void recoverTornLeaf(final int round) {
+    if (round > MAX_TORN_ROUNDS) {
+      throw new IllegalStateException("HOT range cursor: leaf failed stamp validation on " + MAX_TORN_ROUNDS
+          + " consecutive rounds — sustained allocator thrashing");
+    }
+    if (!reader.refreshCurrentLeaf()) {
+      // A leaf that was resolvable once must stay resolvable — committed content is always
+      // reloadable and log-backed content lives for the transaction. Failing loudly beats
+      // silently truncating the scan.
+      throw new IllegalStateException("HOT range cursor: evicted leaf could not be reloaded through its PageReference");
+    }
+    currentLeaf = reader.currentLeafPage();
   }
 
   /**
@@ -286,8 +334,7 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * its highest key is still below {@code fromKey}. Sound because a leaf's own entries are sorted —
    * it is only the order BETWEEN leaves that is unreliable.
    */
-  private boolean leafCannotContainInRangeKeys() {
-    final int entryCount = currentLeaf.getEntryCount();
+  private boolean leafCannotContainInRangeKeys(final int entryCount) {
     if (entryCount == 0) {
       return true;
     }
@@ -309,8 +356,9 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    */
   private boolean advanceToNextLeaf() {
     // reader.advanceToNextLeaf resolves the next leaf through HOTTrieReader.loadPage, which
-    // guards it as the reader's single guarded leaf (releasing the previous one). The cursor
-    // holds no guard of its own — currentLeaf stays live for as long as it is current.
+    // snapshots its optimistic stamp as the reader's current leaf. No pin is taken — the leaf
+    // stays evictable, and every read of it goes through the validate-then-commit discipline
+    // in advanceToValid()/next().
     currentLeaf = reader.advanceToNextLeaf();
     if (currentLeaf == null) {
       return false;
@@ -330,10 +378,38 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
       throw new NoSuchElementException("No more entries in range");
     }
 
-    // Legacy Iterator API: materialise the Entry record on demand.
-    // Zero-alloc callers must use {@link #advance} +
-    // {@link #currentKeySlice} / {@link #currentValueSlice} / {@link #currentLeafPage} instead.
-    final Entry result = new Entry(currentLeaf.getKeySlice(currentIndex), currentLeaf.getValueSlice(currentIndex));
+    // Legacy Iterator API: materialise the Entry record on demand. The value bytes are COPIED out
+    // of the unpinned leaf slot and the copy stamp-validated, so the returned Entry stays readable
+    // no matter when the leaf is evicted afterwards (the key slice is already a heap-backed copy —
+    // see currentKeySlice()). Zero-alloc callers use {@link #advance} + the positional accessors
+    // and run their own validation via {@link #validateLeaf}.
+    Entry result = null;
+    for (int round = 1; result == null; round++) {
+      try {
+        final MemorySegment keySlice = currentLeaf.getKeySlice(currentIndex);
+        final MemorySegment valueSlice = currentLeaf.getValueSlice(currentIndex);
+        final long valueSize = valueSlice.byteSize();
+        if (valueSize > currentLeaf.slotCapacity()) {
+          // A length no slot can hold is either a torn read (validation below fails — retry) or
+          // real corruption (it holds — the throw escapes); either way it must not drive the
+          // allocation.
+          throw new IllegalStateException("value slice of " + valueSize + " bytes exceeds the slot capacity");
+        }
+        final byte[] valueCopy = new byte[(int) valueSize];
+        MemorySegment.copy(valueSlice, ValueLayout.JAVA_BYTE, 0, valueCopy, 0, valueCopy.length);
+        result = new Entry(keySlice, MemorySegment.ofArray(valueCopy));
+      } catch (RuntimeException e) {
+        if (reader.validateCurrentLeaf()) {
+          throw e;
+        }
+        recoverTornLeaf(round);
+        continue;
+      }
+      if (!reader.validateCurrentLeaf()) {
+        result = null;
+        recoverTornLeaf(round);
+      }
+    }
 
     // Advance to next entry
     currentIndex++;
@@ -372,9 +448,58 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
   }
 
   /**
+   * Whether every read of the current leaf's content since it was resolved saw stable bytes. One call
+   * covers the whole batch of reads since the leaf's stamp snapshot — consumers of the positional
+   * accessors call this AFTER reading (and before trusting the result), exactly like the cursor's own
+   * advance machinery does internally.
+   */
+  public boolean validateLeaf() {
+    return reader.validateCurrentLeaf();
+  }
+
+  /**
+   * Reload the current leaf through its {@link PageReference} after a failed {@link #validateLeaf}.
+   * The cursor keeps its position: content per reference is immutable, so every entry index computed
+   * against the stale copy stays valid against the fresh one. Callers re-read from
+   * {@link #currentLeafPage()} — the reload creates a NEW page object.
+   */
+  public void refreshLeaf() {
+    if (!reader.refreshCurrentLeaf()) {
+      throw new IllegalStateException("HOT range cursor: evicted leaf could not be reloaded through its PageReference");
+    }
+    currentLeaf = reader.currentLeafPage();
+  }
+
+  /**
+   * Re-seek the cursor to the first in-range entry whose composite key is {@code >=} the given key,
+   * keeping the cursor's original range bounds. Group-retry hook for consumers that aggregate several
+   * consecutive entries into one result: when a torn read is detected mid-group, the aggregate is
+   * discarded and the walk restarted at the group's first composite — which the caller holds as
+   * validated heap bytes.
+   *
+   * @param compositeKey the composite key to re-position at (inclusive)
+   */
+  public void restartAtComposite(final byte[] compositeKey) {
+    Objects.requireNonNull(compositeKey);
+    exhausted = false;
+    positionedValid = false;
+    nextEntry = null;
+    final HOTTrieReader.LowerBoundResult lb = reader.lowerBound(rootRef, compositeKey);
+    if (lb == null || lb.leaf == null) {
+      exhausted = true;
+      currentLeaf = null;
+      return;
+    }
+    currentLeaf = lb.leaf;
+    currentIndex = lb.indexInLeaf;
+    advanceToValid();
+  }
+
+  /**
    * iter#08 zero-alloc — key slice for the current positioned entry. Requires {@link #hasNext()} /
-   * {@link #advance()} to have returned {@code true}. The returned slice is valid for the duration of
-   * the current leaf guard; callers must not retain it across an {@link #advance} call.
+   * {@link #advance()} to have returned {@code true}. Callers must not retain the returned slice
+   * across an {@link #advance} call, and must confirm reads via {@link #validateLeaf()} before
+   * trusting them — the leaf is unpinned.
    *
    * <p>
    * Note this method still allocates a heap-backed {@link MemorySegment} wrapper — the underlying key
@@ -391,7 +516,9 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
 
   /**
    * iter#08 zero-alloc — value slice for the current positioned entry (already zero-copy via
-   * {@link HOTLeafPage#getValueSlice}). Slice lifetime bounded by the leaf guard.
+   * {@link HOTLeafPage#getValueSlice}). The slice views UNPINNED slot memory: consume it, then
+   * confirm via {@link #validateLeaf()} (retrying through {@link #refreshLeaf()} on failure) before
+   * trusting what was read.
    */
   public MemorySegment currentValueSlice() {
     if (!positionedValid) {
@@ -437,8 +564,8 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
 
   @Override
   public void close() {
-    // No guard to release here: HOTTrieReader.loadPage owns the single leaf guard and frees
-    // it on the next navigation or when the reader itself is closed.
+    // Nothing to release: neither the cursor nor the reader pins leaves. Clearing just drops the
+    // references so an abandoned cursor does not keep a leaf object reachable.
     currentLeaf = null;
     nextEntry = null;
     positionedValid = false;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTRangeCursor.java
@@ -111,8 +111,6 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
   private int currentIndex;
   private boolean exhausted = false;
 
-  // Pre-computed next entry (for hasNext/next pattern)
-  private Entry nextEntry = null;
 
   /**
    * iter#08 — when {@code true}, the cursor stays positioned on the current valid entry without
@@ -137,13 +135,6 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * whole trie.
    */
   private static final boolean EARLY_EXIT_PAST_UPPER_BOUND = !Boolean.getBoolean("sirix.hot.range.scanToEnd");
-
-  /**
-   * Bound on consecutive torn-read recovery rounds. Each round re-reads a freshly reloaded copy of
-   * the same immutable content, so every round races eviction independently — exhausting this many
-   * implies pathological allocator thrashing, not a logic error.
-   */
-  private static final int MAX_TORN_ROUNDS = 64;
 
   // Verdicts computed by one batch of unpinned-leaf reads in advanceToValid(), applied only after
   // the batch passes stamp validation.
@@ -209,9 +200,8 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    *
    * <p>
    * iter#08 — the positional state ({@link #positionedValid}, {@link #currentLeaf},
-   * {@link #currentIndex}) is authoritative. The legacy {@link #nextEntry} field is only populated on
-   * demand by {@link #next()} to preserve the {@link Iterator} API; the fast-path accessors read
-   * directly from the positional state.
+   * {@link #currentIndex}) is authoritative. The fast-path accessors read directly from that
+   * positional state.
    */
   private void advanceToValid() {
     int tornRounds = 0;
@@ -223,6 +213,7 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
       // across a leaf reload (content per PageReference is immutable).
       final int verdict;
       int entryCount = 0;
+      int rangeVerdict = 0;
       try {
         entryCount = currentLeaf.getEntryCount();
         if (currentIndex >= entryCount) {
@@ -239,16 +230,18 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
           verdict = EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(0, toKey) > 0
               ? VERDICT_EXIT_SCAN
               : VERDICT_SKIP_LEAF;
-        } else if (isOutOfRange(currentIndex)) {
+        } else if ((rangeVerdict = classifyAgainstBounds(currentIndex)) != 0) {
           // Per-entry range check — zero-alloc comparison against the pre-supplied bounds,
           // reading the key bytes straight from the HOT leaf's on/off-heap storage. Same
           // early-exit-vs-skip split as the whole-leaf case above: the first key past
           // {@code toKey} ends the scan on lex-monotonic tries, and merely skips under
           // -Dsirix.hot.range.scanToEnd=true.
-          verdict =
-              EARLY_EXIT_PAST_UPPER_BOUND && toKey != null && currentLeaf.compareKeyWithBound(currentIndex, toKey) > 0
-                  ? VERDICT_EXIT_SCAN
-                  : VERDICT_SKIP_ENTRY;
+          // rangeVerdict > 0 means "past toKey", which the compare above already established — no
+          // second full-key comparison per rejected entry (these run byte-at-a-time over keys up to
+          // 256 bytes, so the duplicate doubled the cost of every out-of-range tail).
+          verdict = EARLY_EXIT_PAST_UPPER_BOUND && rangeVerdict > 0
+              ? VERDICT_EXIT_SCAN
+              : VERDICT_SKIP_ENTRY;
         } else {
           verdict = VERDICT_EMIT;
         }
@@ -269,14 +262,12 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
           if (!advanceToNextLeaf()) {
             exhausted = true;
             positionedValid = false;
-            nextEntry = null;
             return;
           }
         }
         case VERDICT_EXIT_SCAN -> {
           exhausted = true;
           positionedValid = false;
-          nextEntry = null;
           return;
         }
         case VERDICT_SKIP_LEAF -> currentIndex = entryCount;
@@ -284,7 +275,6 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
         default -> {
           // Valid entry found — expose via positional accessors.
           positionedValid = true;
-          nextEntry = null;
           return;
         }
       }
@@ -299,21 +289,30 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * @param round the number of consecutive torn rounds including this one, for the retry bound
    */
   private void recoverTornLeaf(final int round) {
-    if (round > MAX_TORN_ROUNDS) {
-      throw new IllegalStateException("HOT range cursor: leaf failed stamp validation on " + MAX_TORN_ROUNDS
-          + " consecutive rounds — sustained allocator thrashing");
-    }
-    if (!reader.refreshCurrentLeaf()) {
-      // A leaf that was resolvable once must stay resolvable — committed content is always
-      // reloadable and log-backed content lives for the transaction. Failing loudly beats
-      // silently truncating the scan.
-      throw new IllegalStateException("HOT range cursor: evicted leaf could not be reloaded through its PageReference");
-    }
+    recoverTorn(round);
+  }
+
+  /**
+   * Bounded torn-read recovery for consumers driving this cursor: reload the current leaf and
+   * re-adopt the fresh copy at the SAME position. Content per {@link PageReference} is immutable, so
+   * {@link #currentEntryIndex()} stays correct across the reload — callers re-read, they do not
+   * rewind.
+   *
+   * @param round how many consecutive torn rounds this is, including the current one
+   */
+  public void recoverTorn(final int round) {
+    reader.recoverTorn(round, "HOT range cursor");
     currentLeaf = reader.currentLeafPage();
   }
 
   /**
-   * Is the entry at {@code index} outside {@code [fromKey, toKey]}?
+   * Where the entry at {@code index} sits relative to {@code [fromKey, toKey]}: {@code -1} below
+   * {@code fromKey}, {@code 0} in range, {@code 1} past {@code toKey}.
+   *
+   * <p>
+   * Three-way rather than boolean so the caller can tell "past the upper bound" (which ends the scan
+   * on a lex-monotonic trie) from "below the lower bound" without repeating the comparison — these
+   * run byte-at-a-time over the full key.
    *
    * <p>
    * Both ends are checked. Checking only the upper bound was safe while the cursor could assume it
@@ -321,12 +320,15 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * can present keys BELOW {@code fromKey} after the scan has begun, and those were being returned to
    * the caller as if they were in range.
    */
-  private boolean isOutOfRange(final int index) {
+  private int classifyAgainstBounds(final int index) {
     if (fromKey != null && currentLeaf.compareKeyWithBound(index, fromKey) < 0) {
-      return true;
+      return -1;
     }
     // Upper bound stays INCLUSIVE, as it was when this comparison ended the scan.
-    return toKey != null && currentLeaf.compareKeyWithBound(index, toKey) > 0;
+    if (toKey != null && currentLeaf.compareKeyWithBound(index, toKey) > 0) {
+      return 1;
+    }
+    return 0;
   }
 
   /**
@@ -464,10 +466,7 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
    * {@link #currentLeafPage()} — the reload creates a NEW page object.
    */
   public void refreshLeaf() {
-    if (!reader.refreshCurrentLeaf()) {
-      throw new IllegalStateException("HOT range cursor: evicted leaf could not be reloaded through its PageReference");
-    }
-    currentLeaf = reader.currentLeafPage();
+    recoverTorn(1);
   }
 
   /**
@@ -483,7 +482,6 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
     Objects.requireNonNull(compositeKey);
     exhausted = false;
     positionedValid = false;
-    nextEntry = null;
     final HOTTrieReader.LowerBoundResult lb = reader.lowerBound(rootRef, compositeKey);
     if (lb == null || lb.leaf == null) {
       exhausted = true;
@@ -567,7 +565,6 @@ public final class HOTRangeCursor implements Iterator<HOTRangeCursor.Entry>, Aut
     // Nothing to release: neither the cursor nor the reader pins leaves. Clearing just drops the
     // references so an abandoned cursor does not keep a leaf object reachable.
     currentLeaf = null;
-    nextEntry = null;
     positionedValid = false;
     exhausted = true;
     reader.clearPath();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -29,6 +29,7 @@
 package io.sirix.access.trx.page;
 
 import io.sirix.api.StorageEngineReader;
+import io.sirix.api.StorageEngineWriter;
 import io.sirix.index.hot.DiscriminativeBitComputer;
 import io.sirix.page.HOTIndirectPage;
 import io.sirix.page.HOTLeafPage;
@@ -217,7 +218,16 @@ public final class HOTTrieReader implements AutoCloseable {
    */
   public HOTTrieReader(StorageEngineReader storageEngineReader) {
     this.storageEngineReader = Objects.requireNonNull(storageEngineReader);
+    // Child-first-key memoization is sound ONLY on a read-only snapshot: everything below a
+    // committed PageReference is immutable (swizzle/evict cycles reload identical content), so
+    // a subtree's first key is a constant of the parent page object. A WRITE transaction can
+    // re-point a child reference's page without touching the parent node, which no
+    // parent-local invalidation can observe — so writer-backed readers never touch the cache.
+    this.firstKeyCacheEnabled = !(storageEngineReader instanceof StorageEngineWriter);
   }
+
+  /** See the constructor — memoized first-key probes are restricted to read-only snapshots. */
+  private final boolean firstKeyCacheEnabled;
 
   /**
    * Find value for exact key match. Returns null if not found - no Optional allocation!
@@ -436,6 +446,39 @@ public final class HOTTrieReader implements AutoCloseable {
       // non-exact match the answer is the same (no leaf entry equals searchKey).
       return new LowerBoundResult(candidateLeaf, insertionPoint);
     }
+
+    // Phase 2c: searchKey sorts past the candidate's LAST entry. Peek the lex-successor leaf
+    // via the phase-1 path stack: candidate.last < searchKey, so when successor.first >=
+    // searchKey, I8 + I12 (leaf ranges globally ordered and disjoint — writer-enforced and
+    // detector-verified on this branch) leave nothing between the two leaves and
+    // (successor, 0) IS the bound. One guarded leaf hop instead of the walk-up. When even the
+    // successor's first key is below searchKey, the PEXT landing was genuinely off-subtree
+    // lexically — the very case the post-hoc verify in lowerBound() has been rejecting into
+    // the lex re-descent — so go there directly (the peek consumed the path stack, and the
+    // lex descent rebuilds it from scratch anyway). Before this shortcut, EVERY absent-key
+    // seek that ran past its landing leaf paid the full re-descent: ~12-16 µs against ~0.7 µs
+    // for a present key on the 33K-key movies index. With the lex fallback explicitly
+    // disabled (hot.strict.phase7u.lexfallback.disable) the peek is skipped and the original
+    // phases 3-5 walk-up below runs on the untouched path stack, exactly as before.
+    if (!Boolean.getBoolean("hot.strict.phase7u.lexfallback.disable")) {
+      final HOTLeafPage successor = advanceToNextLeaf();
+      if (successor != null && successor.getEntryCount() > 0) {
+        final int cmp = successor.compareKeyWithBound(0, searchKey);
+        if (cmp > 0 || (cmp == 0 && isLowerBound)) {
+          return new LowerBoundResult(successor, 0);
+        }
+        if (cmp == 0) {
+          // upper_bound and the successor's first entry EQUALS searchKey: step past it.
+          return advanceOneFrom(successor, 0);
+        }
+      }
+      // successor == null: searchKey is past every key reachable from the landing. An empty
+      // successor or one whose first key is still below searchKey: off-subtree landing. All
+      // three re-derive the answer from scratch via the lex descent (which also repopulates
+      // the path stack the peek consumed).
+      return phase7uLexDescentFallback(rootRef, searchKey, isLowerBound);
+    }
+
     final byte[] candidateKey = candidateLeaf.getFirstKey();
     final int discBit = DiscriminativeBitComputer.computeDifferingBit(candidateKey, searchKey);
     if (discBit < 0) {
@@ -677,6 +720,12 @@ public final class HOTTrieReader implements AutoCloseable {
    * </p>
    */
   private byte[] getFirstKeyOfChild(HOTIndirectPage parent, int childIdx) {
+    if (firstKeyCacheEnabled) {
+      final byte[] cached = parent.cachedChildFirstKey(childIdx);
+      if (cached != null) {
+        return cached;
+      }
+    }
     PageReference ref = parent.getChildReference(childIdx);
     while (ref != null) {
       final Page page = loadPage(ref);
@@ -684,7 +733,11 @@ public final class HOTTrieReader implements AutoCloseable {
         return new byte[0];
       }
       if (page instanceof HOTLeafPage leaf) {
-        return leaf.getFirstKey();
+        final byte[] firstKey = leaf.getFirstKey();
+        if (firstKeyCacheEnabled && firstKey != null && firstKey.length > 0) {
+          parent.cacheChildFirstKey(childIdx, firstKey);
+        }
+        return firstKey;
       }
       if (!(page instanceof HOTIndirectPage indirect)) {
         return new byte[0];
@@ -711,6 +764,12 @@ public final class HOTTrieReader implements AutoCloseable {
    * @return the comparison result, or {@link #UNRESOLVABLE_SUBTREE} when the descent dead-ends
    */
   private int compareFirstKeyOfChildWithBound(HOTIndirectPage parent, int childIdx, byte[] bound) {
+    if (firstKeyCacheEnabled) {
+      final byte[] cached = parent.cachedChildFirstKey(childIdx);
+      if (cached != null) {
+        return Arrays.compareUnsigned(cached, bound);
+      }
+    }
     PageReference ref = parent.getChildReference(childIdx);
     int depth = 0;
     while (ref != null && depth++ < MAX_TREE_HEIGHT) {
@@ -719,9 +778,19 @@ public final class HOTTrieReader implements AutoCloseable {
         return UNRESOLVABLE_SUBTREE;
       }
       if (page instanceof HOTLeafPage leaf) {
-        return leaf.getEntryCount() == 0
-            ? UNRESOLVABLE_SUBTREE
-            : leaf.compareKeyWithBound(0, bound);
+        if (leaf.getEntryCount() == 0) {
+          return UNRESOLVABLE_SUBTREE;
+        }
+        if (firstKeyCacheEnabled) {
+          // Materialize once so every later probe of this slot is a plain array compare with
+          // zero page loads and zero guard churn — the dominant cost of absent-key seeks.
+          final byte[] firstKey = leaf.getFirstKey();
+          if (firstKey != null && firstKey.length > 0) {
+            parent.cacheChildFirstKey(childIdx, firstKey);
+            return Arrays.compareUnsigned(firstKey, bound);
+          }
+        }
+        return leaf.compareKeyWithBound(0, bound);
       }
       if (!(page instanceof HOTIndirectPage indirect)) {
         return UNRESOLVABLE_SUBTREE;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -222,6 +222,19 @@ public final class HOTTrieReader implements AutoCloseable {
   private long currentLeafStamp = HOTLeafPage.STAMP_INVALID;
 
   /**
+   * The leaf binding {@link #currentLeafStamp} was issued under, snapshotted immediately before it.
+   *
+   * <p>
+   * A stamp is a per-SLOT sequence number and proves nothing without the slot it belongs to: two
+   * slots' counters are unrelated and can hold equal values at once, so validating a stamp against
+   * whatever slot the leaf is bound to NOW can return {@code true} by coincidence. Carrying the
+   * binding here costs one {@code long} per reader and turns that coincidence into a rejected read.
+   * {@link HOTLeafPage#STAMP_INVALID} is odd, so the initial value never validates either.
+   * </p>
+   */
+  private long currentLeafBinding = HOTLeafPage.STAMP_INVALID;
+
+  /**
    * Bound on how many times {@link #loadPage} reloads a leaf that keeps getting evicted between
    * resolve and stamp snapshot. Each retry reads a fresh copy from storage, so the race is
    * independent per attempt; exhausting this many implies pathological thrashing.
@@ -1402,8 +1415,13 @@ public final class HOTTrieReader implements AutoCloseable {
       // closed or its slot is mid-teardown — drop the swizzle and reload a fresh copy. Every
       // read of this leaf's content must later pass validateCurrentLeaf() before its result is
       // trusted; the leaf stays evictable the entire time.
+      //
+      // The binding comes FIRST and travels with the stamp: a stamp is a per-slot sequence, so a
+      // rebind between the two reads must be detectable, and an ODD binding means a rebind is in
+      // flight right now — nothing read under it could be proved, so reload instead of reading.
+      final long binding = leaf.readStampBinding();
       final long stamp = leaf.readStamp();
-      if ((stamp & 1L) != 0L) {
+      if ((binding & 1L) != 0L || (stamp & 1L) != 0L) {
         ref.setPage(null);
         continue;
       }
@@ -1417,6 +1435,7 @@ public final class HOTTrieReader implements AutoCloseable {
       }
       currentLeaf = leaf;
       currentLeafRef = ref;
+      currentLeafBinding = binding;
       currentLeafStamp = stamp;
       return leaf;
     }
@@ -1430,7 +1449,7 @@ public final class HOTTrieReader implements AutoCloseable {
    */
   public boolean validateCurrentLeaf() {
     final HOTLeafPage leaf = currentLeaf;
-    return leaf == null || leaf.validateStamp(currentLeafStamp);
+    return leaf == null || leaf.validateStamp(currentLeafBinding, currentLeafStamp);
   }
 
   /** The most-recently-resolved leaf, or {@code null}. Reads of it require stamp validation. */
@@ -1549,6 +1568,7 @@ public final class HOTTrieReader implements AutoCloseable {
     // idle reader does not keep a leaf object (and its stamp) reachable.
     currentLeaf = null;
     currentLeafRef = null;
+    currentLeafBinding = HOTLeafPage.STAMP_INVALID;
     currentLeafStamp = HOTLeafPage.STAMP_INVALID;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -29,7 +29,6 @@
 package io.sirix.access.trx.page;
 
 import io.sirix.api.StorageEngineReader;
-import io.sirix.api.StorageEngineWriter;
 import io.sirix.index.hot.DiscriminativeBitComputer;
 import io.sirix.page.HOTIndirectPage;
 import io.sirix.page.HOTLeafPage;
@@ -255,7 +254,16 @@ public final class HOTTrieReader implements AutoCloseable {
     // a subtree's first key is a constant of the parent page object. A WRITE transaction can
     // re-point a child reference's page without touching the parent node, which no
     // parent-local invalidation can observe — so writer-backed readers never touch the cache.
-    this.firstKeyCacheEnabled = !(storageEngineReader instanceof StorageEngineWriter);
+    //
+    // hasTrxIntentLog() rather than `instanceof StorageEngineWriter`, and the distinction is
+    // load-bearing here for the same reason AbstractHOTIndexReader states it for the lookup cache:
+    // StorageEngineWriter#getStorageEngineReader hands out a PLAIN NodeStorageEngineReader carrying
+    // the writer's intent log, which is not a StorageEngineWriter yet resolves uncommitted pages
+    // under an already-committed revision number. AbstractHOTIndexReader constructs this class with
+    // exactly the reader it was handed, so the two memoizations sit one call apart and must agree
+    // on what "read-only snapshot" means — the intent-log test is the property that actually
+    // matters, and it is strictly the more conservative of the two.
+    this.firstKeyCacheEnabled = !storageEngineReader.hasTrxIntentLog();
   }
 
   /** See the constructor — memoized first-key probes are restricted to read-only snapshots. */

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -46,15 +46,17 @@ import java.util.concurrent.Semaphore;
  * HOT trie reader for HOT (Height Optimized Trie) navigation.
  * 
  * <p>
- * This class provides read-only access to HOT indexes with proper guard management to prevent page
- * eviction during active use.
+ * This class provides read-only access to HOT indexes with OPTIMISTIC stamp validation instead of
+ * page pinning: leaves stay evictable at all times, every batch of leaf-content reads is confirmed
+ * against the FrameSlotAllocator's per-slot seqlock version before its result escapes, and a failed
+ * validation retries on a freshly reloaded copy of the same immutable content.
  * </p>
- * 
+ *
  * <p>
  * <b>Key Features:</b>
  * </p>
  * <ul>
- * <li>Guard acquisition for page lifetime management</li>
+ * <li>Optimistic stamp validation for page lifetime safety — no pins, no guard churn</li>
  * <li>Zero-copy value access via MemorySegment slices</li>
  * <li>SIMD-optimized child lookup via HOTIndirectPage</li>
  * <li>Pre-allocated traversal arrays for zero allocations</li>
@@ -181,6 +183,18 @@ public final class HOTTrieReader implements AutoCloseable {
     return new Semaphore(Math.max(0, configured));
   }
 
+  /**
+   * Phase-7u strategy flags, resolved ONCE at class load. They are JVM-lifetime debug switches, but
+   * they were being read per seek through {@link Boolean#getBoolean}, i.e. a lookup in the JDK's
+   * synchronized system-Properties table on the microsecond-scale absent-key path — a process-wide
+   * lock acquisition per seek under concurrent readers. Worse, since they select between different
+   * bound algorithms, a property changed mid-run used to change lower-bound semantics between calls.
+   * As constants the JIT folds the branches away entirely.
+   */
+  private static final boolean LEX_PRIMARY = Boolean.getBoolean("hot.strict.phase7u.lexprimary");
+
+  private static final boolean LEX_FALLBACK_DISABLED = Boolean.getBoolean("hot.strict.phase7u.lexfallback.disable");
+
   /** The storage engine reader. */
   private final StorageEngineReader storageEngineReader;
 
@@ -197,19 +211,29 @@ public final class HOTTrieReader implements AutoCloseable {
   private final short[] pathMsbAtDepth = new short[MAX_TREE_HEIGHT];
   private int pathDepth = 0;
 
-  // ===== Currently guarded leaf page =====
-  // This reader holds at most one leaf guard at a time: the most-recently-resolved leaf,
-  // managed entirely by loadPage. A guarded leaf cannot be evicted, so every read of leaf
-  // content by this reader (point lookup, range cursor, lower-bound walk) is safe for as
-  // long as that leaf remains the current one.
-  private HOTLeafPage guardedLeaf = null;
+  // ===== Current leaf, protected by OPTIMISTIC STAMPS — never pinned =====
+  // The reader holds no guard: leaves stay evictable at all times, and safety comes from the
+  // FrameSlotAllocator's per-slot seqlock versions instead. loadPage snapshots the resolved
+  // leaf's stamp; every read of leaf content is trusted only after validateCurrentLeaf()
+  // confirms the stamp, and one validation covers every read since the snapshot. On a failed
+  // validation the leaf is re-resolved through its PageReference — content per reference is
+  // immutable, so every slot index computed before the failure stays valid after the reload.
+  private HOTLeafPage currentLeaf = null;
+  private PageReference currentLeafRef = null;
+  private long currentLeafStamp = HOTLeafPage.STAMP_INVALID;
 
   /**
-   * Bound on how many times {@link #loadPage} reloads a leaf after losing the resolve-then- guard
-   * race to a concurrent eviction. Each retry reads a fresh copy from storage, so the race is
+   * Bound on how many times {@link #loadPage} reloads a leaf that keeps getting evicted between
+   * resolve and stamp snapshot. Each retry reads a fresh copy from storage, so the race is
    * independent per attempt; exhausting this many implies pathological thrashing.
    */
-  private static final int MAX_GUARD_ACQUIRE_RETRIES = 256;
+  private static final int MAX_LOAD_RETRIES = 256;
+
+  /**
+   * Bound on validate-and-retry rounds for a single positioning decision. A retry re-reads a freshly
+   * reloaded copy of the same immutable content, so each round races eviction independently.
+   */
+  private static final int MAX_STAMP_RETRIES = 64;
 
   /**
    * Create a new HOTTrieReader.
@@ -232,6 +256,13 @@ public final class HOTTrieReader implements AutoCloseable {
   /**
    * Find value for exact key match. Returns null if not found - no Optional allocation!
    *
+   * <p>
+   * The returned slice views UNPINNED slot memory: the found/not-found decision is stamp-validated
+   * before this method returns, but a caller that reads the slice afterwards must confirm those reads
+   * via {@link #validateCurrentLeaf()} (retrying through {@link #refreshCurrentLeaf()} on failure) —
+   * or copy the bytes and validate the copy.
+   * </p>
+   *
    * @param rootRef the root page reference
    * @param key the search key
    * @return the value as a MemorySegment slice, or null if not found
@@ -250,17 +281,34 @@ public final class HOTTrieReader implements AutoCloseable {
     // that land at the leaf; for now we always re-navigate, which is
     // still cheap for log_32-shallow HOT trees.
 
-    // navigateToLeaf resolves the leaf through loadPage, which holds the leaf's guard as
-    // this reader's single guarded leaf — it cannot be evicted until the next navigation.
-    final HOTLeafPage leaf = navigateToLeaf(rootRef, key);
-    if (leaf == null) {
-      return null;
+    // navigateToLeaf resolves the leaf through loadPage, which snapshots its optimistic stamp
+    // as this reader's current leaf. The leaf stays evictable the whole time: findEntry and the
+    // slice computation may read torn bytes if the slot is reclaimed mid-read, so the batch is
+    // validated once before the result escapes — and retried on a fresh copy if it fails.
+    // Content per PageReference is immutable, so a retry re-derives the identical answer.
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      final HOTLeafPage leaf = navigateToLeaf(rootRef, key);
+      if (leaf == null) {
+        return null;
+      }
+      final MemorySegment value;
+      try {
+        final int index = leaf.findEntry(key);
+        value = index >= 0
+            ? leaf.getValueSlice(index)
+            : null;
+      } catch (RuntimeException e) {
+        if (validateCurrentLeaf()) {
+          throw e; // stable bytes — genuine corruption, not a torn read
+        }
+        continue;
+      }
+      if (!validateCurrentLeaf()) {
+        continue;
+      }
+      return value;
     }
-    final int index = leaf.findEntry(key);
-    if (index < 0) {
-      return null;
-    }
-    return leaf.getValueSlice(index);
+    throw stampRetriesExhausted("get");
   }
 
   /**
@@ -274,21 +322,42 @@ public final class HOTTrieReader implements AutoCloseable {
     Objects.requireNonNull(rootRef);
     Objects.requireNonNull(key);
 
-    // navigateToLeaf resolves the leaf through loadPage, which guards it as this reader's
-    // single guarded leaf for the duration of the lookup — see get().
-    final HOTLeafPage leaf = navigateToLeaf(rootRef, key);
-    return leaf != null && leaf.findEntry(key) >= 0;
+    // Same optimistic discipline as get(): compute on the evictable leaf, validate the stamp
+    // before the boolean escapes, retry on a reloaded copy if the bytes were torn.
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      final HOTLeafPage leaf = navigateToLeaf(rootRef, key);
+      if (leaf == null) {
+        return false;
+      }
+      final boolean found;
+      try {
+        found = leaf.findEntry(key) >= 0;
+      } catch (RuntimeException e) {
+        if (validateCurrentLeaf()) {
+          throw e;
+        }
+        continue;
+      }
+      if (!validateCurrentLeaf()) {
+        continue;
+      }
+      return found;
+    }
+    throw stampRetriesExhausted("containsKey");
   }
 
   /**
    * Create a range cursor for iterating over a key range.
    *
    * @param rootRef the root page reference
-   * @param fromKey the start key (inclusive)
-   * @param toKey the end key (inclusive)
+   * @param fromKey the start key (inclusive), or {@code null} to start at the leftmost leaf — which
+   *        is NOT the same as an empty array: {@code null} takes the deterministic
+   *        {@code navigateToLeftmostLeaf} descent, an empty array a PEXT-routed
+   *        {@link #lowerBound(PageReference, byte[])} on an all-zero partial key
+   * @param toKey the end key (inclusive), or {@code null} for an unbounded upper end
    * @return the range cursor
    */
-  public HOTRangeCursor range(PageReference rootRef, byte[] fromKey, byte[] toKey) {
+  public HOTRangeCursor range(PageReference rootRef, byte @Nullable [] fromKey, byte @Nullable [] toKey) {
     return new HOTRangeCursor(this, rootRef, fromKey, toKey);
   }
 
@@ -312,6 +381,13 @@ public final class HOTTrieReader implements AutoCloseable {
 
     /** Sentinel for "seek past end of trie". */
     private static final LowerBoundResult EXHAUSTED = new LowerBoundResult(null, -1);
+
+    /**
+     * Sentinel for "a stamp validation failed mid-seek" — the leaf whose content fed a positioning
+     * decision was reclaimed while being read. Never escapes to callers: the public entry points
+     * ({@code lowerBound}/{@code upperBound}) re-run the whole seek on freshly reloaded copies.
+     */
+    private static final LowerBoundResult RETRY = new LowerBoundResult(null, -2);
   }
 
   /**
@@ -361,31 +437,53 @@ public final class HOTTrieReader implements AutoCloseable {
     // firstKey), and unaffected by I5/I6 violations from byte-10 encoder discontinuity.
     // Cost: one extra firstKey-load per indirect-child during descent; works on any
     // I8-conformant trie.
-    if (Boolean.getBoolean("hot.strict.phase7u.lexprimary")) {
-      return phase7uLexDescentFallback(rootRef, searchKey, true);
+    if (LEX_PRIMARY) {
+      return retryingLexDescent(rootRef, searchKey, true);
     }
-    final LowerBoundResult result = lowerOrUpperBound(rootRef, searchKey, true);
-    // Phase 7u — verify-and-fall-back. The normal PEXT descent + walk-up returns a result,
-    // but for trees with I5/I6 violations from byte-10 encoder discontinuity, the returned
-    // leaf may not contain searchKey even though it IS stored. Opt-out via
-    // -Dhot.strict.phase7u.lexfallback.disable=true.
-    if (Boolean.getBoolean("hot.strict.phase7u.lexfallback.disable"))
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      final LowerBoundResult result = lowerOrUpperBound(rootRef, searchKey, true);
+      if (result == LowerBoundResult.RETRY) {
+        continue; // a leaf feeding a positioning decision was reclaimed mid-read — redo the seek
+      }
+      // Phase 7u — verify-and-fall-back. The normal PEXT descent + walk-up returns a result,
+      // but for trees with I5/I6 violations from byte-10 encoder discontinuity, the returned
+      // leaf may not contain searchKey even though it IS stored. Opt-out via
+      // -Dhot.strict.phase7u.lexfallback.disable=true.
+      if (LEX_FALLBACK_DISABLED)
+        return result;
+      if (result == LowerBoundResult.EXHAUSTED) {
+        return retryingLexDescent(rootRef, searchKey, true);
+      }
+      // Check whether returned leaf actually contains searchKey or has it as next-key.
+      // For lower_bound semantics: returned key must be ≥ searchKey AND ≤ any other stored key
+      // ≥ searchKey. If returned key < searchKey, PEXT routing missed — fall back.
+      // Zero-alloc: compareKeyWithBound reads commonPrefix + slot suffix directly off the leaf's
+      // off-heap segment, skipping the byte[] reconstruction that getKey + Arrays.compareUnsigned
+      // would force on every fallback check. The compare reads the (unpinned) leaf's slot bytes,
+      // so the misrouted/not-misrouted verdict is trusted only after a stamp validation — every
+      // result path in lowerOrUpperBound leaves its leaf as the reader's current leaf.
+      final HOTLeafPage leaf = result.leaf;
+      final int idx = result.indexInLeaf;
+      if (leaf != null) {
+        final boolean misrouted;
+        try {
+          misrouted = idx < leaf.getEntryCount() && leaf.compareKeyWithBound(idx, searchKey) < 0;
+        } catch (RuntimeException e) {
+          if (validateCurrentLeaf()) {
+            throw e;
+          }
+          continue;
+        }
+        if (!validateCurrentLeaf()) {
+          continue;
+        }
+        if (misrouted) {
+          return retryingLexDescent(rootRef, searchKey, true);
+        }
+      }
       return result;
-    if (result == LowerBoundResult.EXHAUSTED) {
-      return phase7uLexDescentFallback(rootRef, searchKey, true);
     }
-    // Check whether returned leaf actually contains searchKey or has it as next-key.
-    // For lower_bound semantics: returned key must be ≥ searchKey AND ≤ any other stored key
-    // ≥ searchKey. If returned key < searchKey, PEXT routing missed — fall back.
-    // Zero-alloc: compareKeyWithBound reads commonPrefix + slot suffix directly off the leaf's
-    // off-heap segment, skipping the byte[] reconstruction that getKey + Arrays.compareUnsigned
-    // would force on every fallback check.
-    final HOTLeafPage leaf = result.leaf;
-    final int idx = result.indexInLeaf;
-    if (leaf != null && idx < leaf.getEntryCount() && leaf.compareKeyWithBound(idx, searchKey) < 0) {
-      return phase7uLexDescentFallback(rootRef, searchKey, true);
-    }
-    return result;
+    throw stampRetriesExhausted("lowerBound");
   }
 
   /**
@@ -393,7 +491,30 @@ public final class HOTTrieReader implements AutoCloseable {
    * {@link #lowerBound(PageReference, byte[])} for algorithm details.
    */
   public LowerBoundResult upperBound(PageReference rootRef, byte[] searchKey) {
-    return lowerOrUpperBound(rootRef, searchKey, false);
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      final LowerBoundResult result = lowerOrUpperBound(rootRef, searchKey, false);
+      if (result != LowerBoundResult.RETRY) {
+        return result;
+      }
+    }
+    throw stampRetriesExhausted("upperBound");
+  }
+
+  /** Bounded-retry wrapper for the lex descent, absorbing {@link LowerBoundResult#RETRY}. */
+  private LowerBoundResult retryingLexDescent(PageReference rootRef, byte[] searchKey, boolean isLowerBound) {
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      final LowerBoundResult result = phase7uLexDescentFallback(rootRef, searchKey, isLowerBound);
+      if (result != LowerBoundResult.RETRY) {
+        return result;
+      }
+    }
+    throw stampRetriesExhausted("lexDescent");
+  }
+
+  /** A seek that could not observe stable leaf bytes in {@link #MAX_STAMP_RETRIES} rounds. */
+  private static IllegalStateException stampRetriesExhausted(final String operation) {
+    return new IllegalStateException("HOT: " + operation + " failed stamp validation on every one of "
+        + MAX_STAMP_RETRIES + " attempts — sustained allocator thrashing");
   }
 
   private LowerBoundResult lowerOrUpperBound(PageReference rootRef, byte[] searchKey, boolean isLowerBound) {
@@ -405,15 +526,31 @@ public final class HOTTrieReader implements AutoCloseable {
     if (candidateLeaf == null) {
       // Phase 7u — lex-descent fallback. PEXT navigation returned null (= structural
       // failure). Try a pure-lex descent that ignores PEXT/partial-key routing.
-      if (!Boolean.getBoolean("hot.strict.phase7u.lexfallback.disable")) {
+      if (!LEX_FALLBACK_DISABLED) {
         return phase7uLexDescentFallback(rootRef, searchKey, isLowerBound);
       }
       return LowerBoundResult.EXHAUSTED;
     }
 
     // Phase 2: try exact match in candidate leaf first (cheap fast path; matches the
-    // C++ reference where exact match through PEXT is the common case).
-    final int exact = candidateLeaf.findEntry(searchKey);
+    // C++ reference where exact match through PEXT is the common case). findEntry and the
+    // entry count are one read batch against the unpinned leaf — validated ONCE below, before
+    // any decision derived from them escapes. This must happen before the phase-2c successor
+    // peek replaces the reader's current-leaf stamp.
+    final int exact;
+    final int candidateEntryCount;
+    try {
+      exact = candidateLeaf.findEntry(searchKey);
+      candidateEntryCount = candidateLeaf.getEntryCount();
+    } catch (RuntimeException e) {
+      if (validateCurrentLeaf()) {
+        throw e; // stable bytes — genuine corruption, not a torn read
+      }
+      return LowerBoundResult.RETRY;
+    }
+    if (!validateCurrentLeaf()) {
+      return LowerBoundResult.RETRY;
+    }
     if (exact >= 0) {
       if (isLowerBound) {
         return new LowerBoundResult(candidateLeaf, exact);
@@ -435,7 +572,6 @@ public final class HOTTrieReader implements AutoCloseable {
     // leaves the walk-up phase below becomes incorrect for queries whose insertion point is
     // strictly inside the candidate (e.g., chunked-bitmap range scans for prefixes whose
     // chunkIdx_be4 trailer differs from any stored composite).
-    final int candidateEntryCount = candidateLeaf.getEntryCount();
     if (candidateEntryCount == 0) {
       // Shouldn't happen — empty leaves aren't part of a populated trie.
       return LowerBoundResult.EXHAUSTED;
@@ -460,16 +596,35 @@ public final class HOTTrieReader implements AutoCloseable {
     // for a present key on the 33K-key movies index. With the lex fallback explicitly
     // disabled (hot.strict.phase7u.lexfallback.disable) the peek is skipped and the original
     // phases 3-5 walk-up below runs on the untouched path stack, exactly as before.
-    if (!Boolean.getBoolean("hot.strict.phase7u.lexfallback.disable")) {
+    if (!LEX_FALLBACK_DISABLED) {
       final HOTLeafPage successor = advanceToNextLeaf();
-      if (successor != null && successor.getEntryCount() > 0) {
-        final int cmp = successor.compareKeyWithBound(0, searchKey);
-        if (cmp > 0 || (cmp == 0 && isLowerBound)) {
-          return new LowerBoundResult(successor, 0);
+      if (successor != null) {
+        // The peek made successor the reader's current leaf; batch its reads and validate once
+        // before the cmp verdict routes the seek.
+        final int successorCount;
+        final int cmp;
+        try {
+          successorCount = successor.getEntryCount();
+          cmp = successorCount > 0
+              ? successor.compareKeyWithBound(0, searchKey)
+              : 0;
+        } catch (RuntimeException e) {
+          if (validateCurrentLeaf()) {
+            throw e;
+          }
+          return LowerBoundResult.RETRY;
         }
-        if (cmp == 0) {
-          // upper_bound and the successor's first entry EQUALS searchKey: step past it.
-          return advanceOneFrom(successor, 0);
+        if (!validateCurrentLeaf()) {
+          return LowerBoundResult.RETRY;
+        }
+        if (successorCount > 0) {
+          if (cmp > 0 || (cmp == 0 && isLowerBound)) {
+            return new LowerBoundResult(successor, 0);
+          }
+          if (cmp == 0) {
+            // upper_bound and the successor's first entry EQUALS searchKey: step past it.
+            return advanceOneFrom(successor, 0);
+          }
         }
       }
       // successor == null: searchKey is past every key reachable from the landing. An empty
@@ -479,7 +634,18 @@ public final class HOTTrieReader implements AutoCloseable {
       return phase7uLexDescentFallback(rootRef, searchKey, isLowerBound);
     }
 
-    final byte[] candidateKey = candidateLeaf.getFirstKey();
+    final byte[] candidateKey;
+    try {
+      candidateKey = candidateLeaf.getFirstKey();
+    } catch (RuntimeException e) {
+      if (validateCurrentLeaf()) {
+        throw e;
+      }
+      return LowerBoundResult.RETRY;
+    }
+    if (!validateCurrentLeaf()) {
+      return LowerBoundResult.RETRY;
+    }
     final int discBit = DiscriminativeBitComputer.computeDifferingBit(candidateKey, searchKey);
     if (discBit < 0) {
       // Candidate first-key equals searchKey but findEntry didn't match: defensive path.
@@ -621,14 +787,29 @@ public final class HOTTrieReader implements AutoCloseable {
       if (page == null)
         return LowerBoundResult.EXHAUSTED;
       if (page instanceof HOTLeafPage leaf) {
-        final int exact = leaf.findEntry(searchKey);
+        // Batch the leaf-content reads and validate once before any positioning decision
+        // escapes; on a torn read the public wrappers redo the whole descent.
+        final int exact;
+        final int entryCount;
+        try {
+          exact = leaf.findEntry(searchKey);
+          entryCount = leaf.getEntryCount();
+        } catch (RuntimeException e) {
+          if (validateCurrentLeaf()) {
+            throw e;
+          }
+          return LowerBoundResult.RETRY;
+        }
+        if (!validateCurrentLeaf()) {
+          return LowerBoundResult.RETRY;
+        }
         if (exact >= 0) {
           if (isLowerBound)
             return new LowerBoundResult(leaf, exact);
           return advanceOneFrom(leaf, exact);
         }
         final int insertionPoint = -(exact + 1);
-        if (insertionPoint < leaf.getEntryCount()) {
+        if (insertionPoint < entryCount) {
           return new LowerBoundResult(leaf, insertionPoint);
         }
         // searchKey is past this leaf's last entry — advance via path stack to next leaf.
@@ -698,7 +879,21 @@ public final class HOTTrieReader implements AutoCloseable {
    * the leaf is exhausted. Used for upper_bound stepping past an exact match.
    */
   private LowerBoundResult advanceOneFrom(HOTLeafPage leaf, int idx) {
-    if (idx + 1 < leaf.getEntryCount()) {
+    // The entry count is a leaf-content read on an unpinned page; validate before the
+    // stay-or-advance decision escapes. leaf is the reader's current leaf on every call path.
+    final int count;
+    try {
+      count = leaf.getEntryCount();
+    } catch (RuntimeException e) {
+      if (validateCurrentLeaf()) {
+        throw e;
+      }
+      return LowerBoundResult.RETRY;
+    }
+    if (!validateCurrentLeaf()) {
+      return LowerBoundResult.RETRY;
+    }
+    if (idx + 1 < count) {
       return new LowerBoundResult(leaf, idx + 1);
     }
     final HOTLeafPage next = advanceToNextLeaf();
@@ -726,25 +921,47 @@ public final class HOTTrieReader implements AutoCloseable {
         return cached;
       }
     }
-    PageReference ref = parent.getChildReference(childIdx);
-    while (ref != null) {
-      final Page page = loadPage(ref);
-      if (page == null) {
-        return new byte[0];
-      }
-      if (page instanceof HOTLeafPage leaf) {
-        final byte[] firstKey = leaf.getFirstKey();
-        if (firstKeyCacheEnabled && firstKey != null && firstKey.length > 0) {
-          parent.cacheChildFirstKey(childIdx, firstKey);
+    // The materialized first key is read off an unpinned leaf and — worse — memoized into the
+    // parent, where a torn copy would poison every later probe. Validate the stamp BEFORE
+    // caching or returning; a failed validation restarts the (cheap, leftmost) descent.
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      PageReference ref = parent.getChildReference(childIdx);
+      boolean torn = false;
+      while (ref != null) {
+        final Page page = loadPage(ref);
+        if (page == null) {
+          return new byte[0];
         }
-        return firstKey;
+        if (page instanceof HOTLeafPage leaf) {
+          final byte[] firstKey;
+          try {
+            firstKey = leaf.getFirstKey();
+          } catch (RuntimeException e) {
+            if (validateCurrentLeaf()) {
+              throw e;
+            }
+            torn = true;
+            break;
+          }
+          if (!validateCurrentLeaf()) {
+            torn = true;
+            break;
+          }
+          if (firstKeyCacheEnabled && firstKey != null && firstKey.length > 0) {
+            parent.cacheChildFirstKey(childIdx, firstKey);
+          }
+          return firstKey;
+        }
+        if (!(page instanceof HOTIndirectPage indirect)) {
+          return new byte[0];
+        }
+        ref = indirect.getChildReference(0);
       }
-      if (!(page instanceof HOTIndirectPage indirect)) {
+      if (!torn) {
         return new byte[0];
       }
-      ref = indirect.getChildReference(0);
     }
-    return new byte[0];
+    throw stampRetriesExhausted("getFirstKeyOfChild");
   }
 
   /**
@@ -770,34 +987,64 @@ public final class HOTTrieReader implements AutoCloseable {
         return Arrays.compareUnsigned(cached, bound);
       }
     }
-    PageReference ref = parent.getChildReference(childIdx);
-    int depth = 0;
-    while (ref != null && depth++ < MAX_TREE_HEIGHT) {
-      final Page page = loadPage(ref);
-      if (page == null) {
-        return UNRESOLVABLE_SUBTREE;
-      }
-      if (page instanceof HOTLeafPage leaf) {
-        if (leaf.getEntryCount() == 0) {
+    // Same discipline as getFirstKeyOfChild: the compare (and any key materialized for the
+    // memo cache) reads unpinned leaf bytes — validate before the verdict escapes or the key
+    // is cached, retry the leftmost descent on a torn read.
+    for (int attempt = 0; attempt < MAX_STAMP_RETRIES; attempt++) {
+      PageReference ref = parent.getChildReference(childIdx);
+      int depth = 0;
+      boolean torn = false;
+      while (ref != null && depth++ < MAX_TREE_HEIGHT) {
+        final Page page = loadPage(ref);
+        if (page == null) {
           return UNRESOLVABLE_SUBTREE;
         }
-        if (firstKeyCacheEnabled) {
-          // Materialize once so every later probe of this slot is a plain array compare with
-          // zero page loads and zero guard churn — the dominant cost of absent-key seeks.
-          final byte[] firstKey = leaf.getFirstKey();
+        if (page instanceof HOTLeafPage leaf) {
+          final int entryCount;
+          byte[] firstKey = null;
+          int inPlaceCmp = 0;
+          try {
+            entryCount = leaf.getEntryCount();
+            if (entryCount > 0) {
+              if (firstKeyCacheEnabled) {
+                // Materialize once so every later probe of this slot is a plain array compare
+                // with zero page loads — the dominant cost of absent-key seeks.
+                firstKey = leaf.getFirstKey();
+              }
+              if (firstKey == null || firstKey.length == 0) {
+                inPlaceCmp = leaf.compareKeyWithBound(0, bound);
+              }
+            }
+          } catch (RuntimeException e) {
+            if (validateCurrentLeaf()) {
+              throw e;
+            }
+            torn = true;
+            break;
+          }
+          if (!validateCurrentLeaf()) {
+            torn = true;
+            break;
+          }
+          if (entryCount == 0) {
+            return UNRESOLVABLE_SUBTREE;
+          }
           if (firstKey != null && firstKey.length > 0) {
             parent.cacheChildFirstKey(childIdx, firstKey);
             return Arrays.compareUnsigned(firstKey, bound);
           }
+          return inPlaceCmp;
         }
-        return leaf.compareKeyWithBound(0, bound);
+        if (!(page instanceof HOTIndirectPage indirect)) {
+          return UNRESOLVABLE_SUBTREE;
+        }
+        ref = indirect.getChildReference(0);
       }
-      if (!(page instanceof HOTIndirectPage indirect)) {
+      if (!torn) {
         return UNRESOLVABLE_SUBTREE;
       }
-      ref = indirect.getChildReference(0);
     }
-    return UNRESOLVABLE_SUBTREE;
+    throw stampRetriesExhausted("compareFirstKeyOfChildWithBound");
   }
 
   /**
@@ -1091,11 +1338,11 @@ public final class HOTTrieReader implements AutoCloseable {
    * </p>
    */
   private @Nullable Page loadPage(PageReference ref) {
-    // Resolving a HOT leaf and guarding it are fused here so no caller can observe a leaf
-    // between the two steps: a concurrent eviction in that window would otherwise close the
-    // leaf and make a reader mistake an evicted page for a missing key. On a lost race the
-    // leaf is simply reloaded — eviction is transient, not absence.
-    for (int attempt = 0; attempt < MAX_GUARD_ACQUIRE_RETRIES; attempt++) {
+    // Resolving a HOT leaf and snapshotting its optimistic stamp are fused here so no caller can
+    // observe a leaf without a stamp to validate against: a concurrent eviction would otherwise
+    // let a reader mistake an evicted page for a missing key. On a lost race the leaf is simply
+    // reloaded — eviction is transient, not absence.
+    for (int attempt = 0; attempt < MAX_LOAD_RETRIES; attempt++) {
       // A swizzled page that is already closed means a concurrent eviction reclaimed its
       // off-heap slot; drop it and reload a fresh copy rather than hand back dead memory.
       Page page = ref.getPage();
@@ -1118,22 +1365,64 @@ public final class HOTTrieReader implements AutoCloseable {
       if (!(page instanceof HOTLeafPage leaf)) {
         return page; // an indirect page — eviction only de-swizzles it, never closes it
       }
-      if (leaf == guardedLeaf) {
-        return leaf; // already this reader's guarded leaf
+      // NO PIN. Snapshot the leaf's optimistic stamp instead: an odd stamp means the leaf is
+      // closed or its slot is mid-teardown — drop the swizzle and reload a fresh copy. Every
+      // read of this leaf's content must later pass validateCurrentLeaf() before its result is
+      // trusted; the leaf stays evictable the entire time.
+      final long stamp = leaf.readStamp();
+      if ((stamp & 1L) != 0L) {
+        ref.setPage(null);
+        continue;
       }
-      // Hold exactly one leaf guard: the most-recently-resolved leaf. Acquire the new guard
-      // before releasing the old one so the new leaf is un-evictable across the swap.
-      if (leaf.acquireGuard()) {
-        releaseGuardedLeaf();
-        guardedLeaf = leaf;
-        return leaf;
-      }
-      // Lost the resolve-then-guard race — the leaf was evicted before its guard could be
-      // taken. Drop the closed swizzle and reload a fresh copy on the next attempt.
+      // Second-chance signal for the ClockSweeper: a leaf under active read survives one
+      // eviction cycle. Purely advisory — correctness never depends on it.
+      leaf.markAccessed();
+      currentLeaf = leaf;
+      currentLeafRef = ref;
+      currentLeafStamp = stamp;
+      return leaf;
+    }
+    throw new IllegalStateException("HOT: leaf at " + ref + " evicted on every one of " + MAX_LOAD_RETRIES
+        + " load attempts — sustained allocator thrashing");
+  }
+
+  /**
+   * Whether every read of {@link #currentLeaf}'s content since {@link #loadPage} resolved it saw
+   * stable bytes. One call covers the whole batch of reads since the snapshot.
+   */
+  public boolean validateCurrentLeaf() {
+    final HOTLeafPage leaf = currentLeaf;
+    return leaf == null || leaf.validateStamp(currentLeafStamp);
+  }
+
+  /** The stamp snapshotted when {@link #currentLeaf} was resolved. */
+  public long currentLeafStamp() {
+    return currentLeafStamp;
+  }
+
+  /** The most-recently-resolved leaf, or {@code null}. Reads of it require stamp validation. */
+  public @Nullable HOTLeafPage currentLeafPage() {
+    return currentLeaf;
+  }
+
+  /**
+   * Re-resolve {@link #currentLeaf} through its {@link PageReference} after a failed validation.
+   * Content per reference is immutable, so every entry index computed against the stale copy remains
+   * valid against the fresh one — callers keep their position and redo only the reads.
+   *
+   * @return {@code true} when the leaf was re-resolved (fields updated), {@code false} when it is no
+   *         longer resolvable
+   */
+  public boolean refreshCurrentLeaf() {
+    final PageReference ref = currentLeafRef;
+    if (ref == null) {
+      return false;
+    }
+    final Page swizzled = ref.getPage();
+    if (swizzled != null && swizzled.isClosed()) {
       ref.setPage(null);
     }
-    throw new IllegalStateException("HOT: leaf at " + ref + " evicted on every one of " + MAX_GUARD_ACQUIRE_RETRIES
-        + " load attempts — sustained allocator thrashing");
+    return loadPage(ref) instanceof HOTLeafPage;
   }
 
   /**
@@ -1222,11 +1511,12 @@ public final class HOTTrieReader implements AutoCloseable {
   /**
    * Release the currently guarded leaf page.
    */
-  private void releaseGuardedLeaf() {
-    if (guardedLeaf != null) {
-      guardedLeaf.releaseGuard();
-      guardedLeaf = null;
-    }
+  private void clearCurrentLeaf() {
+    // Nothing to release: the reader holds no guard. Clearing only drops the references so an
+    // idle reader does not keep a leaf object (and its stamp) reachable.
+    currentLeaf = null;
+    currentLeafRef = null;
+    currentLeafStamp = HOTLeafPage.STAMP_INVALID;
   }
 
   /**
@@ -1238,7 +1528,7 @@ public final class HOTTrieReader implements AutoCloseable {
 
   @Override
   public void close() {
-    releaseGuardedLeaf();
+    clearCurrentLeaf();
     clearPath();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -230,10 +230,18 @@ public final class HOTTrieReader implements AutoCloseable {
   private static final int MAX_LOAD_RETRIES = 256;
 
   /**
-   * Bound on validate-and-retry rounds for a single positioning decision. A retry re-reads a freshly
-   * reloaded copy of the same immutable content, so each round races eviction independently.
+   * Bound on validate-and-retry rounds for a single positioning decision, shared by every consumer of
+   * the optimistic-stamp protocol. A retry re-reads a freshly reloaded copy of the same immutable
+   * content, so each round races eviction independently; exhausting this many implies pathological
+   * allocator thrashing, not a logic error.
+   *
+   * <p>
+   * ONE declaration on purpose: this budget was previously restated under five different names across
+   * five classes (plus a bare literal), so tuning it meant finding all six and missing one left a
+   * single scan path on the old value.
+   * </p>
    */
-  private static final int MAX_STAMP_RETRIES = 64;
+  public static final int MAX_STAMP_RETRIES = 64;
 
   /**
    * Create a new HOTTrieReader.
@@ -511,8 +519,25 @@ public final class HOTTrieReader implements AutoCloseable {
     throw stampRetriesExhausted("lexDescent");
   }
 
+  /**
+   * Bounded torn-read recovery: reload the current leaf through its {@link PageReference} so the
+   * caller can re-read the SAME position on a fresh copy. Content per reference is immutable, so
+   * every index the caller already computed stays valid.
+   *
+   * @param round how many consecutive torn rounds this is, including the current one
+   * @param operation names the caller, for the exhaustion diagnostic
+   */
+  public void recoverTorn(final int round, final String operation) {
+    if (round > MAX_STAMP_RETRIES) {
+      throw stampRetriesExhausted(operation);
+    }
+    if (!refreshCurrentLeaf()) {
+      throw new IllegalStateException(operation + ": evicted leaf could not be reloaded through its PageReference");
+    }
+  }
+
   /** A seek that could not observe stable leaf bytes in {@link #MAX_STAMP_RETRIES} rounds. */
-  private static IllegalStateException stampRetriesExhausted(final String operation) {
+  public static IllegalStateException stampRetriesExhausted(final String operation) {
     return new IllegalStateException("HOT: " + operation + " failed stamp validation on every one of "
         + MAX_STAMP_RETRIES + " attempts — sustained allocator thrashing");
   }
@@ -1375,8 +1400,13 @@ public final class HOTTrieReader implements AutoCloseable {
         continue;
       }
       // Second-chance signal for the ClockSweeper: a leaf under active read survives one
-      // eviction cycle. Purely advisory — correctness never depends on it.
-      leaf.markAccessed();
+      // eviction cycle. Purely advisory — correctness never depends on it. Guarded because
+      // markAccessed is a volatile store and a seek re-resolves the same leaf many times (every
+      // first-key probe descends to one), so the unguarded form paid a store fence per probe on a
+      // flag that is already set after the first.
+      if (!leaf.isHot()) {
+        leaf.markAccessed();
+      }
       currentLeaf = leaf;
       currentLeafRef = ref;
       currentLeafStamp = stamp;
@@ -1393,11 +1423,6 @@ public final class HOTTrieReader implements AutoCloseable {
   public boolean validateCurrentLeaf() {
     final HOTLeafPage leaf = currentLeaf;
     return leaf == null || leaf.validateStamp(currentLeafStamp);
-  }
-
-  /** The stamp snapshotted when {@link #currentLeaf} was resolved. */
-  public long currentLeafStamp() {
-    return currentLeafStamp;
   }
 
   /** The most-recently-resolved leaf, or {@code null}. Reads of it require stamp validation. */

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieReader.java
@@ -596,18 +596,45 @@ public final class HOTTrieReader implements AutoCloseable {
       }
       if (!(page instanceof HOTIndirectPage indirect))
         return LowerBoundResult.EXHAUSTED;
-      // Find the LAST child whose firstKey is ≤ searchKey.
+      // Find the LAST child whose firstKey is ≤ searchKey. Children are I8-sorted by subtree
+      // first-key, so binary search over them: ~5 first-key probes per 32-way node instead of a
+      // linear sweep, and each probe compares the candidate leaf's first key IN PLACE
+      // (compareKeyWithBound) instead of materializing it. This descent runs on every miss and
+      // on every PEXT-landing the verify rejects, so it dominates absent-key lookup latency —
+      // the linear materializing sweep measured ~16 µs per miss, ~20× the hit cost.
       final int n = indirect.getNumChildren();
       int chosenIdx = -1;
-      for (int i = 0; i < n; i++) {
-        final byte[] fk = getFirstKeyOfChild(indirect, i);
-        if (fk == null || fk.length == 0)
-          continue;
-        final int cmp = Arrays.compareUnsigned(fk, searchKey);
-        if (cmp <= 0) {
-          chosenIdx = i;
-        } else {
+      int lo = 0;
+      int hi = n - 1;
+      boolean binarySearchValid = true;
+      while (lo <= hi) {
+        final int mid = (lo + hi) >>> 1;
+        final int cmp = compareFirstKeyOfChildWithBound(indirect, mid, searchKey);
+        if (cmp == UNRESOLVABLE_SUBTREE) {
+          binarySearchValid = false;
           break;
+        }
+        if (cmp <= 0) {
+          chosenIdx = mid;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      if (!binarySearchValid) {
+        // A child's subtree could not be resolved — its first key is unknown, so ordered probing
+        // is off the table. Recover with the original linear sweep, which skips such children.
+        chosenIdx = -1;
+        for (int i = 0; i < n; i++) {
+          final byte[] fk = getFirstKeyOfChild(indirect, i);
+          if (fk == null || fk.length == 0)
+            continue;
+          final int cmp = Arrays.compareUnsigned(fk, searchKey);
+          if (cmp <= 0) {
+            chosenIdx = i;
+          } else {
+            break;
+          }
         }
       }
       if (chosenIdx < 0) {
@@ -665,6 +692,43 @@ public final class HOTTrieReader implements AutoCloseable {
       ref = indirect.getChildReference(0);
     }
     return new byte[0];
+  }
+
+  /**
+   * Sentinel for {@link #compareFirstKeyOfChildWithBound}: the child's subtree bottomed out on an
+   * unresolvable or empty page, so its first key is unknown. Outside the value range of
+   * {@link HOTLeafPage#compareKeyWithBound} (byte diffs are ±255, length diffs bounded by key
+   * lengths).
+   */
+  private static final int UNRESOLVABLE_SUBTREE = Integer.MIN_VALUE;
+
+  /**
+   * Compare the subtree first-key of {@code parent}'s child {@code childIdx} against {@code bound}
+   * without materializing it: descend leftmost to the child's first leaf and run
+   * {@link HOTLeafPage#compareKeyWithBound} on entry 0 — the zero-copy twin of
+   * {@link #getFirstKeyOfChild} + {@code Arrays.compareUnsigned}.
+   *
+   * @return the comparison result, or {@link #UNRESOLVABLE_SUBTREE} when the descent dead-ends
+   */
+  private int compareFirstKeyOfChildWithBound(HOTIndirectPage parent, int childIdx, byte[] bound) {
+    PageReference ref = parent.getChildReference(childIdx);
+    int depth = 0;
+    while (ref != null && depth++ < MAX_TREE_HEIGHT) {
+      final Page page = loadPage(ref);
+      if (page == null) {
+        return UNRESOLVABLE_SUBTREE;
+      }
+      if (page instanceof HOTLeafPage leaf) {
+        return leaf.getEntryCount() == 0
+            ? UNRESOLVABLE_SUBTREE
+            : leaf.compareKeyWithBound(0, bound);
+      }
+      if (!(page instanceof HOTIndirectPage indirect)) {
+        return UNRESOLVABLE_SUBTREE;
+      }
+      ref = indirect.getChildReference(0);
+    }
+    return UNRESOLVABLE_SUBTREE;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -113,12 +113,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
   /**
    * Enable path summary cache debugging.
+   * 
    * @see DiagnosticSettings#PATH_SUMMARY_DEBUG
    */
   private static final boolean DEBUG_PATH_SUMMARY = DiagnosticSettings.PATH_SUMMARY_DEBUG;
 
   private record RecordPage(int index, IndexType indexType, long recordPageKey, int revision,
-                            PageReference pageReference, KeyValueLeafPage page) {
+      PageReference pageReference, KeyValueLeafPage page) {
   }
 
   /**
@@ -153,11 +154,11 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   private volatile boolean isClosed;
 
   /**
-   * One-shot latch making {@link #close()} run exactly once. {@link #isClosed} is only set at
-   * the END of the close body (so {@code assertNotClosed} guards stay quiet during cleanup),
-   * which used to let a concurrent or reentrant second close pass the {@code !isClosed} check
-   * and deregister the epoch-tracker ticket twice — poisoning the process-wide tracker
-   * (issue #1102). CASed 0 → 1 on entry; losers return immediately.
+   * One-shot latch making {@link #close()} run exactly once. {@link #isClosed} is only set at the END
+   * of the close body (so {@code assertNotClosed} guards stay quiet during cleanup), which used to
+   * let a concurrent or reentrant second close pass the {@code !isClosed} check and deregister the
+   * epoch-tracker ticket twice — poisoning the process-wide tracker (issue #1102). CASed 0 → 1 on
+   * entry; losers return immediately.
    */
   @SuppressWarnings("unused")
   private volatile int closeInitiated;
@@ -204,22 +205,19 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   private final long resourceId;
 
   /**
-   * Epoch tracker ticket for this transaction (for MVCC-aware eviction).
-   * Registered when transaction opens, deregistered when it closes.
+   * Epoch tracker ticket for this transaction (for MVCC-aware eviction). Registered when transaction
+   * opens, deregistered when it closes.
    */
   private final RevisionEpochTracker.Ticket epochTicket;
 
   /**
    * Current page guard - protects the page where cursor is currently positioned.
    * <p>
-   * Guard lifecycle:
-   * - Acquired when cursor moves to a page
-   * - Released when cursor moves to a DIFFERENT page
-   * - Released on transaction close
+   * Guard lifecycle: - Acquired when cursor moves to a page - Released when cursor moves to a
+   * DIFFERENT page - Released on transaction close
    * <p>
-   * This matches database cursor semantics: only the "current" page is guarded.
-   * Node keys are primitives (copied from MemorySegments), so old pages can be
-   * evicted after cursor moves away.
+   * This matches database cursor semantics: only the "current" page is guarded. Node keys are
+   * primitives (copied from MemorySegments), so old pages can be evicted after cursor moves away.
    */
   private PageGuard currentPageGuard;
 
@@ -231,11 +229,11 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * {@link NamePage} of this revision, resolved LAZILY through {@link #namePage()}.
    *
-   * <p>Loading it in the constructor made every transaction — including the many that only
-   * navigate structure or read values — pay a page load plus the surrounding revision-root
-   * dereference at open. Not final, and deliberately unsynchronised: a
-   * {@link NodeStorageEngineReader} is confined to its transaction, and a benign double-resolve
-   * would return equal pages anyway.
+   * <p>
+   * Loading it in the constructor made every transaction — including the many that only navigate
+   * structure or read values — pay a page load plus the surrounding revision-root dereference at
+   * open. Not final, and deliberately unsynchronised: a {@link NodeStorageEngineReader} is confined
+   * to its transaction, and a benign double-resolve would return equal pages anyway.
    */
   private NamePage namePage;
 
@@ -244,15 +242,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * through {@link #alreadyBuiltNames(NodeKind)}. Sized to cover every offset
    * {@link NamePage#dictionaryOffset(NodeKind)} can return (0–3), with headroom.
    *
-   * <p>Entries are the shared, immutable {@code NamesCache} copies for this reader's revision, so
+   * <p>
+   * Entries are the shared, immutable {@code NamesCache} copies for this reader's revision, so
    * holding them for the reader's lifetime is a reference, not a copy.
    */
   private final Names[] namesByOffset = new Names[5];
 
   /**
-   * Most recently read pages by type and index.
-   * Using specific fields instead of generic cache for clear ownership and lifecycle.
-   * Index-aware: NAME/PATH/CAS can have multiple indexes (0-3).
+   * Most recently read pages by type and index. Using specific fields instead of generic cache for
+   * clear ownership and lifecycle. Index-aware: NAME/PATH/CAS can have multiple indexes (0-3).
    */
   private RecordPage mostRecentDocumentPage;
   private RecordPage mostRecentChangedNodesPage;
@@ -266,41 +264,46 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * PATH_SUMMARY pages this reader loaded through the write-transaction BYPASS, and only those.
    *
-   * <p>The bypass (see {@code getRecordPage}) deliberately caches nothing, so these instances are
+   * <p>
+   * The bypass (see {@code getRecordPage}) deliberately caches nothing, so these instances are
    * transaction-private and this reader is their sole owner — unlike everything else that passes
    * through {@code pathSummaryRecordPage}, which can be a page the transaction-intent log owns.
    * Tracking them by identity is what makes teardown at {@link #close()} safe: the slot alone cannot
    * distinguish the two, and retiring a TIL-owned page here would free it before {@code log.close()}
-   * runs.</p>
+   * runs.
+   * </p>
    *
-   * <p>Needed because the slot can be cleared without anyone closing what was in it —
+   * <p>
+   * Needed because the slot can be cleared without anyone closing what was in it —
    * {@code invalidateMostRecentlyReadRecordPage} nulls it so the next read re-resolves through the
-   * TIL, and a bypass page dropped that way became unreachable with its frame still allocated.</p>
+   * TIL, and a bypass page dropped that way became unreachable with its frame still allocated.
+   * </p>
    */
   private @Nullable List<KeyValueLeafPage> bypassLoadedPathSummaryPages;
 
   /**
    * Size at which {@link #bypassLoadedPathSummaryPages} is compacted, doubling after each sweep.
    *
-   * <p>The list is a teardown backstop, not an ownership record: a page displaced from the
+   * <p>
+   * The list is a teardown backstop, not an ownership record: a page displaced from the
    * {@code pathSummaryRecordPage} slot is retired right there, and its entry here is dead weight
-   * afterwards. Without a sweep the list is append-only, so a long write transaction holds one
-   * CLOSED {@link KeyValueLeafPage} — records array, slot offsets and all — per bypass load, even
-   * though the off-heap frame behind it was freed long ago. Compacting on a doubling threshold
-   * keeps the amortized cost per load O(1): a sweep that frees less than half the list raises the
-   * bar before the next one.
+   * afterwards. Without a sweep the list is append-only, so a long write transaction holds one CLOSED
+   * {@link KeyValueLeafPage} — records array, slot offsets and all — per bypass load, even though the
+   * off-heap frame behind it was freed long ago. Compacting on a doubling threshold keeps the
+   * amortized cost per load O(1): a sweep that frees less than half the list raises the bar before
+   * the next one.
    */
   private int bypassLoadedPathSummaryPagesSweepAt = MIN_BYPASS_PAGE_SWEEP_SIZE;
 
   /**
-   * Reusable IndexLogKey to avoid allocations on every getRecord/lookupSlot call.
-   * Safe to reuse because this transaction is single-threaded (see class javadoc).
+   * Reusable IndexLogKey to avoid allocations on every getRecord/lookupSlot call. Safe to reuse
+   * because this transaction is single-threaded (see class javadoc).
    */
   private final IndexLogKey reusableIndexLogKey = new IndexLogKey(null, 0, 0, 0);
 
   /**
-   * Reusable MemorySegmentBytesIn to avoid allocations on every non-flyweight record
-   * deserialization. Safe to reuse because this transaction is single-threaded (see class javadoc).
+   * Reusable MemorySegmentBytesIn to avoid allocations on every non-flyweight record deserialization.
+   * Safe to reuse because this transaction is single-threaded (see class javadoc).
    */
   private final MemorySegmentBytesIn reusableBytesIn = new MemorySegmentBytesIn(MemorySegment.NULL);
 
@@ -312,20 +315,19 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Standard constructor.
    *
-   * @param trxId                 the transaction-ID.
-   * @param resourceSession       the resource manager
-   * @param uberPage              {@link UberPage} to start reading from
-   * @param revision              key of revision to read from uber page
-   * @param reader                to read stored pages for this transaction
+   * @param trxId the transaction-ID.
+   * @param resourceSession the resource manager
+   * @param uberPage {@link UberPage} to start reading from
+   * @param revision key of revision to read from uber page
+   * @param reader to read stored pages for this transaction
    * @param resourceBufferManager caches in-memory reconstructed pages
-   * @param trxIntentLog          the transaction intent log (can be {@code null})
+   * @param trxIntentLog the transaction intent log (can be {@code null})
    * @throws SirixIOException if reading of the persistent storage fails
    */
   public NodeStorageEngineReader(final int trxId,
       final InternalResourceSession<? extends NodeReadOnlyTrx, ? extends NodeTrx> resourceSession,
-      final UberPage uberPage, final int revision, final Reader reader,
-      final BufferManager resourceBufferManager, final RevisionRootPageReader revisionRootPageReader,
-      final @Nullable TransactionIntentLog trxIntentLog) {
+      final UberPage uberPage, final int revision, final Reader reader, final BufferManager resourceBufferManager,
+      final RevisionRootPageReader revisionRootPageReader, final @Nullable TransactionIntentLog trxIntentLog) {
     checkArgument(trxId > 0, "Transaction-ID must be >= 0.");
     this.trxId = trxId;
     this.resourceBufferManager = resourceBufferManager;
@@ -365,7 +367,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // logKey might still be set, so don't assert it's NULL_ID_INT
     }
 
-    //   if (trxIntentLog == null) {
+    // if (trxIntentLog == null) {
     // REMOVED INCORRECT ASSERTION: logKey can be != NULL_ID_INT if page was in TIL then cleared
     // assert reference.getLogKey() == Constants.NULL_ID_INT;
     page = resourceBufferManager.getPageCache().get(reference, (_, _) -> {
@@ -380,17 +382,18 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       reference.setPage(page);
     }
     return page;
-    //    }
+    // }
 
-    //    if (reference.getKey() != Constants.NULL_ID_LONG || reference.getLogKey() != Constants.NULL_ID_INT) {
-    //      page = pageReader.read(reference, resourceSession.getResourceConfig());
-    //    }
+    // if (reference.getKey() != Constants.NULL_ID_LONG || reference.getLogKey() !=
+    // Constants.NULL_ID_INT) {
+    // page = pageReader.read(reference, resourceSession.getResourceConfig());
+    // }
     //
-    //    if (page != null) {
-    //      putIntoPageCache(reference, page);
-    //      reference.setPage(page);
-    //    }
-    //    return page;
+    // if (page != null) {
+    // putIntoPageCache(reference, page);
+    // reference.setPage(page);
+    // }
+    // return page;
   }
 
   @Override
@@ -402,7 +405,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   private Page getFromTrxIntentLog(PageReference reference) {
     // Try to get it from the transaction log if it's present.
     final PageContainer cont = trxIntentLog.get(reference);
-    return cont == null ? null : cont.getComplete();
+    return cont == null
+        ? null
+        : cont.getComplete();
   }
 
   @Override
@@ -438,8 +443,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <V extends DataRecord> V getRecord(final long recordKey, final IndexType indexType,
-      final int index) {
+  public <V extends DataRecord> V getRecord(final long recordKey, final IndexType indexType, final int index) {
     requireNonNull(indexType);
     assertNotClosed();
 
@@ -451,13 +455,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
     // OPTIMIZATION: Reuse IndexLogKey instance to avoid allocation on every getRecord call
     reusableIndexLogKey.setIndexType(indexType)
-        .setRecordPageKey(recordPageKey)
-        .setIndexNumber(index)
-        .setRevisionNumber(revisionNumber);
+                       .setRecordPageKey(recordPageKey)
+                       .setIndexNumber(index)
+                       .setRevisionNumber(revisionNumber);
 
     // $CASES-OMITTED$
     final PageReferenceToPage pageReferenceToPage = switch (indexType) {
-      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR -> getRecordPage(reusableIndexLogKey);
+      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR ->
+        getRecordPage(reusableIndexLogKey);
       default -> throw new IllegalStateException();
     };
 
@@ -471,7 +476,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
     final var dataRecord = getValue(((KeyValueLeafPage) pageReferenceToPage.page), recordKey);
 
-    //noinspection unchecked
+    // noinspection unchecked
     return (V) checkItemIfDeleted(dataRecord);
   }
 
@@ -522,13 +527,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Get a record from a slotted page. Flyweight records (nodeKindId > 0) are
-   * created via FlyweightNodeFactory and bound directly to page memory.
-   * Legacy records (nodeKindId == 0) are deserialized from the heap bytes.
+   * Get a record from a slotted page. Flyweight records (nodeKindId > 0) are created via
+   * FlyweightNodeFactory and bound directly to page memory. Legacy records (nodeKindId == 0) are
+   * deserialized from the heap bytes.
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
-  private DataRecord getRecordFromSlottedPage(final KeyValueLeafPage kvlPage,
-      final long nodeKey, final int offset) {
+  private DataRecord getRecordFromSlottedPage(final KeyValueLeafPage kvlPage, final long nodeKey, final int offset) {
     final MemorySegment slottedPage = kvlPage.getSlottedPage();
     if (!PageLayout.isSlotPopulated(slottedPage, offset)) {
       return null;
@@ -536,8 +540,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     final int nodeKindId = PageLayout.getDirNodeKindId(slottedPage, offset);
     if (nodeKindId > 0) {
       // Flyweight format: create binding shell and bind to page memory (zero-copy read)
-      final FlyweightNode fn = FlyweightNodeFactory.createAndBind(
-          slottedPage, offset, nodeKey, resourceConfig.nodeHashFunction);
+      final FlyweightNode fn =
+          FlyweightNodeFactory.createAndBind(slottedPage, offset, nodeKey, resourceConfig.nodeHashFunction);
       // Propagate DeweyID from page to flyweight node (stored inline after record data).
       // setDeweyIDBytes stores raw bytes lazily — no SirixDeweyID parsing until getDeweyID().
       if (resourceConfig.areDeweyIDsStored && fn instanceof Node node) {
@@ -563,17 +567,16 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
   /**
    * Read an {@link OverflowPage} through its reference, swizzling the deserialized page onto the
-   * reference so subsequent lookups reuse it. Overflow records are re-resolved on every
-   * navigation step (they have no slot), so without the swizzle each {@code moveTo} would pay a
-   * full page read + decompression — quadratic cost for sibling walks over large values (#1076).
-   * The page wraps an immutable byte[], so racy swizzles by concurrent readers are benign.
+   * reference so subsequent lookups reuse it. Overflow records are re-resolved on every navigation
+   * step (they have no slot), so without the swizzle each {@code moveTo} would pay a full page read +
+   * decompression — quadratic cost for sibling walks over large values (#1076). The page wraps an
+   * immutable byte[], so racy swizzles by concurrent readers are benign.
    */
   private OverflowPage readOverflowPage(final PageReference reference) {
     if (reference.getPage() instanceof OverflowPage overflowPage) {
       return overflowPage;
     }
-    final OverflowPage overflowPage =
-        (OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig());
+    final OverflowPage overflowPage = (OverflowPage) pageReader.read(reference, resourceSession.getResourceConfig());
     reference.setPage(overflowPage);
     return overflowPage;
   }
@@ -581,8 +584,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * {@inheritDoc}
    *
-   * <p>Mirrors {@link #readOverflowPage(PageReference)}: resolve by disk offset key, swizzle
-   * the immutable page onto the reference for reuse.
+   * <p>
+   * Mirrors {@link #readOverflowPage(PageReference)}: resolve by disk offset key, swizzle the
+   * immutable page onto the reference for reuse.
    */
   @Override
   public @Nullable OverflowPage readSideOverflowPage(final PageReference reference) {
@@ -597,8 +601,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // that into an attributable error instead of a ClassCastException deep in a scan.
     final var loadedPage = pageReader.read(reference, resourceSession.getResourceConfig());
     if (!(loadedPage instanceof OverflowPage segmentPage)) {
-      throw new SirixIOException("Side-map overflow reference (offset key " + reference.getKey()
-          + ") resolved to " + (loadedPage == null ? "null" : loadedPage.getClass().getSimpleName())
+      throw new SirixIOException("Side-map overflow reference (offset key " + reference.getKey() + ") resolved to "
+          + (loadedPage == null
+              ? "null"
+              : loadedPage.getClass().getSimpleName())
           + " — dangling or corrupted side-map reference.");
     }
     reference.setPage(segmentPage);
@@ -608,9 +614,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * {@inheritDoc}
    *
-   * <p>Routes through the backend reader's COALESCED batch read (two preads per run of
-   * near-adjacent offsets instead of two per segment) — the projection column fetch's
-   * dominant cost on warm caches was the per-segment syscall pair.
+   * <p>
+   * Routes through the backend reader's COALESCED batch read (two preads per run of near-adjacent
+   * offsets instead of two per segment) — the projection column fetch's dominant cost on warm caches
+   * was the per-segment syscall pair.
    */
   @Override
   public OverflowPage[] readSideOverflowPageBatch(final long[] offsets) {
@@ -630,9 +637,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         continue;
       }
       if (!(loadedPage instanceof OverflowPage segmentPage)) {
-        throw new SirixIOException("Side-map overflow reference (offset key " + offsets[i]
-            + ") resolved to " + loadedPage.getClass().getSimpleName()
-            + " — dangling or corrupted side-map reference.");
+        throw new SirixIOException("Side-map overflow reference (offset key " + offsets[i] + ") resolved to "
+            + loadedPage.getClass().getSimpleName() + " — dangling or corrupted side-map reference.");
       }
       pages[i] = segmentPage;
     }
@@ -642,10 +648,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   @SuppressWarnings({"unchecked", "rawtypes"})
   private DataRecord getDataRecord(long key, int offset, MemorySegment data, KeyValuePage<? extends DataRecord> page) {
     reusableBytesIn.reset(data, 0);
-    var record = resourceConfig.recordPersister.deserialize(reusableBytesIn,
-                                                            key,
-                                                            page.getDeweyIdAsByteArray(offset),
-                                                            resourceConfig);
+    var record = resourceConfig.recordPersister.deserialize(reusableBytesIn, key, page.getDeweyIdAsByteArray(offset),
+        resourceConfig);
 
     // Propagate FSST symbol table to string nodes for lazy decompression
     // Only KeyValueLeafPage has FSST symbol table support
@@ -662,8 +666,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Propagate FSST symbol table from page to string nodes.
-   * This enables lazy decompression when getValue() is called.
+   * Propagate FSST symbol table from page to string nodes. This enables lazy decompression when
+   * getValue() is called.
    */
   private void propagateFsstSymbolTableToRecord(DataRecord record, KeyValueLeafPage page) {
     if (record == null || page == null) {
@@ -689,18 +693,20 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * The symbol table this page's strings were encoded against, fetching it from the dictionary
-   * trie the first time and caching it on the page.
+   * The symbol table this page's strings were encoded against, fetching it from the dictionary trie
+   * the first time and caching it on the page.
    *
-   * <p>A page carries the table itself only in databases written before symbol tables moved into
-   * the dictionary; since then it carries an id, and this is where that id becomes bytes. It
-   * cannot happen at deserialization — that has no reader to walk the trie with — and it should
-   * not happen eagerly, because most pages are never asked for a string.
+   * <p>
+   * A page carries the table itself only in databases written before symbol tables moved into the
+   * dictionary; since then it carries an id, and this is where that id becomes bytes. It cannot
+   * happen at deserialization — that has no reader to walk the trie with — and it should not happen
+   * eagerly, because most pages are never asked for a string.
    *
-   * <p>Resolution goes through this reader, so it lands on the revision this reader is positioned
-   * at. That is the whole point of storing the tables as versioned records: a page written at
-   * revision N names the table that existed at revision N, and copy-on-write keeps that record
-   * reachable no matter how many times later revisions rebuild.
+   * <p>
+   * Resolution goes through this reader, so it lands on the revision this reader is positioned at.
+   * That is the whole point of storing the tables as versioned records: a page written at revision N
+   * names the table that existed at revision N, and copy-on-write keeps that record reachable no
+   * matter how many times later revisions rebuild.
    *
    * @param page the page whose symbol table is wanted
    * @return the symbol table, or {@code null} if the page has none
@@ -708,17 +714,19 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Resolve the symbol table of every fragment about to be combined.
    *
-   * <p>The versioning combine decodes each fragment's compressed strings through
-   * {@code FsstAwareSlotCopier}, built from the fragment's table <em>bytes</em>. A fragment fresh
-   * off disk carries only the dictionary id — and a copier built from {@code null} is inactive,
-   * which would make the combine raw-copy still-compressed payloads into a target page that, by
-   * the copier's own invariant, carries no table. Nothing would fail at that point; the strings
-   * would simply read back as garbage later. So the ids are turned into bytes here, at the last
-   * moment before the combine, where every caller funnels through.
+   * <p>
+   * The versioning combine decodes each fragment's compressed strings through
+   * {@code FsstAwareSlotCopier}, built from the fragment's table <em>bytes</em>. A fragment fresh off
+   * disk carries only the dictionary id — and a copier built from {@code null} is inactive, which
+   * would make the combine raw-copy still-compressed payloads into a target page that, by the
+   * copier's own invariant, carries no table. Nothing would fail at that point; the strings would
+   * simply read back as garbage later. So the ids are turned into bytes here, at the last moment
+   * before the combine, where every caller funnels through.
    *
-   * <p>Costs nothing when FSST is off: no fragment carries an id, and the loop reduces to an
-   * instanceof and a field check per fragment. Package-private for the writer's combine-for-
-   * modification, which funnels through the same requirement.
+   * <p>
+   * Costs nothing when FSST is off: no fragment carries an id, and the loop reduces to an instanceof
+   * and a field check per fragment. Package-private for the writer's combine-for- modification, which
+   * funnels through the same requirement.
    *
    * @param fragments the fragments about to be combined, oldest to newest
    */
@@ -732,38 +740,40 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
   /**
    * All FSST symbol tables reachable from this reader's revision, keyed by dictionary id.
-   * {@code null} until {@link #ensureFsstSymbolTablesLoaded()} runs; stays {@code null} forever
-   * when the resource does not use FSST.
+   * {@code null} until {@link #ensureFsstSymbolTablesLoaded()} runs; stays {@code null} forever when
+   * the resource does not use FSST.
    */
   private Long2ObjectOpenHashMap<byte[]> fsstSymbolTablesById;
 
   /**
-   * The database type of this reader's resource, which fixes the NamePage dictionary offsets in
-   * use. The single derivation point for reader and writer alike — the two must never
-   * disagree, or tables get stored under one offset and looked up under another.
+   * The database type of this reader's resource, which fixes the NamePage dictionary offsets in use.
+   * The single derivation point for reader and writer alike — the two must never disagree, or tables
+   * get stored under one offset and looked up under another.
    */
   DatabaseType databaseType() {
-    return resourceSession instanceof JsonResourceSession ? DatabaseType.JSON : DatabaseType.XML;
+    return resourceSession instanceof JsonResourceSession
+        ? DatabaseType.JSON
+        : DatabaseType.XML;
   }
 
   /**
    * Materialise the revision's symbol tables from the dictionary trie, once per reader.
    *
-   * <p>Eager and whole rather than lazy and per-id, for a structural reason: the place that needs
-   * a table most urgently — the fragment combine — runs <em>inside</em> the record-page cache's
+   * <p>
+   * Eager and whole rather than lazy and per-id, for a structural reason: the place that needs a
+   * table most urgently — the fragment combine — runs <em>inside</em> the record-page cache's
    * compute, and walking the NAME trie from there re-enters the same cache, which its map forbids
    * outright ("recursive update"). So tables are fetched out here, where the trie can be walked
    * freely, and resolution inside the compute becomes a plain map lookup. The dictionary is tiny —
    * one table per revision that rebuilt, a couple of kilobytes each — and a resource without FSST
    * pays a single field test.
    *
-   * <p>This is the same shape {@code Names} uses for the name dictionary itself: load the whole
-   * thing through {@code getRecord} from outside any cache compute, then answer lookups from
-   * memory.
+   * <p>
+   * This is the same shape {@code Names} uses for the name dictionary itself: load the whole thing
+   * through {@code getRecord} from outside any cache compute, then answer lookups from memory.
    */
   void ensureFsstSymbolTablesLoaded() {
-    if (fsstSymbolTablesById != null
-        || resourceConfig.stringCompressionType != StringCompressionType.FSST) {
+    if (fsstSymbolTablesById != null || resourceConfig.stringCompressionType != StringCompressionType.FSST) {
       return;
     }
     final Long2ObjectOpenHashMap<byte[]> tables = new Long2ObjectOpenHashMap<>(4);
@@ -789,8 +799,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       if (referenceToPage == null || referenceToPage.page == null) {
         continue;
       }
-      if (getValue((KeyValueLeafPage) referenceToPage.page, id)
-          instanceof FsstSymbolTableNode symbolTable) {
+      if (getValue((KeyValueLeafPage) referenceToPage.page, id) instanceof FsstSymbolTableNode symbolTable) {
         tables.put(id, symbolTable.getTable());
       }
     }
@@ -799,16 +808,18 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * The symbol table this page's strings were encoded against, from the pre-loaded dictionary.
    *
-   * <p>A page carries the table itself only when this commit's writer handed it over before
-   * serialization; a page fresh off disk carries an id, and this is where the id becomes bytes.
-   * It cannot happen at deserialization — no reader in scope — and the trie cannot be walked from
-   * here, because this may run inside the record-page cache's compute (see
+   * <p>
+   * A page carries the table itself only when this commit's writer handed it over before
+   * serialization; a page fresh off disk carries an id, and this is where the id becomes bytes. It
+   * cannot happen at deserialization — no reader in scope — and the trie cannot be walked from here,
+   * because this may run inside the record-page cache's compute (see
    * {@link #ensureFsstSymbolTablesLoaded()}).
    *
-   * <p>Resolution lands on the tables reachable from this reader's revision. That is the point of
-   * storing them as versioned records: a page written at revision N names the table that existed
-   * at revision N, appends never displace it, and copy-on-write keeps it reachable from every
-   * later root.
+   * <p>
+   * Resolution lands on the tables reachable from this reader's revision. That is the point of
+   * storing them as versioned records: a page written at revision N names the table that existed at
+   * revision N, appends never displace it, and copy-on-write keeps it reachable from every later
+   * root.
    *
    * @param page the page whose symbol table is wanted
    * @return the symbol table, or {@code null} if the page has none
@@ -835,32 +846,33 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // passes the DOCUMENT guard in getRecordPage that loads the dictionary. If this fires, a
       // new call path skipped that guard — fail here, at the cause, rather than hand back
       // plausible garbage from a missing table.
-      throw new IllegalStateException("page " + page.getPageKey() + " references FSST symbol table "
-          + id + " but the symbol-table dictionary was never loaded for this reader");
+      throw new IllegalStateException("page " + page.getPageKey() + " references FSST symbol table " + id
+          + " but the symbol-table dictionary was never loaded for this reader");
     }
     final byte[] table = fsstSymbolTablesById.get(id);
     if (table == null) {
-      throw new IllegalStateException("page " + page.getPageKey() + " references FSST symbol table "
-          + id + ", which does not exist at revision " + getRevisionNumber()
-          + " — its compressed strings cannot be decoded");
+      throw new IllegalStateException(
+          "page " + page.getPageKey() + " references FSST symbol table " + id + ", which does not exist at revision "
+              + getRevisionNumber() + " — its compressed strings cannot be decoded");
     }
     page.setFsstSymbolTable(table);
     return table;
   }
 
   // ==================== FLYWEIGHT CURSOR SUPPORT ====================
-  
+
   /**
-   * Record containing slot location data for zero-allocation access.
-   * Holds all information needed to read node fields directly from memory.
+   * Record containing slot location data for zero-allocation access. Holds all information needed to
+   * read node fields directly from memory.
    *
-   * @param page   the KeyValueLeafPage containing the slot
+   * @param page the KeyValueLeafPage containing the slot
    * @param offset the slot offset within the page (for DeweyID lookup)
-   * @param data   the MemorySegment containing the serialized node data
-   * @param guard  the PageGuard protecting the page from eviction
+   * @param data the MemorySegment containing the serialized node data
+   * @param guard the PageGuard protecting the page from eviction
    */
-  public record SlotLocation(KeyValueLeafPage page, int offset, MemorySegment data, PageGuard guard) {}
-  
+  public record SlotLocation(KeyValueLeafPage page, int offset, MemorySegment data, PageGuard guard) {
+  }
+
   /**
    * Result of lookupSlotOrCached - either a cached record or a slot location.
    */
@@ -868,22 +880,22 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     public boolean hasCachedRecord() {
       return cachedRecord != null;
     }
+
     public boolean hasSlotLocation() {
       return slotLocation != null;
     }
   }
-  
+
   /**
-   * Lookup a node, returning cached record if available, otherwise slot location.
-   * This does ONE page lookup and checks the cache first, avoiding double lookups.
+   * Lookup a node, returning cached record if available, otherwise slot location. This does ONE page
+   * lookup and checks the cache first, avoiding double lookups.
    *
    * @param recordKey the node key to look up
    * @param indexType the index type
-   * @param index     the index number
+   * @param index the index number
    * @return SlotOrCachedResult with either cachedRecord or slotLocation, or both null if not found
    */
-  public SlotOrCachedResult lookupSlotOrCached(final long recordKey, final IndexType indexType,
-      final int index) {
+  public SlotOrCachedResult lookupSlotOrCached(final long recordKey, final IndexType indexType, final int index) {
     requireNonNull(indexType);
     assertNotClosed();
 
@@ -894,13 +906,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     final long recordPageKey = pageKey(recordKey, indexType);
     // OPTIMIZATION: Reuse IndexLogKey instance to avoid allocation
     reusableIndexLogKey.setIndexType(indexType)
-        .setRecordPageKey(recordPageKey)
-        .setIndexNumber(index)
-        .setRevisionNumber(revisionNumber);
+                       .setRecordPageKey(recordPageKey)
+                       .setIndexNumber(index)
+                       .setRevisionNumber(revisionNumber);
 
     // Get the page reference (uses cache) - ONE lookup for both paths
     final PageReferenceToPage pageReferenceToPage = switch (indexType) {
-      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR -> getRecordPage(reusableIndexLogKey);
+      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR ->
+        getRecordPage(reusableIndexLogKey);
       default -> null;
     };
 
@@ -921,7 +934,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // Record was deleted - return not found
       return new SlotOrCachedResult(null, null);
     }
-    
+
     // Not cached - atomically acquire guard only if page is still live.
     // Split acquireGuard + isClosed races with close() under severe eviction.
     if (!page.tryAcquireGuard()) {
@@ -966,28 +979,29 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Lookup a slot directly without deserializing to a node object.
-   * This is the core method for zero-allocation flyweight cursor access.
+   * Lookup a slot directly without deserializing to a node object. This is the core method for
+   * zero-allocation flyweight cursor access.
    * <p>
-   * IMPORTANT: The returned PageGuard MUST be closed when the slot is no longer needed.
-   * Failure to close the guard will prevent page eviction and cause memory issues.
+   * IMPORTANT: The returned PageGuard MUST be closed when the slot is no longer needed. Failure to
+   * close the guard will prevent page eviction and cause memory issues.
    * <p>
    * Usage:
+   * 
    * <pre>{@code
    * var location = reader.lookupSlotWithGuard(nodeKey, IndexType.DOCUMENT, -1);
    * if (location != null) {
-   *     try {
-   *         // Read directly from location.data()
-   *         long parentKey = DeltaVarIntCodec.decodeDeltaFromSegment(location.data(), offset, nodeKey);
-   *     } finally {
-   *         location.guard().close();
-   *     }
+   *   try {
+   *     // Read directly from location.data()
+   *     long parentKey = DeltaVarIntCodec.decodeDeltaFromSegment(location.data(), offset, nodeKey);
+   *   } finally {
+   *     location.guard().close();
+   *   }
    * }
    * }</pre>
    *
    * @param recordKey the node key to lookup
    * @param indexType the index type (typically DOCUMENT for regular nodes)
-   * @param index     the index number (-1 for DOCUMENT)
+   * @param index the index number (-1 for DOCUMENT)
    * @return SlotLocation with page guard, or null if not found
    */
   public SlotLocation lookupSlotWithGuard(long recordKey, IndexType indexType, int index) {
@@ -1001,13 +1015,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     final long recordPageKey = pageKey(recordKey, indexType);
     // OPTIMIZATION: Reuse IndexLogKey instance to avoid allocation
     reusableIndexLogKey.setIndexType(indexType)
-        .setRecordPageKey(recordPageKey)
-        .setIndexNumber(index)
-        .setRevisionNumber(revisionNumber);
+                       .setRecordPageKey(recordPageKey)
+                       .setIndexNumber(index)
+                       .setRevisionNumber(revisionNumber);
 
     // Get the page reference
     final PageReferenceToPage pageReferenceToPage = switch (indexType) {
-      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR -> getRecordPage(reusableIndexLogKey);
+      case DOCUMENT, CHANGED_NODES, RECORD_TO_REVISIONS, PATH_SUMMARY, PATH, CAS, NAME, VECTOR ->
+        getRecordPage(reusableIndexLogKey);
       default -> throw new IllegalStateException("Unsupported index type: " + indexType);
     };
 
@@ -1099,25 +1114,29 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * This revision's name dictionary for {@code nodeKind}, but ONLY if reaching it costs nothing —
    * otherwise {@code null}, and the caller resolves it the long way through {@link #namePage()}.
    *
-   * <p>Worth the detour because the long way is not cheap once per transaction: {@link NamePage} is
-   * on {@code PageCache}'s index-root exclusion list, so {@link #namePage()} READS AND DESERIALIZES
-   * it every time. That exclusion is correct and must stay — sharing one index-root instance would
-   * let a time-travel read of revision N follow revision N+1's root — but its consequence is that
-   * {@code NamePage.jsonObjectKeys} starts null in every transaction, and the first name a
-   * serializer emits pays for the page underneath it.
+   * <p>
+   * Worth the detour because the long way is not cheap once per transaction: {@link NamePage} is on
+   * {@code PageCache}'s index-root exclusion list, so {@link #namePage()} READS AND DESERIALIZES it
+   * every time. That exclusion is correct and must stay — sharing one index-root instance would let a
+   * time-travel read of revision N follow revision N+1's root — but its consequence is that
+   * {@code NamePage.jsonObjectKeys} starts null in every transaction, and the first name a serializer
+   * emits pays for the page underneath it.
    *
-   * <p>The dictionary itself has no such problem: {@code NamesCache} is keyed by
+   * <p>
+   * The dictionary itself has no such problem: {@code NamesCache} is keyed by
    * {@code (database, resource, REVISION, offset)} and holds an immutable copy, and the revision in
-   * that key is exactly what the reference-keyed page cache lacks. So the dictionary is safe to
-   * reach directly, and the page is only needed to build it — on a miss, or for a writer.
+   * that key is exactly what the reference-keyed page cache lacks. So the dictionary is safe to reach
+   * directly, and the page is only needed to build it — on a miss, or for a writer.
    *
-   * <p>Write transactions always take the long way. A writer's uncommitted names live in its
+   * <p>
+   * Write transactions always take the long way. A writer's uncommitted names live in its
    * transaction-intent log, not in a committed revision's dictionary, and {@code NamePage.getNames}
    * already refuses the shared cache for exactly that reason.
    *
-   * <p>The per-reader memo makes this one cache probe per dictionary per transaction rather than
-   * one per name: it also keeps a {@code NamesCacheKey} from being allocated on a path the
-   * serializer walks once per named node.
+   * <p>
+   * The per-reader memo makes this one cache probe per dictionary per transaction rather than one per
+   * name: it also keeps a {@code NamesCacheKey} from being allocated on a path the serializer walks
+   * once per named node.
    *
    * @param nodeKind the kind whose names are wanted
    * @return the dictionary, or {@code null} if it must be built through the name page
@@ -1137,8 +1156,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     if (memo != null) {
       return memo;
     }
-    final Names cached = resourceBufferManager.getNamesCache()
-                                              .get(new NamesCacheKey(databaseId, resourceId, revisionNumber, offset));
+    final Names cached =
+        resourceBufferManager.getNamesCache().get(new NamesCacheKey(databaseId, resourceId, revisionNumber, offset));
     if (cached != null) {
       namesByOffset[offset] = cached;
     }
@@ -1186,8 +1205,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * This revision's {@link NamePage}, loaded on first use. {@code RevisionRootPageReader.getNamePage}
    * delegates straight back to {@link #getNamePage(RevisionRootPage)}, so resolving it here is
-   * exactly what the constructor used to do eagerly — just deferred to the first caller that
-   * actually needs a name.
+   * exactly what the constructor used to do eagerly — just deferred to the first caller that actually
+   * needs a name.
    *
    * @return the name page of this reader's revision
    */
@@ -1238,8 +1257,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // have a bare PageReference with no page attached. Seed an empty container page
     // on first access so callers never get null — matches the legacy semantics for
     // CASPage/PathPage/NamePage which are always present on fresh revisions.
-    if (ref.getPage() == null && ref.getKey() == Constants.NULL_ID_LONG
-        && ref.getLogKey() == Constants.NULL_ID_INT) {
+    if (ref.getPage() == null && ref.getKey() == Constants.NULL_ID_LONG && ref.getLogKey() == Constants.NULL_ID_INT) {
       final ProjectionIndexPage fresh = new ProjectionIndexPage();
       ref.setPage(fresh);
       return fresh;
@@ -1255,8 +1273,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // PageReference with no page attached. Seed an empty container page on first access so callers
     // never get null — matches the legacy semantics for CASPage/PathPage/NamePage which are always
     // present on fresh revisions.
-    if (ref.getPage() == null && ref.getKey() == Constants.NULL_ID_LONG
-        && ref.getLogKey() == Constants.NULL_ID_INT) {
+    if (ref.getPage() == null && ref.getKey() == Constants.NULL_ID_LONG && ref.getLogKey() == Constants.NULL_ID_INT) {
       final ValidTimeIndexPage fresh = new ValidTimeIndexPage();
       ref.setPage(fresh);
       return fresh;
@@ -1293,11 +1310,11 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Prefetch a page into the cache without blocking on the result.
    * <p>
-   * This method loads the specified page into the buffer cache so that
-   * subsequent accesses to nodes on that page will be cache hits.
+   * This method loads the specified page into the buffer cache so that subsequent accesses to nodes
+   * on that page will be cache hits.
    * <p>
-   * Called by prefetching axes (e.g., PrefetchingDescendantAxis) to
-   * asynchronously load pages that will be needed soon.
+   * Called by prefetching axes (e.g., PrefetchingDescendantAxis) to asynchronously load pages that
+   * will be needed soon.
    *
    * @param recordPageKey the page key to prefetch
    * @param indexType the index type (typically DOCUMENT)
@@ -1340,10 +1357,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
 
     // Check the most recent page for this type/index
-    var cachedPage = getMostRecentPage(indexLogKey.getIndexType(),
-                                       indexLogKey.getIndexNumber(),
-                                       indexLogKey.getRecordPageKey(),
-                                       indexLogKey.getRevisionNumber());
+    var cachedPage = getMostRecentPage(indexLogKey.getIndexType(), indexLogKey.getIndexNumber(),
+        indexLogKey.getRecordPageKey(), indexLogKey.getRevisionNumber());
     if (cachedPage != null) {
       var page = cachedPage.page();
 
@@ -1376,8 +1391,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
     // Second: Traverse trie.
     final var pageReferenceToRecordPage = getLeafPageReference(indexLogKey.getRecordPageKey(),
-                                                               indexLogKey.getIndexNumber(),
-                                                               requireNonNull(indexLogKey.getIndexType()));
+        indexLogKey.getIndexNumber(), requireNonNull(indexLogKey.getIndexType()));
 
     if (pageReferenceToRecordPage == null) {
       return null;
@@ -1403,12 +1417,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
       if (DEBUG_PATH_SUMMARY && indexLogKey.getIndexType() == IndexType.PATH_SUMMARY
           && page instanceof KeyValueLeafPage kvp) {
-        LOGGER.debug("[PATH_SUMMARY-NORMAL]   -> Got page from cache: pageKey={}, revision={}",
-                     kvp.getPageKey(),
-                     kvp.getRevision());
+        LOGGER.debug("[PATH_SUMMARY-NORMAL]   -> Got page from cache: pageKey={}, revision={}", kvp.getPageKey(),
+            kvp.getRevision());
       }
 
-      // CRITICAL: Handle case where page doesn't exist (e.g., temporal queries accessing non-existent revisions)
+      // CRITICAL: Handle case where page doesn't exist (e.g., temporal queries accessing non-existent
+      // revisions)
       if (page == null) {
         // Page doesn't exist for this revision/index - this can happen with temporal queries
         // Return null to signal page not found (caller should handle gracefully)
@@ -1422,7 +1436,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
     // PATH_SUMMARY bypass for write transactions - REQUIRED due to cache key limitations
     // RecordPageCache uses PageReference (key + logKey) as cache key, which doesn't include revision.
-    // Different revisions of the same page can have the same PageReference → cache returns wrong revision.
+    // Different revisions of the same page can have the same PageReference → cache returns wrong
+    // revision.
     // Bypass loads directly from disk to avoid stale cached pages.
     if (DEBUG_PATH_SUMMARY) {
       LOGGER.debug("\n[PATH_SUMMARY-DECISION] Using bypass (write trx):");
@@ -1464,17 +1479,18 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // A write transaction reads through its intent log, so prefetchRecordPages below is an
     // unconditional no-op for it — advertising the backend's batch would make callers size
     // windows and pay per-window work for warm-ups that can never happen.
-    return trxIntentLog != null ? 0 : recordPagePrefetchBatch;
+    return trxIntentLog != null
+        ? 0
+        : recordPagePrefetchBatch;
   }
 
   @Override
-  public void prefetchRecordPages(final long[] recordPageKeys, final int count,
-      final IndexType indexType) {
+  public void prefetchRecordPages(final long[] recordPageKeys, final int count, final IndexType indexType) {
     assertNotClosed();
     requireNonNull(recordPageKeys);
     requireNonNull(indexType);
-    checkArgument(count <= recordPageKeys.length,
-                  "count %s exceeds recordPageKeys.length %s", count, recordPageKeys.length);
+    checkArgument(count <= recordPageKeys.length, "count %s exceeds recordPageKeys.length %s", count,
+        recordPageKeys.length);
     // Capability gate first: a backend without the batching primitive must not pay the
     // per-page trie resolution and cache probes below. Write transactions read through the
     // intent log (in-memory, uncommitted) — nothing to warm there either.
@@ -1521,7 +1537,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Whether warming this reference can save a device read.
    *
-   * <p>Skipped are: a reference the trie does not resolve, swizzled OPEN pages (a closed swizzle is
+   * <p>
+   * Skipped are: a reference the trie does not resolve, swizzled OPEN pages (a closed swizzle is
    * stale — the sweeper evicted it and the next read goes to the device after all), combined pages
    * resident in the buffer pool, and first fragments resident in the fragment cache (versioned
    * resources serve the staged offset from there).
@@ -1545,8 +1562,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   @Override
-  public @Nullable RegionsOnlyPage getRecordPageRegionsOnly(final IndexLogKey indexLogKey,
-      final int regionKindMask, final int regionDeferMask) {
+  public @Nullable RegionsOnlyPage getRecordPageRegionsOnly(final IndexLogKey indexLogKey, final int regionKindMask,
+      final int regionDeferMask) {
     assertNotClosed();
     // A write transaction reads through its intent log, where pages are uncommitted and live only
     // in memory — there is no on-disk image to read columns from.
@@ -1557,9 +1574,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       return null;
     }
 
-    final PageReference reference = getLeafPageReference(indexLogKey.getRecordPageKey(),
-                                                        indexLogKey.getIndexNumber(),
-                                                        indexLogKey.getIndexType());
+    final PageReference reference =
+        getLeafPageReference(indexLogKey.getRecordPageKey(), indexLogKey.getIndexNumber(), indexLogKey.getIndexType());
     if (reference == null || reference.getKey() == Constants.NULL_ID_LONG) {
       return null;
     }
@@ -1585,16 +1601,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       // usable on a resident page. Falling through instead reads the committed image, which has
       // the columns.
       if (regions != null && !regions.isEmpty() && satisfies(regions, regionKindMask)) {
-        final RegionsOnlyPage served = serveFromCached(cached, indexLogKey.getRecordPageKey(),
-                                                       regions);
+        final RegionsOnlyPage served = serveFromCached(cached, indexLogKey.getRecordPageKey(), regions);
         if (served != null) {
           return served;
         }
       }
     }
 
-    if (resourceConfig.versioningType != VersioningType.FULL
-        && !reference.getPageFragments().isEmpty()) {
+    if (resourceConfig.versioningType != VersioningType.FULL && !reference.getPageFragments().isEmpty()) {
       // Multi-fragment page. If a RECONSTRUCTED page is resident, its merged slots hold every
       // requested column in ONE coordinate space — derive the missing kinds right here and serve.
       // This is what lets a cross-column (fused) predicate run on versioned data at all: the
@@ -1616,8 +1630,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         cached.ensureRegionsFor(regionKindMask);
         final RegionTable derived = cached.getRegionTable();
         if (derived != null && !derived.isEmpty() && satisfies(derived, regionKindMask)) {
-          final RegionsOnlyPage served = serveFromCached(cached, indexLogKey.getRecordPageKey(),
-                                                         derived);
+          final RegionsOnlyPage served = serveFromCached(cached, indexLogKey.getRecordPageKey(), derived);
           if (served != null) {
             return served;
           }
@@ -1635,40 +1648,40 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * Package a resident page's regions as a {@link RegionsOnlyPage}, or {@code null} when the page
    * closed mid-read.
    *
-   * <p>One definition for both cached branches above, so the two paths cannot drift structurally —
-   * and LOCK-FREE, because this is the hottest serve path and N workers re-reading one resident
-   * page must not serialize on its monitor. The region payloads are backed by the table's
-   * automatic arena and stay valid for as long as the returned object holds them; everything else
-   * read here is snapshotted seqlock-style and validated instead of pinned. The snapshot covers
-   * the slot bitmap (a copy out of POOLED slotted memory that eviction may recycle) and the FSST
-   * symbol-table id (which {@code close()} clears — packaging the cleared id beside an
-   * FSST-encoded dictionary would make every literal probe miss). {@code close()} sets its flag
-   * before it releases the segment or clears the binding, so a clear flag read AFTER the snapshot
-   * — the full fence keeps the order — proves every snapshotted read saw live data. The copy
-   * {@link KeyValueLeafPage#getSlotBitmap} returns is already fresh and never null, which is why
-   * it is passed through without another defensive clone.
+   * <p>
+   * One definition for both cached branches above, so the two paths cannot drift structurally — and
+   * LOCK-FREE, because this is the hottest serve path and N workers re-reading one resident page must
+   * not serialize on its monitor. The region payloads are backed by the table's automatic arena and
+   * stay valid for as long as the returned object holds them; everything else read here is
+   * snapshotted seqlock-style and validated instead of pinned. The snapshot covers the slot bitmap (a
+   * copy out of POOLED slotted memory that eviction may recycle) and the FSST symbol-table id (which
+   * {@code close()} clears — packaging the cleared id beside an FSST-encoded dictionary would make
+   * every literal probe miss). {@code close()} sets its flag before it releases the segment or clears
+   * the binding, so a clear flag read AFTER the snapshot — the full fence keeps the order — proves
+   * every snapshotted read saw live data. The copy {@link KeyValueLeafPage#getSlotBitmap} returns is
+   * already fresh and never null, which is why it is passed through without another defensive clone.
    */
-  private static @Nullable RegionsOnlyPage serveFromCached(final KeyValueLeafPage cached,
-      final long recordPageKey, final RegionTable regions) {
+  private static @Nullable RegionsOnlyPage serveFromCached(final KeyValueLeafPage cached, final long recordPageKey,
+      final RegionTable regions) {
     final long[] slotBitmap = cached.getSlotBitmap();
     final int revision = cached.getRevision();
     final int populatedCount = cached.getCachedPopulatedCount();
     final long fsstSymbolTableId = cached.getFsstSymbolTableId();
     VarHandle.fullFence();
     if (cached.isClosed()) {
-      return null;  // mid-close: the snapshot may be of recycled memory — the fallback serves
+      return null; // mid-close: the snapshot may be of recycled memory — the fallback serves
     }
-    return new RegionsOnlyPage(recordPageKey, revision, populatedCount, fsstSymbolTableId,
-                               regions, slotBitmap);
+    return new RegionsOnlyPage(recordPageKey, revision, populatedCount, fsstSymbolTableId, regions, slotBitmap);
   }
 
   /**
    * Whether {@code regions} holds every kind named in {@code kindMask}.
    *
-   * <p>A mask bit for a kind the page genuinely does not have (no strings on the page, say) makes
-   * this false and costs one image read that finds the same absence. That is the right trade: the
-   * alternative is handing back a table that silently lacks what the caller asked for, which reads
-   * as "this page has no such column" and is indistinguishable from the truth.
+   * <p>
+   * A mask bit for a kind the page genuinely does not have (no strings on the page, say) makes this
+   * false and costs one image read that finds the same absence. That is the right trade: the
+   * alternative is handing back a table that silently lacks what the caller asked for, which reads as
+   * "this page has no such column" and is indistinguishable from the truth.
    */
   private static boolean satisfies(final RegionTable regions, final int kindMask) {
     for (int kind = 0; kind < RegionTable.KIND_COUNT; kind++) {
@@ -1689,22 +1702,21 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   @Override
-  public RegionsOnlyPage @Nullable [] getRecordPageFragmentRegions(
-      final IndexLogKey indexLogKey, final int regionKindMask) {
+  public RegionsOnlyPage @Nullable [] getRecordPageFragmentRegions(final IndexLogKey indexLogKey,
+      final int regionKindMask) {
     assertNotClosed();
     if (trxIntentLog != null || indexLogKey.getIndexType() != IndexType.DOCUMENT
         || indexLogKey.getRecordPageKey() < 0) {
       return null;
     }
-    final PageReference reference = getLeafPageReference(indexLogKey.getRecordPageKey(),
-                                                        indexLogKey.getIndexNumber(),
-                                                        indexLogKey.getIndexType());
+    final PageReference reference =
+        getLeafPageReference(indexLogKey.getRecordPageKey(), indexLogKey.getIndexNumber(), indexLogKey.getIndexType());
     if (reference == null || reference.getKey() == Constants.NULL_ID_LONG) {
       return null;
     }
     final var fragmentKeys = reference.getPageFragments();
     if (fragmentKeys.isEmpty() || resourceConfig.versioningType == VersioningType.FULL) {
-      return null;  // not a multi-fragment page — the single-page entry point serves it
+      return null; // not a multi-fragment page — the single-page entry point serves it
     }
     // Newest first, and the chain read WHOLE — exactly what getPageFragments hands to
     // combineRecordPages. Capping it here would be a silent undercount: a slot living only in a
@@ -1720,11 +1732,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       return null;
     }
     for (int i = 1; i < count; i++) {
-      final PageReference fragmentRef = new PageReference().setKey(fragmentKeys.get(i - 1).key())
-                                                           .setDatabaseId(databaseId)
-                                                           .setResourceId(resourceId);
-      final RegionsOnlyPage fragment =
-          pageReader.readRegionsOnly(fragmentRef, resourceConfig, regionKindMask, 0);
+      final PageReference fragmentRef =
+          new PageReference().setKey(fragmentKeys.get(i - 1).key()).setDatabaseId(databaseId).setResourceId(resourceId);
+      final RegionsOnlyPage fragment = pageReader.readRegionsOnly(fragmentRef, resourceConfig, regionKindMask, 0);
       if (fragment == null || !fragment.hasSlotBitmap()) {
         return null;
       }
@@ -1740,38 +1750,36 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
     ensureFsstSymbolTablesLoaded();
     final var tables = fsstSymbolTablesById;
-    return tables == null ? null : tables.get(id);
+    return tables == null
+        ? null
+        : tables.get(id);
   }
 
   /**
-   * Refuses to serve a page whose fragment chain is longer than any versioning strategy produces —
-   * a corruption guard on a length read from disk, not a cap on the merge.
+   * Refuses to serve a page whose fragment chain is longer than any versioning strategy produces — a
+   * corruption guard on a length read from disk, not a cap on the merge.
    */
   private static final int MAX_FRAGMENT_CHAIN = 64;
 
   /**
-   * Accounting for versioned page reconstruction, off unless
-   * {@code -Dsirix.versioning.diag=true}. A cold analytical scan pays this only on the pages that
-   * span commits, so the interesting quantities are how many such pages there are, how many
-   * fragments each needs, and how the time splits between decoding those fragments and merging
-   * them — none of which a wall clock or a sampling profile separates on its own.
+   * Accounting for versioned page reconstruction, off unless {@code -Dsirix.versioning.diag=true}. A
+   * cold analytical scan pays this only on the pages that span commits, so the interesting quantities
+   * are how many such pages there are, how many fragments each needs, and how the time splits between
+   * decoding those fragments and merging them — none of which a wall clock or a sampling profile
+   * separates on its own.
    */
   private static final boolean VERSIONING_DIAG = Boolean.getBoolean("sirix.versioning.diag");
 
-  private static final LongAdder COMBINES =
-      new LongAdder();
-  private static final LongAdder FRAGMENTS_LOADED =
-      new LongAdder();
-  private static final LongAdder COMBINE_NANOS =
-      new LongAdder();
+  private static final LongAdder COMBINES = new LongAdder();
+  private static final LongAdder FRAGMENTS_LOADED = new LongAdder();
+  private static final LongAdder COMBINE_NANOS = new LongAdder();
 
   /**
    * Thread time spent fetching a page's fragments — the reads and their decodes — as opposed to
    * merging them. The merge is CPU the scan can spread across workers; a fragment fetch blocks the
    * worker that wants the page, which is a different kind of cost and has to be measured separately.
    */
-  private static final LongAdder FRAGMENT_FETCH_NANOS =
-      new LongAdder();
+  private static final LongAdder FRAGMENT_FETCH_NANOS = new LongAdder();
 
   /** Thread time fetching fragments (read + decode) across reconstructions. */
   public static long versioningFragmentFetchNanos() {
@@ -1804,9 +1812,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   private static final int MIN_BYPASS_PAGE_SWEEP_SIZE = 32;
 
   /**
-   * Drop every already-retired page from {@link #bypassLoadedPathSummaryPages} and re-arm the
-   * sweep threshold at twice what survived. Compacts in place — no iterator, no lambda, no
-   * intermediate list — because this runs on the page-load path.
+   * Drop every already-retired page from {@link #bypassLoadedPathSummaryPages} and re-arm the sweep
+   * threshold at twice what survived. Compacts in place — no iterator, no lambda, no intermediate
+   * list — because this runs on the page-load path.
    */
   private void dropClosedBypassLoadedPathSummaryPages() {
     final List<KeyValueLeafPage> pages = bypassLoadedPathSummaryPages;
@@ -1840,9 +1848,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       case CHANGED_NODES -> mostRecentChangedNodesPage;
       case RECORD_TO_REVISIONS -> mostRecentRecordToRevisionsPage;
       case PATH_SUMMARY -> pathSummaryRecordPage;
-      case PATH -> index < mostRecentPathPages.length ? mostRecentPathPages[index] : null;
-      case CAS -> index < mostRecentCasPages.length ? mostRecentCasPages[index] : null;
-      case NAME -> index < mostRecentNamePages.length ? mostRecentNamePages[index] : null;
+      case PATH -> index < mostRecentPathPages.length
+          ? mostRecentPathPages[index]
+          : null;
+      case CAS -> index < mostRecentCasPages.length
+          ? mostRecentCasPages[index]
+          : null;
+      case NAME -> index < mostRecentNamePages.length
+          ? mostRecentNamePages[index]
+          : null;
       case DEWEYID_TO_RECORDID -> mostRecentDeweyIdPage;
       case VECTOR -> null;
       default -> null;
@@ -1858,16 +1872,16 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Invalidate the most-recently-read record page for the given index (async CoW, #1077).
    *
-   * <p>On the synchronous path this cache self-invalidates: {@code TransactionIntentLog.put}
-   * closes the superseded page instance, so the next read's {@code tryAcquireGuard} on the cached
-   * instance fails and the lookup falls through to the trie/TIL. On the ASYNC path the superseded
-   * instance is the frozen snapshot page, which must stay open for the background flush — the
-   * guard succeeds and every read for the rest of the epoch keeps returning the frozen (stale)
-   * instance while writes go into the CoW copy. For a hot page like the one holding a parent
-   * whose {@code firstChildKey} advances with each insert, that split durably corrupts the
-   * sibling chain: each new node links to the stale first child, orphaning everything inserted
-   * after the epoch boundary. The writer calls this after CoW-ing a frozen container so the next
-   * read re-resolves through the TIL.
+   * <p>
+   * On the synchronous path this cache self-invalidates: {@code TransactionIntentLog.put} closes the
+   * superseded page instance, so the next read's {@code tryAcquireGuard} on the cached instance fails
+   * and the lookup falls through to the trie/TIL. On the ASYNC path the superseded instance is the
+   * frozen snapshot page, which must stay open for the background flush — the guard succeeds and
+   * every read for the rest of the epoch keeps returning the frozen (stale) instance while writes go
+   * into the CoW copy. For a hot page like the one holding a parent whose {@code firstChildKey}
+   * advances with each insert, that split durably corrupts the sibling chain: each new node links to
+   * the stale first child, orphaning everything inserted after the epoch boundary. The writer calls
+   * this after CoW-ing a frozen container so the next read re-resolves through the TIL.
    */
   void invalidateMostRecentlyReadRecordPage(final IndexType indexType, final int index) {
     setMostRecentPage(indexType, index, null);
@@ -1900,21 +1914,27 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         yield old;
       }
       case PATH -> {
-        RecordPage old = index < mostRecentPathPages.length ? mostRecentPathPages[index] : null;
+        RecordPage old = index < mostRecentPathPages.length
+            ? mostRecentPathPages[index]
+            : null;
         if (index < mostRecentPathPages.length) {
           mostRecentPathPages[index] = page;
         }
         yield old;
       }
       case CAS -> {
-        RecordPage old = index < mostRecentCasPages.length ? mostRecentCasPages[index] : null;
+        RecordPage old = index < mostRecentCasPages.length
+            ? mostRecentCasPages[index]
+            : null;
         if (index < mostRecentCasPages.length) {
           mostRecentCasPages[index] = page;
         }
         yield old;
       }
       case NAME -> {
-        RecordPage old = index < mostRecentNamePages.length ? mostRecentNamePages[index] : null;
+        RecordPage old = index < mostRecentNamePages.length
+            ? mostRecentNamePages[index]
+            : null;
         if (index < mostRecentNamePages.length) {
           mostRecentNamePages[index] = page;
         }
@@ -1943,9 +1963,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Load a page from the buffer manager's cache, or from storage if not cached.
    * <p>
-   * Uses atomic compute() to prevent race conditions between cache lookup and
-   * guard acquisition. Guards are acquired inside the compute block to ensure
-   * the page cannot be evicted before this transaction has protected it.
+   * Uses atomic compute() to prevent race conditions between cache lookup and guard acquisition.
+   * Guards are acquired inside the compute block to ensure the page cannot be evicted before this
+   * transaction has protected it.
    *
    * @param indexLogKey the index log key for lookup
    * @param pageReferenceToRecordPage reference to the page
@@ -1954,8 +1974,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   @Nullable
   private Page getFromBufferManager(IndexLogKey indexLogKey, PageReference pageReferenceToRecordPage) {
     if (DEBUG_PATH_SUMMARY && indexLogKey.getIndexType() == IndexType.PATH_SUMMARY && LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Path summary cache lookup: key={}, revision={}",
-                   pageReferenceToRecordPage.getKey(), indexLogKey.getRevisionNumber());
+      LOGGER.debug("Path summary cache lookup: key={}, revision={}", pageReferenceToRecordPage.getKey(),
+          indexLogKey.getRevisionNumber());
     }
 
     final ResourceConfiguration config = resourceSession.getResourceConfig();
@@ -1967,14 +1987,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // In both cases skip the RecordPageFragmentCache + combineRecordPages
     // round-trip and load straight into RecordPageCache. Profile showed
     // combineRecordPages at ~50% inclusive CPU before this change.
-    final boolean singleFragmentFastPath =
-        pageReferenceToRecordPage.getKey() != Constants.NULL_ID_LONG
-            && (config.versioningType == VersioningType.FULL
-                || pageReferenceToRecordPage.getPageFragments().isEmpty());
+    final boolean singleFragmentFastPath = pageReferenceToRecordPage.getKey() != Constants.NULL_ID_LONG
+        && (config.versioningType == VersioningType.FULL || pageReferenceToRecordPage.getPageFragments().isEmpty());
     if (singleFragmentFastPath) {
       KeyValueLeafPage page = resourceBufferManager.getRecordPageCache()
-          .getOrLoadAndGuard(pageReferenceToRecordPage,
-              ref -> (KeyValueLeafPage) pageReader.read(ref, config));
+                                                   .getOrLoadAndGuard(pageReferenceToRecordPage,
+                                                       ref -> (KeyValueLeafPage) pageReader.read(ref, config));
 
       if (page != null) {
         pageReferenceToRecordPage.setPage(page);
@@ -1985,9 +2003,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
 
     // Other versioning types with fragment history: load fragments → combine → cache
-    KeyValueLeafPage page = resourceBufferManager.getRecordPageCache()
-        .getOrLoadAndGuard(pageReferenceToRecordPage,
-            ref -> (KeyValueLeafPage) loadDataPageFromDurableStorageAndCombinePageFragments(ref));
+    KeyValueLeafPage page =
+        resourceBufferManager.getRecordPageCache()
+                             .getOrLoadAndGuard(pageReferenceToRecordPage,
+                                 ref -> (KeyValueLeafPage) loadDataPageFromDurableStorageAndCombinePageFragments(ref));
 
     if (page != null) {
       pageReferenceToRecordPage.setPage(page);
@@ -2009,9 +2028,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         if (DEBUG_PATH_SUMMARY && recordPage != null) {
           LOGGER.debug(
               "[PATH_SUMMARY-REPLACE] Replacing old pathSummaryRecordPage: oldPageKey={}, newPageKey={}, trxIntentLog={}",
-              pathSummaryRecordPage.page.getPageKey(),
-              recordPage.getPageKey(),
-              (trxIntentLog != null));
+              pathSummaryRecordPage.page.getPageKey(), recordPage.getPageKey(), (trxIntentLog != null));
         }
 
         if (trxIntentLog == null) {
@@ -2027,13 +2044,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
           // But if bypass is disabled for testing, they might be cached
           // Remove from cache before closing to prevent "closed page in cache" errors
           pathSummaryRecordPage.pageReference.setPage(null);
-          //resourceBufferManager.getRecordPageCache().remove(pathSummaryRecordPage.pageReference);
+          // resourceBufferManager.getRecordPageCache().remove(pathSummaryRecordPage.pageReference);
 
           if (!pathSummaryRecordPage.page.isClosed()) {
             if (DEBUG_PATH_SUMMARY) {
               LOGGER.debug("[PATH_SUMMARY-REPLACE]   -> Write trx: Closing bypassed page pageKey={}, revision={}",
-                           pathSummaryRecordPage.page.getPageKey(),
-                           pathSummaryRecordPage.page.getRevision());
+                  pathSummaryRecordPage.page.getPageKey(), pathSummaryRecordPage.page.getRevision());
             }
             // retire(), not close(): a bypassed page is transaction-private (write transactions skip
             // caching PATH_SUMMARY), so nothing else can free it — and close() alone returns early
@@ -2044,20 +2060,12 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         }
       }
 
-      pathSummaryRecordPage = new RecordPage(indexLogKey.getIndexNumber(),
-                                             indexLogKey.getIndexType(),
-                                             indexLogKey.getRecordPageKey(),
-                                             indexLogKey.getRevisionNumber(),
-                                             pageReference,
-                                             recordPage);
+      pathSummaryRecordPage = new RecordPage(indexLogKey.getIndexNumber(), indexLogKey.getIndexType(),
+          indexLogKey.getRecordPageKey(), indexLogKey.getRevisionNumber(), pageReference, recordPage);
     } else {
       // Set as most recent page for this type/index (auto-unpins previous)
-      var newRecordPage = new RecordPage(indexLogKey.getIndexNumber(),
-                                         indexLogKey.getIndexType(),
-                                         indexLogKey.getRecordPageKey(),
-                                         indexLogKey.getRevisionNumber(),
-                                         pageReference,
-                                         recordPage);
+      var newRecordPage = new RecordPage(indexLogKey.getIndexNumber(), indexLogKey.getIndexType(),
+          indexLogKey.getRecordPageKey(), indexLogKey.getRevisionNumber(), pageReference, recordPage);
       setMostRecentPage(indexLogKey.getIndexType(), indexLogKey.getIndexNumber(), newRecordPage);
     }
   }
@@ -2065,9 +2073,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Load a page from storage and combine with historical fragments for versioning.
    * <p>
-   * This method handles the versioning reconstruction by loading the current page
-   * fragment and combining it with previous revisions according to the configured
-   * versioning strategy (e.g., incremental, differential, full).
+   * This method handles the versioning reconstruction by loading the current page fragment and
+   * combining it with previous revisions according to the configured versioning strategy (e.g.,
+   * incremental, differential, full).
    *
    * @param pageReferenceToRecordPage reference to the page to load
    * @return the combined page, or null if no page exists at this reference
@@ -2078,7 +2086,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       return null;
     }
 
-    final long reconstructStart = VERSIONING_DIAG ? System.nanoTime() : 0L;
+    final long reconstructStart = VERSIONING_DIAG
+        ? System.nanoTime()
+        : 0L;
     final var result = getPageFragments(pageReferenceToRecordPage);
     if (result.pages().isEmpty()) {
       return null;
@@ -2106,7 +2116,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       }
 
       resolveFsstSymbolTables(result.pages());
-      final long combineStart = VERSIONING_DIAG ? System.nanoTime() : 0L;
+      final long combineStart = VERSIONING_DIAG
+          ? System.nanoTime()
+          : 0L;
       final Page completePage = versioningApproach.combineRecordPages(result.pages(), maxRevisionsToRestore, this);
       if (VERSIONING_DIAG) {
         COMBINE_NANOS.add(System.nanoTime() - combineStart);
@@ -2130,8 +2142,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   @Nullable
-  private Page getInMemoryPageInstance(IndexLogKey indexLogKey,
-      PageReference pageReferenceToRecordPage) {
+  private Page getInMemoryPageInstance(IndexLogKey indexLogKey, PageReference pageReferenceToRecordPage) {
     Page page = pageReferenceToRecordPage.getPage();
 
     if (page != null) {
@@ -2140,9 +2151,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       if (trxIntentLog == null || indexLogKey.getIndexType() != IndexType.PATH_SUMMARY) {
         var kvLeafPage = ((KeyValueLeafPage) page);
         if (DEBUG_PATH_SUMMARY && indexLogKey.getIndexType() == IndexType.PATH_SUMMARY) {
-          LOGGER.debug("[PATH_SUMMARY-SWIZZLED] Found swizzled page: pageKey={}, revision={}",
-                       kvLeafPage.getPageKey(),
-                       kvLeafPage.getRevision());
+          LOGGER.debug("[PATH_SUMMARY-SWIZZLED] Found swizzled page: pageKey={}, revision={}", kvLeafPage.getPageKey(),
+              kvLeafPage.getRevision());
         }
 
         // tryAcquireGuard is atomic with close(): split acquire + isClosed
@@ -2180,18 +2190,19 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Result of loading page fragments, including pages, original fragment keys, and storage key for pages[0].
+   * Result of loading page fragments, including pages, original fragment keys, and storage key for
+   * pages[0].
    */
   record PageFragmentsResult(List<KeyValuePage<DataRecord>> pages, List<PageFragmentKey> originalKeys,
-                             long storageKeyForFirstFragment) {
+      long storageKeyForFirstFragment) {
   }
 
   /**
    * Dereference key/value page reference and get all page fragments from revision-trees.
    * <p>
-   * For versioning systems (incremental, differential), a complete page may be composed
-   * of multiple fragments from different revisions. This method loads all required
-   * fragments and returns them in order for combining.
+   * For versioning systems (incremental, differential), a complete page may be composed of multiple
+   * fragments from different revisions. This method loads all required fragments and returns them in
+   * order for combining.
    *
    * @param pageReference reference pointing to the first (most recent) page fragment
    * @return result containing all page fragments and their original keys
@@ -2204,31 +2215,22 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // FULL versioning fast path: Page IS complete - use RecordPageCache directly
     // This bypasses the fragment cache since there are no fragments to combine
     if (config.versioningType == VersioningType.FULL) {
-      final var pageReferenceWithKey = new PageReference()
-          .setKey(pageReference.getKey())
-          .setDatabaseId(databaseId)
-          .setResourceId(resourceId);
+      final var pageReferenceWithKey =
+          new PageReference().setKey(pageReference.getKey()).setDatabaseId(databaseId).setResourceId(resourceId);
       // Copy hash for checksum verification
       if (pageReference.getHash() != null) {
         pageReferenceWithKey.setHash(pageReference.getHash());
       }
 
       KeyValueLeafPage page = resourceBufferManager.getRecordPageCache()
-          .getOrLoadAndGuard(pageReferenceWithKey,
-              key -> (KeyValueLeafPage) pageReader.read(key, config));
+                                                   .getOrLoadAndGuard(pageReferenceWithKey,
+                                                       key -> (KeyValueLeafPage) pageReader.read(key, config));
 
       if (page != null && !page.isClosed()) {
-        return new PageFragmentsResult(
-            Collections.singletonList(page),
-            Collections.emptyList(),
-            pageReference.getKey()
-        );
+        return new PageFragmentsResult(Collections.singletonList(page), Collections.emptyList(),
+            pageReference.getKey());
       }
-      return new PageFragmentsResult(
-          Collections.emptyList(),
-          Collections.emptyList(),
-          pageReference.getKey()
-      );
+      return new PageFragmentsResult(Collections.emptyList(), Collections.emptyList(), pageReference.getKey());
     }
 
     // Other versioning types: load fragments from RecordPageFragmentCache
@@ -2247,9 +2249,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     }
 
     // Load first fragment atomically with guard
-    KeyValueLeafPage page = resourceBufferManager.getRecordPageFragmentCache()
-        .getOrLoadAndGuard(pageReferenceWithKey,
-            key -> (KeyValueLeafPage) pageReader.read(key, resourceSession.getResourceConfig()));
+    KeyValueLeafPage page =
+        resourceBufferManager.getRecordPageFragmentCache()
+                             .getOrLoadAndGuard(pageReferenceWithKey,
+                                 key -> (KeyValueLeafPage) pageReader.read(key, resourceSession.getResourceConfig()));
 
     assert page != null && !page.isClosed();
     pages.add(page);
@@ -2277,12 +2280,11 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Thread-local scratch PageReference used as a cache-lookup key on the fast
-   * path. ConcurrentHashMap.get only needs an object with matching hashCode/
-   * equals — it never stores the passed-in key. Allocating a fresh
-   * PageReference per cache hit was 21% of all allocations (async-profiler
-   * alloc mode). On cache miss we still allocate a fresh PageReference for
-   * insertion so each cache entry owns a stable key.
+   * Thread-local scratch PageReference used as a cache-lookup key on the fast path.
+   * ConcurrentHashMap.get only needs an object with matching hashCode/ equals — it never stores the
+   * passed-in key. Allocating a fresh PageReference per cache hit was 21% of all allocations
+   * (async-profiler alloc mode). On cache miss we still allocate a fresh PageReference for insertion
+   * so each cache entry owns a stable key.
    */
   private static final ThreadLocal<PageReference> LOOKUP_REF = ThreadLocal.withInitial(PageReference::new);
 
@@ -2296,14 +2298,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     KeyValueLeafPage pageFromCache = resourceBufferManager.getRecordPageFragmentCache().getAndGuard(lookup);
 
     if (pageFromCache != null) {
-      assert pageFragmentKey.revision() == pageFromCache.getRevision() :
-          "Revision mismatch: key=" + pageFragmentKey.revision() + ", page=" + pageFromCache.getRevision();
+      assert pageFragmentKey.revision() == pageFromCache.getRevision()
+          : "Revision mismatch: key=" + pageFragmentKey.revision() + ", page=" + pageFromCache.getRevision();
       return CompletableFuture.completedFuture(pageFromCache);
     }
 
     // Cache miss — allocate a proper PageReference for insertion as the map key.
-    final var pageReference =
-        new PageReference().setKey(key).setDatabaseId(databaseId).setResourceId(resourceId);
+    final var pageReference = new PageReference().setKey(key).setDatabaseId(databaseId).setResourceId(resourceId);
 
     // Read on THIS thread with the reader this transaction already owns, rather than borrowing a
     // fresh one and hopping to a virtual thread. The caller blocks on the result either way, so the
@@ -2313,13 +2314,14 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     // path of every scan worker. Measured on a cold scan of a store with 529 multi-fragment pages,
     // fetching their fragments cost 19.07 ms of thread time per page against 0.92 ms to merge them.
     final Page loadedPage = pageReader.read(pageReference, resourceSession.getResourceConfig());
-    assert pageFragmentKey.revision() == ((KeyValuePage<DataRecord>) loadedPage).getRevision() :
-        "Revision mismatch: key=" + pageFragmentKey.revision() + ", page="
+    assert pageFragmentKey.revision() == ((KeyValuePage<DataRecord>) loadedPage).getRevision()
+        : "Revision mismatch: key=" + pageFragmentKey.revision() + ", page="
             + ((KeyValuePage<DataRecord>) loadedPage).getRevision();
 
     // Atomic cache-or-store with guard (handles race with other threads).
-    final KeyValueLeafPage cachedPage = resourceBufferManager.getRecordPageFragmentCache()
-        .getOrLoadAndGuard(pageReference, _ -> (KeyValueLeafPage) loadedPage);
+    final KeyValueLeafPage cachedPage =
+        resourceBufferManager.getRecordPageFragmentCache()
+                             .getOrLoadAndGuard(pageReference, _ -> (KeyValueLeafPage) loadedPage);
 
     // If another thread won the race, its instance is now cached and the page we loaded from disk
     // was never adopted — close it to free its off-heap segments (production builds have no
@@ -2332,14 +2334,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   static <T> CompletableFuture<List<T>> sequence(List<CompletableFuture<T>> listOfCompletableFutures) {
-    return CompletableFuture.allOf(listOfCompletableFutures.toArray(new CompletableFuture[0]))
-                            .thenApply(_ -> {
-                              final var result = new ArrayList<T>(listOfCompletableFutures.size());
-                              for (final var future : listOfCompletableFutures) {
-                                result.add(future.join());
-                              }
-                              return result;
-                            });
+    return CompletableFuture.allOf(listOfCompletableFutures.toArray(new CompletableFuture[0])).thenApply(_ -> {
+      final var result = new ArrayList<T>(listOfCompletableFutures.size());
+      for (final var future : listOfCompletableFutures) {
+        result.add(future.join());
+      }
+      return result;
+    });
   }
 
   /**
@@ -2347,8 +2348,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * nodes, Path index nodes or Name index nodes).
    *
    * @param revisionRoot {@link RevisionRootPage} instance
-   * @param indexType    the index type
-   * @param index        the index to use
+   * @param indexType the index type
+   * @param index the index to use
    */
   PageReference getPageReference(final RevisionRootPage revisionRoot, final IndexType indexType, final int index) {
     assert revisionRoot != null;
@@ -2366,7 +2367,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       case PROJECTION -> getProjectionIndexPage(revisionRoot).getIndirectPageReference(index);
       case VALIDTIME -> getValidTimeIndexPage(revisionRoot).getIndirectPageReference(index);
       default ->
-          throw new IllegalStateException("Only defined for node, path summary, text value and attribute value pages!");
+        throw new IllegalStateException("Only defined for node, path summary, text value and attribute value pages!");
     };
   }
 
@@ -2375,7 +2376,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    *
    * @param reference reference to dereference
    * @return dereferenced page
-   * @throws SirixIOException     if something odd happens within the creation process
+   * @throws SirixIOException if something odd happens within the creation process
    * @throws NullPointerException if {@code reference} is {@code null}
    */
   @Override
@@ -2387,7 +2388,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
    * Find reference pointing to leaf page of an indirect tree.
    *
    * @param startReference start reference pointing to the indirect tree
-   * @param pageKey        key to look up in the indirect tree
+   * @param pageKey key to look up in the indirect tree
    * @return reference denoted by key pointing to the leaf page
    * @throws SirixIOException if an I/O error occurs
    */
@@ -2396,8 +2397,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   public PageReference getReferenceToLeafOfSubtree(final PageReference startReference, final long pageKey,
       final int indexNumber, final IndexType indexType, final RevisionRootPage revisionRootPage) {
     assertNotClosed();
-    return keyedTrieReader.getReferenceToLeafOfSubtree(this, uberPage, startReference, pageKey, indexNumber,
-        indexType, revisionRootPage);
+    return keyedTrieReader.getReferenceToLeafOfSubtree(this, uberPage, startReference, pageKey, indexNumber, indexType,
+        revisionRootPage);
   }
 
   @Override
@@ -2407,14 +2408,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     return switch (indexType) {
       case PATH_SUMMARY -> recordKey >> Constants.PATHINP_REFERENCE_COUNT_EXPONENT;
       case REVISIONS -> recordKey >> Constants.UBPINP_REFERENCE_COUNT_EXPONENT;
-      case PATH, DOCUMENT, CAS, NAME, VECTOR, PROJECTION, VALIDTIME -> recordKey >> Constants.INP_REFERENCE_COUNT_EXPONENT;
+      case PATH, DOCUMENT, CAS, NAME, VECTOR, PROJECTION, VALIDTIME ->
+        recordKey >> Constants.INP_REFERENCE_COUNT_EXPONENT;
       default -> recordKey >> Constants.NDP_NODE_COUNT_EXPONENT;
     };
   }
 
   /**
-   * Fast-path page key computation for DOCUMENT index type.
-   * Skips assertNotClosed() and the IndexType switch — inlines the DOCUMENT case directly.
+   * Fast-path page key computation for DOCUMENT index type. Skips assertNotClosed() and the IndexType
+   * switch — inlines the DOCUMENT case directly.
    *
    * @param recordKey the record key
    * @return the page key
@@ -2427,7 +2429,9 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   public int getCurrentMaxIndirectPageTreeLevel(final IndexType indexType, final int index,
       final RevisionRootPage revisionRootPage) {
     final int maxLevel;
-    final RevisionRootPage currentRevisionRootPage = revisionRootPage == null ? rootPage : revisionRootPage;
+    final RevisionRootPage currentRevisionRootPage = revisionRootPage == null
+        ? rootPage
+        : revisionRootPage;
 
     // $CASES-OMITTED$
     maxLevel = switch (indexType) {
@@ -2457,16 +2461,16 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   @Override
   public String toString() {
     return ToStringHelper.of(this)
-                      .add("Session", resourceSession)
-                      .add("PageReader", pageReader)
-                      .add("UberPage", uberPage)
-                      .add("RevRootPage", rootPage)
-                      .toString();
+                         .add("Session", resourceSession)
+                         .add("PageReader", pageReader)
+                         .add("UberPage", uberPage)
+                         .add("RevRootPage", rootPage)
+                         .toString();
   }
 
   /**
-   * Close the current page guard if one is active.
-   * Should be called before fetching a different page or when transaction closes.
+   * Close the current page guard if one is active. Should be called before fetching a different page
+   * or when transaction closes.
    * <p>
    * Package-private to allow NodeStorageEngineWriter to release guards before TIL operations.
    */
@@ -2490,13 +2494,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   }
 
   /**
-   * Get the page that the current page guard is protecting.
-   * Used by NodeStorageEngineWriter for acquiring additional guards on the current page.
+   * Get the page that the current page guard is protecting. Used by NodeStorageEngineWriter for
+   * acquiring additional guards on the current page.
    *
    * @return the current page, or null if no page is currently guarded
    */
   public KeyValueLeafPage getCurrentPage() {
-    return currentPageGuard != null ? currentPageGuard.page() : null;
+    return currentPageGuard != null
+        ? currentPageGuard.page()
+        : null;
   }
 
   @Override
@@ -2612,13 +2618,13 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   @Override
   public @Nullable HOTLeafPage getHOTLeafPage(IndexType indexType, int indexNumber) {
     assertNotClosed();
-    
+
     // CRITICAL: Use getActualRevisionRootPage() to get the current revision root,
     // which for write transactions is the NEW revision root page where HOT pages are stored.
     // Using the old 'rootPage' field would fail for write transactions because the HOT
     // pages are stored against the new revision's PathPage/CASPage/NamePage references.
     final RevisionRootPage actualRootPage = getActualRevisionRootPage();
-    
+
     // Get the root reference for the index
     final PageReference rootRef = switch (indexType) {
       case PATH -> {
@@ -2680,17 +2686,15 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         }
       }
     }
-    
+
     // For uncommitted pages with no disk key, we're done
     if (rootRef.getKey() < 0) {
       return null;
     }
 
     // Build canonical cache key (logKey=-1) so writes and reads use the same key
-    final PageReference cacheKey = new PageReference()
-        .setKey(rootRef.getKey())
-        .setDatabaseId(getDatabaseId())
-        .setResourceId(getResourceId());
+    final PageReference cacheKey =
+        new PageReference().setKey(rootRef.getKey()).setDatabaseId(getDatabaseId()).setResourceId(getResourceId());
 
     final HOTLeafPage cached = resourceBufferManager.getHOTLeafPageCache().get(cacheKey);
     if (cached != null && !cached.isClosed()) {
@@ -2707,20 +2711,24 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       return null;
     }
   }
-  
+
   /**
    * Load a HOTLeafPage from storage with proper versioning fragment combining.
    *
-   * <p>For FULL versioning, the already-loaded page is complete — no additional I/O needed.
-   * For INCREMENTAL/DIFFERENTIAL/SLIDING_SNAPSHOT, loads additional fragments and combines.</p>
+   * <p>
+   * For FULL versioning, the already-loaded page is complete — no additional I/O needed. For
+   * INCREMENTAL/DIFFERENTIAL/SLIDING_SNAPSHOT, loads additional fragments and combines.
+   * </p>
    *
-   * <p>The fragment chain ({@link PageReference#getPageFragments()}) is read from {@code chainRef}
-   * — the real index-root reference — NOT from {@code cacheKey}. The canonical {@code cacheKey}
-   * carries no chain, so passing it for fragment lookup would silently drop every older revision's
-   * delta fragment and lose all historical entries.</p>
+   * <p>
+   * The fragment chain ({@link PageReference#getPageFragments()}) is read from {@code chainRef} — the
+   * real index-root reference — NOT from {@code cacheKey}. The canonical {@code cacheKey} carries no
+   * chain, so passing it for fragment lookup would silently drop every older revision's delta
+   * fragment and lose all historical entries.
+   * </p>
    *
-   * @param chainRef  the index-root reference carrying the prior-fragment chain
-   * @param cacheKey  the canonical key (logKey=-1) used to store the combined page in the cache
+   * @param chainRef the index-root reference carrying the prior-fragment chain
+   * @param cacheKey the canonical key (logKey=-1) used to store the combined page in the cache
    * @param firstPage the already-loaded newest fragment (avoids a redundant SSD read)
    * @return the combined HOTLeafPage, or null if not found
    */
@@ -2754,21 +2762,24 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
     resourceBufferManager.getHOTLeafPageCache().put(cacheKey, combinedPage);
     return combinedPage;
   }
-  
+
   /**
    * Load all HOTLeafPage fragments for versioning reconstruction.
    *
-   * <p>Accepts the already-loaded first page to eliminate a redundant SSD read.
-   * Additional fragments are loaded sequentially from the versioning chain.</p>
+   * <p>
+   * Accepts the already-loaded first page to eliminate a redundant SSD read. Additional fragments are
+   * loaded sequentially from the versioning chain.
+   * </p>
    *
-   * <p><b>An empty result means "there is no prior fragment", never "the window could not be
-   * read".</b> This window is the WRITE path's input: {@code combineHOTLeafPagesForModification}
-   * carries the aging fragment's still-live entries (SLIDING_SNAPSHOT) or re-emits the prior
-   * cumulative delta (DIFFERENTIAL) from it, and then rotates the chain REGARDLESS. Both
-   * carry-forwards no-op on an empty window, so degrading a read failure to {@code List.of()}
-   * committed a sparse fragment without the entries it was required to carry, and dropped the
-   * fragment that still held them — silent, permanent data loss with no exception and no log. A
-   * failure therefore propagates; the commit aborts instead.
+   * <p>
+   * <b>An empty result means "there is no prior fragment", never "the window could not be read".</b>
+   * This window is the WRITE path's input: {@code combineHOTLeafPagesForModification} carries the
+   * aging fragment's still-live entries (SLIDING_SNAPSHOT) or re-emits the prior cumulative delta
+   * (DIFFERENTIAL) from it, and then rotates the chain REGARDLESS. Both carry-forwards no-op on an
+   * empty window, so degrading a read failure to {@code List.of()} committed a sparse fragment
+   * without the entries it was required to carry, and dropped the fragment that still held them —
+   * silent, permanent data loss with no exception and no log. A failure therefore propagates; the
+   * commit aborts instead.
    *
    * @param chainRef the index-root reference carrying the prior-fragment chain
    * @return the window, newest first, of exactly {@code 1 + chainRef.getPageFragments().size()}
@@ -2788,8 +2799,10 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       if (first != null) {
         first.close();
       }
-      throw new SirixIOException("HOT fragment window head at key " + chainRef.getKey()
-          + " is not a HOTLeafPage but " + (first == null ? "null" : first.getClass().getSimpleName())
+      throw new SirixIOException("HOT fragment window head at key " + chainRef.getKey() + " is not a HOTLeafPage but "
+          + (first == null
+              ? "null"
+              : first.getClass().getSimpleName())
           + " — refusing to carry forward from an unreadable window");
     }
     return loadHOTPageFragments(chainRef, firstPage);
@@ -2848,38 +2861,44 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Load one chain fragment through {@link BufferManager#getHOTLeafFragmentCache()}, GUARDED.
    *
-   * <p>Chain fragments are re-read by every commit that copy-on-writes the same leaf while the
+   * <p>
+   * Chain fragments are re-read by every commit that copy-on-writes the same leaf while the
    * versioning window still spans them — under the default SLIDING_SNAPSHOT with
-   * {@code revsToRestore=3} that is essentially every commit of a hot leaf. Reading them straight
-   * off {@code pageReader} made the write path pay a synchronous, uncached page read per fragment
-   * per commit where it previously did no I/O at all.</p>
+   * {@code revsToRestore=3} that is essentially every commit of a hot leaf. Reading them straight off
+   * {@code pageReader} made the write path pay a synchronous, uncached page read per fragment per
+   * commit where it previously did no I/O at all.
+   * </p>
    *
-   * <p>Scope, precisely: this caches the CHAIN fragments only. Element 0 of a window is the page at
+   * <p>
+   * Scope, precisely: this caches the CHAIN fragments only. Element 0 of a window is the page at
    * {@code reference.getKey()}, which its caller reads fresh and owns, so at the default chain cap
-   * the steady-state cost goes from three reads per commit to two rather than to one. Caching
-   * element 0 as well would need it to stop being caller-owned — it can become the combined page and
-   * is then handed to {@code getHOTLeafPageCache()}, so one instance would sit in two caches.</p>
+   * the steady-state cost goes from three reads per commit to two rather than to one. Caching element
+   * 0 as well would need it to stop being caller-owned — it can become the combined page and is then
+   * handed to {@code getHOTLeafPageCache()}, so one instance would sit in two caches.
+   * </p>
    *
-   * <p>Fragments are treated as immutable at a given offset, which holds only while the data file is
+   * <p>
+   * Fragments are treated as immutable at a given offset, which holds only while the data file is
    * append-only. Truncation (rollback / crash recovery) REUSES offsets, so both
    * {@code BufferManagerImpl.clearCachesForDatabase} and {@code clearCachesForResource} must drop
-   * this cache — otherwise a reused offset serves pre-truncation bytes into a live merge.</p>
+   * this cache — otherwise a reused offset serves pre-truncation bytes into a live merge.
+   * </p>
    *
-   * <p>The returned page is always guarded, whether or not it was adopted by the cache, so callers
-   * have ONE lifetime rule (release exactly once — see
-   * {@link #releaseHOTLeafFragments}). When the cache cannot adopt it (a guard-less
-   * {@code EmptyCache}, or a lost adoption race) the page is guarded and immediately orphaned, so
-   * the caller's release drops the last guard and frees its off-heap slot right there.</p>
+   * <p>
+   * The returned page is always guarded, whether or not it was adopted by the cache, so callers have
+   * ONE lifetime rule (release exactly once — see {@link #releaseHOTLeafFragments}). When the cache
+   * cannot adopt it (a guard-less {@code EmptyCache}, or a lost adoption race) the page is guarded
+   * and immediately orphaned, so the caller's release drops the last guard and frees its off-heap
+   * slot right there.
+   * </p>
    *
    * @param fragmentKey the fragment's durable offset
    * @return the guarded fragment, or {@code null} if it is absent or not a HOT leaf
    */
   private @Nullable HOTLeafPage loadChainFragmentGuarded(final long fragmentKey) {
-    final PageReference fragmentRef = new PageReference().setKey(fragmentKey)
-                                                        .setDatabaseId(databaseId)
-                                                        .setResourceId(resourceId);
-    final Cache<PageReference, HOTLeafPage> fragmentCache =
-        resourceBufferManager.getHOTLeafFragmentCache();
+    final PageReference fragmentRef =
+        new PageReference().setKey(fragmentKey).setDatabaseId(databaseId).setResourceId(resourceId);
+    final Cache<PageReference, HOTLeafPage> fragmentCache = resourceBufferManager.getHOTLeafFragmentCache();
     try {
       final HOTLeafPage cached = fragmentCache.getAndGuard(fragmentRef);
       if (cached != null) {
@@ -2920,18 +2939,19 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
   /**
    * Counterpart of {@link #loadHOTLeafFragments}: end the caller's use of a fragment window.
    *
-   * <p>The list's first element is the caller-supplied newest page and stays caller-owned (it is
-   * closed here unless it is {@code keepOpen}, typically because it became the combined page). Every
-   * later element is a GUARDED chain fragment and must be RELEASED, never closed — closing would
-   * orphan the shared cache entry, so the next commit would miss and re-read it, defeating the
-   * cache while still appearing to work.</p>
+   * <p>
+   * The list's first element is the caller-supplied newest page and stays caller-owned (it is closed
+   * here unless it is {@code keepOpen}, typically because it became the combined page). Every later
+   * element is a GUARDED chain fragment and must be RELEASED, never closed — closing would orphan the
+   * shared cache entry, so the next commit would miss and re-read it, defeating the cache while still
+   * appearing to work.
+   * </p>
    *
    * @param fragments the window as returned by {@link #loadHOTLeafFragments}
-   * @param keepOpen  a page the caller still owns and that must not be closed, or {@code null}
+   * @param keepOpen a page the caller still owns and that must not be closed, or {@code null}
    */
   @Override
-  public void releaseHOTLeafFragments(final List<HOTLeafPage> fragments,
-      final @Nullable HOTLeafPage keepOpen) {
+  public void releaseHOTLeafFragments(final List<HOTLeafPage> fragments, final @Nullable HOTLeafPage keepOpen) {
     for (int i = 0; i < fragments.size(); i++) {
       final HOTLeafPage fragment = fragments.get(i);
       if (i == 0) {
@@ -2943,7 +2963,7 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
       }
     }
   }
-  
+
   public @Nullable Page loadHOTPage(PageReference reference) {
     assertNotClosed();
 
@@ -2984,10 +3004,8 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
 
     // Load from storage (only if key >= 0)
     if (reference.getKey() >= 0) {
-      final PageReference canonicalKey = new PageReference()
-          .setKey(reference.getKey())
-          .setDatabaseId(getDatabaseId())
-          .setResourceId(getResourceId());
+      final PageReference canonicalKey =
+          new PageReference().setKey(reference.getKey()).setDatabaseId(getDatabaseId()).setResourceId(getResourceId());
 
       final HOTLeafPage cachedHot = resourceBufferManager.getHOTLeafPageCache().get(canonicalKey);
       if (cachedHot != null && !cachedHot.isClosed()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineReader.java
@@ -2515,9 +2515,18 @@ public final class NodeStorageEngineReader implements StorageEngineReader {
         pageReader.close();
       }
 
-      if (resourceSession.getNodeReadTrxByTrxId(trxId).isEmpty()) {
-        resourceSession.closePageReadTransaction(trxId);
-      }
+      // Drop this reader from the session's bookkeeping, unconditionally and by identity.
+      //
+      // This used to be gated on "no node transaction carries my id" — a check across two
+      // then-independent id spaces: trxId is a storage engine id, while getNodeReadTrxByTrxId
+      // consults the node transaction map. The two counters advanced in lockstep for a
+      // read-only workload, so the gate was a false positive on EVERY beginNodeReadOnlyTrx
+      // close and the entry was never removed; conversely a writer-bound reader (whose node
+      // transaction had just been unregistered) passed the gate and removed an unrelated live
+      // reader that happened to hold the same number. Ids are now drawn from one session-wide
+      // counter and the removal below is identity-scoped, so neither is expressible: a reader
+      // that is closing is not running, and only its own entry can go.
+      resourceSession.closePageReadTransaction(trxId, this);
 
       // Drop most-recent slot references. They are UNGUARDED references to SHARED cache
       // instances — this transaction holds no pin on them (the only guard it owns is

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -1849,7 +1849,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       storageEngineReader.resourceSession.setLastCommittedUberPage(lastUberPage);
 
       if (!isBoundToNodeTrx) {
-        storageEngineReader.resourceSession.closePageWriteTransaction(storageEngineReader.getTrxId());
+        storageEngineReader.resourceSession.closePageWriteTransaction(storageEngineReader.getTrxId(), this);
       }
 
       // CRITICAL: Close storageEngineReader FIRST to release guards BEFORE TIL tries to close pages

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -126,8 +126,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   /**
    * Buffered output for page writes.
    *
-   * <p>Use 2x FLUSH_SIZE so single large page fragments do not force grow/copy on every write
-   * before the subsequent flush threshold check.
+   * <p>
+   * Use 2x FLUSH_SIZE so single large page fragments do not force grow/copy on every write before the
+   * subsequent flush threshold check.
    */
   private BytesOut<?> bufferBytes = Bytes.borrowElasticOffHeapByteBuffer(Writer.FLUSH_SIZE * 2);
 
@@ -157,16 +158,16 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   private volatile boolean isClosed;
 
   /**
-   * Shared Cleaner that runs the leak-detection callback on every NodeStorageEngineWriter
-   * once it becomes phantom-reachable. Used as the post-Java-9 replacement for the
-   * deprecated {@code finalize()} override.
+   * Shared Cleaner that runs the leak-detection callback on every NodeStorageEngineWriter once it
+   * becomes phantom-reachable. Used as the post-Java-9 replacement for the deprecated
+   * {@code finalize()} override.
    */
   private static final java.lang.ref.Cleaner LEAK_CLEANER = java.lang.ref.Cleaner.create();
 
   /**
-   * State captured for leak diagnostics. Static class with no reference to the enclosing
-   * writer — capturing {@code this} would make the writer strongly reachable through the
-   * Cleaner queue and defeat the leak detection it implements.
+   * State captured for leak diagnostics. Static class with no reference to the enclosing writer —
+   * capturing {@code this} would make the writer strongly reachable through the Cleaner queue and
+   * defeat the leak detection it implements.
    */
   private static final class LeakDetectorState implements Runnable {
     final int trxId;
@@ -189,7 +190,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         return;
       }
       final TransactionIntentLog log = logRef.get();
-      final int containerCount = log != null ? log.getList().size() : -1;
+      final int containerCount = log != null
+          ? log.getList().size()
+          : -1;
       LOGGER.warn(
           "NodeStorageEngineWriter FINALIZED WITHOUT CLOSE: trxId={} instance={} TIL={} with {} containers in TIL",
           trxId, writerIdentity, logIdentity, containerCount);
@@ -231,13 +234,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     int revisionNumber;
     PageContainer pageContainer;
 
-    IndexLogKeyToPageContainer(final IndexType indexType, final long recordPageKey,
-        final int indexNumber, final int revisionNumber, final PageContainer pageContainer) {
+    IndexLogKeyToPageContainer(final IndexType indexType, final long recordPageKey, final int indexNumber,
+        final int revisionNumber, final PageContainer pageContainer) {
       set(indexType, recordPageKey, indexNumber, revisionNumber, pageContainer);
     }
 
-    void set(final IndexType indexType, final long recordPageKey, final int indexNumber,
-        final int revisionNumber, final PageContainer pageContainer) {
+    void set(final IndexType indexType, final long recordPageKey, final int indexNumber, final int revisionNumber,
+        final PageContainer pageContainer) {
       this.indexType = indexType;
       this.recordPageKey = recordPageKey;
       this.indexNumber = indexNumber;
@@ -246,8 +249,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     void copyFrom(final IndexLogKeyToPageContainer other) {
-      set(other.indexType, other.recordPageKey, other.indexNumber,
-          other.revisionNumber, other.pageContainer);
+      set(other.indexType, other.recordPageKey, other.indexNumber, other.revisionNumber, other.pageContainer);
     }
   }
 
@@ -267,29 +269,28 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   private IndexLogKeyToPageContainer mostRecentPathSummaryPageContainer;
 
   /**
-   * Most recent page container per {@link IndexType} (ordinal-indexed, lazily populated).
-   * The shared {@link #mostRecentPageContainer}/{@link #secondMostRecentPageContainer} pair
-   * thrashes when a commit interleaves streams of three or more index types (DOCUMENT +
-   * secondary indexes during shredding): every switch to another type evicts, so lookups
-   * fall through to the access-ordered {@link #pageContainerCache} probe (hashing plus LRU
-   * relink per hit). One slot per type keeps the hot page of EVERY stream one comparison
-   * away. PATH_SUMMARY keeps its dedicated {@link #mostRecentPathSummaryPageContainer}
-   * slot; its array entry stays unused.
+   * Most recent page container per {@link IndexType} (ordinal-indexed, lazily populated). The shared
+   * {@link #mostRecentPageContainer}/{@link #secondMostRecentPageContainer} pair thrashes when a
+   * commit interleaves streams of three or more index types (DOCUMENT + secondary indexes during
+   * shredding): every switch to another type evicts, so lookups fall through to the access-ordered
+   * {@link #pageContainerCache} probe (hashing plus LRU relink per hit). One slot per type keeps the
+   * hot page of EVERY stream one comparison away. PATH_SUMMARY keeps its dedicated
+   * {@link #mostRecentPathSummaryPageContainer} slot; its array entry stays unused.
    */
   private IndexLogKeyToPageContainer[] mostRecentByIndexType;
 
   private final LinkedHashMap<IndexLogKey, PageContainer> pageContainerCache;
 
   /**
-   * Reusable lookup key for pageContainerCache to avoid allocating a new IndexLogKey on every
-   * cache probe. MUST NOT be passed to computeIfAbsent as the stored key — the map retains a
-   * reference, and subsequent mutations would corrupt it.
+   * Reusable lookup key for pageContainerCache to avoid allocating a new IndexLogKey on every cache
+   * probe. MUST NOT be passed to computeIfAbsent as the stored key — the map retains a reference, and
+   * subsequent mutations would corrupt it.
    */
   private final IndexLogKey lookupKey = new IndexLogKey(IndexType.DOCUMENT, -1, -1, -1);
 
   /**
-   * Optional binder for write-path singletons.
-   * When set, prepareRecordForModification uses factory singletons instead of allocating new nodes.
+   * Optional binder for write-path singletons. When set, prepareRecordForModification uses factory
+   * singletons instead of allocating new nodes.
    */
   private WriteSingletonBinder writeSingletonBinder;
 
@@ -320,8 +321,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    *        {@code false} otherwise
    */
   NodeStorageEngineWriter(final Writer writer, final TransactionIntentLog log, final RevisionRootPage revisionRootPage,
-      final NodeStorageEngineReader storageEngineReader, final IndexController<?, ?> indexController, final int representRevision,
-      final boolean isBoundToNodeTrx) {
+      final NodeStorageEngineReader storageEngineReader, final IndexController<?, ?> indexController,
+      final int representRevision, final boolean isBoundToNodeTrx) {
     this.keyedTrieWriter = new KeyedTrieWriter();
     storagePageReaderWriter = requireNonNull(writer);
     this.log = requireNonNull(log);
@@ -333,8 +334,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     this.isBoundToNodeTrx = isBoundToNodeTrx;
     // Immutable per-resource configuration, resolved once — the insert hot path only branches
     // on a final field.
-    this.insertFsstEnabled = storageEngineReader.getResourceSession().getResourceConfig()
-        .stringCompressionType == StringCompressionType.FSST;
+    this.insertFsstEnabled =
+        storageEngineReader.getResourceSession()
+                           .getResourceConfig().stringCompressionType == StringCompressionType.FSST;
     mostRecentPageContainer = new IndexLogKeyToPageContainer(IndexType.DOCUMENT, -1, -1, -1, null);
     secondMostRecentPageContainer = new IndexLogKeyToPageContainer(IndexType.DOCUMENT, -1, -1, -1, null);
     mostRecentPathSummaryPageContainer = new IndexLogKeyToPageContainer(IndexType.PATH_SUMMARY, -1, -1, -1, null);
@@ -360,8 +362,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // finalize() override; runs on a Cleaner thread (not the GC thread), no resurrection,
     // survives finalize() removal in future JDKs. close() flips the closed flag so the
     // detector skips the leak warning on properly-closed writers.
-    this.leakDetectorState = new LeakDetectorState(
-        storageEngineReader.getTrxId(), System.identityHashCode(this),
+    this.leakDetectorState = new LeakDetectorState(storageEngineReader.getTrxId(), System.identityHashCode(this),
         System.identityHashCode(log), log);
     LEAK_CLEANER.register(this, leakDetectorState);
   }
@@ -401,8 +402,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Override
-  public DataRecord prepareRecordForModification(final long recordKey, final IndexType indexType,
-      final int index) {
+  public DataRecord prepareRecordForModification(final long recordKey, final IndexType indexType, final int index) {
     storageEngineReader.assertNotClosed();
     checkArgument(recordKey >= 0, "recordKey must be >= 0!");
     requireNonNull(indexType);
@@ -459,18 +459,18 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       final int offset = StorageEngineReader.recordPageOffset(recordKey);
       final var kvlComplete = (KeyValueLeafPage) completePage;
       final var slottedPage = kvlComplete.getSlottedPage();
-      final boolean slotPopulated = slottedPage != null
-          && PageLayout.isSlotPopulated(slottedPage, offset);
+      final boolean slotPopulated = slottedPage != null && PageLayout.isSlotPopulated(slottedPage, offset);
       final var slotData = completePage.getSlot(offset);
       final int populatedCount = slottedPage != null
-          ? PageLayout.getPopulatedCount(slottedPage) : -1;
+          ? PageLayout.getPopulatedCount(slottedPage)
+          : -1;
       throw new SirixIOException("Cannot retrieve record from cache: (key: " + recordKey + ") (indexType: " + indexType
-          + ") (index: " + index + ") (slotPopulated: " + slotPopulated
-          + ") (populatedCount: " + populatedCount
-          + ") (slotData: " + (slotData != null ? slotData.byteSize() + " bytes" : "null")
-          + ") (completePage.pageKey: " + completePage.getPageKey()
-          + ") (completePage.revision: " + completePage.getRevision()
-          + ") (modifiedPage.pageKey: " + modifiedPage.getPageKey() + ")");
+          + ") (index: " + index + ") (slotPopulated: " + slotPopulated + ") (populatedCount: " + populatedCount
+          + ") (slotData: " + (slotData != null
+              ? slotData.byteSize() + " bytes"
+              : "null")
+          + ") (completePage.pageKey: " + completePage.getPageKey() + ") (completePage.revision: "
+          + completePage.getRevision() + ") (modifiedPage.pageKey: " + modifiedPage.getPageKey() + ")");
     }
     record = oldRecord;
 
@@ -486,8 +486,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Fast-path variant for the DOCUMENT index type on the insert hot path.
-   * Skips assertNotClosed(), argument validation, and the IndexType switch in pageKey().
+   * Fast-path variant for the DOCUMENT index type on the insert hot path. Skips assertNotClosed(),
+   * argument validation, and the IndexType switch in pageKey().
    */
   @SuppressWarnings("unchecked")
   @Override
@@ -535,17 +535,22 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Override
-  public KeyValueLeafPage getAllocKvl() { return allocKvl; }
+  public KeyValueLeafPage getAllocKvl() {
+    return allocKvl;
+  }
 
   @Override
-  public int getAllocSlotOffset() { return allocSlotOffset; }
+  public int getAllocSlotOffset() {
+    return allocSlotOffset;
+  }
 
   @Override
-  public long getAllocNodeKey() { return allocNodeKey; }
+  public long getAllocNodeKey() {
+    return allocNodeKey;
+  }
 
   @Override
-  public DataRecord createRecord(final DataRecord record, final IndexType indexType,
-      final int index) {
+  public DataRecord createRecord(final DataRecord record, final IndexType indexType, final int index) {
     storageEngineReader.assertNotClosed();
 
     // Allocate record key and increment record count.
@@ -611,8 +616,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     if (modified instanceof KeyValueLeafPage kvl) {
       if (record instanceof FlyweightNode fn) {
         final int offset = (int) (createdRecordKey
-            - ((createdRecordKey >> Constants.NDP_NODE_COUNT_EXPONENT)
-               << Constants.NDP_NODE_COUNT_EXPONENT));
+            - ((createdRecordKey >> Constants.NDP_NODE_COUNT_EXPONENT) << Constants.NDP_NODE_COUNT_EXPONENT));
         kvl.serializeNewRecord(fn, createdRecordKey, offset);
       } else {
         kvl.setNewRecord(record);
@@ -649,15 +653,14 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       throw new IllegalStateException("Node not found: " + recordKey);
     }
 
-    final Node delNode = new DeletedNode(
-        new NodeDelegate(node.getNodeKey(), -1, null, -1, storageEngineReader.getRevisionNumber(), (SirixDeweyID) null));
+    final Node delNode = new DeletedNode(new NodeDelegate(node.getNodeKey(), -1, null, -1,
+        storageEngineReader.getRevisionNumber(), (SirixDeweyID) null));
     cont.getModifiedAsKeyValuePage().setRecord(delNode);
     cont.getCompleteAsKeyValuePage().setRecord(delNode);
   }
 
   @Override
-  public <V extends DataRecord> V getRecord(final long recordKey, final IndexType indexType,
-      final int index) {
+  public <V extends DataRecord> V getRecord(final long recordKey, final IndexType indexType, final int index) {
     storageEngineReader.assertNotClosed();
 
     checkArgument(recordKey >= Fixed.NULL_NODE_KEY.getStandardProperty());
@@ -689,8 +692,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
   }
 
-  private DataRecord getRecordForWriteAccess(final KeyValuePage<? extends DataRecord> page,
-      final long recordKey) {
+  private DataRecord getRecordForWriteAccess(final KeyValuePage<? extends DataRecord> page, final long recordKey) {
     final int recordOffset = StorageEngineReader.recordPageOffset(recordKey);
     final DataRecord cachedRecord = page.getRecord(recordOffset);
     if (cachedRecord != null) {
@@ -755,8 +757,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   public void asyncFlush() {
     // Fail-fast: terminal failure is a permanent latch — transaction is unusable.
     if (asyncTerminalFailure) {
-      throw new SirixIOException(
-          "Transaction in terminal failure state from prior async commit error");
+      throw new SirixIOException("Transaction in terminal failure state from prior async commit error");
     }
 
     // Backpressure: block if previous background flush still running
@@ -830,34 +831,32 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Sliding-window width of the background snapshot flush: how many KVL pages are
-   * deep-copied and pre-serialized in parallel before the sequential append pass writes
-   * and closes them. Two windows are in flight at once (double buffering), so the
-   * transient draw on the shared segment-allocator budget is bounded by
-   * {@code 2 × WINDOW} copies, each holding a pooled slotted segment (64&nbsp;KiB
-   * typical, up to 256&nbsp;KiB) plus its cached encoded form — roughly 35&nbsp;MB
-   * typical, ≈100&nbsp;MB worst case, per in-flight flush. The double buffering keeps
-   * the flush pool's workers serializing while this thread appends; widening the window
-   * past the pool's appetite only inflates the footprint.
+   * Sliding-window width of the background snapshot flush: how many KVL pages are deep-copied and
+   * pre-serialized in parallel before the sequential append pass writes and closes them. Two windows
+   * are in flight at once (double buffering), so the transient draw on the shared segment-allocator
+   * budget is bounded by {@code 2 × WINDOW} copies, each holding a pooled slotted segment
+   * (64&nbsp;KiB typical, up to 256&nbsp;KiB) plus its cached encoded form — roughly 35&nbsp;MB
+   * typical, ≈100&nbsp;MB worst case, per in-flight flush. The double buffering keeps the flush
+   * pool's workers serializing while this thread appends; widening the window past the pool's
+   * appetite only inflates the footprint.
    */
   private static final int SNAPSHOT_FLUSH_WINDOW = 128;
 
   /**
-   * Background thread: write all KVL pages from the frozen snapshot to disk.
-   * Uses thread-local buffer and shadow PageReference — NEVER writes to real refs.
+   * Background thread: write all KVL pages from the frozen snapshot to disk. Uses thread-local buffer
+   * and shadow PageReference — NEVER writes to real refs.
    * <p>
-   * CRITICAL: Each KVL page is deep-copied before serialization. The serialization path
-   * mutates the page (addReferences → processEntries, FSST compression, string compression).
-   * Without the copy, the insert thread's concurrent deep-copy for CoW would race against
-   * these mutations, producing corrupted pages (e.g., zeroed headers, inconsistent slot data).
+   * CRITICAL: Each KVL page is deep-copied before serialization. The serialization path mutates the
+   * page (addReferences → processEntries, FSST compression, string compression). Without the copy,
+   * the insert thread's concurrent deep-copy for CoW would race against these mutations, producing
+   * corrupted pages (e.g., zeroed headers, inconsistent slot data).
    * <p>
-   * The flush proceeds in sliding windows: each window's pages are deep-copied and
-   * pre-serialized IN PARALLEL (the encode caches its output on the copy — the same
-   * mechanism the synchronous commit's {@code parallelSerializationOfKeyValuePages}
-   * relies on), then a sequential pass appends the cached bytes in snapshot order,
-   * records offsets and hashes, and closes the copies. A single-threaded flush cannot
-   * keep pace with the insert thread (serialization dominates the flush), which turned
-   * the {@code flushPermit} backpressure into a near-synchronous stall; parallel
+   * The flush proceeds in sliding windows: each window's pages are deep-copied and pre-serialized IN
+   * PARALLEL (the encode caches its output on the copy — the same mechanism the synchronous commit's
+   * {@code parallelSerializationOfKeyValuePages} relies on), then a sequential pass appends the
+   * cached bytes in snapshot order, records offsets and hashes, and closes the copies. A
+   * single-threaded flush cannot keep pace with the insert thread (serialization dominates the
+   * flush), which turned the {@code flushPermit} backpressure into a near-synchronous stall; parallel
    * pre-serialization restores the intended overlap.
    */
   private void executeSnapshotWrite() {
@@ -936,30 +935,28 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Dedicated pool for the background snapshot flush's parallel pre-serialization,
-   * shared JVM-wide by every resource's flushes (concurrent bulk imports divide it).
-   * Capped below the core count on purpose: the flush runs CONCURRENTLY with the insert
-   * thread, and letting it fan out across every core halves insert throughput through
-   * memory-bandwidth contention (the encode path streams 64&nbsp;KB segments through
-   * LZ4/RLE codecs). Two workers keep the flush ahead of the rotation cadence on small
-   * hosts while leaving the insert thread its core; larger hosts and multi-import
-   * services scale it via {@code -Dsirix.asyncFlush.parallelism} (clamped to
-   * ForkJoinPool's maximum of 32767 — an oversized value must degrade, not turn every
-   * write transaction into an ExceptionInInitializerError).
+   * Dedicated pool for the background snapshot flush's parallel pre-serialization, shared JVM-wide by
+   * every resource's flushes (concurrent bulk imports divide it). Capped below the core count on
+   * purpose: the flush runs CONCURRENTLY with the insert thread, and letting it fan out across every
+   * core halves insert throughput through memory-bandwidth contention (the encode path streams
+   * 64&nbsp;KB segments through LZ4/RLE codecs). Two workers keep the flush ahead of the rotation
+   * cadence on small hosts while leaving the insert thread its core; larger hosts and multi-import
+   * services scale it via {@code -Dsirix.asyncFlush.parallelism} (clamped to ForkJoinPool's maximum
+   * of 32767 — an oversized value must degrade, not turn every write transaction into an
+   * ExceptionInInitializerError).
    */
   private static final ForkJoinPool SNAPSHOT_FLUSH_POOL =
-      new ForkJoinPool(Math.min(32767, Math.max(1,
-          Integer.getInteger("sirix.asyncFlush.parallelism",
-              Math.min(2, Runtime.getRuntime().availableProcessors() - 1)))));
+      new ForkJoinPool(Math.min(32767, Math.max(1, Integer.getInteger("sirix.asyncFlush.parallelism",
+          Math.min(2, Runtime.getRuntime().availableProcessors() - 1)))));
 
   /**
    * Kick off the parallel deep-copy + pre-serialize pass for the snapshot window starting at
-   * {@code base} (exclusive end {@code min(base + SNAPSHOT_FLUSH_WINDOW, size)}) on the
-   * dedicated flush pool. Each produced copy carries its encoded bytes in the page-local
-   * compressed cache, so the subsequent sequential append emits without re-encoding.
+   * {@code base} (exclusive end {@code min(base + SNAPSHOT_FLUSH_WINDOW, size)}) on the dedicated
+   * flush pool. Each produced copy carries its encoded bytes in the page-local compressed cache, so
+   * the subsequent sequential append emits without re-encoding.
    */
-  private CompletableFuture<Void> serializeSnapshotWindowAsync(final ResourceConfiguration config,
-      final int base, final int size, final KeyValueLeafPage[] window) {
+  private CompletableFuture<Void> serializeSnapshotWindowAsync(final ResourceConfiguration config, final int base,
+      final int size, final KeyValueLeafPage[] window) {
     final int end = Math.min(base + SNAPSHOT_FLUSH_WINDOW, size);
     // Parallel streams execute inside the pool that invokes the terminal operation, so
     // submitting the whole stream confines its splits to SNAPSHOT_FLUSH_POOL.
@@ -1024,9 +1021,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * {@code true} when serialization left overflow {@link PageReference}s on {@code page}
-   * whose disk keys are still unassigned — such a page's encoded form is only valid after
-   * the recursive commit writes its OverflowPages (#1076).
+   * {@code true} when serialization left overflow {@link PageReference}s on {@code page} whose disk
+   * keys are still unassigned — such a page's encoded form is only valid after the recursive commit
+   * writes its OverflowPages (#1076).
    */
   private static boolean hasUnresolvedOverflowReferences(final KeyValueLeafPage page) {
     for (final PageReference reference : page.getReferencesMap().values()) {
@@ -1049,8 +1046,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Invalidate all local container caches to prevent stale cache hits
-   * returning frozen-zone containers after snapshot.
+   * Invalidate all local container caches to prevent stale cache hits returning frozen-zone
+   * containers after snapshot.
    */
   private void clearLocalContainerCaches() {
     pageContainerCache.clear();
@@ -1061,10 +1058,10 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Invalidate every per-{@link IndexType} most-recent slot. Holder objects are kept
-   * allocated (zero-alloc steady state) — the {@code recordPageKey = -1} sentinel can
-   * never match a real lookup, and dropping the {@link PageContainer} reference prevents
-   * both stale hits and pinned garbage.
+   * Invalidate every per-{@link IndexType} most-recent slot. Holder objects are kept allocated
+   * (zero-alloc steady state) — the {@code recordPageKey = -1} sentinel can never match a real
+   * lookup, and dropping the {@link PageContainer} reference prevents both stale hits and pinned
+   * garbage.
    */
   private void clearMostRecentByIndexTypeSlots() {
     final IndexLogKeyToPageContainer[] byType = mostRecentByIndexType;
@@ -1082,13 +1079,12 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   /**
    * Re-add structural pages to the fresh TIL after snapshot.
    * <p>
-   * After snapshot, the current TIL is empty. Structural pages (RevisionRootPage,
-   * PathSummaryPage, NamePage, etc.) are in the frozen snapshot. We re-add them
-   * to the current TIL so the insert thread can continue without CoW overhead
-   * for these frequently-accessed pages.
+   * After snapshot, the current TIL is empty. Structural pages (RevisionRootPage, PathSummaryPage,
+   * NamePage, etc.) are in the frozen snapshot. We re-add them to the current TIL so the insert
+   * thread can continue without CoW overhead for these frequently-accessed pages.
    * <p>
-   * IndirectPages in the trie are NOT re-added — they will be CoW'd on first
-   * access via prepareIndirectPage() if needed.
+   * IndirectPages in the trie are NOT re-added — they will be CoW'd on first access via
+   * prepareIndirectPage() if needed.
    */
   private void reAddStructuralPagesToTil() {
     // Re-add structural pages referenced by RevisionRootPage.
@@ -1103,8 +1099,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * If a page reference is in the frozen snapshot, re-add its container to the current TIL.
-   * This ensures the insert thread can continue modifying structural pages without CoW.
+   * If a page reference is in the frozen snapshot, re-add its container to the current TIL. This
+   * ensures the insert thread can continue modifying structural pages without CoW.
    */
   private void reAddPageIfFrozen(final PageReference ref) {
     if (ref != null && log.isFrozen(ref)) {
@@ -1116,8 +1112,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * Deep-copy a frozen PageContainer for Copy-on-Write. Both complete and modified KVL pages
-   * are deep-copied to ensure full independence from the frozen originals.
+   * Deep-copy a frozen PageContainer for Copy-on-Write. Both complete and modified KVL pages are
+   * deep-copied to ensure full independence from the frozen originals.
    *
    * @param container the frozen container to copy
    * @return a fully independent deep copy
@@ -1155,8 +1151,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       // falls through to the no-op return below by design.
       final var sideMapPage = reference.getPage();
       if (sideMapPage instanceof OverflowPage && reference.getKey() == Constants.NULL_ID_LONG) {
-        storagePageReaderWriter.write(getResourceSession().getResourceConfig(), reference, sideMapPage,
-                                      bufferBytes);
+        storagePageReaderWriter.write(getResourceSession().getResourceConfig(), reference, sideMapPage, bufferBytes);
         reference.setPage(null);
         return;
       }
@@ -1167,11 +1162,10 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       // without any error. (A Layer-3 resolution resets the logKey and assigns the disk key,
       // so a resolved stale copy never trips this guard.)
       if (reference.getLogKey() >= 0 && reference.getKey() == Constants.NULL_ID_LONG) {
-        throw new SirixIOException(
-            "Commit traversal hit an unresolvable stale page reference (logKey=" + reference.getLogKey()
-                + ", generation=" + reference.getActiveTilGeneration()
-                + "): the referenced page is in no TIL layer and has no disk offset — refusing to"
-                + " serialize a dangling child pointer (data would silently be lost).");
+        throw new SirixIOException("Commit traversal hit an unresolvable stale page reference (logKey="
+            + reference.getLogKey() + ", generation=" + reference.getActiveTilGeneration()
+            + "): the referenced page is in no TIL layer and has no disk offset — refusing to"
+            + " serialize a dangling child pointer (data would silently be lost).");
       }
       return;
     }
@@ -1256,13 +1250,17 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
       // PIPELINING: Serialize pages WHILE previous fsync may still be running.
       // This overlaps CPU work (serialization) with IO work (fsync).
-      final long t0 = timing ? System.nanoTime() : 0;
+      final long t0 = timing
+          ? System.nanoTime()
+          : 0;
       // Must precede the serialization pass: pages need the revision's symbol-table id in hand
       // by the time their bytes are cached, and the pass below is the last point before that.
       buildRevisionFsstSymbolTable();
       parallelSerializationOfKeyValuePages();
 
-      final long t1 = timing ? System.nanoTime() : 0;
+      final long t1 = timing
+          ? System.nanoTime()
+          : 0;
       LOGGER.debug("TIL size before recursive commit: {}", log.getList().size());
       uberPage.commit(this);
       LOGGER.debug("TIL size after recursive commit: {} (closed entries not cleaned)", log.getList().size());
@@ -1274,8 +1272,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       storagePageReaderWriter.flushBufferedWrites(bufferBytes);
 
       if (timing) {
-        LOGGER.debug("Commit phase 1 r{}: serialize={}ms recursive={}ms", uberPage.getRevisionNumber(),
-            ms(t1 - t0), ms(System.nanoTime() - t1));
+        LOGGER.debug("Commit phase 1 r{}: serialize={}ms recursive={}ms", uberPage.getRevisionNumber(), ms(t1 - t0),
+            ms(System.nanoTime() - t1));
       }
       return uberPage;
     }
@@ -1288,11 +1286,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
       final Path commitFile = storageEngineReader.resourceSession.getCommitFile();
 
-      final PageReference uberPageReference =
-          new PageReference().setDatabaseId(storageEngineReader.getDatabaseId()).setResourceId(storageEngineReader.getResourceId());
+      final PageReference uberPageReference = new PageReference().setDatabaseId(storageEngineReader.getDatabaseId())
+                                                                 .setResourceId(storageEngineReader.getResourceId());
       uberPageReference.setPage(uberPage);
 
-      final long t2 = timing ? System.nanoTime() : 0;
+      final long t2 = timing
+          ? System.nanoTime()
+          : 0;
 
       final int revision = uberPage.getRevisionNumber();
 
@@ -1312,7 +1312,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         indexController.getIndexes().clearDirty();
       }
 
-      final long t3 = timing ? System.nanoTime() : 0;
+      final long t3 = timing
+          ? System.nanoTime()
+          : 0;
 
       // CRITICAL crash-safety invariant (write-ahead property): all data pages AND the index
       // catalogue (above) MUST be durable BEFORE either uber-page beacon is written.
@@ -1325,7 +1327,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       storagePageReaderWriter.writeUberPageReference(getResourceSession().getResourceConfig(), uberPageReference,
           uberPage, bufferBytes);
 
-      final long t4 = timing ? System.nanoTime() : 0;
+      final long t4 = timing
+          ? System.nanoTime()
+          : 0;
 
       // CRITICAL: Release current page guard BEFORE TIL.clear()
       // If guard is on a TIL page, the page won't close (guardCount > 0 check)
@@ -1343,7 +1347,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       mostRecentPathSummaryPageContainer.set(IndexType.PATH_SUMMARY, -1, -1, -1, null);
       clearMostRecentByIndexTypeSlots();
 
-      final long t5 = timing ? System.nanoTime() : 0;
+      final long t5 = timing
+          ? System.nanoTime()
+          : 0;
 
       // Delete commit file which denotes that a commit must write the log in the data file.
       try {
@@ -1353,8 +1359,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       }
 
       if (timing) {
-        LOGGER.debug("Commit phase 2 r{}: indexDefs={}ms uberWrite={}ms tilClear={}ms total={}ms",
-            revision, ms(t3 - t2), ms(t4 - t3), ms(t5 - t4), ms(t5 - t2));
+        LOGGER.debug("Commit phase 2 r{}: indexDefs={}ms uberWrite={}ms tilClear={}ms total={}ms", revision,
+            ms(t3 - t2), ms(t4 - t3), ms(t5 - t4), ms(t5 - t2));
       }
     }
   }
@@ -1410,38 +1416,43 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       Integer.getInteger("sirix.commit.parallelSerializationThreshold", 4);
 
   /**
-   * How many string samples the commit-wide sweep gathers before it stops looking. Generous
-   * relative to {@link FSSTCompressor#MAX_SAMPLES_TO_ANALYZE} (which further filters by length),
-   * yet a fixed bound, so the sweep's cost never scales with commit size.
+   * How many string samples the commit-wide sweep gathers before it stops looking. Generous relative
+   * to {@link FSSTCompressor#MAX_SAMPLES_TO_ANALYZE} (which further filters by length), yet a fixed
+   * bound, so the sweep's cost never scales with commit size.
    */
   private static final int FSST_REVISION_SAMPLE_CAP = 1024;
 
-  /** The database type of this writer's resource; delegated so reader and writer share one derivation. */
+  /**
+   * The database type of this writer's resource; delegated so reader and writer share one derivation.
+   */
   private DatabaseType databaseTypeOfSession() {
     return storageEngineReader.databaseType();
   }
 
   /**
    * Build this revision's FSST symbol table — once, from strings pooled across the whole commit —
-   * store it as a record in the name dictionary's trie, and hand every document page the table
-   * plus its dictionary id before serialization begins.
+   * store it as a record in the name dictionary's trie, and hand every document page the table plus
+   * its dictionary id before serialization begins.
    *
-   * <p>This replaces the per-page build that {@code PageKind.serializePage} used to run, which
-   * failed in both directions at once: a full slot scan plus frequency analysis per page made
-   * ingest 18× slower, and a single page rarely holds the
-   * {@link FSSTCompressor#MIN_SAMPLES_FOR_TABLE} strings a table needs before it beats raw bytes,
-   * so the table was rejected on essentially every page anyway. Pooling inverts both: one build
-   * per commit, fed by more samples than any page could supply.
+   * <p>
+   * This replaces the per-page build that {@code PageKind.serializePage} used to run, which failed in
+   * both directions at once: a full slot scan plus frequency analysis per page made ingest 18×
+   * slower, and a single page rarely holds the {@link FSSTCompressor#MIN_SAMPLES_FOR_TABLE} strings a
+   * table needs before it beats raw bytes, so the table was rejected on essentially every page
+   * anyway. Pooling inverts both: one build per commit, fed by more samples than any page could
+   * supply.
    *
-   * <p>Handing the pages the table itself (not just the id) is what serialization needs —
-   * {@code compressStringValues} encodes against it, and the id is what
-   * {@code writeFsstSymbolTable} emits in place of the table's bytes. The table record is created
-   * <em>between</em> the sampling sweep and the hand-out sweep, because creating it mutates the
-   * transaction intent log this method iterates.
+   * <p>
+   * Handing the pages the table itself (not just the id) is what serialization needs —
+   * {@code compressStringValues} encodes against it, and the id is what {@code writeFsstSymbolTable}
+   * emits in place of the table's bytes. The table record is created <em>between</em> the sampling
+   * sweep and the hand-out sweep, because creating it mutates the transaction intent log this method
+   * iterates.
    *
-   * <p>When the samples are too few or compression would not pay, no table is stored and pages
-   * serialize their strings raw — which is also exactly what happens for resources whose
-   * configuration disables FSST.
+   * <p>
+   * When the samples are too few or compression would not pay, no table is stored and pages serialize
+   * their strings raw — which is also exactly what happens for resources whose configuration disables
+   * FSST.
    */
   private void buildRevisionFsstSymbolTable() {
     final var resourceConfig = getResourceSession().getResourceConfig();
@@ -1490,8 +1501,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       final byte[] previousTable = insertFsstResolved && insertFsstTableId == previousId
           ? insertFsstTable
           : namePage.getFsstSymbolTable(previousId, databaseType, this);
-      if (previousTable != null
-          && FSSTCompressor.isCompressionBeneficial(samples, previousTable)) {
+      if (previousTable != null && FSSTCompressor.isCompressionBeneficial(samples, previousTable)) {
         if (LOGGER.isDebugEnabled()) {
           LOGGER.debug("FSST reusing table id {} ({}B)", previousId, previousTable.length);
         }
@@ -1501,11 +1511,12 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     final byte[] table = FSSTCompressor.buildSymbolTable(samples);
-    final boolean beneficial = table != null && table.length > 0
-        && FSSTCompressor.isCompressionBeneficial(samples, table);
+    final boolean beneficial =
+        table != null && table.length > 0 && FSSTCompressor.isCompressionBeneficial(samples, table);
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("FSST built table: {}B beneficial={}", table == null ? -1 : table.length,
-          beneficial);
+      LOGGER.debug("FSST built table: {}B beneficial={}", table == null
+          ? -1
+          : table.length, beneficial);
     }
     if (!beneficial) {
       return;
@@ -1519,9 +1530,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * The resource's current FSST symbol table, loaded once per transaction for insert-time
-   * encoding. {@code insertFsstResolved} distinguishes "not looked up yet" from "looked up,
-   * resource has none" so absence costs one lookup, not one per string.
+   * The resource's current FSST symbol table, loaded once per transaction for insert-time encoding.
+   * {@code insertFsstResolved} distinguishes "not looked up yet" from "looked up, resource has none"
+   * so absence costs one lookup, not one per string.
    */
   private boolean insertFsstResolved;
   private byte[] insertFsstTable;
@@ -1532,24 +1543,25 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   private final boolean insertFsstEnabled;
 
   /**
-   * Encode a string-carrying record against the resource's current symbol table as it is
-   * inserted, and hand its page the table at the same moment.
+   * Encode a string-carrying record against the resource's current symbol table as it is inserted,
+   * and hand its page the table at the same moment.
    *
-   * <p>This is where FSST's ingest cost belongs. Commit-time compression re-reads, re-encodes
-   * and rewrites every string of the commit after the fact — a full extra pass that made FSST
-   * slower end to end than the generic byte codec it was meant to beat. Encoding here rides
-   * work the insert already does (the value is in hand, the record is being serialized anyway),
-   * so the marginal cost is the encode itself; the commit pass then skips every slot that
-   * arrives already compressed. The first-ever commit still bootstraps through the commit-time
-   * path, because no table exists until it stores one.
+   * <p>
+   * This is where FSST's ingest cost belongs. Commit-time compression re-reads, re-encodes and
+   * rewrites every string of the commit after the fact — a full extra pass that made FSST slower end
+   * to end than the generic byte codec it was meant to beat. Encoding here rides work the insert
+   * already does (the value is in hand, the record is being serialized anyway), so the marginal cost
+   * is the encode itself; the commit pass then skips every slot that arrives already compressed. The
+   * first-ever commit still bootstraps through the commit-time path, because no table exists until it
+   * stores one.
    *
-   * <p>Tagging the page immediately — bytes and id together — keeps every in-transaction read
-   * correct (flyweight and record decodes resolve through the page) and makes the commit-time
-   * distribution skip the page ({@code carriesSymbolTable}), preserving the rule that a page
-   * binds to exactly one table for life.
+   * <p>
+   * Tagging the page immediately — bytes and id together — keeps every in-transaction read correct
+   * (flyweight and record decodes resolve through the page) and makes the commit-time distribution
+   * skip the page ({@code carriesSymbolTable}), preserving the rule that a page binds to exactly one
+   * table for life.
    */
-  private void maybeEncodeStringValueAtInsert(final DataRecord record,
-      final KeyValuePage<DataRecord> page) {
+  private void maybeEncodeStringValueAtInsert(final DataRecord record, final KeyValuePage<DataRecord> page) {
     if (!insertFsstEnabled) {
       return;
     }
@@ -1581,8 +1593,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Override
-  public byte[] encodeStringValueForInsert(final KeyValueLeafPage page, final byte[] value,
-      final int off, final int len) {
+  public byte[] encodeStringValueForInsert(final KeyValueLeafPage page, final byte[] value, final int off,
+      final int len) {
     if (page == null || value == null || !insertFsstEnabled) {
       return null;
     }
@@ -1590,27 +1602,26 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   /**
-   * The shared insert-time encode core: encode {@code raw[off..off+len)} against the
-   * transaction's table if — and only if — the target page can legally hold the result.
+   * The shared insert-time encode core: encode {@code raw[off..off+len)} against the transaction's
+   * table if — and only if — the target page can legally hold the result.
    *
-   * <p>The table is a property of the PAGE the record lands on, not of the transaction: a page
-   * binds to exactly one table for life, and the record's bytes must be decodable through
-   * that binding. Three cases:
+   * <p>
+   * The table is a property of the PAGE the record lands on, not of the transaction: a page binds to
+   * exactly one table for life, and the record's bytes must be decodable through that binding. Three
+   * cases:
    * <ul>
    * <li>page bound to this transaction's table: encode.</li>
    * <li>page unbound: encode, then bind it (bytes and id together).</li>
-   * <li>page bound to a DIFFERENT table (a tail page from before a vocabulary-shift rebuild):
-   * leave the value raw. Encoding with the latest table would store bytes the page's
-   * persisted table id cannot decode — silent corruption after reload — and encoding with
-   * the page's own table would require resolving it here, for a case reuse makes rare.
-   * Raw is always correct; commit-time compression picks it up when the page's bytes are
-   * resolved, and never otherwise.</li>
+   * <li>page bound to a DIFFERENT table (a tail page from before a vocabulary-shift rebuild): leave
+   * the value raw. Encoding with the latest table would store bytes the page's persisted table id
+   * cannot decode — silent corruption after reload — and encoding with the page's own table would
+   * require resolving it here, for a case reuse makes rare. Raw is always correct; commit-time
+   * compression picks it up when the page's bytes are resolved, and never otherwise.</li>
    * </ul>
    *
    * @return the encoded bytes (strictly shorter than {@code len}), or {@code null} to store raw
    */
-  private byte[] encodeForInsert(final KeyValueLeafPage kvl, final byte[] raw, final int off,
-      final int len) {
+  private byte[] encodeForInsert(final KeyValueLeafPage kvl, final byte[] raw, final int off, final int len) {
     if (len < FSSTCompressor.MIN_COMPRESSION_SIZE) {
       return null;
     }
@@ -1699,8 +1710,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
   /**
    * Whether this page may still be given a symbol table: it can hold string-compressed records
-   * (document index) and is not already bound to a table. The single statement of the
-   * eligibility rule shared by the sampling sweep and the distribution sweep.
+   * (document index) and is not already bound to a table. The single statement of the eligibility
+   * rule shared by the sampling sweep and the distribution sweep.
    */
   private static boolean needsSymbolTable(final KeyValueLeafPage page) {
     return page.getIndexType() == IndexType.DOCUMENT && !carriesSymbolTable(page);
@@ -1709,14 +1720,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   /**
    * Whether this page is already bound to a symbol table — by bytes, by reference, or both.
    *
-   * <p>Such a page keeps that binding for life: its compressed slots were encoded against it and
-   * cannot be re-encoded in place, so both the revision build's sampling (its raw strings will be
-   * encoded against the old table, not the new one) and its distribution (see above) must pass
-   * the page over.
+   * <p>
+   * Such a page keeps that binding for life: its compressed slots were encoded against it and cannot
+   * be re-encoded in place, so both the revision build's sampling (its raw strings will be encoded
+   * against the old table, not the new one) and its distribution (see above) must pass the page over.
    */
   private static boolean carriesSymbolTable(final KeyValueLeafPage page) {
-    return page.getFsstSymbolTable() != null
-        || page.getFsstSymbolTableId() != KeyValueLeafPage.NO_FSST_SYMBOL_TABLE_ID;
+    return page.getFsstSymbolTable() != null || page.getFsstSymbolTableId() != KeyValueLeafPage.NO_FSST_SYMBOL_TABLE_ID;
   }
 
   private void parallelSerializationOfKeyValuePages() {
@@ -1734,9 +1744,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     } else {
       // Parallel: stream-filter avoids materializing an intermediate ArrayList
       logList.parallelStream()
-          .map(PageContainer::getModified)
-          .filter(p -> p instanceof KeyValueLeafPage)
-          .forEach(page -> serializeKeyValuePage(resourceConfig, page));
+             .map(PageContainer::getModified)
+             .filter(p -> p instanceof KeyValueLeafPage)
+             .forEach(page -> serializeKeyValuePage(resourceConfig, page));
     }
   }
 
@@ -1767,13 +1777,14 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   /**
    * Create the commit marker, tolerating a marker that is already there.
    *
-   * <p>This runs at the head of EVERY commit, before any data is written. The previous
+   * <p>
+   * This runs at the head of EVERY commit, before any data is written. The previous
    * {@code while (!Files.exists(file)) Files.createFile(file)} paid a {@code stat} on top of the
-   * {@code create} — and the loop could only ever run twice, since {@code createFile} either
-   * succeeds or throws. Creating directly and treating "already exists" as success is the same
-   * outcome in one syscall, and it is also race-free: two callers no longer both observe "absent"
-   * and race into {@code createFile}, where the loser previously surfaced the
-   * {@link FileAlreadyExistsException} as a commit failure.
+   * {@code create} — and the loop could only ever run twice, since {@code createFile} either succeeds
+   * or throws. Creating directly and treating "already exists" as success is the same outcome in one
+   * syscall, and it is also race-free: two callers no longer both observe "absent" and race into
+   * {@code createFile}, where the loser previously surfaced the {@link FileAlreadyExistsException} as
+   * a commit failure.
    *
    * @param file the commit marker path
    */
@@ -1945,8 +1956,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     return null;
   }
 
-  private PageContainer getPageContainer(final long recordPageKey, final int indexNumber,
-      final IndexType indexType) {
+  private PageContainer getPageContainer(final long recordPageKey, final int indexNumber, final IndexType indexType) {
     PageContainer pageContainer =
         getMostRecentPageContainer(indexType, recordPageKey, indexNumber, newRevisionRootPage.getRevision());
     if (pageContainer != null) {
@@ -1954,20 +1964,23 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     final int revision = newRevisionRootPage.getRevision();
-    lookupKey.setIndexType(indexType).setRecordPageKey(recordPageKey)
-        .setIndexNumber(indexNumber).setRevisionNumber(revision);
+    lookupKey.setIndexType(indexType)
+             .setRecordPageKey(recordPageKey)
+             .setIndexNumber(indexNumber)
+             .setRevisionNumber(revision);
     final PageContainer cached = pageContainerCache.get(lookupKey);
     if (cached != null) {
       return cached;
     }
 
-    final PageReference pageReference = storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
+    final PageReference pageReference =
+        storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
     // Use writer's TIL-aware trie traversal instead of reader's disk-only traversal.
     // After async epoch rotation, IndirectPages may be in the TIL but not yet on disk;
     // the reader's getLeafPageReference would try to load them from disk with key=-1.
-    final PageReference reference = keyedTrieWriter.prepareLeafOfTree(this, log,
-        getUberPage().getPageCountExp(indexType), pageReference, recordPageKey, indexNumber,
-        indexType, newRevisionRootPage);
+    final PageReference reference =
+        keyedTrieWriter.prepareLeafOfTree(this, log, getUberPage().getPageCountExp(indexType), pageReference,
+            recordPageKey, indexNumber, indexType, newRevisionRootPage);
     final PageContainer resolved = log.get(reference);
 
     // NEVER cache a FROZEN container here (#1077): this read-path helper runs between an async
@@ -1983,8 +1996,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Nullable
-  private PageContainer getMostRecentPageContainer(IndexType indexType, long recordPageKey,
-      int indexNumber, int revisionNumber) {
+  private PageContainer getMostRecentPageContainer(IndexType indexType, long recordPageKey, int indexNumber,
+      int revisionNumber) {
     if (indexType == IndexType.PATH_SUMMARY) {
       return mostRecentPathSummaryPageContainer != null && mostRecentPathSummaryPageContainer.indexType == indexType
           && mostRecentPathSummaryPageContainer.indexNumber == indexNumber
@@ -1998,8 +2011,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     if (byType != null) {
       final IndexLogKeyToPageContainer slot = byType[indexType.ordinal()];
       if (slot != null && slot.recordPageKey == recordPageKey && slot.indexNumber == indexNumber
-          && slot.revisionNumber == revisionNumber && slot.indexType == indexType
-          && slot.pageContainer != null) {
+          && slot.revisionNumber == revisionNumber && slot.indexType == indexType && slot.pageContainer != null) {
         return slot.pageContainer;
       }
     }
@@ -2029,8 +2041,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * @return {@link PageContainer} instance
    * @throws SirixIOException if an I/O error occurs
    */
-  private PageContainer prepareRecordPage(final long recordPageKey, final int indexNumber,
-      final IndexType indexType) {
+  private PageContainer prepareRecordPage(final long recordPageKey, final int indexNumber, final IndexType indexType) {
     assert indexType != null;
     // Traditional KEYED_TRIE path (bit-decomposed).
     // HOT secondary indexes use dedicated HOT*IndexWriter/Reader implementations.
@@ -2052,11 +2063,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     final Function<IndexLogKey, PageContainer> fetchPageContainer = _ -> {
-      final PageReference pageReference = storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
+      final PageReference pageReference =
+          storageEngineReader.getPageReference(newRevisionRootPage, indexType, indexNumber);
 
       // Get the reference to the unordered key/value page storing the records.
-      final PageReference reference = keyedTrieWriter.prepareLeafOfTree(this, log, getUberPage().getPageCountExp(indexType),
-          pageReference, recordPageKey, indexNumber, indexType, newRevisionRootPage);
+      final PageReference reference =
+          keyedTrieWriter.prepareLeafOfTree(this, log, getUberPage().getPageCountExp(indexType), pageReference,
+              recordPageKey, indexNumber, indexType, newRevisionRootPage);
 
       var pageContainer = log.get(reference);
 
@@ -2079,16 +2092,16 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         final MemorySegmentAllocator allocator = Allocators.getInstance();
 
         final KeyValueLeafPage completePage = new KeyValueLeafPage(recordPageKey, indexType,
-            getResourceSession().getResourceConfig(), storageEngineReader.getRevisionNumber(), allocator.allocate(SIXTYFOUR_KB),
-            getResourceSession().getResourceConfig().areDeweyIDsStored
+            getResourceSession().getResourceConfig(), storageEngineReader.getRevisionNumber(),
+            allocator.allocate(SIXTYFOUR_KB), getResourceSession().getResourceConfig().areDeweyIDsStored
                 ? allocator.allocate(SIXTYFOUR_KB)
                 : null,
             false // Memory from allocator - release on close()
         );
 
         final KeyValueLeafPage modifyPage = new KeyValueLeafPage(recordPageKey, indexType,
-            getResourceSession().getResourceConfig(), storageEngineReader.getRevisionNumber(), allocator.allocate(SIXTYFOUR_KB),
-            getResourceSession().getResourceConfig().areDeweyIDsStored
+            getResourceSession().getResourceConfig(), storageEngineReader.getRevisionNumber(),
+            allocator.allocate(SIXTYFOUR_KB), getResourceSession().getResourceConfig().areDeweyIDsStored
                 ? allocator.allocate(SIXTYFOUR_KB)
                 : null,
             false // Memory from allocator - release on close()
@@ -2104,8 +2117,10 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     };
 
     final int revision = newRevisionRootPage.getRevision();
-    lookupKey.setIndexType(indexType).setRecordPageKey(recordPageKey)
-        .setIndexNumber(indexNumber).setRevisionNumber(revision);
+    lookupKey.setIndexType(indexType)
+             .setRecordPageKey(recordPageKey)
+             .setIndexNumber(indexNumber)
+             .setRevisionNumber(revision);
     var currPageContainer = pageContainerCache.get(lookupKey);
     if (currPageContainer == null) {
       currPageContainer = pageContainerCache.computeIfAbsent(
@@ -2113,13 +2128,13 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     }
 
     if (indexType == IndexType.PATH_SUMMARY) {
-      mostRecentPathSummaryPageContainer.set(indexType, recordPageKey, indexNumber,
-          newRevisionRootPage.getRevision(), currPageContainer);
+      mostRecentPathSummaryPageContainer.set(indexType, recordPageKey, indexNumber, newRevisionRootPage.getRevision(),
+          currPageContainer);
     } else {
       // Copy mostRecent into secondMostRecent BEFORE mutating mostRecent
       secondMostRecentPageContainer.copyFrom(mostRecentPageContainer);
-      mostRecentPageContainer.set(indexType, recordPageKey, indexNumber,
-          newRevisionRootPage.getRevision(), currPageContainer);
+      mostRecentPageContainer.set(indexType, recordPageKey, indexNumber, newRevisionRootPage.getRevision(),
+          currPageContainer);
       final IndexLogKeyToPageContainer[] byType = mostRecentByIndexType;
       if (byType != null) {
         final int ordinal = indexType.ordinal();
@@ -2128,8 +2143,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
           byTypeUpd = new IndexLogKeyToPageContainer(indexType, -1, -1, -1, null);
           byType[ordinal] = byTypeUpd;
         }
-        byTypeUpd.set(indexType, recordPageKey, indexNumber,
-            newRevisionRootPage.getRevision(), currPageContainer);
+        byTypeUpd.set(indexType, recordPageKey, indexNumber, newRevisionRootPage.getRevision(), currPageContainer);
       }
     }
 
@@ -2318,8 +2332,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Override
-  public KeyValueLeafPage getModifiedPageForRead(final long recordPageKey,
-      final IndexType indexType, final int index) {
+  public KeyValueLeafPage getModifiedPageForRead(final long recordPageKey, final IndexType indexType, final int index) {
     final PageContainer pc = getPageContainer(recordPageKey, index, indexType);
     if (pc != null) {
       final var modified = pc.getModified();
@@ -2331,8 +2344,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   }
 
   @Override
-  public StorageEngineWriter appendLogRecord(final PageReference reference,
-      final PageContainer pageContainer) {
+  public StorageEngineWriter appendLogRecord(final PageReference reference, final PageContainer pageContainer) {
     requireNonNull(pageContainer);
     log.put(reference, pageContainer);
     return this;
@@ -2352,9 +2364,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // the session's last-committed uber page already downgraded, the pages never discarded, and
     // the cache never cleared, because the throw jumps past clearCachesForDatabase.
     if (!storagePageReaderWriter.supportsTruncateTo()) {
-      throw new UnsupportedOperationException("Storage backend "
-          + storagePageReaderWriter.getClass().getSimpleName() + " cannot truncate to revision "
-          + revision + " — rollback and crash recovery need a persistent StorageType.");
+      throw new UnsupportedOperationException(
+          "Storage backend " + storagePageReaderWriter.getClass().getSimpleName() + " cannot truncate to revision "
+              + revision + " — rollback and crash recovery need a persistent StorageType.");
     }
     // Rollback semantics: any buffered (uncommitted) page writes refer to the world being
     // truncated away — discard them before touching the files.
@@ -2429,10 +2441,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       // The page-key comparison matters as much as the null check: a leftover guard on some OTHER
       // page would satisfy the old code and then protect the wrong page, which is the very thing
       // this guard exists to prevent.
-      reader.getRecordPage(new IndexLogKey(IndexType.DOCUMENT,
-                                           reader.pageKey(nodeKey, IndexType.DOCUMENT),
-                                           0,
-                                           reader.getRevisionNumber()));
+      reader.getRecordPage(new IndexLogKey(IndexType.DOCUMENT, reader.pageKey(nodeKey, IndexType.DOCUMENT), 0,
+          reader.getRevisionNumber()));
       currentPage = reader.getCurrentPage();
     }
     // Re-check the page KEY, not just for null. getRecordPage returns null without touching the
@@ -2443,10 +2453,11 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     // about to mutate are pinned, and they are not.
     final long expectedPageKey = reader.pageKey(nodeKey, IndexType.DOCUMENT);
     if (currentPage == null || currentPage.getPageKey() != expectedPageKey) {
-      throw new IllegalStateException(
-          "No page holds node " + nodeKey + " - cannot acquire guard (expected page "
-              + expectedPageKey + ", got "
-              + (currentPage == null ? "none" : Long.toString(currentPage.getPageKey())) + ")");
+      throw new IllegalStateException("No page holds node " + nodeKey + " - cannot acquire guard (expected page "
+          + expectedPageKey + ", got " + (currentPage == null
+              ? "none"
+              : Long.toString(currentPage.getPageKey()))
+          + ")");
     }
     return new PageGuard(currentPage);
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/ResourceSession.java
@@ -29,6 +29,7 @@ import io.sirix.api.xml.XmlNodeTrx;
 import io.sirix.exception.SirixException;
 import io.sirix.exception.SirixThreadedException;
 import io.sirix.exception.SirixUsageException;
+import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.interfaces.Node;
 import io.sirix.access.trx.node.AfterCommitState;
 import io.sirix.access.trx.node.xml.XmlIndexController;
@@ -81,8 +82,9 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   /**
    * Get the history, that is the metadata informations about the revisions.
    *
-   * <p>The bounds are inclusive and may be passed in either order (and may be equal); results
-   * are returned newest-first.
+   * <p>
+   * The bounds are inclusive and may be passed in either order (and may be equal); results are
+   * returned newest-first.
    *
    * @param fromRevision one bound of the revision range (must be positive)
    * @param toRevision the other bound of the revision range (must be positive)
@@ -93,27 +95,28 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   /**
    * Get the commit timestamps (epoch milliseconds) of all revisions, newest-first.
    *
-   * <p>This is a fast path for callers that only need the timestamps of the history (not the
-   * commit author or message). Unlike {@link #getHistory()}, it is served entirely from the
-   * in-memory revision index: no {@link StorageEngineReader} is opened, no
-   * {@code RevisionRootPage} is read, and no per-revision asynchronous work is scheduled.
-   * Covers revisions {@code [1, mostRecentRevision]} (revision {@code 0} is the empty
-   * bootstrap, mirroring {@link #getHistory()}).
+   * <p>
+   * This is a fast path for callers that only need the timestamps of the history (not the commit
+   * author or message). Unlike {@link #getHistory()}, it is served entirely from the in-memory
+   * revision index: no {@link StorageEngineReader} is opened, no {@code RevisionRootPage} is read,
+   * and no per-revision asynchronous work is scheduled. Covers revisions
+   * {@code [1, mostRecentRevision]} (revision {@code 0} is the empty bootstrap, mirroring
+   * {@link #getHistory()}).
    *
-   * @return the commit timestamps as epoch milliseconds, ordered most-recent revision first
-   *         (empty if the resource has no committed revisions yet)
+   * @return the commit timestamps as epoch milliseconds, ordered most-recent revision first (empty if
+   *         the resource has no committed revisions yet)
    */
   long[] getHistoryTimestamps();
 
   /**
-   * Get the commit timestamps (epoch milliseconds) for an inclusive revision range,
-   * newest-first.
+   * Get the commit timestamps (epoch milliseconds) for an inclusive revision range, newest-first.
    *
-   * <p>The bounds are inclusive and may be passed in either order (and may be equal). Like
+   * <p>
+   * The bounds are inclusive and may be passed in either order (and may be equal). Like
    * {@link #getHistoryTimestamps()} this reads only from the in-memory revision index.
    *
    * @param fromRevision one bound of the revision range (must be positive)
-   * @param toRevision   the other bound of the revision range (must be positive)
+   * @param toRevision the other bound of the revision range (must be positive)
    * @return the commit timestamps as epoch milliseconds, ordered most-recent revision first
    */
   long[] getHistoryTimestamps(int fromRevision, int toRevision);
@@ -122,10 +125,11 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * Get the ascending list of revisions in which the record with the given {@code nodeKey} was
    * created or modified.
    *
-   * <p>This is served by a single lookup of the {@code RECORD_TO_REVISIONS} node-history index
-   * (one lightweight storage reader, no full node transaction). It is the basis for value-history
-   * scans that only need to read the revisions in which a value actually changed (the value is
-   * unchanged between consecutive entries), rather than every revision.
+   * <p>
+   * This is served by a single lookup of the {@code RECORD_TO_REVISIONS} node-history index (one
+   * lightweight storage reader, no full node transaction). It is the basis for value-history scans
+   * that only need to read the revisions in which a value actually changed (the value is unchanged
+   * between consecutive entries), rather than every revision.
    *
    * @param nodeKey the stable node key of the record
    * @return the change revisions in ascending order; an empty array when the resource was created
@@ -137,16 +141,17 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * Scan the value history of the record with the given {@code nodeKey}, invoking {@code visitor}
    * once per revision in which the record exists.
    *
-   * <p>When the resource keeps a node-history index ({@code storeNodeHistory}), only the revisions
-   * in which the record actually changed are read (see {@link #getRecordChangeRevisions(long)}) —
-   * the value is unchanged in between, so a consumer can treat each visited revision as the start
-   * of a run that lasts until the next visited revision. Without the index, every revision is
-   * scanned. Either way each revision is read through a lightweight storage reader rather than a
-   * full read-only node transaction, avoiding the per-revision transaction-construction cost.
+   * <p>
+   * When the resource keeps a node-history index ({@code storeNodeHistory}), only the revisions in
+   * which the record actually changed are read (see {@link #getRecordChangeRevisions(long)}) — the
+   * value is unchanged in between, so a consumer can treat each visited revision as the start of a
+   * run that lasts until the next visited revision. Without the index, every revision is scanned.
+   * Either way each revision is read through a lightweight storage reader rather than a full
+   * read-only node transaction, avoiding the per-revision transaction-construction cost.
    *
-   * <p>Revisions in which the record does not exist (before creation, or after deletion) are
-   * skipped. The {@link io.sirix.node.interfaces.DataRecord} handed to the visitor is valid only
-   * for the duration of the callback.
+   * <p>
+   * Revisions in which the record does not exist (before creation, or after deletion) are skipped.
+   * The {@link DataRecord} handed to the visitor is valid only for the duration of the callback.
    *
    * @param nodeKey the stable node key of the record
    * @param visitor the callback invoked for each existing historical version (must not be null)
@@ -157,16 +162,18 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * Scan the value history of the record with the given {@code nodeKey} as <i>runs</i>: invoke
    * {@code visitor} once per maximal range of revisions over which the record holds the same value.
    *
-   * <p>This is the value-at-every-revision view of {@link #scanRecordHistory(long,
-   * RecordHistoryVisitor)}: when the node-history index is present, the record is read only once per
-   * change (O(changes), not O(revisions)) and each callback reports the inclusive revision range
-   * {@code [fromRevision, toRevision]} over which that value holds — so an aggregate over the whole
-   * history can be computed as {@code value * (toRevision - fromRevision + 1)} without reading every
-   * revision. Without the index, each existing revision is reported as its own single-revision run.
+   * <p>
+   * This is the value-at-every-revision view of
+   * {@link #scanRecordHistory(long, RecordHistoryVisitor)}: when the node-history index is present,
+   * the record is read only once per change (O(changes), not O(revisions)) and each callback reports
+   * the inclusive revision range {@code [fromRevision, toRevision]} over which that value holds — so
+   * an aggregate over the whole history can be computed as
+   * {@code value * (toRevision - fromRevision + 1)} without reading every revision. Without the
+   * index, each existing revision is reported as its own single-revision run.
    *
-   * <p>Runs in which the record does not exist (before creation, or after deletion) are not
-   * reported. The {@link io.sirix.node.interfaces.DataRecord} handed to the visitor is valid only
-   * for the duration of the callback.
+   * <p>
+   * Runs in which the record does not exist (before creation, or after deletion) are not reported.
+   * The {@link DataRecord} handed to the visitor is valid only for the duration of the callback.
    *
    * @param nodeKey the stable node key of the record
    * @param visitor the callback invoked for each value run (must not be null)
@@ -181,8 +188,8 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   Optional<W> getNodeTrx();
 
   /**
-   * Number of currently-open read-only or read-write node transactions on this session.
-   * Useful for diagnostics and for asserting the absence of resource leaks in tests.
+   * Number of currently-open read-only or read-write node transactions on this session. Useful for
+   * diagnostics and for asserting the absence of resource leaks in tests.
    *
    * @return the number of open node transactions, including the single writer if any
    */
@@ -307,8 +314,7 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
    * @throws IllegalArgumentException if {@code maxNodes < 0}
    * @throws NullPointerException if {@code timeUnit} is {@code null}
    */
-  W beginNodeTrx(int maxNodes, int maxTime, TimeUnit timeUnit,
-      AfterCommitState afterCommitState);
+  W beginNodeTrx(int maxNodes, int maxTime, TimeUnit timeUnit, AfterCommitState afterCommitState);
 
   /**
    * Begin exclusive read/write transaction without auto commit.
@@ -457,9 +463,9 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   Optional<User> getUser();
 
   /**
-   * Get or create a shared read-only transaction for the calling thread at the
-   * given revision. The transaction is cached per thread+revision so that
-   * multiple items on the same worker thread share a single cursor.
+   * Get or create a shared read-only transaction for the calling thread at the given revision. The
+   * transaction is cached per thread+revision so that multiple items on the same worker thread share
+   * a single cursor.
    *
    * @param revision the revision number to read
    * @return a read-only transaction bound to the current thread and revision
@@ -467,8 +473,8 @@ public interface ResourceSession<R extends NodeReadOnlyTrx & NodeCursor, W exten
   R getOrCreateSharedReadOnlyTrx(int revision);
 
   /**
-   * Close and remove all shared read-only transactions for the given revision.
-   * Called when a thread-safe proxy is closed to free per-worker cursors.
+   * Close and remove all shared read-only transactions for the given revision. Called when a
+   * thread-safe proxy is closed to free per-worker cursors.
    *
    * @param revision the revision whose shared transactions should be closed
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManager.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManager.java
@@ -21,17 +21,31 @@ public interface BufferManager extends AutoCloseable {
    * Cache of individual HOT leaf FRAGMENTS, keyed by each fragment's own durable offset — the HOT
    * analogue of {@link #getRecordPageFragmentCache()}.
    *
-   * <p>Deliberately separate from {@link #getHOTLeafPageCache()}: that one holds the COMBINED page
-   * under a canonical key whose value is the newest fragment's offset, so a fragment stored there
-   * would alias a merged page with one of its own sparse inputs. Fragments are immutable once
-   * written and are re-read by every commit that copy-on-writes the same leaf while the versioning
-   * window still spans them, which is what makes them worth caching.</p>
+   * <p>
+   * Deliberately separate from {@link #getHOTLeafPageCache()}: that one holds the COMBINED page under
+   * a canonical key whose value is the newest fragment's offset, so a fragment stored there would
+   * alias a merged page with one of its own sparse inputs. Fragments are immutable once written and
+   * are re-read by every commit that copy-on-writes the same leaf while the versioning window still
+   * spans them, which is what makes them worth caching.
+   * </p>
    */
   Cache<PageReference, HOTLeafPage> getHOTLeafFragmentCache();
 
   Cache<RevisionRootPageCacheKey, RevisionRootPage> getRevisionRootPageCache();
 
   Cache<RBIndexKey, Node> getIndexCache();
+
+  /**
+   * Memoized HOT point lookups, keyed by committed revision — the HOT analogue of
+   * {@link #getIndexCache()}, which serves the red-black-tree backend.
+   *
+   * <p>
+   * Not a {@link Cache} like its neighbours because it does not hold pages: it holds the ANSWER to a
+   * lookup, so it has neither guards nor a second-level tier, and it needs an admission rule the page
+   * caches do not (see {@link HOTLookupCache#MAX_CACHED_NODE_KEYS}).
+   * </p>
+   */
+  HOTLookupCache getHOTLookupCache();
 
   Cache<NamesCacheKey, Names> getNamesCache();
 

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManagerImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/BufferManagerImpl.java
@@ -7,12 +7,14 @@ import io.sirix.page.KeyValueLeafPage;
 import io.sirix.page.PageReference;
 import io.sirix.page.RevisionRootPage;
 import io.sirix.page.interfaces.Page;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 
 /**
@@ -51,11 +53,12 @@ public final class BufferManagerImpl implements BufferManager {
   /**
    * Pages that were still guarded when an invalidation sweep reached them.
    *
-   * <p>A destructive sweep is supposed to run when nothing of the swept scope is in use, so a
-   * non-zero count means some caller invalidates while it is itself holding pages — the shape of bug
-   * that made {@code createPageTransaction} truncate after constructing its writer. The sweep stays
-   * correct either way (teardown defers to the holder's last release), so this is an anomaly signal
-   * rather than an error, and it costs one already-loaded field read per swept page on a cold path.
+   * <p>
+   * A destructive sweep is supposed to run when nothing of the swept scope is in use, so a non-zero
+   * count means some caller invalidates while it is itself holding pages — the shape of bug that made
+   * {@code createPageTransaction} truncate after constructing its writer. The sweep stays correct
+   * either way (teardown defers to the holder's last release), so this is an anomaly signal rather
+   * than an error, and it costs one already-loaded field read per swept page on a cold path.
    */
   private static final LongAdder GUARDED_PAGES_SWEPT = new LongAdder();
 
@@ -64,6 +67,146 @@ public final class BufferManagerImpl implements BufferManager {
    * the default chain cap. Below this the cache thrashes instead of serving anything.
    */
   private static final long MIN_HOT_FRAGMENT_BUDGET_BYTES = 32L * HOTLeafPage.DEFAULT_SIZE;
+
+  /**
+   * Memoized HOT point lookups to retain.
+   *
+   * <p>
+   * The CEILING when no budget is available to derive one from — see
+   * {@link #defaultHotLookupCacheEntries(long)}, which is what the constructor actually uses. A FULL
+   * entry is the {@code long[]} ({@code MAX_CACHED_NODE_KEYS} x 8 = ~2 KB) plus the key's owned byte
+   * copy plus two small objects, so 64K entries is ~150 MB if every slot holds a maximum-length
+   * posting list. That is the worst case, not the expectation — posting lists near the bound are
+   * rare, absent-key entries cost a shared empty array, and the table only fills where keys are
+   * actually re-asked — but it is the number a bound has to be built from.
+   * </p>
+   */
+  private static final int DEFAULT_HOT_LOOKUP_CACHE_ENTRIES = 1 << 16;
+
+  /**
+   * Worst-case retained bytes per admitted entry, for turning a byte budget into an entry count.
+   *
+   * <p>
+   * {@code long[MAX_CACHED_NODE_KEYS]} (2064) + the {@code Entry} record (~24) + the
+   * {@link HOTLookupKey} (~56) + its owned key copy (~256 for a maxed CAS key). Deliberately the
+   * worst case: an average would size the table so that a workload of large posting lists overshoots
+   * the budget, which is exactly the workload that most needs the bound to hold.
+   * </p>
+   */
+  private static final long HOT_LOOKUP_WORST_CASE_ENTRY_BYTES = 2400L;
+
+  /**
+   * Share of the record-page budget the lookup cache may retain on the heap.
+   *
+   * <p>
+   * A thirty-second, which is deliberately small: every other cache here is budgeted in BYTES from
+   * the same pool, and this one is the only one that is ON-heap in a process that keeps its page
+   * frames off it. Sizing it in entries alone — which is what shipped first — meant the default was a
+   * flat count that no configured budget could restrain, so a heap tuned around the page caches
+   * silently acquired up to ~150 MB it never accounted for.
+   * </p>
+   */
+  private static final long HOT_LOOKUP_BUDGET_DIVISOR = 32L;
+
+  /** Floor, so a tiny budget yields a cache that is still worth consulting rather than one slot. */
+  private static final int MIN_HOT_LOOKUP_CACHE_ENTRIES = 1 << 10;
+
+  /**
+   * Entry count for {@code recordPageBudgetBytes}, bounded by the same pool as its siblings.
+   *
+   * @param recordPageBudgetBytes the record-page cache budget this instance was constructed with
+   * @return the entry count to build the lookup cache with
+   */
+  private static int defaultHotLookupCacheEntries(final long recordPageBudgetBytes) {
+    if (recordPageBudgetBytes <= 0) {
+      return DEFAULT_HOT_LOOKUP_CACHE_ENTRIES;
+    }
+    final long affordable = recordPageBudgetBytes / HOT_LOOKUP_BUDGET_DIVISOR / HOT_LOOKUP_WORST_CASE_ENTRY_BYTES;
+    final long bounded = Math.min(affordable, DEFAULT_HOT_LOOKUP_CACHE_ENTRIES);
+    return (int) Math.max(bounded, MIN_HOT_LOOKUP_CACHE_ENTRIES);
+  }
+
+  /**
+   * System property overriding {@link #DEFAULT_HOT_LOOKUP_CACHE_ENTRIES}.
+   *
+   * <p>
+   * Operator-facing, because the right size depends on the read pattern rather than on the data: the
+   * cache pays off only for keys asked about more than once within a revision, so a workload with no
+   * key reuse wants it small and one serving repeated lookups wants it large. {@code 0} disables the
+   * cache outright, which is also how a measurement isolates the MISS path — sizing it below the
+   * working set is the only way to see what the memoization costs when it never hits.
+   * </p>
+   */
+  public static final String HOT_LOOKUP_CACHE_ENTRIES_PROPERTY = "sirix.hotLookupCache.maxEntries";
+
+  /**
+   * @param recordPageBudgetBytes the record-page cache budget this instance was constructed with
+   * @param configured the raw property value, read ONCE by the caller and passed in — reading it a
+   *        second time for the startup log let a value that appeared or vanished between the two
+   *        reads make the log report the wrong provenance for the size actually built
+   * @return the entry count to build the lookup cache with
+   */
+  private static HotLookupSize hotLookupCacheEntries(final long recordPageBudgetBytes,
+      final @Nullable String configured) {
+    if (configured == null) {
+      return new HotLookupSize(defaultHotLookupCacheEntries(recordPageBudgetBytes), false);
+    }
+    // Not final: javac treats a blank final assigned in the `try` as possibly-assigned on entry to
+    // the `catch`, so the catch's assignment does not compile.
+    int parsed;
+    try {
+      parsed = Integer.parseInt(configured.trim());
+    } catch (final NumberFormatException e) {
+      parsed = -1; // unusable, same as a negative value — one rejection rule, one message
+    }
+    // Negatives are NOT clamped silently to 0: 0 is the documented "disable" sentinel, so a typo'd
+    // minus sign would turn the cache off and cost every lookup full price with nothing in the log.
+    if (parsed < 0) {
+      // The SAME default the no-property path takes, which is the whole point: falling back to the
+      // raw DEFAULT_HOT_LOOKUP_CACHE_ENTRIES ceiling instead meant a single typo'd or negative value
+      // built a 65536-slot table where setting nothing at all builds 4096 — 16x the on-heap
+      // retention, past the very budget HOT_LOOKUP_BUDGET_DIVISOR exists to enforce — and announced
+      // it as "the default", which it was not. An invalid override must land exactly where no
+      // override lands.
+      final int fallback = defaultHotLookupCacheEntries(recordPageBudgetBytes);
+      LOGGER.warn("Ignoring invalid {}={} (expected an integer >= 0), using the default of {} entries",
+          HOT_LOOKUP_CACHE_ENTRIES_PROPERTY, configured, fallback);
+      return new HotLookupSize(fallback, false);
+    }
+    // A huge POSITIVE value is clamped too, and loudly. The rejection rule above only caught
+    // negatives, so an extra zero on an otherwise sensible value sailed through: the constructor
+    // clamps to MAX_SLOTS internally and silently, so the operator got a 16.7M-slot table — hundreds
+    // of megabytes of references alone — while the startup line below dutifully reported the enormous
+    // figure as if it had been honoured. Clamping HERE is what makes the discrepancy visible; the
+    // ceiling itself is the constructor's, restated so the two cannot drift apart.
+    if (parsed > HOTLookupCache.MAX_SLOTS) {
+      LOGGER.warn("Clamping {}={} to the maximum of {} entries (~{} MB retained)", HOT_LOOKUP_CACHE_ENTRIES_PROPERTY,
+          parsed, HOTLookupCache.MAX_SLOTS,
+          (long) HOTLookupCache.MAX_SLOTS * HOT_LOOKUP_WORST_CASE_ENTRY_BYTES / (1024 * 1024));
+      // fromProperty = false: the property did not decide the size, the ceiling did, and the log
+      // line must not attribute the built table to a number that was overridden.
+      return new HotLookupSize(HOTLookupCache.MAX_SLOTS, false);
+    }
+    return new HotLookupSize(parsed, true);
+  }
+
+  /**
+   * The entry count to build the lookup cache with, and whether the property is what decided it.
+   *
+   * <p>
+   * One value carrying both, rather than a second predicate re-deriving provenance from the raw
+   * string, because the two drifted the moment they were separate: a rejected value logged "Ignoring
+   * invalid …" and was then reported as "set by …" four lines later, and an over-large value was
+   * clamped and still reported verbatim. Both times the startup line pointed an operator triaging a
+   * mis-set override at the one number that was NOT in effect.
+   * </p>
+   *
+   * @param entries the size the cache is built with
+   * @param fromProperty whether the property both was set and survived validation unchanged, so the
+   *        startup line may attribute the size to it
+   */
+  private record HotLookupSize(int entries, boolean fromProperty) {
+  }
 
   // Use ShardedPageCache for KeyValueLeafPage caches (direct eviction control)
   private final ShardedPageCache<KeyValueLeafPage> recordPageCache;
@@ -81,6 +224,10 @@ public final class BufferManagerImpl implements BufferManager {
 
   private final RevisionRootPageCache revisionRootPageCache;
   private final RedBlackTreeNodeCache redBlackTreeNodeCache;
+
+  // Memoized HOT point-lookup answers. Sized independently of the page caches: entries are a key
+  // plus a bounded long[], so this is kilobytes where the page caches are megabytes.
+  private final HOTLookupCache hotLookupCache;
   private final NamesCache namesCache;
   private final PathSummaryCache pathSummaryCache;
 
@@ -156,6 +303,12 @@ public final class BufferManagerImpl implements BufferManager {
 
     revisionRootPageCache = new RevisionRootPageCache(maxRevisionRootPageCache);
     redBlackTreeNodeCache = new RedBlackTreeNodeCache(maxRBTreeNodeCache);
+    final String configuredHotLookupEntries = System.getProperty(HOT_LOOKUP_CACHE_ENTRIES_PROPERTY);
+    final HotLookupSize hotLookupSize = hotLookupCacheEntries(maxRecordPageCacheWeight, configuredHotLookupEntries);
+    final int hotLookupEntries = hotLookupSize.entries();
+    hotLookupCache = hotLookupEntries == 0
+        ? HOTLookupCache.disabled()
+        : new HOTLookupCache(hotLookupEntries);
     namesCache = new NamesCache(maxNamesCacheSize);
     pathSummaryCache = new PathSummaryCache(maxPathSummaryCacheSize);
 
@@ -167,6 +320,19 @@ public final class BufferManagerImpl implements BufferManager {
     LOGGER.info("  - RecordPageCache: {} MB", maxRecordPageCacheWeight / (1024 * 1024));
     LOGGER.info("  - RecordPageFragmentCache: {} MB", maxRecordPageFragmentCacheWeight / (1024 * 1024));
     LOGGER.info("  - PageCache: {} MB", maxPageCacheWeight / (1024 * 1024));
+    // Reported alongside its siblings, in the same units they are budgeted in. Without this the one
+    // cache an operator can size by system property was also the only one whose effective size never
+    // appeared anywhere, so a mis-set (or ignored) override was invisible during triage.
+    //
+    // The figure is capacity(), the table that was BUILT, not the entry count that was requested:
+    // the constructor rounds down to a power-of-two set count, so with the shipped default the two
+    // differ by nearly half (6990 requested, 4096 built) — and a log line whose whole purpose is to
+    // show the effective size must not print the number the cache ignored.
+    final int hotLookupSlots = hotLookupCache.capacity();
+    LOGGER.info("  - HOTLookupCache: {} entries, up to ~{} MB retained{}", hotLookupSlots,
+        hotLookupSlots * HOT_LOOKUP_WORST_CASE_ENTRY_BYTES / (1024 * 1024), hotLookupSize.fromProperty()
+            ? " (set by " + HOT_LOOKUP_CACHE_ENTRIES_PROPERTY + "=" + configuredHotLookupEntries + ')'
+            : " (derived from the record-page budget)");
   }
 
   @Override
@@ -192,6 +358,11 @@ public final class BufferManagerImpl implements BufferManager {
   @Override
   public Cache<RBIndexKey, Node> getIndexCache() {
     return redBlackTreeNodeCache;
+  }
+
+  @Override
+  public HOTLookupCache getHOTLookupCache() {
+    return hotLookupCache;
   }
 
   @Override
@@ -233,9 +404,10 @@ public final class BufferManagerImpl implements BufferManager {
 
     // Start ClockSweeper for RecordPageFragmentCache (GLOBAL)
     {
-      ShardedPageCache.Shard<KeyValueLeafPage> shard = recordPageFragmentCache.getShard(new PageReference());
-      ClockSweeper sweeper = new ClockSweeper(shard, recordPageFragmentCache, globalEpochTracker, sweepIntervalMs, 0, 0, 0);
-      Thread thread = new Thread(sweeper, "ClockSweeper-FragmentPage-GLOBAL");
+      final ShardedPageCache.Shard<KeyValueLeafPage> shard = recordPageFragmentCache.getShard(new PageReference());
+      final ClockSweeper sweeper =
+          new ClockSweeper(shard, recordPageFragmentCache, globalEpochTracker, sweepIntervalMs, 0, 0, 0);
+      final Thread thread = new Thread(sweeper, "ClockSweeper-FragmentPage-GLOBAL");
       thread.setDaemon(true);
       thread.start();
       clockSweepers.add(sweeper);
@@ -257,9 +429,10 @@ public final class BufferManagerImpl implements BufferManager {
 
     // Start ClockSweeper for HOTLeafFragmentCache (GLOBAL)
     {
-      ShardedPageCache.Shard<HOTLeafPage> shard = hotLeafFragmentCache.getShard(new PageReference());
-      ClockSweeper sweeper = new ClockSweeper(shard, hotLeafFragmentCache, globalEpochTracker, sweepIntervalMs, 0, 0, 0);
-      Thread thread = new Thread(sweeper, "ClockSweeper-HOTLeafFragment-GLOBAL");
+      final ShardedPageCache.Shard<HOTLeafPage> shard = hotLeafFragmentCache.getShard(new PageReference());
+      final ClockSweeper sweeper =
+          new ClockSweeper(shard, hotLeafFragmentCache, globalEpochTracker, sweepIntervalMs, 0, 0, 0);
+      final Thread thread = new Thread(sweeper, "ClockSweeper-HOTLeafFragment-GLOBAL");
       thread.setDaemon(true);
       thread.start();
       clockSweepers.add(sweeper);
@@ -319,15 +492,24 @@ public final class BufferManagerImpl implements BufferManager {
    */
   @Override
   public void clearAllCaches() {
-    pageCache.clear();
-    recordPageCache.clear();
-    recordPageFragmentCache.clear();
-    hotLeafPageCache.clear();
-    hotLeafFragmentCache.clear();
-    revisionRootPageCache.clear();
-    redBlackTreeNodeCache.clear();
-    namesCache.clear();
-    pathSummaryCache.clear();
+    // Memoized index answers are derived from the pages cleared below, so they go with them: this is
+    // the "cold process" contract Databases.clearGlobalCaches() promises its corruption tests. In a
+    // finally because an exception from any page cache above would otherwise leave the derived
+    // answers behind — a cache that outlives the pages it was derived from is precisely what the
+    // "cold process" contract rules out.
+    try {
+      pageCache.clear();
+      recordPageCache.clear();
+      recordPageFragmentCache.clear();
+      hotLeafPageCache.clear();
+      hotLeafFragmentCache.clear();
+      revisionRootPageCache.clear();
+      redBlackTreeNodeCache.clear();
+      namesCache.clear();
+      pathSummaryCache.clear();
+    } finally {
+      hotLookupCache.clear();
+    }
   }
 
   @Override
@@ -392,201 +574,331 @@ public final class BufferManagerImpl implements BufferManager {
 
   @Override
   public void clearCachesForDatabase(long databaseId) {
+    // try/catch/finally around the WHOLE body, not just around the HOT page sweep. The body's
+    // exception is CAPTURED rather than left to propagate on its own, because a bare finally that
+    // itself throws discards it outright — not even as a suppressed cause — and the body's failure is
+    // the one an operator needs. It is rethrown below with the sweep's failure attached. The memoized
+    // answers
+    // are derived from these pages, and the loops above retire live off-heap frames and build
+    // unbounded key lists — any of which can throw. When one did, this method unwound before the
+    // memoized answers were ever swept, and truncateTo went on to re-issue the very revision numbers
+    // those answers are keyed by: every later lookup at those revisions was served from discarded
+    // history, permanently. The page sweep failing is bad; the page sweep failing SILENTLY while the
+    // answers derived from it survive is unrecoverable, so the second sweep must not depend on the
+    // first one finishing. clearAllCaches has had this guarantee all along.
     // CRITICAL FIX: Remove all pages belonging to this database from global caches
     // This prevents cache pollution when database is removed and recreated with same ID
     // THREAD-SAFE: Collect keys first, then remove atomically to avoid concurrent modification
-
+    // Declared OUTSIDE the try so the finally below can report what was actually removed before a
+    // failure, rather than losing the tally with the frame.
     int removedFromRecordCache = 0;
     int removedFromFragmentCache = 0;
     int removedFromPageCache = 0;
     int removedFromRevisionCache = 0;
 
-    // Clear RecordPageCache - close pages BEFORE removing from cache
-    var recordKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : recordPageCache.asMap().entrySet()) {
-      if (entry.getKey().getDatabaseId() == databaseId) {
-        recordKeysToRemove.add(entry.getKey());
-      }
-    }
-    for (var key : recordKeysToRemove) {
-      KeyValueLeafPage page = recordPageCache.get(key);
-      if (page != null && !page.isClosed()) {
-        // Teardown/destructive-admin path. NEVER force-release guards this thread does not own:
-        // the sweep is database-scoped while the truncation that triggers it is resource-scoped, so
-        // a live transaction on a sibling resource can be holding a guard on a page whose bytes were
-        // never truncated — draining frees the frame under it. markOrphaned() + close() is the
-        // guard-aware protocol TransactionIntentLog.closePage already uses: close() alone SKIPS a
-        // guarded page without arranging any teardown, while the orphan bit makes the holder's last
-        // releaseGuard() free the slot.
-        if (page.getGuardCount() > 0) {
-          GUARDED_PAGES_SWEPT.increment();
+    // Holds the body's failure so the finally can attach the sweep's to it instead of replacing it.
+    Throwable fromBody = null;
+
+    try {
+
+      // Clear RecordPageCache - close pages BEFORE removing from cache
+      var recordKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : recordPageCache.asMap().entrySet()) {
+        if (entry.getKey().getDatabaseId() == databaseId) {
+          recordKeysToRemove.add(entry.getKey());
         }
-        page.retire();
       }
-      recordPageCache.remove(key);
-      removedFromRecordCache++;
-    }
-
-    // Clear RecordPageFragmentCache - close fragments BEFORE removing from cache
-    var fragmentKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : recordPageFragmentCache.asMap().entrySet()) {
-      if (entry.getKey().getDatabaseId() == databaseId) {
-        fragmentKeysToRemove.add(entry.getKey());
-      }
-    }
-    for (var key : fragmentKeysToRemove) {
-      KeyValueLeafPage page = recordPageFragmentCache.get(key);
-      if (page != null && !page.isClosed()) {
-        // See above: unmap, never drain a guard this thread does not own.
-        if (page.getGuardCount() > 0) {
-          GUARDED_PAGES_SWEPT.increment();
+      for (var key : recordKeysToRemove) {
+        KeyValueLeafPage page = recordPageCache.get(key);
+        if (page != null && !page.isClosed()) {
+          // Teardown/destructive-admin path. NEVER force-release guards this thread does not own:
+          // the sweep is database-scoped while the truncation that triggers it is resource-scoped, so
+          // a live transaction on a sibling resource can be holding a guard on a page whose bytes were
+          // never truncated — draining frees the frame under it. markOrphaned() + close() is the
+          // guard-aware protocol TransactionIntentLog.closePage already uses: close() alone SKIPS a
+          // guarded page without arranging any teardown, while the orphan bit makes the holder's last
+          // releaseGuard() free the slot.
+          if (page.getGuardCount() > 0) {
+            GUARDED_PAGES_SWEPT.increment();
+          }
+          page.retire();
         }
-        page.retire();
+        recordPageCache.remove(key);
+        removedFromRecordCache++;
       }
-      recordPageFragmentCache.remove(key);
-      removedFromFragmentCache++;
-    }
 
-    // Clear PageCache
-    var pageKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : pageCache.asMap().entrySet()) {
-      if (entry.getKey().getDatabaseId() == databaseId) {
-        pageKeysToRemove.add(entry.getKey());
+      // Clear RecordPageFragmentCache - close fragments BEFORE removing from cache
+      var fragmentKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : recordPageFragmentCache.asMap().entrySet()) {
+        if (entry.getKey().getDatabaseId() == databaseId) {
+          fragmentKeysToRemove.add(entry.getKey());
+        }
       }
-    }
-    for (var key : pageKeysToRemove) {
-      pageCache.remove(key); // Cache.remove() is thread-safe
-      removedFromPageCache++;
-    }
-
-    // Clear RevisionRootPageCache
-    var revisionKeysToRemove = new ArrayList<RevisionRootPageCacheKey>();
-    for (var entry : revisionRootPageCache.asMap().entrySet()) {
-      if (entry.getKey().databaseId() == databaseId) { // Record field access
-        revisionKeysToRemove.add(entry.getKey());
+      for (var key : fragmentKeysToRemove) {
+        KeyValueLeafPage page = recordPageFragmentCache.get(key);
+        if (page != null && !page.isClosed()) {
+          // See above: unmap, never drain a guard this thread does not own.
+          if (page.getGuardCount() > 0) {
+            GUARDED_PAGES_SWEPT.increment();
+          }
+          page.retire();
+        }
+        recordPageFragmentCache.remove(key);
+        removedFromFragmentCache++;
       }
-    }
-    for (var key : revisionKeysToRemove) {
-      revisionRootPageCache.remove(key); // Thread-safe
-      removedFromRevisionCache++;
-    }
 
-    if (removedFromRecordCache + removedFromFragmentCache + removedFromPageCache + removedFromRevisionCache > 0) {
-      LOGGER.debug("Cleared caches for database {}: RecordCache={}, FragmentCache={}, PageCache={}, RevisionCache={}",
-          databaseId, removedFromRecordCache, removedFromFragmentCache, removedFromPageCache, removedFromRevisionCache);
-    }
+      // Clear PageCache
+      var pageKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : pageCache.asMap().entrySet()) {
+        if (entry.getKey().getDatabaseId() == databaseId) {
+          pageKeysToRemove.add(entry.getKey());
+        }
+      }
+      for (var key : pageKeysToRemove) {
+        pageCache.remove(key); // Cache.remove() is thread-safe
+        removedFromPageCache++;
+      }
 
-    // HOT leaf + fragment caches: truncation reuses the freed offsets, so a stale HOT fragment would
-    // be merged into a live leaf. Deliberately OUTSIDE the log guard above — gating this on the
-    // record/page/revision counters would skip HOT invalidation whenever those caches happened to
-    // hold nothing for this database (a HOT-only resource, or a second clear right after a first),
-    // which is precisely the stale-fragment path.
-    clearHotPageCaches(key -> key.getDatabaseId() == databaseId);
+      // Clear RevisionRootPageCache
+      var revisionKeysToRemove = new ArrayList<RevisionRootPageCacheKey>();
+      for (var entry : revisionRootPageCache.asMap().entrySet()) {
+        if (entry.getKey().databaseId() == databaseId) { // Record field access
+          revisionKeysToRemove.add(entry.getKey());
+        }
+      }
+      for (var key : revisionKeysToRemove) {
+        revisionRootPageCache.remove(key); // Thread-safe
+        removedFromRevisionCache++;
+      }
+    } catch (final Throwable e) {
+      fromBody = e;
+      throw e;
+    } finally {
+      sweepHotCachesAndReport(fromBody, key -> key.getDatabaseId() == databaseId,
+          () -> hotLookupCache.invalidateDatabase(databaseId), "database " + databaseId, removedFromRecordCache,
+          removedFromFragmentCache, removedFromPageCache, removedFromRevisionCache);
+    }
   }
 
   @Override
   public void clearCachesForResource(long databaseId, long resourceId) {
+    // try/catch/finally around the WHOLE body, not just around the HOT page sweep. The body's
+    // exception is CAPTURED rather than left to propagate on its own, because a bare finally that
+    // itself throws discards it outright — not even as a suppressed cause — and the body's failure is
+    // the one an operator needs. It is rethrown below with the sweep's failure attached. The memoized
+    // answers
+    // are derived from these pages, and the loops above retire live off-heap frames and build
+    // unbounded key lists — any of which can throw. When one did, this method unwound before the
+    // memoized answers were ever swept, and truncateTo went on to re-issue the very revision numbers
+    // those answers are keyed by: every later lookup at those revisions was served from discarded
+    // history, permanently. The page sweep failing is bad; the page sweep failing SILENTLY while the
+    // answers derived from it survive is unrecoverable, so the second sweep must not depend on the
+    // first one finishing. clearAllCaches has had this guarantee all along.
     // CRITICAL FIX: Remove all pages belonging to this resource from global caches
     // This prevents cache pollution when resource is closed and recreated with same IDs
     // THREAD-SAFE: Collect keys first, then remove atomically to avoid concurrent modification
-
+    // Declared OUTSIDE the try so the finally below can report what was actually removed before a
+    // failure, rather than losing the tally with the frame.
     int removedFromRecordCache = 0;
     int removedFromFragmentCache = 0;
     int removedFromPageCache = 0;
     int removedFromRevisionCache = 0;
 
-    // Clear RecordPageCache - close pages BEFORE removing from cache
-    var recordKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : recordPageCache.asMap().entrySet()) {
-      var key = entry.getKey();
-      if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
-        recordKeysToRemove.add(key);
-      }
-    }
-    for (var key : recordKeysToRemove) {
-      KeyValueLeafPage page = recordPageCache.get(key);
-      if (page != null && !page.isClosed()) {
-        // Teardown/destructive-admin path. NEVER force-release guards this thread does not own:
-        // the sweep is database-scoped while the truncation that triggers it is resource-scoped, so
-        // a live transaction on a sibling resource can be holding a guard on a page whose bytes were
-        // never truncated — draining frees the frame under it. markOrphaned() + close() is the
-        // guard-aware protocol TransactionIntentLog.closePage already uses: close() alone SKIPS a
-        // guarded page without arranging any teardown, while the orphan bit makes the holder's last
-        // releaseGuard() free the slot.
-        if (page.getGuardCount() > 0) {
-          GUARDED_PAGES_SWEPT.increment();
+    // Holds the body's failure so the finally can attach the sweep's to it instead of replacing it.
+    Throwable fromBody = null;
+
+    try {
+
+      // Clear RecordPageCache - close pages BEFORE removing from cache
+      var recordKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : recordPageCache.asMap().entrySet()) {
+        var key = entry.getKey();
+        if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
+          recordKeysToRemove.add(key);
         }
-        page.retire();
       }
-      recordPageCache.remove(key);
-      removedFromRecordCache++;
-    }
-
-    // Clear RecordPageFragmentCache - close fragments BEFORE removing from cache
-    var fragmentKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : recordPageFragmentCache.asMap().entrySet()) {
-      var key = entry.getKey();
-      if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
-        fragmentKeysToRemove.add(key);
-      }
-    }
-    for (var key : fragmentKeysToRemove) {
-      KeyValueLeafPage page = recordPageFragmentCache.get(key);
-      if (page != null && !page.isClosed()) {
-        // See above: unmap, never drain a guard this thread does not own.
-        if (page.getGuardCount() > 0) {
-          GUARDED_PAGES_SWEPT.increment();
+      for (var key : recordKeysToRemove) {
+        KeyValueLeafPage page = recordPageCache.get(key);
+        if (page != null && !page.isClosed()) {
+          // Teardown/destructive-admin path. NEVER force-release guards this thread does not own:
+          // the sweep is database-scoped while the truncation that triggers it is resource-scoped, so
+          // a live transaction on a sibling resource can be holding a guard on a page whose bytes were
+          // never truncated — draining frees the frame under it. markOrphaned() + close() is the
+          // guard-aware protocol TransactionIntentLog.closePage already uses: close() alone SKIPS a
+          // guarded page without arranging any teardown, while the orphan bit makes the holder's last
+          // releaseGuard() free the slot.
+          if (page.getGuardCount() > 0) {
+            GUARDED_PAGES_SWEPT.increment();
+          }
+          page.retire();
         }
-        page.retire();
+        recordPageCache.remove(key);
+        removedFromRecordCache++;
       }
-      recordPageFragmentCache.remove(key);
-      removedFromFragmentCache++;
-    }
 
-    // Clear PageCache
-    var pageKeysToRemove = new ArrayList<PageReference>();
-    for (var entry : pageCache.asMap().entrySet()) {
-      var key = entry.getKey();
-      if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
-        pageKeysToRemove.add(key);
+      // Clear RecordPageFragmentCache - close fragments BEFORE removing from cache
+      var fragmentKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : recordPageFragmentCache.asMap().entrySet()) {
+        var key = entry.getKey();
+        if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
+          fragmentKeysToRemove.add(key);
+        }
+      }
+      for (var key : fragmentKeysToRemove) {
+        KeyValueLeafPage page = recordPageFragmentCache.get(key);
+        if (page != null && !page.isClosed()) {
+          // See above: unmap, never drain a guard this thread does not own.
+          if (page.getGuardCount() > 0) {
+            GUARDED_PAGES_SWEPT.increment();
+          }
+          page.retire();
+        }
+        recordPageFragmentCache.remove(key);
+        removedFromFragmentCache++;
+      }
+
+      // Clear PageCache
+      var pageKeysToRemove = new ArrayList<PageReference>();
+      for (var entry : pageCache.asMap().entrySet()) {
+        var key = entry.getKey();
+        if (key.getDatabaseId() == databaseId && key.getResourceId() == resourceId) {
+          pageKeysToRemove.add(key);
+        }
+      }
+      for (var key : pageKeysToRemove) {
+        pageCache.remove(key); // Cache.remove() is thread-safe
+        removedFromPageCache++;
+      }
+
+      // Clear RevisionRootPageCache
+      var revisionKeysToRemove = new ArrayList<RevisionRootPageCacheKey>();
+      for (var entry : revisionRootPageCache.asMap().entrySet()) {
+        var key = entry.getKey();
+        if (key.databaseId() == databaseId && key.resourceId() == resourceId) {
+          revisionKeysToRemove.add(key);
+        }
+      }
+      for (var key : revisionKeysToRemove) {
+        revisionRootPageCache.remove(key); // Thread-safe
+        removedFromRevisionCache++;
+      }
+    } catch (final Throwable e) {
+      fromBody = e;
+      throw e;
+    } finally {
+      sweepHotCachesAndReport(fromBody, key -> key.getDatabaseId() == databaseId && key.getResourceId() == resourceId,
+          () -> hotLookupCache.invalidateResource(databaseId, resourceId),
+          "resource (db=" + databaseId + ", res=" + resourceId + ')', removedFromRecordCache, removedFromFragmentCache,
+          removedFromPageCache, removedFromRevisionCache);
+    }
+  }
+
+  /**
+   * Drop the HOT pages of one scope, then the memoized point-lookup answers DERIVED from them, then
+   * report what the whole sweep removed.
+   *
+   * <p>
+   * ONE copy for {@link #clearCachesForDatabase} and {@link #clearCachesForResource}, which differ
+   * only in the key predicate and the invalidation scope. Stating the reasoning once is the point —
+   * the alternative was two bodies whose identical rationale had to be kept in step by hand.
+   * </p>
+   *
+   * <p>
+   * <b>Pages first, answers second.</b> The answers are derived from the pages, so dropping them
+   * first leaves a window in which a lookup racing the sweep re-memoizes the entries just removed out
+   * of pages the sweep has not reached yet. Note what this ordering does NOT buy: a lookup that
+   * already READ the pages before the page sweep can still admit its answer after the answer sweep
+   * has passed. Nothing here closes that window — only the quiescence precondition documented on
+   * {@link #clearHotPageCache} (nothing is reading the resource's file while it is truncated) does,
+   * and it covers the memoized answers for exactly the same reason it covers the pages.
+   * </p>
+   *
+   * <p>
+   * <b>Both sweeps always run, and the first failure stays the reported one.</b> The page sweep
+   * rethrows, so a plain sequential statement would let its exception skip the answer sweep — the
+   * same wrong-data outcome as never sweeping, since the pages would be gone while every answer
+   * derived from the discarded history survived under a revision number {@code truncateTo} is about
+   * to re-issue. A {@code finally} would run the answer sweep but let ITS exception replace the page
+   * sweep's, which is the diagnosis the caller actually needs; hence the explicit capture and
+   * {@code addSuppressed}. The counters are logged before the rethrow, because a partially failed
+   * sweep is precisely when they matter.
+   * </p>
+   *
+   * <p>
+   * The capture is {@code Throwable}, not {@code RuntimeException}. {@code clearHotPageCache} builds
+   * a list over every cache entry and calls {@code retire()} on each, so an {@code OutOfMemoryError}
+   * during a recovery sweep — or an {@code AssertionError} from a page invariant under {@code -ea} —
+   * is a realistic escape, and narrowing the catch to {@code RuntimeException} would let exactly that
+   * skip the answer sweep. That is the outcome the paragraph above says this method exists to
+   * prevent, so the guarantee has to cover what can actually be thrown.
+   * </p>
+   *
+   * @param fromBody the caller body's failure when it is already propagating, so this attaches its
+   *        own rather than replacing it; {@code null} when the body completed normally
+   * @param matches selects the HOT page-cache entries of this scope
+   * @param answerSweep drops the memoized answers of this scope and returns how many it dropped
+   * @param scope human-readable scope for the diagnostic log line
+   * @param removedFromRecordCache record-page entries the caller already removed
+   * @param removedFromFragmentCache record-fragment entries the caller already removed
+   * @param removedFromPageCache page entries the caller already removed
+   * @param removedFromRevisionCache revision-root entries the caller already removed
+   */
+  private void sweepHotCachesAndReport(final @Nullable Throwable fromBody, final Predicate<PageReference> matches,
+      final IntSupplier answerSweep, final String scope, final int removedFromRecordCache,
+      final int removedFromFragmentCache, final int removedFromPageCache, final int removedFromRevisionCache) {
+    Throwable failure = null;
+    try {
+      clearHotPageCaches(matches);
+    } catch (final RuntimeException | Error e) {
+      failure = e;
+    }
+    int removedLookups = 0;
+    try {
+      removedLookups = answerSweep.getAsInt();
+    } catch (final RuntimeException | Error e) {
+      if (failure == null) {
+        failure = e;
+      } else {
+        failure.addSuppressed(e);
       }
     }
-    for (var key : pageKeysToRemove) {
-      pageCache.remove(key); // Cache.remove() is thread-safe
-      removedFromPageCache++;
-    }
-
-    // Clear RevisionRootPageCache
-    var revisionKeysToRemove = new ArrayList<RevisionRootPageCacheKey>();
-    for (var entry : revisionRootPageCache.asMap().entrySet()) {
-      var key = entry.getKey();
-      if (key.databaseId() == databaseId && key.resourceId() == resourceId) {
-        revisionKeysToRemove.add(key);
-      }
-    }
-    for (var key : revisionKeysToRemove) {
-      revisionRootPageCache.remove(key); // Thread-safe
-      removedFromRevisionCache++;
-    }
-
-    if (removedFromRecordCache + removedFromFragmentCache + removedFromPageCache + removedFromRevisionCache > 0) {
+    if (removedFromRecordCache + removedFromFragmentCache + removedFromPageCache + removedFromRevisionCache
+        + removedLookups > 0) {
       LOGGER.debug(
-          "Cleared caches for resource (db={}, res={}): RecordCache={}, FragmentCache={}, PageCache={}, RevisionCache={}",
-          databaseId, resourceId, removedFromRecordCache, removedFromFragmentCache, removedFromPageCache,
-          removedFromRevisionCache);
+          "Cleared caches for {}: RecordCache={}, FragmentCache={}, PageCache={}, RevisionCache={}, LookupCache={}",
+          scope, removedFromRecordCache, removedFromFragmentCache, removedFromPageCache, removedFromRevisionCache,
+          removedLookups);
     }
-
-    // See clearCachesForDatabase: reused offsets after truncation make stale HOT fragments a
-    // silent-wrong-data hazard.
-    clearHotPageCaches(key -> key.getDatabaseId() == databaseId && key.getResourceId() == resourceId);
+    if (failure == null) {
+      return;
+    }
+    if (fromBody != null) {
+      // The CALLER's body already failed, and its exception is in flight through the finally that
+      // invoked this method. Throwing here would silently REPLACE it — Java drops an in-flight
+      // exception when a finally completes abruptly, not even recording it as a cause — and the
+      // body's failure is both the earlier one and the one that usually explains this one. Attach and
+      // return, so the caller sees the original with this hanging off it.
+      if (fromBody != failure) {
+        fromBody.addSuppressed(failure);
+      }
+      return;
+    }
+    // Rethrown unwrapped, in the two shapes the catches above can produce. Neither sweep declares a
+    // checked exception, so these are exhaustive and there is nothing to wrap.
+    if (failure instanceof final RuntimeException runtime) {
+      throw runtime;
+    }
+    throw (Error) failure;
   }
 
   /**
    * Sweep both HOT caches, guaranteeing the fragment cache is swept even if the leaf sweep throws.
    *
-   * <p>Sequential statements would not: the fragment cache is the one whose stale entries are
-   * silently merged into a live leaf after truncation reuses their offsets, so letting an exception
-   * from the leaf sweep skip it reaches the same wrong-data outcome as not calling it at all.</p>
+   * <p>
+   * Sequential statements would not: the fragment cache is the one whose stale entries are silently
+   * merged into a live leaf after truncation reuses their offsets, so letting an exception from the
+   * leaf sweep skip it reaches the same wrong-data outcome as not calling it at all.
+   * </p>
    */
   private void clearHotPageCaches(final Predicate<PageReference> matches) {
     try {
@@ -599,25 +911,31 @@ public final class BufferManagerImpl implements BufferManager {
   /**
    * Drop every entry of a HOT page cache whose key matches.
    *
-   * <p>Both truncate/rollback paths depend on this: {@code truncateTo} shortens the data file and the
+   * <p>
+   * Both truncate/rollback paths depend on this: {@code truncateTo} shortens the data file and the
    * NEXT commit REUSES those offsets, so a HOT fragment cached under a reused offset would serve
    * pre-truncation bytes into a live merge — silent wrong data, no exception. Fragments are immutable
-   * only while the file is append-only, which truncation ends.</p>
+   * only while the file is append-only, which truncation ends.
+   * </p>
    *
-   * <p><b>Guards are NOT drained here</b>, unlike the record-page blocks above. A HOT chain fragment
-   * is a SHARED cache entry held under a guard for the length of a merge, and draining that guard
-   * would free the off-heap slot under it (torn read, or a {@code releaseGuard} underflow when the
-   * merge's {@code finally} runs). Dropping the mapping is what the stale-offset hazard actually
-   * requires; {@link CacheablePage#retire()} is guard-aware and defers the teardown to the last
-   * release, so the slot is still reclaimed, just not out from under a live reader.</p>
+   * <p>
+   * <b>Guards are NOT drained here</b>, unlike the record-page blocks above. A HOT chain fragment is
+   * a SHARED cache entry held under a guard for the length of a merge, and draining that guard would
+   * free the off-heap slot under it (torn read, or a {@code releaseGuard} underflow when the merge's
+   * {@code finally} runs). Dropping the mapping is what the stale-offset hazard actually requires;
+   * {@link CacheablePage#retire()} is guard-aware and defers the teardown to the last release, so the
+   * slot is still reclaimed, just not out from under a live reader.
+   * </p>
    *
-   * <p><b>That deferral only exists for the FRAGMENT cache.</b> Entries of the HOT leaf-page cache
-   * are handed out unguarded, so {@code retire()} on one frees its frame there and then — exactly
-   * what ordinary eviction does to an unguarded page, and safe for the same reason: this sweep runs
-   * only from truncate/rollback, whose documented precondition is that nothing is reading the
-   * resource's file. What makes that precondition sufficient is that the sweep is RESOURCE-scoped
-   * (see {@code Databases.clearCachesForResource}); a database-wide sweep would reach sibling
-   * resources the precondition never covered, and free pages under their live readers.</p>
+   * <p>
+   * <b>That deferral only exists for the FRAGMENT cache.</b> Entries of the HOT leaf-page cache are
+   * handed out unguarded, so {@code retire()} on one frees its frame there and then — exactly what
+   * ordinary eviction does to an unguarded page, and safe for the same reason: this sweep runs only
+   * from truncate/rollback, whose documented precondition is that nothing is reading the resource's
+   * file. What makes that precondition sufficient is that the sweep is RESOURCE-scoped (see
+   * {@code Databases.clearCachesForResource}); a database-wide sweep would reach sibling resources
+   * the precondition never covered, and free pages under their live readers.
+   * </p>
    */
   private static int clearHotPageCache(final ShardedPageCache<HOTLeafPage> cache,
       final Predicate<PageReference> matches) {

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -659,6 +659,35 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
    * caller must re-resolve the page via the cache (which may return a different slot or a cache miss
    * that triggers a reload) and retry the read.
    */
+  /**
+   * Sentinel for {@link #slotCoordinates(MemorySegment)}: the segment is not (or no longer) a live
+   * slot of this allocator — a heap-backed test segment, a pool-allocator segment, or a slot already
+   * released. Pages backed by such segments cannot be torn by slot reuse, so stamp validation for
+   * them is trivially true.
+   */
+  public static final long NO_SLOT_COORDINATES = -1L;
+
+  /**
+   * Locate the live slot backing {@code segment}, packed as {@code (classIdx << 32) | slotIdx}.
+   *
+   * <p>
+   * One concurrent-map probe; callers bind the result ONCE per page and thereafter read/validate the
+   * slot version with two plain array indexes — this lookup must never sit on a per-read hot path.
+   *
+   * @param segment a segment previously returned by {@link #allocate(long)}
+   * @return packed coordinates, or {@link #NO_SLOT_COORDINATES} when the segment is not a live slot
+   */
+  public long slotCoordinates(final MemorySegment segment) {
+    if (segment == null) {
+      return NO_SLOT_COORDINATES;
+    }
+    final Issued issued = liveByAddress.get(segment.address());
+    if (issued == null) {
+      return NO_SLOT_COORDINATES;
+    }
+    return (((long) issued.slot().classIndex()) << 32) | (issued.slot().slotIndex() & 0xFFFF_FFFFL);
+  }
+
   public long acquireVersion(final int classIdx, final int slotIdx) {
     return classes[classIdx].slotVersion.getAcquire(slotIdx);
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/HOTLookupCache.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/HOTLookupCache.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+/**
+ * Memoizes the answer to a HOT point lookup for a COMMITTED revision.
+ *
+ * <p>
+ * A point lookup on a HOT index is pure CPU once the pages are resident — the descent, the in-leaf
+ * binary search, the chunk walk and the posting-list reassembly all re-run on every call, because
+ * nothing above {@code HOTIndexReader.get} memoizes anything. For a committed revision that work is
+ * deterministic, so repeating it for a key already asked about is pure waste.
+ * </p>
+ *
+ * <h2>Why there is no invalidation protocol</h2>
+ * <p>
+ * The revision number is part of {@link HOTLookupKey}, and a committed revision's index content
+ * never changes — a write produces a NEW revision with new keys. An entry therefore cannot go
+ * stale; it can only become unreachable, and the capacity bound ages it out. This is the whole
+ * reason the cache is cheap to reason about, and it is also why a WRITER-backed reader must never
+ * consult it: an uncommitted transaction mutates the index under a revision number that is already
+ * a key here. Enforcing that is the caller's job — see {@code AbstractHOTIndexReader}'s
+ * {@code lookupCache}.
+ * </p>
+ *
+ * <h2>Why a set-associative array and not a general-purpose cache</h2>
+ * <p>
+ * This started out backed by Caffeine and it made the MISS path twice as expensive as no cache at
+ * all: measured on a 33K-key index sized to 64 entries, so that every miss admitted and therefore
+ * evicted, a point lookup went from 622 ns uncached to 1207 ns. The read path was never the problem
+ * — the hit path measured 121 ns in the same run. The write path was: admitting under sustained
+ * eviction pressure appends to a write buffer and runs the admission policy's maintenance, and that
+ * work lands on the calling thread.
+ * </p>
+ * <p>
+ * A cache whose miss costs more than the computation it is avoiding is worse than no cache, and a
+ * workload with poor key reuse would have paid that with no signal. So the table is a fixed-size,
+ * set-associative array instead: a lookup indexes one set and compares at most {@link #WAYS} keys,
+ * and an admission is a SINGLE reference store — no buffers, no policy, no maintenance, and
+ * eviction is just overwriting the slot. That gives up hit-RATE quality, which a general-purpose
+ * cache is built to maximise, in exchange for both paths being predictable. Here that is the right
+ * trade: the entries are immutable and re-derivable, so a wrong eviction costs one recomputation,
+ * whereas an expensive admission costs every miss forever.
+ * </p>
+ *
+ * <h2>Why the value is a long[] and not a NodeReferences</h2>
+ * <p>
+ * {@link NodeReferences} is MUTABLE — {@code addNodeKey}, {@code removeNodeKey}, and
+ * {@code getNodeKeys()} which hands out the live set. Handing the same instance to two callers
+ * would turn "every lookup returns a fresh object" into a shared-aliasing contract, so the first
+ * consumer to mutate a result would silently corrupt every other query that asked for the same key.
+ * Storing the sorted node keys as a bare {@code long[]} and rebuilding a fresh
+ * {@code NodeReferences} per hit keeps the existing contract exactly as it was.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class HOTLookupCache {
+
+  /**
+   * Largest posting list that is worth memoizing, in node keys.
+   *
+   * <p>
+   * Two independent reasons for a bound, both pointing at a small number. Memory: a frequently
+   * occurring indexed value can carry a posting list of millions of node keys, and caching a handful
+   * of those would cost more than the entire page cache it is meant to complement. Time: a hit copies
+   * the array, so the saving shrinks as the list grows and inverts once the copy costs more than the
+   * walk it replaces. At 256 keys the copy is ~2 KB — still far cheaper than the walk — and the
+   * entry's own footprint stays in the low kilobytes.
+   * </p>
+   */
+  public static final int MAX_CACHED_NODE_KEYS = 256;
+
+  /**
+   * Entries per set.
+   *
+   * <p>
+   * Associativity buys back the conflict misses a hash-indexed table suffers when several live keys
+   * land in one set. Keys distribute over sets roughly as a Poisson variable, so at eight ways the
+   * fraction of sets that overflow — and therefore evict something still wanted — is a small fraction
+   * of what it is at four, which matters once the working set approaches capacity. Measured on a
+   * 33K-key corpus in a 65536-slot table with every key resident: 308 ns per lookup at four ways, 223
+   * ns at eight. Four ways lost enough entries to conflict that a policy-driven cache beat it (241
+   * ns); eight ways beats that, while keeping the miss path a policy-driven cache cannot — see the
+   * class comment.
+   * </p>
+   * <p>
+   * Eight is where that stops being free: with compressed oops a set is 8 x 4 = 32 bytes, so a lookup
+   * still touches ONE cache line whichever way it hits on. Sixteen would straddle two lines and start
+   * paying for what it saves.
+   * </p>
+   */
+  private static final int WAYS = 8;
+
+  /** One immutable (key, answer) pair. Final fields, so publishing the reference publishes both. */
+  private record Entry(HOTLookupKey key, long[] nodeKeys) {
+  }
+
+  /**
+   * Slot table of {@code sets * WAYS} entries, or {@code null} when the cache is disabled.
+   *
+   * <p>
+   * Accessed through {@link #TABLE} rather than directly. {@link Entry} is a record, so its fields
+   * are final and the JLS freeze already guarantees that a thread reading the reference sees them
+   * initialised even through a data race — the acquire/release is therefore defence in depth, not the
+   * thing that makes publication safe. It is kept because it costs nothing on x86 (both compile to
+   * plain moves) and it keeps the guarantee if {@code Entry} ever stops being a record; do NOT read
+   * that as licence to give {@code Entry} mutable fields, which the VarHandle would not save.
+   * </p>
+   */
+  private final @Nullable Object @Nullable [] table;
+
+  /** {@code sets - 1}; a power-of-two set count turns the set index into one AND. */
+  private final int setMask;
+
+  /**
+   * Per-set rotating victim, consulted only when a set is full.
+   *
+   * <p>
+   * Plain {@code int} reads and writes, deliberately: a race here picks the same victim twice, which
+   * costs one extra recomputation later and nothing else. Making it atomic would put a contended
+   * write on the admission path to protect a counter whose exact value does not matter.
+   * </p>
+   */
+  private final int @Nullable [] victims;
+
+  private static final VarHandle TABLE = MethodHandles.arrayElementVarHandle(Object[].class);
+
+  /**
+   * Bumped by every sweep, so a read-through admission can tell whether the answer it computed
+   * belongs to a scope that has since been invalidated.
+   *
+   * <p>
+   * Ordering alone cannot close that race, which is worth stating because it is tempting to believe
+   * otherwise: a lookup that read its pages BEFORE a sweep and calls {@link #put} AFTER it re-admits
+   * the discarded history no matter which order the sweeper drops pages and answers in. Sweeping
+   * answers last only narrows the window. Since {@code truncateTo} re-issues committed revision
+   * numbers over different content, that resurrected entry is then served indefinitely, and a stale
+   * memoized answer — unlike a stale page — is never re-derived and never re-validated.
+   * </p>
+   *
+   * <p>
+   * The counter is what makes the sweep actually authoritative. A reader captures it before it starts
+   * computing and hands it back at admission; a sweep bumps it BEFORE clearing slots, so every put
+   * either lands before the bump (and is then cleared by that same sweep) or sees a changed value
+   * (and declines).
+   * </p>
+   */
+  private volatile long generation;
+
+  /** Handle on {@link #generation}, for the atomic bump on the sweep path. */
+  private static final VarHandle GENERATION;
+
+  static {
+    try {
+      GENERATION = MethodHandles.lookup().findVarHandle(HOTLookupCache.class, "generation", long.class);
+    } catch (final ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  /**
+   * Largest table this class will build, in slots.
+   *
+   * <p>
+   * A ceiling is needed because {@code sets * WAYS} is int arithmetic reachable from an
+   * operator-settable property: without it, {@code maxEntries >= 1073741832} made the product
+   * overflow to {@code Integer.MIN_VALUE} and the constructor threw
+   * {@code NegativeArraySizeException} — out of {@code BufferManagerImpl}'s constructor, so a single
+   * typo'd system property made every database in the JVM unopenable. Sixteen million slots is
+   * already far past any useful working set and keeps the product two orders of magnitude clear of
+   * overflow.
+   * </p>
+   */
+  public static final int MAX_SLOTS = 1 << 24;
+
+  /**
+   * @param maxEntries capacity ceiling in entries; the table is the largest power-of-two set count
+   *        that does NOT exceed it, clamped to {@link #MAX_SLOTS}. A value below {@link #WAYS} still
+   *        gets one set, since a set-associative table cannot be narrower than its associativity.
+   * @throws IllegalArgumentException if {@code maxEntries} is not positive — use {@link #disabled()}
+   */
+  public HOTLookupCache(final int maxEntries) {
+    if (maxEntries <= 0) {
+      throw new IllegalArgumentException("maxEntries must be positive, use disabled() instead: " + maxEntries);
+    }
+    // Round DOWN to a power-of-two set count: rounding up overshot the operator's budget by as much
+    // as 2x (32776 entries asked, 65536 slots built), which mattered because the memory estimate the
+    // default is justified against is computed from the requested number.
+    final int requestedSets = Math.max(1, Integer.highestOneBit(maxEntries / WAYS));
+    final int sets = Math.min(requestedSets, MAX_SLOTS / WAYS);
+    this.setMask = sets - 1;
+    this.table = new Object[sets * WAYS];
+    this.victims = new int[sets];
+  }
+
+  private HOTLookupCache() {
+    this.table = null;
+    this.setMask = 0;
+    this.victims = null;
+  }
+
+  /**
+   * The one no-op instance. Stateless and immutable — {@link #table} and {@link #victims} are both
+   * {@code null} — so minting a fresh one per caller bought nothing and made reference identity
+   * against "the" disabled cache silently false.
+   */
+  private static final HOTLookupCache DISABLED = new HOTLookupCache();
+
+  /**
+   * A cache that never retains anything, for buffer managers that do no buffering at all. Reports
+   * every lookup as a miss and refuses every admission, so callers need no null checks and no feature
+   * flag — they simply never get a hit.
+   *
+   * @return the no-op instance
+   */
+  public static HOTLookupCache disabled() {
+    return DISABLED;
+  }
+
+  /**
+   * Whether this cache can retain anything.
+   *
+   * <p>
+   * Lets a caller skip the work of building a key and draining a posting list for an admission that
+   * would be refused anyway — which is what makes {@code maxEntries=0} a genuine measurement of the
+   * uncached path rather than the uncached path plus this class's overhead.
+   * </p>
+   *
+   * @return {@code false} for {@link #disabled()}
+   */
+  public boolean isEnabled() {
+    return table != null;
+  }
+
+  /**
+   * Slots this cache actually holds.
+   *
+   * <p>
+   * NOT the {@code maxEntries} it was constructed with: the constructor rounds DOWN to a power-of-two
+   * set count, so a request of 6990 builds 512 sets = 4096 slots. Exposed because the startup log
+   * exists to let an operator see the effective size, and printing the requested figure there
+   * reported a capacity up to twice the truth. {@link #size()} is the occupancy, not this.
+   * </p>
+   *
+   * @return the number of slots, or {@code 0} for {@link #disabled()}
+   */
+  public int capacity() {
+    final Object[] slots = table;
+    return slots == null
+        ? 0
+        : slots.length;
+  }
+
+  /** Index of the first way of the set {@code hash} maps to. */
+  private int setBase(final int hash) {
+    return (hash & setMask) * WAYS;
+  }
+
+  /**
+   * The memoized node keys for {@code key}, ascending, or {@code null} on a miss.
+   *
+   * <p>
+   * The returned array is the CACHED instance and must be treated as immutable — callers rebuild a
+   * {@code NodeReferences} from a copy. It is returned uncopied so a caller that only wants the
+   * cardinality does not pay for one.
+   * </p>
+   *
+   * @param key the lookup identity
+   * @return the cached ascending node keys, or {@code null} if not present
+   */
+  public long @Nullable [] get(final HOTLookupKey key) {
+    Objects.requireNonNull(key, "key");
+    final Object[] slots = table;
+    if (slots == null) {
+      return null;
+    }
+    final int base = setBase(key.hashCode());
+    for (int way = 0; way < WAYS; way++) {
+      final Entry entry = (Entry) TABLE.getAcquire(slots, base + way);
+      if (entry != null && entry.key.equals(key)) {
+        return entry.nodeKeys;
+      }
+    }
+    return null;
+  }
+
+
+  /**
+   * The current sweep generation, to be captured BEFORE reading anything the admission will be
+   * derived from and handed back to {@link #put(HOTLookupKey, long[], long)}.
+   *
+   * @return the generation to admit against
+   */
+  public long generation() {
+    return generation;
+  }
+
+
+  /**
+   * Admit an entry only if no sweep has run since {@code expectedGeneration} was captured.
+   *
+   * <p>
+   * The read-through form, and the only one. {@code expectedGeneration} must come from
+   * {@link #generation()} read BEFORE the answer was computed: a variant that captured it at the
+   * moment of this call could never detect a sweep that overlapped the computation, which is
+   * precisely the race the parameter exists to close.
+   * </p>
+   *
+   * @param key the lookup identity, owning its bytes
+   * @param nodeKeys ascending node keys answering the lookup; not retained by the caller
+   * @param expectedGeneration the generation observed before the answer was computed
+   * @return {@code true} if the entry was admitted
+   */
+  public boolean put(final HOTLookupKey key, final long[] nodeKeys, final long expectedGeneration) {
+    Objects.requireNonNull(key, "key");
+    Objects.requireNonNull(nodeKeys, "nodeKeys");
+    final Object[] slots = table;
+    // Both nullable finals are read together, so the compiler (and NullAway) can see the coupling
+    // that makes victims[set] safe below rather than having to infer it from a check 30 lines up.
+    final int[] rotation = victims;
+    if (slots == null || rotation == null) {
+      // BEFORE the ownership check, not after: disabled() promises callers "refuses every admission,
+      // so callers need no null checks and no feature flag". A no-op that throws for one class of
+      // argument is not a no-op, and the argument it would throw for — a borrowing probe key — is
+      // exactly what a caller who took that promise at face value would hand it.
+      return false;
+    }
+    if (!key.isOwned()) {
+      // Storing a borrowing probe key aliases a reused serialization buffer: the next lookup on this
+      // thread rewrites the stored key's bytes while its precomputed hash stays frozen, after which
+      // the entry answers a DIFFERENT logical key. Previously this contract was documented in three
+      // places and enforced in none.
+      throw new IllegalArgumentException("only an owned() key may be stored; a probe key aliases a reusable buffer");
+    }
+    if (nodeKeys.length > MAX_CACHED_NODE_KEYS) {
+      return false;
+    }
+    if (generation != expectedGeneration) {
+      // A sweep ran while this answer was being computed, so it may describe content the sweep
+      // exists to discard. Cheap and early: nothing has been written yet.
+      return false;
+    }
+    final int base = setBase(key.hashCode());
+    int free = -1;
+    for (int way = 0; way < WAYS; way++) {
+      final Entry entry = (Entry) TABLE.getAcquire(slots, base + way);
+      if (entry == null) {
+        if (free < 0) {
+          free = base + way;
+        }
+      } else if (entry.key.equals(key)) {
+        // Same key, same revision: the answer is identical, so refreshing it is pointless work.
+        return true;
+      }
+    }
+    final int slot;
+    if (free >= 0) {
+      slot = free;
+    } else {
+      final int set = base / WAYS;
+      final int victim = rotation[set];
+      rotation[set] = victim + 1;
+      slot = base + (victim & (WAYS - 1));
+    }
+    final Entry admitted = new Entry(key, nodeKeys);
+    TABLE.setRelease(slots, slot, admitted);
+    // A StoreLoad barrier, which NEITHER the release store above NOR the volatile read below
+    // supplies. `setRelease` is not a synchronization action, and HotSpot fences volatile STORES,
+    // not volatile loads — so on x86-TSO the store can still be sitting in this thread's store
+    // buffer when the read below is satisfied from cache. Without the fence the sequence
+    // "store slot -> read old generation -> sweeper bumps -> sweeper scans slot and finds it empty
+    // -> store drains" is legal, and it republishes an answer built from the very content the sweep
+    // exists to discard, under a revision number truncateTo is about to re-issue.
+    //
+    // With the fence here and the sweeper's own getAndAdd fencing its side, this is Dekker: at
+    // least one of the two threads observes the other, so either we see the bump and undo, or the
+    // sweeper sees our entry and clears it.
+    VarHandle.fullFence();
+    // Re-check AFTER the store, which is what actually closes the race. The check before it can be
+    // overtaken: a sweep may bump and finish scanning this slot between that check and the store,
+    // leaving the entry behind the sweeper.
+    if (generation != expectedGeneration) {
+      // Undo OUR entry only. Between the store and here another thread may have taken this slot —
+      // its own free-slot pick, the victim rotation, or a legitimate admission carrying the NEW
+      // generation — and a blind null would evict that instead of ours, which is a lost memo the
+      // sweep never asked for.
+      TABLE.compareAndSet(slots, slot, admitted, null);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Drop every memoized lookup belonging to one resource.
+   *
+   * <p>
+   * The reason this exists: {@code (databaseId, resourceId, revisionNumber)} does NOT uniquely
+   * identify content over a resource's lifetime. {@code truncateTo} re-issues committed revision
+   * numbers over different content on rollback and on the undo path of a failed multi-resource
+   * commit, and crash recovery does the same. Both already sweep the page caches, and the memoized
+   * ANSWERS derived from those pages have to go with them or a reader is served the discarded history
+   * — silently, since a stale entry is indistinguishable from a fresh one.
+   * </p>
+   *
+   * <p>
+   * Note what is NOT a trigger, so a maintainer does not reason from it: resource ids are NOT reused.
+   * {@code LocalDatabase.createResource} draws them from the monotonic persisted
+   * {@code maxResourceID}, which {@code removeResource} never rolls back, and a database recreated at
+   * a removed path mints a fresh random {@code databaseId}. Revision re-issue is the whole hazard.
+   * </p>
+   *
+   * <p>
+   * O(capacity) and rare, which is the right trade for a structure whose lookup path must stay a
+   * single set probe: keeping a per-resource index would put bookkeeping on every admission to speed
+   * up an operation that happens on rollback and resource deletion.
+   * </p>
+   *
+   * @param databaseId the database the resource belongs to
+   * @param resourceId the resource whose memoized lookups must go
+   * @return the number of entries dropped
+   */
+  public int invalidateResource(final long databaseId, final long resourceId) {
+    return invalidateMatching(databaseId, resourceId, true);
+  }
+
+  /**
+   * Drop every memoized lookup belonging to one database, across all of its resources.
+   *
+   * @param databaseId the database whose memoized lookups must go
+   * @return the number of entries dropped
+   * @see #invalidateResource
+   */
+  public int invalidateDatabase(final long databaseId) {
+    return invalidateMatching(databaseId, 0L, false);
+  }
+
+  private int invalidateMatching(final long databaseId, final long resourceId, final boolean matchResource) {
+    final Object[] slots = table;
+    if (slots == null) {
+      return 0;
+    }
+    // BEFORE the scan, never after: a concurrent read-through that admits between the bump and its
+    // slot being scanned is cleared by this very scan, and one that admits after the scan sees the
+    // bumped value and declines. Bumping afterwards would leave both of those windows open.
+    //
+    // ONE counter for every scope, deliberately: a RESOURCE sweep bumps the same global generation a
+    // DATABASE sweep does, so it also makes every unrelated in-flight admission process-wide decline.
+    // That is the conservative direction — the cost of an over-broad bump is one recomputation, while
+    // the cost of a missed one is a stale answer served for the rest of the revision — and it keeps
+    // the admission path a single volatile read. Do NOT "optimise" this into per-resource stripes
+    // without re-deriving the Dekker argument in put(): the counter a writer captures before its walk
+    // and the counter a sweeper bumps must be the SAME location, or neither thread observes the other.
+    GENERATION.getAndAdd(this, 1L);
+    int dropped = 0;
+    for (int i = 0; i < slots.length; i++) {
+      final Entry entry = (Entry) TABLE.getAcquire(slots, i);
+      if (entry == null || entry.key.databaseId() != databaseId) {
+        continue;
+      }
+      if (matchResource && entry.key.resourceId() != resourceId) {
+        continue;
+      }
+      TABLE.setRelease(slots, i, null);
+      dropped++;
+    }
+    return dropped;
+  }
+
+  /** Drop every entry. Intended for shutdown and for tests that assert on a cold cache. */
+  public void clear() {
+    final Object[] slots = table;
+    if (slots == null) {
+      return;
+    }
+    // Same reason as invalidateMatching: bump first, so an in-flight admission cannot outlive it.
+    GENERATION.getAndAdd(this, 1L);
+    for (int i = 0; i < slots.length; i++) {
+      TABLE.setRelease(slots, i, null);
+    }
+  }
+
+  /**
+   * Occupied slots. O(capacity) and racy — a diagnostic, never a hot-path call.
+   *
+   * @return the number of populated slots
+   */
+  public long size() {
+    final Object[] slots = table;
+    if (slots == null) {
+      return 0L;
+    }
+    long occupied = 0L;
+    // Through TABLE like every other reader in this class: the field's javadoc makes the
+    // acquire/release the class's stated access discipline, and a plain load here would be the one
+    // place it is not honoured — the place that would observe a half-initialised Entry the day Entry
+    // stops being a record.
+    for (int i = 0; i < slots.length; i++) {
+      if (TABLE.getAcquire(slots, i) != null) {
+        occupied++;
+      }
+    }
+    return occupied;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/HOTLookupKey.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/HOTLookupKey.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.index.IndexType;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Identity of one HOT point lookup: a serialized index key within a single index of a single
+ * committed revision.
+ *
+ * <p>
+ * The revision is part of the identity rather than a validity check, which is what lets
+ * {@link HOTLookupCache} run WITHOUT an invalidation protocol: a committed revision's index content
+ * is immutable, so an entry can never go stale — a write produces a new revision and therefore new
+ * keys, and the old entries simply age out. The database and resource ids are carried for the same
+ * reason {@link RBIndexKey} carries them: one buffer manager serves more than one resource.
+ * </p>
+ *
+ * <h2>Probing without copying</h2>
+ * <p>
+ * The key bytes are compared and hashed BY CONTENT over a {@code (offset, length)} range, so a
+ * lookup can be answered straight out of the caller's reusable serialization buffer. That matters
+ * because the miss path is the common one on a cold cache and must not be made slower than the walk
+ * it is trying to avoid: {@link #probe} borrows the caller's buffer and allocates nothing beyond
+ * the key object itself, while {@link #owned} takes the copy that a stored entry needs. Only
+ * {@code owned} keys may be handed to {@link HOTLookupCache#put(HOTLookupKey, long[], long)} — a
+ * probe key's buffer is overwritten by the very next lookup.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class HOTLookupKey {
+
+  private final long databaseId;
+  private final long resourceId;
+  private final int revisionNumber;
+  private final IndexType indexType;
+  private final int indexNumber;
+  private final byte[] key;
+  private final int offset;
+  private final int length;
+
+  /**
+   * Whether {@link #key} is this key's own copy rather than a borrowed buffer.
+   *
+   * <p>
+   * The distinction is load-bearing and was previously documented but unenforceable: a probe key
+   * stored in the cache aliases a reused serialization buffer, so the next lookup on that thread
+   * rewrites the stored key's bytes while its precomputed {@link #hash} stays frozen — after which
+   * the entry answers a DIFFERENT logical key's probe. Carrying the flag lets
+   * {@link HOTLookupCache#put} reject that outright instead of corrupting silently.
+   * </p>
+   */
+  private final boolean owned;
+
+  /** Precomputed because this key is hashed on every lookup and never mutated after construction. */
+  private final int hash;
+
+  private HOTLookupKey(final long databaseId, final long resourceId, final int revisionNumber,
+      final IndexType indexType, final int indexNumber, final byte[] key, final int offset, final int length,
+      final int hash, final boolean owned) {
+    this.databaseId = databaseId;
+    this.resourceId = resourceId;
+    this.revisionNumber = revisionNumber;
+    this.indexType = indexType;
+    this.indexNumber = indexNumber;
+    this.key = key;
+    this.offset = offset;
+    this.length = length;
+    this.hash = hash;
+    this.owned = owned;
+  }
+
+  /**
+   * A key that BORROWS {@code key[offset, offset + length)} for the duration of a cache lookup.
+   *
+   * <p>
+   * Never store one: the buffer is typically a reused thread-local that the next lookup overwrites,
+   * which would silently corrupt the cache's key space.
+   * </p>
+   *
+   * @param databaseId the database id
+   * @param resourceId the resource id
+   * @param revisionNumber the committed revision the lookup is answered from
+   * @param indexType the index type (PATH, CAS, NAME, ...)
+   * @param indexNumber the index number within that type
+   * @param key buffer holding the serialized index key; may be oversized and reused
+   * @param offset offset of the serialized key within {@code key}
+   * @param length serialized length of the key
+   * @return a borrowing key, valid only until {@code key} is next written
+   */
+  public static HOTLookupKey probe(final long databaseId, final long resourceId, final int revisionNumber,
+      final IndexType indexType, final int indexNumber, final byte[] key, final int offset, final int length) {
+    Objects.requireNonNull(indexType, "indexType");
+    Objects.requireNonNull(key, "key");
+    Objects.checkFromIndexSize(offset, length, key.length);
+    return new HOTLookupKey(databaseId, resourceId, revisionNumber, indexType, indexNumber, key, offset, length,
+        computeHash(databaseId, resourceId, revisionNumber, indexType, indexNumber, key, offset, length), false);
+  }
+
+  /**
+   * The storable twin of this key: identical identity, over bytes this key owns.
+   *
+   * <p>
+   * Equal to the probe it was derived from — same content, same hash — so the entry it stores is
+   * found by the next probe of the same key.
+   * </p>
+   *
+   * @return a key owning a copy of the serialized bytes
+   */
+  public HOTLookupKey owned() {
+    // The copy holds the same bytes, so the hash carries over verbatim — recomputing it would be a
+    // second full pass over the key on the one path (admission) that is already doing a copy.
+    return new HOTLookupKey(databaseId, resourceId, revisionNumber, indexType, indexNumber,
+        Arrays.copyOfRange(key, offset, offset + length), 0, length, hash, true);
+  }
+
+  /**
+   * Mixes the identity and the key bytes into one {@code int}.
+   *
+   * <p>
+   * HFT: the bytes are consumed EIGHT AT A TIME. This runs on every lookup, hit or miss, and a CAS
+   * key is tens of bytes — the textbook {@code 31 * h + b} polynomial would be one dependent
+   * multiply-add per byte, a serial chain roughly as long as the key. Four word reads and four
+   * multiplies cover a 32-byte key instead, and the 64-bit Fibonacci multiplier mixes high bits down
+   * so the low bits the hash table indexes on actually depend on the whole key. Native byte order:
+   * the hash never leaves the process, so there is nothing to keep stable across hosts.
+   * </p>
+   */
+  private static int computeHash(final long databaseId, final long resourceId, final int revisionNumber,
+      final IndexType indexType, final int indexNumber, final byte[] key, final int offset, final int length) {
+    long h = databaseId * MIX ^ resourceId;
+    h = (h ^ ((long) revisionNumber << 32 | Integer.toUnsignedLong(indexNumber))) * MIX;
+    h = (h ^ indexType.ordinal()) * MIX;
+
+    int i = offset;
+    for (final int wordEnd = offset + length - Long.BYTES; i <= wordEnd; i += Long.BYTES) {
+      h = (h ^ (long) BYTE_ARRAY_LONG.get(key, i)) * MIX;
+    }
+    for (final int end = offset + length; i < end; i++) {
+      h = (h ^ (key[i] & 0xFFL)) * MIX;
+    }
+    // Length participates so that two keys differing only by trailing bytes the tail loop consumed
+    // in a different grouping cannot collide.
+    h = (h ^ length) * MIX;
+    return (int) (h ^ (h >>> 32));
+  }
+
+  /** 2^64 / phi — the standard Fibonacci hashing multiplier, odd so it is invertible mod 2^64. */
+  private static final long MIX = 0x9E3779B97F4A7C15L;
+
+  /** Reads eight key bytes as one {@code long} for {@link #computeHash}. */
+  private static final VarHandle BYTE_ARRAY_LONG =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
+
+
+  /**
+   * Whether this key owns its bytes and may therefore be stored.
+   *
+   * @return {@code true} for a key produced by {@link #owned()}
+   */
+  public boolean isOwned() {
+    return owned;
+  }
+
+  /**
+   * The database this lookup belongs to — the scope a cache sweep invalidates by.
+   *
+   * @return the database id
+   */
+  public long databaseId() {
+    return databaseId;
+  }
+
+  /**
+   * The resource this lookup belongs to — the scope a cache sweep invalidates by.
+   *
+   * @return the resource id
+   */
+  public long resourceId() {
+    return resourceId;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof HOTLookupKey other)) {
+      return false;
+    }
+    // Cheap scalar discriminators first: two keys that differ at all almost always differ here, so
+    // the byte-range compare is reached only by genuine candidates.
+    return hash == other.hash && length == other.length && revisionNumber == other.revisionNumber
+        && indexNumber == other.indexNumber && databaseId == other.databaseId && resourceId == other.resourceId
+        && indexType == other.indexType
+        && Arrays.equals(key, offset, offset + length, other.key, other.offset, other.offset + other.length);
+  }
+
+  @Override
+  public int hashCode() {
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "HOTLookupKey[db=" + databaseId + ", resource=" + resourceId + ", revision=" + revisionNumber + ", type="
+        + indexType + ", index=" + indexNumber + ", keyLength=" + length + ']';
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -45,6 +45,29 @@ public final class TransactionIntentLog implements AutoCloseable {
   /** Number of active entries in the current arrays. */
   private int size;
 
+  // ============== HOT-LEAF ENTRY INDEX (sharing-check scan narrowing) ==============
+  // Two places have to answer "is this leaf page also held by another log entry?" before they may
+  // free its 64KB off-heap slot — releaseOrphanedHOTLeaves once per subtree rebuild, and put()'s
+  // CoW path once per replaced container — and both did it by walking all `size` entries. A
+  // transaction that shreds a document while maintaining HOT indexes runs those against a log of
+  // hundreds of thousands of entries, so the walks grew with the square of the transaction. Almost
+  // none of those entries hold a HOT leaf — the vast majority are node record pages — so the log
+  // records which indices have EVER held one and both walks visit only those.
+  //
+  // Deliberately a superset, never a refcount: `put` is the only writer of `entries`, so every
+  // index currently holding a HOT leaf is in here, and a stale index costs one re-read of
+  // `entries[i]`, which stays the authority. A drifting count could free a live page; a stale
+  // superset cannot.
+
+  /** Log indices that have ever held a {@link HOTLeafPage} in the current generation. */
+  private int[] hotLeafIndices = new int[16];
+
+  /** Number of valid entries in {@link #hotLeafIndices}. */
+  private int hotLeafIndexCount;
+
+  /** Membership bitset over log indices, so each index is appended at most once. */
+  private long[] hotLeafIndexBits = new long[8];
+
   // ==================== GENERATION COUNTER ====================
 
   /** Current generation. Incremented on each snapshot(). Used for O(1) epoch membership. */
@@ -294,6 +317,7 @@ public final class TransactionIntentLog implements AutoCloseable {
       // the same logKey will resolve to the latest container.
       entries[existingKey] = value;
       entryRefs[existingKey] = ref;
+      noteHOTLeafEntry(existingKey, value);
       ref.setActiveTilGeneration(currentGeneration);
     } else {
       // A cross-generation re-put supersedes the frozen entry this reference used to identify:
@@ -312,6 +336,7 @@ public final class TransactionIntentLog implements AutoCloseable {
       ref.setActiveTilGeneration(currentGeneration);
       entries[size] = value;
       entryRefs[size] = ref;
+      noteHOTLeafEntry(size, value);
 
       if (supersedesPriorEntry) {
         final long oldPacked = ((long) priorGeneration << 32) | (existingKey & 0xFFFFFFFFL);
@@ -354,6 +379,42 @@ public final class TransactionIntentLog implements AutoCloseable {
     if (value.getModified() instanceof HOTLeafPage modified && modified != value.getComplete()) {
       hotLeafCache.removePage(modified);
     }
+  }
+
+  /**
+   * Note that log index {@code index} holds a HOT leaf page, so
+   * {@link #releaseOrphanedHOTLeaves(List)} will look at it. Idempotent and O(1).
+   *
+   * @param index the log index the container was stored at
+   * @param container the container just stored there
+   */
+  private void noteHOTLeafEntry(final int index, final PageContainer container) {
+    if (container == null
+        || (!(container.getComplete() instanceof HOTLeafPage) && !(container.getModified() instanceof HOTLeafPage))) {
+      return;
+    }
+    final int word = index >>> 6;
+    if (word >= hotLeafIndexBits.length) {
+      hotLeafIndexBits = Arrays.copyOf(hotLeafIndexBits, Math.max(hotLeafIndexBits.length << 1, word + 1));
+    }
+    final long bit = 1L << (index & 63);
+    if ((hotLeafIndexBits[word] & bit) != 0) {
+      return;
+    }
+    hotLeafIndexBits[word] |= bit;
+    if (hotLeafIndexCount == hotLeafIndices.length) {
+      hotLeafIndices = Arrays.copyOf(hotLeafIndices, hotLeafIndices.length << 1);
+    }
+    hotLeafIndices[hotLeafIndexCount++] = index;
+  }
+
+  /**
+   * Forget the HOT-leaf index; the log indices it holds no longer address the current arrays.
+   * Called wherever {@link #entries} is replaced or emptied.
+   */
+  private void resetHOTLeafIndex() {
+    hotLeafIndexCount = 0;
+    Arrays.fill(hotLeafIndexBits, 0L);
   }
 
   /**
@@ -425,6 +486,7 @@ public final class TransactionIntentLog implements AutoCloseable {
     entries = new PageContainer[snapshotEntries.length];
     entryRefs = new PageReference[snapshotRefs.length];
     size = 0;
+    resetHOTLeafIndex();
 
     return snapshotSize;
   }
@@ -646,6 +708,7 @@ public final class TransactionIntentLog implements AutoCloseable {
       }
     }
     size = 0;
+    resetHOTLeafIndex();
 
     // Close snapshot pages unconditionally (best-effort — no offset validation).
     // This handles the error/rollback path where bg thread may have failed mid-write.
@@ -677,6 +740,7 @@ public final class TransactionIntentLog implements AutoCloseable {
       }
     }
     size = 0;
+    resetHOTLeafIndex();
 
     // Close snapshot pages unconditionally
     clearSnapshotPages();
@@ -795,9 +859,18 @@ public final class TransactionIntentLog implements AutoCloseable {
     return false;
   }
 
+  /**
+   * Whether {@code page} is also held by a log entry other than {@code excludeIndex}. Walks only
+   * the entries that can hold a HOT leaf — {@link #hotLeafIndices}, a superset re-checked against
+   * {@code entries[i]} — because this runs on {@link #put}'s HOT-leaf CoW path, once per replaced
+   * container, and a full walk made that quadratic in the log size.
+   */
   private boolean isHOTLeafInOtherEntry(final HOTLeafPage page, final int excludeIndex) {
-    for (int i = 0; i < size; i++) {
-      if (i == excludeIndex) continue;
+    for (int k = 0; k < hotLeafIndexCount; k++) {
+      final int i = hotLeafIndices[k];
+      if (i == excludeIndex || i >= size) {
+        continue;
+      }
       final PageContainer entry = entries[i];
       if (entry != null && (entry.getComplete() == page || entry.getModified() == page)) {
         return true;
@@ -853,9 +926,15 @@ public final class TransactionIntentLog implements AutoCloseable {
     if (closeable.isEmpty()) {
       return;
     }
-    // One pass over the log: an orphan leaf that also appears at an entry other than its own is
-    // shared (a CoW reference copy) and is dropped from the closeable set.
-    for (int i = 0; i < size; i++) {
+    // One pass over the log entries that can hold a HOT leaf: an orphan leaf that also appears at
+    // an entry other than its own is shared (a CoW reference copy) and is dropped from the
+    // closeable set. hotLeafIndices is a superset of those entries (see its declaration), and
+    // entries[i] is re-checked here, so narrowing the walk cannot change any decision.
+    for (int k = 0; k < hotLeafIndexCount; k++) {
+      final int i = hotLeafIndices[k];
+      if (i >= size) {
+        continue;
+      }
       final PageContainer entry = entries[i];
       if (entry == null) {
         continue;

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -10,11 +10,12 @@ import io.sirix.settings.Constants;
 
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 
 import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.List;
 
 /**
@@ -67,6 +68,19 @@ public final class TransactionIntentLog implements AutoCloseable {
 
   /** Membership bitset over log indices, so each index is appended at most once. */
   private long[] hotLeafIndexBits = new long[8];
+
+  /**
+   * Scratch for {@link #releaseOrphanedHOTLeaves(List)}: orphan leaf -> the log index that owns it.
+   *
+   * <p>Reference-keyed (identity, like {@code IdentityHashMap}) with a primitive {@code int} value,
+   * and reused across calls. The subtree rebuilds this method serves fire in the thousands during a
+   * shred that maintains an index, each handing over a whole subtree's leaves, so a fresh map and an
+   * {@code Integer} box per orphan were the bulk of its cost. The TIL is transaction-private, so a
+   * field is as safe here as a local was.</p>
+   */
+  private final Reference2IntMap<HOTLeafPage> orphanCloseable = new Reference2IntOpenHashMap<>();
+
+  { orphanCloseable.defaultReturnValue(-1); }
 
   // ==================== GENERATION COUNTER ====================
 
@@ -901,8 +915,10 @@ public final class TransactionIntentLog implements AutoCloseable {
       return;
     }
     // Map each orphan leaf page to its own TIL index; this set is whittled down to the pages
-    // that are safe to close.
-    final IdentityHashMap<HOTLeafPage, Integer> closeable = new IdentityHashMap<>();
+    // that are safe to close. Log indices are non-negative here (see the guard below), so the
+    // map's -1 default doubles as "absent".
+    final Reference2IntMap<HOTLeafPage> closeable = orphanCloseable;
+    closeable.clear();
     for (int r = 0; r < orphanRefs.size(); r++) {
       final PageReference ref = orphanRefs.get(r);
       if (ref == null) {
@@ -922,6 +938,8 @@ public final class TransactionIntentLog implements AutoCloseable {
       if (container.getComplete() instanceof HOTLeafPage leaf) {
         closeable.putIfAbsent(leaf, logKey);
       }
+      // (putIfAbsent, not put: a leaf reachable twice keeps the first index it was seen at, which
+      // is the index the sharing check below must exclude.)
     }
     if (closeable.isEmpty()) {
       return;
@@ -949,14 +967,16 @@ public final class TransactionIntentLog implements AutoCloseable {
         leaf.close();
       }
     }
+    // Do not let the scratch map pin the pages it just released until the next call.
+    closeable.clear();
   }
 
   private static void unshareIfElsewhere(final Page page, final int entryIndex,
-      final IdentityHashMap<HOTLeafPage, Integer> closeable) {
+      final Reference2IntMap<HOTLeafPage> closeable) {
     if (page instanceof HOTLeafPage leaf) {
-      final Integer ownIndex = closeable.get(leaf);
-      if (ownIndex != null && ownIndex.intValue() != entryIndex) {
-        closeable.remove(leaf);
+      final int ownIndex = closeable.getInt(leaf);
+      if (ownIndex >= 0 && ownIndex != entryIndex) {
+        closeable.removeInt(leaf);
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/TransactionIntentLog.java
@@ -72,15 +72,19 @@ public final class TransactionIntentLog implements AutoCloseable {
   /**
    * Scratch for {@link #releaseOrphanedHOTLeaves(List)}: orphan leaf -> the log index that owns it.
    *
-   * <p>Reference-keyed (identity, like {@code IdentityHashMap}) with a primitive {@code int} value,
-   * and reused across calls. The subtree rebuilds this method serves fire in the thousands during a
-   * shred that maintains an index, each handing over a whole subtree's leaves, so a fresh map and an
+   * <p>
+   * Reference-keyed (identity, like {@code IdentityHashMap}) with a primitive {@code int} value, and
+   * reused across calls. The subtree rebuilds this method serves fire in the thousands during a shred
+   * that maintains an index, each handing over a whole subtree's leaves, so a fresh map and an
    * {@code Integer} box per orphan were the bulk of its cost. The TIL is transaction-private, so a
-   * field is as safe here as a local was.</p>
+   * field is as safe here as a local was.
+   * </p>
    */
   private final Reference2IntMap<HOTLeafPage> orphanCloseable = new Reference2IntOpenHashMap<>();
 
-  { orphanCloseable.defaultReturnValue(-1); }
+  {
+    orphanCloseable.defaultReturnValue(-1);
+  }
 
   // ==================== GENERATION COUNTER ====================
 
@@ -144,7 +148,9 @@ public final class TransactionIntentLog implements AutoCloseable {
   /** Forwarding chain for superseded (generation << 32 | logKey) identities. */
   private final Long2LongOpenHashMap forwardedEntries = new Long2LongOpenHashMap();
 
-  { forwardedEntries.defaultReturnValue(-1L); }
+  {
+    forwardedEntries.defaultReturnValue(-1L);
+  }
 
   // ==================== BUFFER MANAGER ====================
 
@@ -171,9 +177,9 @@ public final class TransactionIntentLog implements AutoCloseable {
   /**
    * Retrieves an entry from the TIL using generation-based 3-layer lookup.
    * <p>
-   * Layer 1: Current TIL (fast path — most common during insertion).
-   * Layer 2: Active snapshot (if any — for reads of pages not yet cleaned up).
-   * Layer 3: Completed disk offsets (for stale reference copies from CoW'd IndirectPages).
+   * Layer 1: Current TIL (fast path — most common during insertion). Layer 2: Active snapshot (if any
+   * — for reads of pages not yet cleaned up). Layer 3: Completed disk offsets (for stale reference
+   * copies from CoW'd IndirectPages).
    *
    * @param ref the page reference whose associated container is to be returned
    * @return the page container, or {@code null} if not in any TIL layer
@@ -252,7 +258,7 @@ public final class TransactionIntentLog implements AutoCloseable {
         ref.setLogKey(Constants.NULL_ID_INT);
         ref.setActiveTilGeneration(-1);
         layer3Hits++;
-        return null;  // Page is on disk, not in TIL — caller loads from disk
+        return null; // Page is on disk, not in TIL — caller loads from disk
       }
     }
 
@@ -292,8 +298,7 @@ public final class TransactionIntentLog implements AutoCloseable {
 
     // Close the old cached page if it's different from the pages going into TIL
     if (oldCachedPage != null && !oldCachedPage.isClosed()) {
-      final boolean isInNewContainer =
-          (oldCachedPage == value.getComplete() || oldCachedPage == value.getModified());
+      final boolean isInNewContainer = (oldCachedPage == value.getComplete() || oldCachedPage == value.getModified());
       if (!isInNewContainer) {
         oldCachedPage.markOrphaned();
         oldCachedPage.close();
@@ -313,9 +318,7 @@ public final class TransactionIntentLog implements AutoCloseable {
     // the container at that index. The visible symptom is a ClassCastException
     // in KeyedTrieWriter.prepareIndirectPage when the trie navigation later
     // walks the structural page's reference and gets back the foreign container.
-    final boolean ownsExistingKey = existingKey != Constants.NULL_ID_INT
-        && existingKey >= 0
-        && existingKey < size
+    final boolean ownsExistingKey = existingKey != Constants.NULL_ID_INT && existingKey >= 0 && existingKey < size
         && ref.getActiveTilGeneration() == currentGeneration;
     if (ownsExistingKey) {
       // Close orphaned HOT leaf pages from the overwritten container.
@@ -340,9 +343,8 @@ public final class TransactionIntentLog implements AutoCloseable {
       // reference copies that still carry the old identity resolve to the new entry instead of
       // the stale disk offset (#1077).
       final int priorGeneration = ref.getActiveTilGeneration();
-      final boolean supersedesPriorEntry =
-          existingKey != Constants.NULL_ID_INT && existingKey >= 0 && priorGeneration >= 0
-              && priorGeneration != currentGeneration;
+      final boolean supersedesPriorEntry = existingKey != Constants.NULL_ID_INT && existingKey >= 0
+          && priorGeneration >= 0 && priorGeneration != currentGeneration;
 
       // New entry
       ensureCapacity();
@@ -374,13 +376,15 @@ public final class TransactionIntentLog implements AutoCloseable {
   /**
    * Remove the HOT leaf pages of a TIL container from the shared HOT-leaf buffer cache.
    *
-   * <p>A {@link HOTLeafPage} instance can be referenced by both a {@link PageContainer} in this
-   * log and the {@code hotLeafPageCache}. Once a page is in the log it is transaction-private and
-   * must survive — unevicted — until commit serializes it. The eviction paths
-   * ({@code ClockSweeper.sweep}, {@code ShardedPageCache.evictUnderPressure}) only gate on guard
-   * count, so a cache-resident dirty leaf would otherwise have its off-heap slot reclaimed under
-   * memory pressure, corrupting the committed page. This mirrors the record-page-cache removal
-   * already performed above for {@link KeyValueLeafPage}s.</p>
+   * <p>
+   * A {@link HOTLeafPage} instance can be referenced by both a {@link PageContainer} in this log and
+   * the {@code hotLeafPageCache}. Once a page is in the log it is transaction-private and must
+   * survive — unevicted — until commit serializes it. The eviction paths ({@code ClockSweeper.sweep},
+   * {@code ShardedPageCache.evictUnderPressure}) only gate on guard count, so a cache-resident dirty
+   * leaf would otherwise have its off-heap slot reclaimed under memory pressure, corrupting the
+   * committed page. This mirrors the record-page-cache removal already performed above for
+   * {@link KeyValueLeafPage}s.
+   * </p>
    */
   private void removeHOTLeavesFromCache(final PageContainer value) {
     if (value == null) {
@@ -423,8 +427,8 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Forget the HOT-leaf index; the log indices it holds no longer address the current arrays.
-   * Called wherever {@link #entries} is replaced or emptied.
+   * Forget the HOT-leaf index; the log indices it holds no longer address the current arrays. Called
+   * wherever {@link #entries} is replaced or emptied.
    */
   private void resetHOTLeafIndex() {
     hotLeafIndexCount = 0;
@@ -432,8 +436,7 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Ensure the entries/entryRefs arrays have room for one more element.
-   * Doubles capacity when full.
+   * Ensure the entries/entryRefs arrays have room for one more element. Doubles capacity when full.
    */
   private void ensureCapacity() {
     if (size == entries.length) {
@@ -444,8 +447,8 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Get the original PageReference stored at a given logKey. Used to copy disk offsets
-   * when a duplicate reference (from HOTIndirectPage COW) resolves to the same TIL entry.
+   * Get the original PageReference stored at a given logKey. Used to copy disk offsets when a
+   * duplicate reference (from HOTIndirectPage COW) resolves to the same TIL entry.
    *
    * @param logKey the log key
    * @return the original PageReference, or null if not found
@@ -460,21 +463,20 @@ public final class TransactionIntentLog implements AutoCloseable {
   // ==================== SNAPSHOT (O(1) array swap) ====================
 
   /**
-   * Side-channel disk-offset sentinel: the background flush DECLINED to write this KVL
-   * entry (its serialization left unresolved overflow references — the encoded bytes are
-   * only valid once the recursive final commit writes the OverflowPages, #1076).
-   * {@link #cleanupSnapshot()} promotes such entries back into the live TIL instead of
-   * applying an offset and closing them, so the final commit serializes them with real
-   * overflow keys. Distinct from the {@code NULL_ID_LONG} init value, which still means
-   * "background write incomplete" and fails the cleanup loudly.
+   * Side-channel disk-offset sentinel: the background flush DECLINED to write this KVL entry (its
+   * serialization left unresolved overflow references — the encoded bytes are only valid once the
+   * recursive final commit writes the OverflowPages, #1076). {@link #cleanupSnapshot()} promotes such
+   * entries back into the live TIL instead of applying an offset and closing them, so the final
+   * commit serializes them with real overflow keys. Distinct from the {@code NULL_ID_LONG} init
+   * value, which still means "background write incomplete" and fails the cleanup loudly.
    */
   public static final long SNAPSHOT_PROMOTE_TO_TIL = Long.MIN_VALUE;
 
   /**
    * Freeze current entries for background flush. O(1) — array reference swap + generation increment.
    * <p>
-   * After this call, the insert thread continues with fresh empty arrays. The frozen arrays
-   * are available to the background thread via {@link #getSnapshotEntry(int)} etc.
+   * After this call, the insert thread continues with fresh empty arrays. The frozen arrays are
+   * available to the background thread via {@link #getSnapshotEntry(int)} etc.
    *
    * @return snapshotSize (0 = nothing to flush)
    */
@@ -506,22 +508,20 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Check if a page reference is in the frozen snapshot zone.
-   * Used to trigger CoW when the insert thread needs to modify a frozen page.
+   * Check if a page reference is in the frozen snapshot zone. Used to trigger CoW when the insert
+   * thread needs to modify a frozen page.
    *
    * @param ref the page reference to check
    * @return true if the reference is in the frozen snapshot
    */
   public boolean isFrozen(final PageReference ref) {
-    return snapshotEntries != null
-        && ref.getActiveTilGeneration() == snapshotGeneration
-        && ref.getLogKey() >= 0
+    return snapshotEntries != null && ref.getActiveTilGeneration() == snapshotGeneration && ref.getLogKey() >= 0
         && ref.getLogKey() < snapshotSize;
   }
 
   /**
-   * Mark the snapshot flush as complete. Called by the background thread after all KVL pages
-   * have been written to disk and their offsets stored in the side-channel arrays.
+   * Mark the snapshot flush as complete. Called by the background thread after all KVL pages have
+   * been written to disk and their offsets stored in the side-channel arrays.
    */
   public void markSnapshotFlushComplete() {
     snapshotCommitComplete = true;
@@ -560,8 +560,8 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Store a disk offset from the background thread into the side-channel.
-   * The background thread NEVER writes to PageReference directly.
+   * Store a disk offset from the background thread into the side-channel. The background thread NEVER
+   * writes to PageReference directly.
    */
   public void setSnapshotDiskOffset(final int index, final long offset) {
     snapshotDiskOffsets[index] = offset;
@@ -577,11 +577,11 @@ public final class TransactionIntentLog implements AutoCloseable {
   // ==================== SNAPSHOT CLEANUP ====================
 
   /**
-   * Clean up a completed snapshot: apply disk offsets to KVL page refs, close written KVL pages,
-   * and promote IndirectPages to the current TIL.
+   * Clean up a completed snapshot: apply disk offsets to KVL page refs, close written KVL pages, and
+   * promote IndirectPages to the current TIL.
    * <p>
-   * MUST be called from the insert thread after the background thread has completed
-   * (after semaphore acquire provides happens-before).
+   * MUST be called from the insert thread after the background thread has completed (after semaphore
+   * acquire provides happens-before).
    *
    * @throws SirixIOException if any KVL entry is missing a disk offset (background write incomplete)
    */
@@ -766,8 +766,8 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Best-effort cleanup of snapshot pages. Does NOT validate disk offsets — used for
-   * rollback/error paths where background writes may be incomplete.
+   * Best-effort cleanup of snapshot pages. Does NOT validate disk offsets — used for rollback/error
+   * paths where background writes may be incomplete.
    */
   private void clearSnapshotPages() {
     if (snapshotEntries != null) {
@@ -797,26 +797,23 @@ public final class TransactionIntentLog implements AutoCloseable {
 
   /**
    * Close HOTLeafPages from an overwritten container that are not reused in the new container.
-   * Prevents FrameSlot memory leaks when leaf splits overwrite TIL entries — the old complete
-   * page (original from disk) is orphaned and its 65KB off-heap MemorySegment must be released.
+   * Prevents FrameSlot memory leaks when leaf splits overwrite TIL entries — the old complete page
+   * (original from disk) is orphaned and its 65KB off-heap MemorySegment must be released.
    */
-  private void closeOrphanedHOTLeafPages(final PageContainer oldContainer,
-      final PageContainer newContainer, final int excludeIndex) {
+  private void closeOrphanedHOTLeafPages(final PageContainer oldContainer, final PageContainer newContainer,
+      final int excludeIndex) {
     final Page oldComplete = oldContainer.getComplete();
     final Page oldModified = oldContainer.getModified();
     final Page newComplete = newContainer.getComplete();
     final Page newModified = newContainer.getModified();
 
-    if (oldComplete instanceof HOTLeafPage completeLeaf
-        && completeLeaf != newComplete && completeLeaf != newModified
+    if (oldComplete instanceof HOTLeafPage completeLeaf && completeLeaf != newComplete && completeLeaf != newModified
         && !isHOTLeafInOtherEntry(completeLeaf, excludeIndex)
         && !bufferManager.getHOTLeafPageCache().containsPage(completeLeaf)) {
       completeLeaf.close();
     }
-    if (oldModified != oldComplete
-        && oldModified instanceof HOTLeafPage modifiedLeaf
-        && modifiedLeaf != newComplete && modifiedLeaf != newModified
-        && !isHOTLeafInOtherEntry(modifiedLeaf, excludeIndex)
+    if (oldModified != oldComplete && oldModified instanceof HOTLeafPage modifiedLeaf && modifiedLeaf != newComplete
+        && modifiedLeaf != newModified && !isHOTLeafInOtherEntry(modifiedLeaf, excludeIndex)
         && !bufferManager.getHOTLeafPageCache().containsPage(modifiedLeaf)) {
       modifiedLeaf.close();
     }
@@ -825,16 +822,20 @@ public final class TransactionIntentLog implements AutoCloseable {
   /**
    * Retire the {@link KeyValueLeafPage}s of an overwritten container that the new one does not reuse.
    *
-   * <p>The HOT counterpart above existed; this did not, so re-putting the same reference into its
+   * <p>
+   * The HOT counterpart above existed; this did not, so re-putting the same reference into its
    * existing log slot dropped the previous container's record pages with nothing left pointing at
    * them. {@link #put} has already taken them OUT of the record-page cache (that is what gives the
    * log exclusive ownership), so no eviction path can reclaim them either — every re-put stranded up
    * to two 64 KiB frames for the process's lifetime, and a write-heavy transaction re-puts the same
    * page on every modification. It showed up as the last population of survivors in the
-   * {@code -Dsirix.debug.memory.leaks} census: cached at some point, never orphaned, never closed.</p>
+   * {@code -Dsirix.debug.memory.leaks} census: cached at some point, never orphaned, never closed.
+   * </p>
    *
-   * <p>Same three exemptions as the HOT path — reused by the new container, held by another log
-   * entry, or still owned by the shared cache (which then owns the teardown).</p>
+   * <p>
+   * Same three exemptions as the HOT path — reused by the new container, held by another log entry,
+   * or still owned by the shared cache (which then owns the teardown).
+   * </p>
    */
   private void closeOrphanedRecordPages(final PageContainer oldContainer, final PageContainer newContainer,
       final int excludeIndex) {
@@ -843,17 +844,14 @@ public final class TransactionIntentLog implements AutoCloseable {
     final Page newComplete = newContainer.getComplete();
     final Page newModified = newContainer.getModified();
 
-    if (oldComplete instanceof KeyValueLeafPage completePage
-        && completePage != newComplete && completePage != newModified
-        && !completePage.isClosed()
+    if (oldComplete instanceof KeyValueLeafPage completePage && completePage != newComplete
+        && completePage != newModified && !completePage.isClosed()
         && !isRecordPageInOtherEntry(completePage, excludeIndex)
         && !bufferManager.getRecordPageCache().containsPage(completePage)) {
       completePage.retire();
     }
-    if (oldModified != oldComplete
-        && oldModified instanceof KeyValueLeafPage modifiedPage
-        && modifiedPage != newComplete && modifiedPage != newModified
-        && !modifiedPage.isClosed()
+    if (oldModified != oldComplete && oldModified instanceof KeyValueLeafPage modifiedPage
+        && modifiedPage != newComplete && modifiedPage != newModified && !modifiedPage.isClosed()
         && !isRecordPageInOtherEntry(modifiedPage, excludeIndex)
         && !bufferManager.getRecordPageCache().containsPage(modifiedPage)) {
       modifiedPage.retire();
@@ -874,8 +872,8 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Whether {@code page} is also held by a log entry other than {@code excludeIndex}. Walks only
-   * the entries that can hold a HOT leaf — {@link #hotLeafIndices}, a superset re-checked against
+   * Whether {@code page} is also held by a log entry other than {@code excludeIndex}. Walks only the
+   * entries that can hold a HOT leaf — {@link #hotLeafIndices}, a superset re-checked against
    * {@code entries[i]} — because this runs on {@link #put}'s HOT-leaf CoW path, once per replaced
    * container, and a full walk made that quadratic in the log size.
    */
@@ -894,19 +892,21 @@ public final class TransactionIntentLog implements AutoCloseable {
   }
 
   /**
-   * Release the off-heap {@code MemorySegment}s of HOT leaf pages that incremental leaf
-   * consolidation or a subtree rebuild merged away. Each page is no longer reachable from the
-   * trie, so the tree-recursive commit never visits its entry — and a per-reference commit that
-   * did reach it would skip it on the {@code isClosed()} guard. Closing here reclaims the 64KB
-   * slots instead of pinning them until end-of-transaction {@link #clear()}.
+   * Release the off-heap {@code MemorySegment}s of HOT leaf pages that incremental leaf consolidation
+   * or a subtree rebuild merged away. Each page is no longer reachable from the trie, so the
+   * tree-recursive commit never visits its entry — and a per-reference commit that did reach it would
+   * skip it on the {@code isClosed()} guard. Closing here reclaims the 64KB slots instead of pinning
+   * them until end-of-transaction {@link #clear()}.
    *
-   * <p>Batched on purpose: the sharing guard ("is this leaf still referenced by another TIL
-   * entry — a CoW reference copy") is a scan of the whole log. Doing it once for the whole drop
-   * list is {@code O(size + orphans)}; doing it per leaf would be {@code O(size * orphans)} —
-   * quadratic, since a large transaction's drop list and log both grow with the entry count.
+   * <p>
+   * Batched on purpose: the sharing guard ("is this leaf still referenced by another TIL entry — a
+   * CoW reference copy") is a scan of the whole log. Doing it once for the whole drop list is
+   * {@code O(size + orphans)}; doing it per leaf would be {@code O(size * orphans)} — quadratic,
+   * since a large transaction's drop list and log both grow with the entry count.
    *
-   * <p>A leaf still shared by another TIL entry or held by the HOT-leaf buffer cache is never
-   * freed, so no concurrent reader loses its segment.
+   * <p>
+   * A leaf still shared by another TIL entry or held by the HOT-leaf buffer cache is never freed, so
+   * no concurrent reader loses its segment.
    *
    * @param orphanRefs references of the merged-away leaves — each carries its TIL log-key
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/AtomicUtil.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/AtomicUtil.java
@@ -98,6 +98,12 @@ public final class AtomicUtil {
         return Calc.fromBigDecimal(((Numeric) atomic).decimalValue());
       }
     }
+    // The instant family, through the same order-preserving codec the HOT backend uses: without it
+    // this method threw "Unsupported type", so a red-black-tree CAS index simply could not be built
+    // over xs:dateTime at all.
+    if (InstantKeyCodec.isInstantType(type)) {
+      return InstantKeyCodec.toBytes(atomic, type);
+    }
     throw new SirixRuntimeException("Unsupported type: %s", type);
   }
 
@@ -130,6 +136,9 @@ public final class AtomicUtil {
       if (type.instanceOf(Type.DEC)) {
         return new Dec(Calc.toBigDecimal(b));
       }
+    }
+    if (InstantKeyCodec.isInstantType(type)) {
+      return InstantKeyCodec.decode(b, 0, b.length, type);
     }
     throw new SirixRuntimeException("Unsupported type: %s", type);
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuildFinalizer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuildFinalizer.java
@@ -3,11 +3,13 @@ package io.sirix.index;
 /**
  * An index builder that has work left to do once the document traversal is over.
  *
- * <p>Most builders write straight through: a visit is a write. A builder that <em>bulk-loads</em>
+ * <p>
+ * Most builders write straight through: a visit is a write. A builder that <em>bulk-loads</em>
  * instead — collecting the whole entry set and materialising the index structure in one pass, the
- * only way to build a HOT trie in {@code Θ(n)} — has nothing on disk until it is told the
- * traversal has ended. {@link IndexBuilder#build} calls {@link #finishIndexBuild()} on every
- * builder that implements this, exactly once, after the last visit.</p>
+ * only way to build a HOT trie in {@code Θ(n)} — has nothing on disk until it is told the traversal
+ * has ended. {@link IndexBuilder#build} calls {@link #finishIndexBuild()} on every builder that
+ * implements this, exactly once, after the last visit.
+ * </p>
  *
  * @author Johannes Lichtenberger
  */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuildFinalizer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuildFinalizer.java
@@ -1,0 +1,18 @@
+package io.sirix.index;
+
+/**
+ * An index builder that has work left to do once the document traversal is over.
+ *
+ * <p>Most builders write straight through: a visit is a write. A builder that <em>bulk-loads</em>
+ * instead — collecting the whole entry set and materialising the index structure in one pass, the
+ * only way to build a HOT trie in {@code Θ(n)} — has nothing on disk until it is told the
+ * traversal has ended. {@link IndexBuilder#build} calls {@link #finishIndexBuild()} on every
+ * builder that implements this, exactly once, after the last visit.</p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public interface IndexBuildFinalizer {
+
+  /** Flush whatever the traversal accumulated. Called once, after the traversal. */
+  void finishIndexBuild();
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/IndexBuilder.java
@@ -40,6 +40,7 @@ public final class IndexBuilder {
         rtx.acceptVisitor(builder);
       }
     }
+    finish(builders);
     rtx.moveTo(nodeKey);
   }
 
@@ -65,7 +66,21 @@ public final class IndexBuilder {
         rtx.acceptVisitor(builder);
       }
     }
+    finish(builders);
     rtx.moveTo(nodeKey);
   }
 
+  /**
+   * Let every bulk-loading builder materialise what the traversal collected. Runs after the last
+   * visit and before the cursor is restored, so a finalizer still sees the revision it indexed.
+   *
+   * @param builders the index builders that took part in the traversal
+   */
+  private static void finish(final Set<?> builders) {
+    for (final Object builder : builders) {
+      if (builder instanceof IndexBuildFinalizer finalizer) {
+        finalizer.finishIndexBuild();
+      }
+    }
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/InstantKeyCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/InstantKeyCodec.java
@@ -18,9 +18,8 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Storage helper for the XQuery instant family — {@code xs:dateTime}, {@code xs:date} and
- * {@code xs:time}: it stores their LEXICAL form and recovers the TYPED atomic on the way back out,
- * so both index backends agree on representation and range predicates are evaluated by the typed
- * comparison rather than by text.
+ * {@code xs:time}: it reduces a value to the absolute instant it denotes, so both index backends
+ * agree on representation and a byte-ordered scan orders them chronologically.
  *
  * <h2>Encode the ABSOLUTE INSTANT, never the calendar components</h2>
  * <p>
@@ -48,11 +47,6 @@ import static java.util.Objects.requireNonNull;
  * opposite — it is the required behaviour, and it is why {@code "12:00:00Z"} and
  * {@code "14:00:00+02:00"} match one another.
  *
- * <p>
- * Colliding keys are the fatal part rather than merely wrong ordering: a CAS key is the index
- * entry's identity, so two distinct values sharing one key merge their posting lists, corrupting
- * equality lookups and deletes as well as ranges. The lexical form is injective, so it is what gets
- * stored.
  *
  * <h2>Untimezoned values</h2>
  * <p>

--- a/bundles/sirix-core/src/main/java/io/sirix/index/InstantKeyCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/InstantKeyCodec.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index;
+
+import io.brackit.query.QueryException;
+import io.brackit.query.atomic.AbstractTimeInstant;
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Date;
+import io.brackit.query.atomic.DateTime;
+import io.brackit.query.atomic.Time;
+import io.brackit.query.jdm.Type;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Storage helper for the XQuery instant family — {@code xs:dateTime}, {@code xs:date} and
+ * {@code xs:time}: it stores their LEXICAL form and recovers the TYPED atomic on the way back out,
+ * so both index backends agree on representation and range predicates are evaluated by the typed
+ * comparison rather than by text.
+ *
+ * <h2>Encode the ABSOLUTE INSTANT, never the calendar components</h2>
+ * <p>
+ * The value is reduced to the point on the timeline it denotes and that is what gets written, so
+ * unsigned byte order is chronological order and two spellings of the same instant produce the same
+ * key (which is what {@code eq} means for these types). An earlier version of this class
+ * canonicalized to UTC and then read the components back off the ORIGINAL type, which silently
+ * discarded whatever the canonicalization had shifted:
+ *
+ * <ul>
+ * <li><b>{@code xs:date}</b> — an offset shift lands in a time-of-day an {@code xs:date} cannot
+ * carry ({@code Date.getHours()} is always {@code 0}), so it was dropped and
+ * {@code 2020-01-01+02:00} produced BYTE-IDENTICAL keys to {@code 2019-12-31Z} — two DIFFERENT
+ * instants sharing one index entry.</li>
+ * <li><b>{@code xs:time}</b> — comparison attaches the reference date {@code 1972-12-31}, whose
+ * ±1-day rollover an {@code xs:time} cannot hold ({@code Time.getDay()} is always {@code 0}), so
+ * byte order came out INVERTED for any non-UTC offset.</li>
+ * </ul>
+ *
+ * <p>
+ * Both are fixed by canonicalizing through a {@link DateTime} — which has room for every component
+ * — and encoding that. A collision is the fatal failure mode: a CAS key is the index entry's
+ * identity, so two DISTINCT values sharing one key merge their posting lists and corrupt equality
+ * lookups and deletes, not just ranges. Two spellings of the SAME instant sharing a key is the
+ * opposite — it is the required behaviour, and it is why {@code "12:00:00Z"} and
+ * {@code "14:00:00+02:00"} match one another.
+ *
+ * <p>
+ * Colliding keys are the fatal part rather than merely wrong ordering: a CAS key is the index
+ * entry's identity, so two distinct values sharing one key merge their posting lists, corrupting
+ * equality lookups and deletes as well as ranges. The lexical form is injective, so it is what gets
+ * stored.
+ *
+ * <h2>Untimezoned values</h2>
+ * <p>
+ * A value without a timezone is interpreted in the implicit one (UTC here), so it encodes to the
+ * same instant as its {@code Z} spelling and the two share a key. That matches {@code eq} under a
+ * UTC implicit timezone. Note brackit's own {@code compareTo} instead applies a has-timezone
+ * tiebreak and answers "less" in BOTH directions for such a pair, i.e. it is not a total order
+ * there; no encoding can reproduce that, and reproducing it is not desirable.
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class InstantKeyCodec {
+
+  private InstantKeyCodec() {
+    throw new AssertionError("no instances");
+  }
+
+  /**
+   * Whether {@code type} is one of the instant types this helper handles.
+   *
+   * <p>
+   * Deliberately NOT including {@code xs:duration} and its subtypes: durations are only partially
+   * ordered (a month is not a fixed number of days), so they have no place in an ordered index key.
+   *
+   * @param type the type to test, may be {@code null}
+   * @return {@code true} iff {@code type} is {@code xs:dateTime}, {@code xs:date} or {@code xs:time}
+   */
+  public static boolean isInstantType(final Type type) {
+    return type != null && (type.instanceOf(Type.DATI) || type.instanceOf(Type.DATE) || type.instanceOf(Type.TIME));
+  }
+
+  /** Bytes an encoded instant occupies: year(2) month(1) day(1) hours(1) minutes(1) micros(4). */
+  public static final int BYTES = 10;
+
+  /**
+   * Reference date XQuery uses to compare bare {@code xs:time} values (§10.4 op:time-less-than).
+   * Encoding relative to it is what preserves the ±1-day carry a timezone conversion can produce.
+   */
+  private static final short TIME_REFERENCE_YEAR = 1972;
+  private static final byte TIME_REFERENCE_MONTH = 12;
+  private static final byte TIME_REFERENCE_DAY = 31;
+
+  /**
+   * Encode {@code value} into {@code dest} at {@code offset}, as the absolute instant it denotes.
+   *
+   * @param value the value; a raw {@code Str} carrying the lexical form is accepted and coerced,
+   *        because that is what the index builders hand over
+   * @param type the declared content type, used to coerce {@code value} when it is untyped
+   * @param dest destination buffer, must hold {@link #BYTES} from {@code offset}
+   * @param offset where to start writing
+   * @return {@link #BYTES}
+   */
+  public static int encode(final Atomic value, final Type type, final byte[] dest, final int offset) {
+    requireNonNull(value, "value");
+    requireNonNull(dest, "dest");
+    Objects.checkFromIndexSize(offset, BYTES, dest.length);
+
+    final DateTime utc = toUtcInstant(asTimeInstant(value, type));
+    final int signFlippedYear = (utc.getYear() ^ 0x8000) & 0xFFFF;
+    int pos = offset;
+    dest[pos++] = (byte) (signFlippedYear >>> 8);
+    dest[pos++] = (byte) signFlippedYear;
+    dest[pos++] = utc.getMonth();
+    dest[pos++] = utc.getDay();
+    dest[pos++] = utc.getHours();
+    dest[pos++] = utc.getMinutes();
+    final int micros = utc.getMicros();
+    dest[pos++] = (byte) (micros >>> 24);
+    dest[pos++] = (byte) (micros >>> 16);
+    dest[pos++] = (byte) (micros >>> 8);
+    dest[pos] = (byte) micros;
+    return BYTES;
+  }
+
+  /** Encode into a right-sized array, for callers that hand back a {@code byte[]}. */
+  public static byte[] toBytes(final Atomic value, final Type type) {
+    final byte[] out = new byte[BYTES];
+    encode(value, type, out, 0);
+    return out;
+  }
+
+  /**
+   * Reduce any instant to the UTC point on the timeline it denotes, WITHOUT routing through the
+   * original type — that is the step whose omission dropped the offset shift for {@code xs:date} (no
+   * time-of-day) and {@code xs:time} (no date). A {@link DateTime} has room for every component, so
+   * nothing is lost, and an absent timezone means the implicit one (UTC).
+   */
+  private static DateTime toUtcInstant(final AbstractTimeInstant instant) {
+    final DateTime asDateTime;
+    if (instant instanceof DateTime dateTime) {
+      asDateTime = dateTime;
+    } else if (instant instanceof Date) {
+      // An xs:date denotes midnight on that day in its own timezone.
+      asDateTime = new DateTime(instant.getYear(), instant.getMonth(), instant.getDay(), (byte) 0, (byte) 0, 0,
+          instant.getTimezone());
+    } else {
+      // An xs:time is compared against the reference date, which is what carries the ±1-day
+      // rollover a timezone conversion can produce.
+      asDateTime = new DateTime(TIME_REFERENCE_YEAR, TIME_REFERENCE_MONTH, TIME_REFERENCE_DAY, instant.getHours(),
+          instant.getMinutes(), instant.getMicros(), instant.getTimezone());
+    }
+    if (asDateTime.getTimezone() == null) {
+      // Already in the implicit timezone; canonicalize() would have nothing to normalize away.
+      return asDateTime;
+    }
+    return (DateTime) asDateTime.canonicalize();
+  }
+
+  /**
+   * Recover the typed instant from stored lexical bytes, so comparisons are chronological.
+   *
+   * @param bytes buffer holding the UTF-8 lexical form
+   * @param offset offset of the lexical form
+   * @param length its length in bytes
+   * @param type the declared content type, which selects the returned atomic's class
+   * @return the decoded value
+   */
+  public static Atomic decode(final byte[] bytes, final int offset, final int length, final Type type) {
+    requireNonNull(bytes, "bytes");
+    if (length < BYTES) {
+      throw new IllegalArgumentException("instant key holds " + length + " bytes, expected " + BYTES);
+    }
+    Objects.checkFromIndexSize(offset, BYTES, bytes.length);
+
+    final short year = (short) ((((bytes[offset] & 0xFF) << 8) | (bytes[offset + 1] & 0xFF)) ^ 0x8000);
+    final DateTime dateTime = new DateTime(year, bytes[offset + 2], bytes[offset + 3], bytes[offset + 4],
+        bytes[offset + 5], ((bytes[offset + 6] & 0xFF) << 24) | ((bytes[offset + 7] & 0xFF) << 16)
+            | ((bytes[offset + 8] & 0xFF) << 8) | (bytes[offset + 9] & 0xFF),
+        AbstractTimeInstant.UTC_TIMEZONE);
+    if (type != null && type.instanceOf(Type.DATE)) {
+      return new Date(dateTime);
+    }
+    if (type != null && type.instanceOf(Type.TIME)) {
+      return new Time(dateTime);
+    }
+    return dateTime;
+  }
+
+  /**
+   * Recover the typed instant from its lexical form.
+   *
+   * @param lexical the lexical form
+   * @param type the declared content type, which selects the returned atomic's class
+   * @return the typed value
+   */
+  public static Atomic fromLexical(final String lexical, final Type type) {
+    requireNonNull(lexical, "lexical");
+    try {
+      if (type != null && type.instanceOf(Type.DATE)) {
+        return new Date(lexical);
+      }
+      if (type != null && type.instanceOf(Type.TIME)) {
+        return new Time(lexical);
+      }
+      return new DateTime(lexical);
+    } catch (final QueryException e) {
+      throw new IllegalArgumentException("value '" + lexical + "' is not a valid " + type, e);
+    }
+  }
+
+  /**
+   * Coerce to a typed instant. The CAS index builder and the change listener both hand a raw
+   * {@link io.brackit.query.atomic.Str} carrying the document's lexical form while the declared type
+   * says {@code xs:dateTime}, so the typed object has to be reconstructed rather than assumed.
+   */
+  private static AbstractTimeInstant asTimeInstant(final Atomic value, final Type type) {
+    if (value instanceof AbstractTimeInstant instant) {
+      return instant;
+    }
+    return (AbstractTimeInstant) fromLexical(value.stringValue(), type);
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
@@ -9,6 +9,7 @@ import io.sirix.index.redblacktree.keyvalue.CASValue;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.QNm;
 import io.brackit.query.util.path.Path;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -56,9 +57,29 @@ public final class CASFilterRange implements Filter {
     this.incMax = incMax;
   }
 
+  /** The minimum value, or {@code null} for an unbounded lower end. */
+  public @Nullable Atomic getMin() {
+    return min;
+  }
+
+  /** The maximum value, or {@code null} for an unbounded upper end. */
+  public @Nullable Atomic getMax() {
+    return max;
+  }
+
+  /** Whether the minimum value itself is in range. */
+  public boolean isMinInclusive() {
+    return incMin;
+  }
+
+  /** Whether the maximum value itself is in range. */
+  public boolean isMaxInclusive() {
+    return incMax;
+  }
+
   /**
    * Get the set of path class records (PCRs) for filtering.
-   * 
+   *
    * @return set of PCRs from the path filter
    */
   public Set<Long> getPCRs() {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
@@ -86,6 +86,16 @@ public final class CASFilterRange implements Filter {
     return pathFilter.getPCRs();
   }
 
+  /**
+   * Get the path class record collector backing this filter, so a caller can ask which PCRs the INDEX
+   * may hold (as opposed to {@link #getPCRs()}, which are the ones the query asked for).
+   *
+   * @return the path class record collector
+   */
+  public PCRCollector getPCRCollector() {
+    return pathFilter.getPCRCollector();
+  }
+
   @Override
   public <K extends Comparable<? super K>> boolean filter(final RBNodeKey<K> node) {
     final K key = node.getKey();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASFilterRange.java
@@ -86,16 +86,6 @@ public final class CASFilterRange implements Filter {
     return pathFilter.getPCRs();
   }
 
-  /**
-   * Get the path class record collector backing this filter, so a caller can ask which PCRs the INDEX
-   * may hold (as opposed to {@link #getPCRs()}, which are the ones the query asked for).
-   *
-   * @return the path class record collector
-   */
-  public PCRCollector getPCRCollector() {
-    return pathFilter.getPCRCollector();
-  }
-
   @Override
   public <K extends Comparable<? super K>> boolean filter(final RBNodeKey<K> node) {
     final K key = node.getKey();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -32,25 +32,29 @@ import java.util.Set;
 import java.util.function.Function;
 
 public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx & NodeCursor> {
-  B createBuilder(R rtx, StorageEngineWriter storageEngineWriter, PathSummaryReader pathSummaryReader, IndexDef indexDef);
+  B createBuilder(R rtx, StorageEngineWriter storageEngineWriter, PathSummaryReader pathSummaryReader,
+      IndexDef indexDef);
 
   L createListener(StorageEngineWriter storageEngineWriter, PathSummaryReader pathSummaryReader, IndexDef indexDef);
 
-  default Iterator<NodeReferences> openIndex(StorageEngineReader storageEngineReader, IndexDef indexDef, CASFilterRange filter) {
+  default Iterator<NodeReferences> openIndex(StorageEngineReader storageEngineReader, IndexDef indexDef,
+      CASFilterRange filter) {
     // Check if HOT is enabled (system property takes precedence, then resource config)
     if (isHOTEnabled(storageEngineReader)) {
       return openHOTIndexWithRangeFilter(storageEngineReader, indexDef, filter);
     }
 
-    final RBTreeReader<CASValue, NodeReferences> reader = RBTreeReader.getInstance(
-        storageEngineReader.getResourceSession().getIndexCache(), storageEngineReader, indexDef.getType(), indexDef.getID());
+    final RBTreeReader<CASValue, NodeReferences> reader =
+        RBTreeReader.getInstance(storageEngineReader.getResourceSession().getIndexCache(), storageEngineReader,
+            indexDef.getType(), indexDef.getID());
 
     final Iterator<RBNodeKey<CASValue>> iter = reader.new RBNodeIterator(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
 
     return new IndexFilterAxis<>(reader, iter, Set.of(filter));
   }
 
-  default Iterator<NodeReferences> openIndex(StorageEngineReader storageEngineReader, IndexDef indexDef, CASFilter filter) {
+  default Iterator<NodeReferences> openIndex(StorageEngineReader storageEngineReader, IndexDef indexDef,
+      CASFilter filter) {
     // Check if HOT is enabled (system property takes precedence, then resource config)
     if (isHOTEnabled(storageEngineReader)) {
       return openHOTIndexWithFilter(storageEngineReader, indexDef, filter);
@@ -116,8 +120,8 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
    * Open HOT-based CAS index with range filter. Applies min/max bounds and inclusivity to filter
    * results.
    */
-  private Iterator<NodeReferences> openHOTIndexWithRangeFilter(StorageEngineReader storageEngineReader, IndexDef indexDef,
-      CASFilterRange filter) {
+  private Iterator<NodeReferences> openHOTIndexWithRangeFilter(StorageEngineReader storageEngineReader,
+      IndexDef indexDef, CASFilterRange filter) {
     final HOTIndexReader<CASValue> reader =
         HOTIndexReader.create(storageEngineReader, CASKeySerializer.INSTANCE, indexDef.getType(), indexDef.getID());
 
@@ -321,9 +325,11 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
   /**
    * Open RBTree-based CAS index (default).
    */
-  private Iterator<NodeReferences> openRBTreeIndex(StorageEngineReader storageEngineReader, IndexDef indexDef, CASFilter filter) {
-    final RBTreeReader<CASValue, NodeReferences> reader = RBTreeReader.getInstance(
-        storageEngineReader.getResourceSession().getIndexCache(), storageEngineReader, indexDef.getType(), indexDef.getID());
+  private Iterator<NodeReferences> openRBTreeIndex(StorageEngineReader storageEngineReader, IndexDef indexDef,
+      CASFilter filter) {
+    final RBTreeReader<CASValue, NodeReferences> reader =
+        RBTreeReader.getInstance(storageEngineReader.getResourceSession().getIndexCache(), storageEngineReader,
+            indexDef.getType(), indexDef.getID());
 
     // PCRs requested.
     final Set<Long> pcrsRequested = filter == null

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -628,6 +628,19 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
       // an xs:decimal index with, say, an xs:double of the same numeric value produced a
       // different key and the lookup silently found nothing. (The RBTree backend never had this
       // problem — CASValue#compareTo coerces both sides with asType before comparing.)
+      // A probe that is not of the index's declared type matches NOTHING, and saying so here is the
+      // difference between an empty answer and a wrong one. CASIndexBuilder skips any node whose
+      // value is not of the declared type, so nothing of that shape was ever indexed — but the
+      // encoder cannot express "no match" and falls back to 0, false or the empty string instead.
+      // `eq "abc"` on an xs:decimal index therefore parsed to 0.0, landed on ZERO's key, and
+      // returned every zero-valued node.
+      //
+      // ScanCASIndex casts its probe and so raises a type error before reaching here; this covers
+      // the programmatic callers that build a CASFilter directly, which is the path that had no
+      // guard at all.
+      if (!CASKeySerializer.isOfType(atomic, indexDef.getContentType())) {
+        return Collections.emptyIterator();
+      }
       final CASValue value = new CASValue(atomic, indexDef.getContentType(), pcr);
 
       // Reaching this branch SKIPS the `pcrsAvailable` short-circuit further down, and that is sound

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -10,7 +10,11 @@ import io.sirix.index.AtomicUtil;
 import io.sirix.index.ChangeListener;
 import io.sirix.index.IndexDef;
 import io.sirix.index.IndexFilterAxis;
+import io.sirix.index.IndexType;
 import io.sirix.index.SearchMode;
+import io.sirix.node.interfaces.DataRecord;
+import io.sirix.node.interfaces.NumericValueNode;
+import io.sirix.node.interfaces.ValueNode;
 import io.sirix.index.hot.AbstractHOTIndexReader;
 import io.sirix.index.hot.CASKeySerializer;
 import io.sirix.index.hot.HOTIndexReader;
@@ -21,9 +25,15 @@ import io.sirix.index.redblacktree.keyvalue.CASValue;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.settings.Fixed;
 import io.brackit.query.atomic.Atomic;
+import io.brackit.query.jdm.Type;
 import io.sirix.index.path.summary.PathSummaryReader;
 import org.jspecify.annotations.Nullable;
 
+import org.roaringbitmap.longlong.LongIterator;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -140,12 +150,36 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
     // stored as its raw lexical form, whose text order is NOT chronological order, so
     // isByteOrderPreserving reports false for it and those queries fall through to the full scan
     // below, which compares typed atomics via CASFilterRange#inRange.
+    //
+    // NOT gated on losesInformation, and that is a deliberate reversal. The full scan below is not a
+    // more accurate answer for a lossy bound — it is the SAME answer at O(index) cost, because
+    // CASKeySerializer#decodeAtomic rebuilds its comparison value out of the very key the cursor
+    // already compared. A decimal key decodes to Dec(BigDecimal.valueOf(d)) — the same double; a
+    // truncated string key decodes to the truncated string. So the scan compares narrowed values
+    // exactly as the cursor does, only after materializing a CASValue for every entry in the index.
+    //
+    // Worse, for a truncating bound the scan is strictly WORSE than the cursor. With a 247-byte bound
+    // V, the stored key for V and the bound's key are byte-identical, so an inclusive cursor returns
+    // V; the scan deserializes the stored key to its 246-byte prefix, finds that prefix < V, and
+    // DROPS V — a missing row where the cursor merely over-matched.
+    //
+    // Truncation still has to be handled, because it does break the cursor in one direction: a bound
+    // at or past the cap collapses onto the same key as every stored value sharing its 246-byte
+    // prefix, so an EXCLUSIVE bound drops that whole group, matching records included. The remedy is
+    // to relax that bound to inclusive rather than to abandon the cursor — it keeps the scan O(result)
+    // and turns the drop into an over-match, which is the direction this index errs in everywhere
+    // else. Numeric narrowing needs no such relaxation: its encoder is monotone and the collapsed
+    // group is one ULP wide, so relaxing would pull every `= bound` row into a `> bound` query.
     if (filter != null && filter.getPCRs().size() == 1 && (filter.getMin() != null || filter.getMax() != null)
         && CASKeySerializer.isByteOrderPreserving(indexDef.getContentType())) {
       final Set<Long> pcrsRequested = filter.getPCRs();
       final long pcr = pcrsRequested.iterator().next();
       final Atomic min = filter.getMin();
       final Atomic max = filter.getMax();
+      final boolean minInclusive =
+          filter.isMinInclusive() || CASKeySerializer.truncates(min, indexDef.getContentType());
+      final boolean maxInclusive =
+          filter.isMaxInclusive() || CASKeySerializer.truncates(max, indexDef.getContentType());
 
       // Two-sided: the logical range is ONE contiguous composite range. CAS keys serialize
       // PCR-major (the sign-flipped pathNodeKey is the first 8 bytes), so BOTH bounds pin the same
@@ -153,7 +187,7 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
       // nothing in the scan deserializes a key at all.
       if (min != null && max != null) {
         return valuesOf(reader.range(new CASValue(min, indexDef.getContentType(), pcr),
-            new CASValue(max, indexDef.getContentType(), pcr), filter.isMinInclusive(), filter.isMaxInclusive()));
+            new CASValue(max, indexDef.getContentType(), pcr), minInclusive, maxInclusive));
       }
 
       // One-sided: only ONE end pins the PCR, so the open end runs straight off this PCR's key range
@@ -165,8 +199,8 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
       // the stale postings under the old one live exactly at the open end. The check is cheap
       // because it reads the PCR in place — it never materializes a key.
       final Iterator<Map.Entry<CASValue, NodeReferences>> boundedIterator = min != null
-          ? reader.iteratorFrom(new CASValue(min, indexDef.getContentType(), pcr), filter.isMinInclusive())
-          : reader.iteratorTo(new CASValue(max, indexDef.getContentType(), pcr), filter.isMaxInclusive());
+          ? reader.iteratorFrom(new CASValue(min, indexDef.getContentType(), pcr), minInclusive)
+          : reader.iteratorTo(new CASValue(max, indexDef.getContentType(), pcr), maxInclusive);
       return valuesOfMatchingPCR(boundedIterator, pcrsRequested);
     }
 
@@ -321,6 +355,219 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
     return key.getPathNodeKey();
   }
 
+  /**
+   * Keep only the candidates whose stored value really equals {@code wanted}.
+   *
+   * <p>
+   * Runs ONLY when {@link CASKeySerializer#losesInformation} reports that the probe cannot be
+   * represented exactly, which is the rare case — a value past the serializer's string cap.
+   * Everything inside that cap is decided by the seek alone and never reaches here, so the ordinary
+   * equality query pays nothing for this.
+   * </p>
+   *
+   * <p>
+   * Reads through its OWN {@link StorageEngineReader}, never the query's. {@code getRecordPage} calls
+   * {@code closeCurrentPageGuard()}, which releases the guard keeping alive the page the caller's
+   * flyweight current node is bound to — so fetching candidates on the query's reader would leave
+   * that node a dangling view into a frame the sweeper may free, and the caller's next field read
+   * would be a use-after-free. {@code AbstractResourceSession#getRecordChangeRevisions} opens its own
+   * reader for exactly this reason.
+   * </p>
+   *
+   * <p>
+   * A WRITER-backed reader cannot be shadowed that way: it represents {@code lastCommitted + 1}, a
+   * revision the session will not open a second reader on, and its uncommitted changes live in a trx
+   * intent log no other reader can see. Re-checking on the caller's own reader instead is not an
+   * option — an index scan inside an updating transaction is precisely a query holding a live cursor,
+   * so that is the hazard above rather than an exception to it. This therefore declines to filter
+   * there and returns the candidates unchanged, which is the superset the branch answered with before
+   * the re-check existed. De-pinning the record-page path would remove the hazard, and with it this
+   * carve-out.
+   * </p>
+   *
+   * <p>
+   * Two rejection rules, and the distinction matters. A candidate whose record this cannot judge is
+   * KEPT: erring towards the superset preserves the behaviour that shipped before, where dropping
+   * would turn an over-match into silently missing rows — the worse of the two failures. A candidate
+   * whose record is NULL is DROPPED: the posting lists span every revision, so a node key that does
+   * not resolve at the query revision provably is not a match, and keeping it hands the caller a key
+   * that {@code moveTo} cannot resolve.
+   * </p>
+   *
+   * <p>
+   * The survivors stay in the COMPACT representation: {@code nodeKeyIterator} yields ascending and
+   * filtering preserves that, so an exactly-sized {@code long[]} is ascending by construction and
+   * {@link NodeReferences#ofSortedArray} adopts it directly. Rebuilding a {@code Roaring64Bitmap}
+   * here would reintroduce the container tree the compact form exists to avoid, and would hand every
+   * downstream {@code cardinality}/{@code contains}/{@code nodeKeyIterator} call the slower branch —
+   * making a FILTERED result more expensive than the unfiltered one it replaces. When nothing is
+   * filtered out, which is the common case, the seek's own instance is handed straight back and
+   * nothing is allocated at all.
+   * </p>
+   *
+   * @param storageEngineReader reader for fetching the candidate records
+   * @param candidates the posting list the seek returned
+   * @param wanted the atomic the query asked for
+   * @param contentType the index's content type, which decides numeric versus lexical comparison
+   * @return the matching references, or {@code null} when none match
+   */
+  private static @Nullable NodeReferences exactMatches(final StorageEngineReader storageEngineReader,
+      final NodeReferences candidates, final Atomic wanted, final Type contentType) {
+    final byte[] wantedBytes = wanted.stringValue().getBytes(StandardCharsets.UTF_8);
+    // Which comparison to use is a property of the INDEX, not of the candidate's node kind. A numeric
+    // index stores its values through a narrowing encoder, and the SAME logical number reaches the
+    // re-check as a NumericValueNode in JSON and as raw lexical bytes in XML — so dispatching on the
+    // node would compare "19.990" against "19.99" for the XML case and drop a row that matches.
+    // Hoisted out of the loop as well: it is the same for every candidate, and the sibling
+    // wantedBytes was already hoisted for exactly that reason.
+    final BigDecimal wantedNumber = CASKeySerializer.isNumericFamily(contentType)
+        ? parseOrNull(wanted.stringValue())
+        : null;
+    if (CASKeySerializer.isNumericFamily(contentType) && wantedNumber == null) {
+      // A numeric probe that is not a finite number — NaN or an infinity. The encoder canonicalizes
+      // NaN onto a real value's key, so the seek's posting list is other values entirely; and XQuery
+      // gives NaN no equals, so the answer is empty rather than that posting list.
+      return null;
+    }
+    if (storageEngineReader.hasTrxIntentLog()) {
+      return candidates; // writer-backed: cannot be shadowed, and must not be borrowed — see above
+    }
+    final long candidateCount = candidates.cardinality();
+    // GROWN, not sized from the cardinality. A posting list is unbounded — a value shared by a
+    // 246-byte prefix across millions of documents is exactly what drives a probe into this method —
+    // and sizing eagerly turned a query that answers from a handful of survivors into a
+    // hundreds-of-megabytes allocation, or an ArithmeticException out of Math.toIntExact past 2^31
+    // postings. Doubling from a small floor costs log(kept) copies and never over-allocates by more
+    // than a factor of two on what actually SURVIVES.
+    long[] matching = new long[(int) Math.min(candidateCount, 16)];
+    int kept = 0;
+    final var session = storageEngineReader.getResourceSession();
+    try (final StorageEngineReader records =
+        session.createStorageEngineReader(storageEngineReader.getRevisionNumber())) {
+      final LongIterator it = candidates.nodeKeyIterator();
+      while (it.hasNext()) {
+        final long nodeKey = it.next();
+        final DataRecord record = records.getRecord(nodeKey, IndexType.DOCUMENT, -1);
+        if (record == null) {
+          continue; // does not resolve at this revision, so it cannot be a match
+        }
+        if (matchesExactly(record, wantedBytes, wantedNumber)) {
+          if (kept == matching.length) {
+            matching = Arrays.copyOf(matching, Math.max(matching.length << 1, 16));
+          }
+          matching[kept++] = nodeKey;
+        }
+      }
+    }
+    if (kept == 0) {
+      return null;
+    }
+    return kept == candidateCount
+        ? candidates
+        : NodeReferences.ofSortedArray(Arrays.copyOf(matching, kept));
+  }
+
+  /**
+   * Whether {@code record}'s stored value really is {@code wanted}.
+   *
+   * <p>
+   * Which comparison applies is decided by the caller from the INDEX's content type, not from the
+   * candidate's node kind, and arrives as {@code wantedNumber} being non-{@code null}. A numeric
+   * index compares NUMBERS — {@code 1.50} and {@code 1.5} are one value and both must match a probe
+   * of {@code 1.5}, and the same logical number reaches here as a {@link NumericValueNode} in JSON
+   * but as a lexical {@link ValueNode} in XML, so a byte comparison would drop the XML row. Every
+   * other index compares BYTES against the probe's UTF-8, which is what the truncating string encoder
+   * lost.
+   * </p>
+   *
+   * <p>
+   * A candidate this cannot read — an unrecognized node kind, or a numeric index over a node whose
+   * value will not parse — is KEPT, preserving the superset rather than risking dropped rows on
+   * something the re-check cannot judge.
+   * </p>
+   *
+   * @param record the candidate's record, never {@code null}
+   * @param wantedBytes the probe's lexical form in UTF-8, computed once by the caller
+   * @param wantedNumber the probe as a number on a numeric index, {@code null} on every other index
+   * @return {@code true} when the candidate matches, or cannot be judged
+   */
+  private static boolean matchesExactly(final DataRecord record, final byte[] wantedBytes,
+      final @Nullable BigDecimal wantedNumber) {
+    if (wantedNumber != null) {
+      // Numeric index: compare NUMBERS, whatever shape the node stores them in. 1.50 and 1.5 are the
+      // same value and must both match a probe of 1.5; a lexical comparison would drop one of them.
+      final BigDecimal stored = storedNumber(record);
+      return stored == null || stored.compareTo(wantedNumber) == 0;
+    }
+    if (record instanceof final ValueNode valueNode) {
+      return Arrays.equals(valueNode.getRawValue(), wantedBytes);
+    }
+    return true;
+  }
+
+  /**
+   * The candidate's value as a number, or {@code null} when it cannot be read as one.
+   *
+   * @param record the candidate's record
+   * @return its numeric value, or {@code null} if unreadable
+   */
+  private static @Nullable BigDecimal storedNumber(final DataRecord record) {
+    if (record instanceof final NumericValueNode numericNode) {
+      final Number stored = numericNode.getValue();
+      return stored == null
+          ? null
+          : parseOrNull(stored.toString());
+    }
+    if (record instanceof final ValueNode valueNode) {
+      return parseOrNull(new String(valueNode.getRawValue(), StandardCharsets.UTF_8));
+    }
+    return null;
+  }
+
+  /**
+   * {@code text} as a decimal, or {@code null} when it is not one — NaN and the infinities included,
+   * which {@link BigDecimal} cannot represent.
+   *
+   * @param text the lexical form
+   * @return the parsed value, or {@code null}
+   */
+  private static @Nullable BigDecimal parseOrNull(final String text) {
+    try {
+      return new BigDecimal(text);
+    } catch (final NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Whether the summary resolves this index's paths to a SINGLE path class that the query did not ask
+   * for — in which case nothing the index holds under the requested class can match at the query
+   * revision, and the caller may answer empty without reading anything.
+   *
+   * <p>
+   * Deliberately narrow. It fires only when the summary resolves exactly one path class, because that
+   * is the only case where "not the requested one" settles the whole question; a multi-path index
+   * needs the per-entry PCR check instead. Callers must therefore treat a {@code false} answer as "no
+   * short cut available", never as "the requested class is current".
+   * </p>
+   *
+   * <p>
+   * Not cheap: {@code getPCRsForPaths} walks the path summary and allocates a fresh set per call.
+   * Call it where a walk is affordable — after a seek has already found something, or ahead of a scan
+   * — never on the path of a query that is about to answer empty anyway.
+   * </p>
+   *
+   * @param filter the query's filter, carrying the PCR collector
+   * @param indexDef the index definition, carrying the indexed paths
+   * @param pcrsRequested the path classes the query pinned
+   * @return {@code true} when the query can answer empty without reading the index
+   */
+  private static boolean resolvesToADifferentPathClass(final CASFilter filter, final IndexDef indexDef,
+      final Set<Long> pcrsRequested) {
+    final Set<Long> pcrsAvailable = filter.getPCRCollector().getPCRsForPaths(indexDef.getPaths()).getPCRs();
+    return pcrsAvailable.size() == 1 && !pcrsRequested.containsAll(pcrsAvailable);
+  }
+
   /** Primitive membership test over a tiny, unsorted PCR array — no boxing, no hashing. */
   private static boolean containsPCR(final long[] acceptedPCRs, final long pcr) {
     for (int i = 0, n = acceptedPCRs.length; i < n; i++) {
@@ -344,14 +591,24 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
         ? Set.of()
         : filter.getPCRs();
 
-    // PCRs available in index.
-    final Set<Long> pcrsAvailable = filter == null
-        ? Collections.emptySet()
-        : filter.getPCRCollector().getPCRsForPaths(indexDef.getPaths()).getPCRs();
-
-    // Only one path indexed and requested. All PCRs are the same in each CASValue.
+    // Gated on what the QUERY pins, not on what the INDEX spans. A seek needs one exact key, so it
+    // needs exactly one requested path class; how many path classes the index happens to hold is
+    // irrelevant, because CAS keys are PCR-major (the sign-flipped pathNodeKey is the first 8 bytes)
+    // and entries under a different path class therefore carry different key bytes and are simply
+    // not reached. This used to also demand pcrsAvailable.size() <= 1, which sent EVERY equality
+    // query over a multi-path index to the full scan at the bottom of this method — O(index) with a
+    // materialized key per entry, in place of one descent. It was not buying correctness: the scan
+    // it fell back to filters on `pcrsRequested` too (see matchesFilter), so both paths return the
+    // postings of the one requested path class and nothing else. The sibling range method never had
+    // the restriction either.
+    //
+    // Note what the RBTree backend below is NOT evidence for. It does point-look-up a multi-path
+    // index, but its multi-path branch wraps the hit in concatWithFilterAxis, i.e. it seeks and then
+    // re-checks each entry against the typed atomic; only its single-path branch returns unfiltered.
+    // This branch returns unfiltered, which matters because a HOT key is lossy where an RBTree
+    // CASValue is not — see the truncation note on the seek below.
     // A null probe key has nothing to seek to, so it falls through to the scan below.
-    if (pcrsAvailable.size() <= 1 && pcrsRequested.size() == 1 && filter != null && filter.getKey() != null) {
+    if (pcrsRequested.size() == 1 && filter != null && filter.getKey() != null) {
       final Atomic atomic = filter.getKey();
       final long pcr = pcrsRequested.iterator().next();
       final SearchMode mode = filter.getMode();
@@ -363,20 +620,76 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
       // problem — CASValue#compareTo coerces both sides with asType before comparing.)
       final CASValue value = new CASValue(atomic, indexDef.getContentType(), pcr);
 
+      // Reaching this branch SKIPS the `pcrsAvailable` short-circuit further down, and that is sound
+      // rather than an oversight — worth stating, because the omission looks like one. Both PCR sets
+      // come from the same PCRCollector at the same revision (PathFilter resolves its own in its
+      // constructor); they differ only in WHICH paths they resolve, the query's against the index's.
+      // So the check asks "is the query's path not the index's path", and a CAS key is PCR-major: a
+      // seek under a pathNodeKey this index never populated matches no key bytes at all, so
+      // reader.get returns null and this branch answers empty — the very thing the check would have
+      // returned, without the path-summary walk it costs. HOTIndexMemoizationJsoniqTest's crossed
+      // probe pins exactly that (an index on one path, probed with another, must answer 0).
       if (mode == SearchMode.EQUAL) {
-        // Direct lookup
-        NodeReferences refs = reader.get(value, mode);
-        if (refs != null) {
+        // Byte-exact seek, and the CAS key encoding is LOSSY, so for some probes the seek alone
+        // answers with a superset rather than an answer. CASKeySerializer truncates a string value at
+        // MAX_STRING_VALUE_BYTES, so two values sharing that prefix share one key and one posting
+        // list; the integer/decimal encoders narrow similarly.
+        //
+        // That is why the seek is not the whole answer here: losesInformation decides whether the
+        // probe survives the encoding, and only when it does NOT is the posting list re-checked
+        // against the real document values by exactMatches below. The disambiguating bytes were never
+        // stored, so nothing in the INDEX can separate the collided values — reaching the document
+        // nodes is the only thing that can, which is exactly what the re-check does. Do not drop it on
+        // the reasoning that a byte-exact seek must already be exact; CASKeyTruncationTest fails if it
+        // goes (it asserts 1, not 2, for two titles sharing a 246-byte prefix).
+        //
+        // The re-check is TYPED, not lexical: it picks its comparison from the index's content type,
+        // so it closes the numeric-narrowing case as well as the truncation one. That matters because
+        // the same logical number arrives as a NumericValueNode in JSON and as raw lexical bytes in
+        // XML, and because 1.50 and 1.5 are one value — a byte comparison would drop rows for both
+        // reasons. See exactMatches.
+        //
+        // Relaxing the pcrsAvailable gate above did not introduce the truncation defect, which is
+        // worth stating because it is easy to misread. A SINGLE-path index has always taken this
+        // branch and returned 2; a multi-path index returned 0 before (the scan compares the truncated
+        // STORED value against the full probe and matches nothing). The relaxation made multi-path
+        // consistent with single-path, and the re-check then made BOTH exact.
+        final NodeReferences refs = reader.get(value, mode);
+        if (refs == null) {
+          return Collections.emptyIterator();
+        }
+        // The requested path class must be one the summary can still resolve, or these postings are
+        // stale. HOT posting lists span EVERY revision while the summary describes the QUERY revision,
+        // so a path node dropped and re-created takes a new pathNodeKey and leaves its old postings
+        // filed under a PCR the summary no longer resolves — which a byte-exact seek under that stale
+        // PCR happily returns. Every mode was checked against this before the EQUAL branch was allowed
+        // to return ahead of it.
+        //
+        // Deferred to HERE, after a hit, rather than hoisted back above the seek: getPCRsForPaths
+        // walks the path summary and allocates a fresh set per call, so hoisting taxes every equality
+        // query — including the ones that MISS, which is exactly when the walk buys nothing, since an
+        // empty seek result cannot be stale. On a hit it is amortized against materializing the rows.
+        if (resolvesToADifferentPathClass(filter, indexDef, pcrsRequested)) {
+          return Collections.emptyIterator();
+        }
+        if (!CASKeySerializer.losesInformation(atomic, indexDef.getContentType())) {
           return Iterators.forArray(refs);
         }
-        return Collections.emptyIterator();
+        // The probe does not fit the key encoding, so the seek answered with a superset: every value
+        // sharing the truncated prefix collapses onto this one key. The index cannot separate them —
+        // the distinguishing bytes were never stored — so the only thing that can is the document.
+        // Re-check the candidates against their real values.
+        final NodeReferences exact = exactMatches(storageEngineReader, refs, atomic, indexDef.getContentType());
+        return exact == null
+            ? Collections.emptyIterator()
+            : Iterators.forArray(exact);
       }
 
       // If the single PCR the summary can resolve is NOT the requested one, no entry can match at
       // all. Note this only ever SHORT-CIRCUITS a scan; it is never grounds for skipping the
       // per-entry PCR check on a cursor that survives it, because the summary describes the query
       // revision while the index holds every revision's postings (see the one-sided branch below).
-      if (pcrsAvailable.size() == 1 && !pcrsRequested.containsAll(pcrsAvailable)) {
+      if (resolvesToADifferentPathClass(filter, indexDef, pcrsRequested)) {
         return Collections.emptyIterator();
       }
 
@@ -385,10 +698,27 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
       // with the PCR check hoisted out nothing in these scans deserializes a key at all. Same
       // content-type gate as the range-filter path: byte order decides these bounds, so a type whose
       // key bytes are its raw lexical form must use the typed comparison in the full scan instead.
+      //
+      // A TRUNCATING bound is handled by relaxing the bound, not by abandoning the cursor — the same
+      // reversal as in openHOTIndexWithRangeFilter, for the same reason. The full scan below is not
+      // the more accurate answer for such a bound: CASFilterRange#inRange judges the atomic that
+      // CASKeySerializer#decodeAtomic rebuilt out of the stored key, and for a truncated value that
+      // is its 246-byte prefix. So the scan compares the bound against the prefix, finds the prefix
+      // below it, and DROPS the record the cursor would have returned — a missing row bought with an
+      // O(index) scan. Once the bound reaches the cap it collapses onto the same key as every stored
+      // value sharing that prefix, and only the EXCLUSIVE cursors mishandle the collapsed group (they
+      // drop it whole, matching records included); making the bound inclusive keeps the group and
+      // errs towards the superset, which is the direction this index errs in everywhere else.
+      //
+      // Note this is NOT a consequence of relaxing the pcrsAvailable gate above; a SINGLE-path index
+      // has always reached this cursor. The relaxation extended the exposure to multi-path indexes,
+      // which is what made the pre-existing hole worth closing at the same time.
       if (CASKeySerializer.isByteOrderPreserving(indexDef.getContentType())) {
+        final boolean inclusive = mode == SearchMode.GREATER_OR_EQUAL || mode == SearchMode.LOWER_OR_EQUAL
+            || CASKeySerializer.truncates(atomic, indexDef.getContentType());
         final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIter = switch (mode) {
-          case GREATER, GREATER_OR_EQUAL -> reader.iteratorFrom(value, mode == SearchMode.GREATER_OR_EQUAL);
-          case LOWER, LOWER_OR_EQUAL -> reader.iteratorTo(value, mode == SearchMode.LOWER_OR_EQUAL);
+          case GREATER, GREATER_OR_EQUAL -> reader.iteratorFrom(value, inclusive);
+          case LOWER, LOWER_OR_EQUAL -> reader.iteratorTo(value, inclusive);
           default -> null;
         };
         if (rangeIter != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -188,14 +188,18 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
         : filter.getPCRCollector().getPCRsForPaths(indexDef.getPaths()).getPCRs();
 
     // Only one path indexed and requested. All PCRs are the same in each CASValue.
-    if (pcrsAvailable.size() <= 1 && pcrsRequested.size() == 1 && filter != null) {
+    // A null probe key has nothing to seek to, so it falls through to the scan below.
+    if (pcrsAvailable.size() <= 1 && pcrsRequested.size() == 1 && filter != null && filter.getKey() != null) {
       final Atomic atomic = filter.getKey();
       final long pcr = pcrsRequested.iterator().next();
       final SearchMode mode = filter.getMode();
 
-      final CASValue value = new CASValue(atomic, atomic != null
-          ? atomic.type()
-          : null, pcr);
+      // The probe key must be typed like the entries the index stores, NOT like the atomic the
+      // caller happened to pass: a HOT key is a byte string that carries the type id, so probing
+      // an xs:decimal index with, say, an xs:double of the same numeric value produced a
+      // different key and the lookup silently found nothing. (The RBTree backend never had this
+      // problem — CASValue#compareTo coerces both sides with asType before comparing.)
+      final CASValue value = new CASValue(atomic, indexDef.getContentType(), pcr);
 
       if (mode == SearchMode.EQUAL) {
         // Direct lookup

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -11,6 +11,7 @@ import io.sirix.index.ChangeListener;
 import io.sirix.index.IndexDef;
 import io.sirix.index.IndexFilterAxis;
 import io.sirix.index.SearchMode;
+import io.sirix.index.hot.AbstractHOTIndexReader;
 import io.sirix.index.hot.CASKeySerializer;
 import io.sirix.index.hot.HOTIndexReader;
 import io.sirix.index.redblacktree.RBNodeKey;
@@ -31,6 +32,8 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
 
 public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx & NodeCursor> {
   B createBuilder(R rtx, StorageEngineWriter storageEngineWriter, PathSummaryReader pathSummaryReader,
@@ -126,58 +129,45 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
     final HOTIndexReader<CASValue> reader =
         HOTIndexReader.create(storageEngineReader, CASKeySerializer.INSTANCE, indexDef.getType(), indexDef.getID());
 
-    // Bounded-cursor fast path: with exactly one PCR and both bounds present, the logical range
-    // is ONE contiguous composite-key range — CAS keys serialize PCR-major, so every composite
-    // between (min@pcr) and (max@pcr) carries that PCR and no per-entry PCR check is needed at
-    // all. The cursor seeks to the lower bound and stops at the upper bound, and thanks to the
-    // reader's lazy entry keys nothing in this loop deserializes a CASValue except the at-most-two
-    // boundary groups an exclusive bound must trim: the equal-to-min group can only be the FIRST
-    // emitted and the equal-to-max group only the LAST (logical keys are unique).
-    if (filter != null && filter.getPCRs().size() == 1 && filter.getMin() != null && filter.getMax() != null) {
-      final long pcr = filter.getPCRs().iterator().next();
-      final CASValue minValue = new CASValue(filter.getMin(), indexDef.getContentType(), pcr);
-      final CASValue maxValue = new CASValue(filter.getMax(), indexDef.getContentType(), pcr);
-      final boolean skipMin = !filter.isMinInclusive();
-      final boolean skipMax = !filter.isMaxInclusive();
-      final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIterator = reader.range(minValue, maxValue);
+    // Bounded-cursor fast path. Bound inclusivity is enforced INSIDE the cursor, on each group's
+    // logical key bytes: index keys are not prefix-free (a string value is raw UTF-8 with no
+    // terminator), so the composite byte window is wider than the logical range — "carpet" sorts
+    // below the ceiling built for "car" — and trimming positionally here would both admit those
+    // extensions and miss an equal group that is not first or last.
+    // Gated on the content type, not just on the bounds: the cursor decides a range by unsigned BYTE
+    // order over the serialized key, which is the value order only for the families
+    // CASKeySerializer encodes deliberately. The instant family (xs:dateTime/xs:date/xs:time) is
+    // stored as its raw lexical form, whose text order is NOT chronological order, so
+    // isByteOrderPreserving reports false for it and those queries fall through to the full scan
+    // below, which compares typed atomics via CASFilterRange#inRange.
+    if (filter != null && filter.getPCRs().size() == 1 && (filter.getMin() != null || filter.getMax() != null)
+        && CASKeySerializer.isByteOrderPreserving(indexDef.getContentType())) {
+      final Set<Long> pcrsRequested = filter.getPCRs();
+      final long pcr = pcrsRequested.iterator().next();
+      final Atomic min = filter.getMin();
+      final Atomic max = filter.getMax();
 
-      return new Iterator<>() {
-        private @Nullable NodeReferences next = null;
-        private boolean atFirst = true;
+      // Two-sided: the logical range is ONE contiguous composite range. CAS keys serialize
+      // PCR-major (the sign-flipped pathNodeKey is the first 8 bytes), so BOTH bounds pin the same
+      // PCR prefix and every key between them carries it — no per-entry PCR check is needed, and
+      // nothing in the scan deserializes a key at all.
+      if (min != null && max != null) {
+        return valuesOf(reader.range(new CASValue(min, indexDef.getContentType(), pcr),
+            new CASValue(max, indexDef.getContentType(), pcr), filter.isMinInclusive(), filter.isMaxInclusive()));
+      }
 
-        @Override
-        public boolean hasNext() {
-          if (next != null) {
-            return true;
-          }
-          while (rangeIterator.hasNext()) {
-            final Map.Entry<CASValue, NodeReferences> entry = rangeIterator.next();
-            final boolean atLast = !rangeIterator.hasNext();
-            if (atFirst) {
-              atFirst = false;
-              if (skipMin && entry.getKey().compareTo(minValue) == 0) {
-                continue;
-              }
-            }
-            if (skipMax && atLast && entry.getKey().compareTo(maxValue) == 0) {
-              continue;
-            }
-            next = entry.getValue();
-            return true;
-          }
-          return false;
-        }
-
-        @Override
-        public NodeReferences next() {
-          if (!hasNext()) {
-            throw new NoSuchElementException();
-          }
-          final NodeReferences result = next;
-          next = null;
-          return result;
-        }
-      };
+      // One-sided: only ONE end pins the PCR, so the open end runs straight off this PCR's key range
+      // into its neighbours' — a `>= min` cursor keeps going into every higher PCR, and a `<= max`
+      // cursor starts at the first key of the index, below every lower PCR. The check is therefore
+      // UNCONDITIONAL here. It is tempting to skip it when the path summary reports a single PCR,
+      // but the summary describes the paths at the QUERY revision while the index holds whatever
+      // every revision put there: a path node dropped and re-created takes a new pathNodeKey, and
+      // the stale postings under the old one live exactly at the open end. The check is cheap
+      // because it reads the PCR in place — it never materializes a key.
+      final Iterator<Map.Entry<CASValue, NodeReferences>> boundedIterator = min != null
+          ? reader.iteratorFrom(new CASValue(min, indexDef.getContentType(), pcr), filter.isMinInclusive())
+          : reader.iteratorTo(new CASValue(max, indexDef.getContentType(), pcr), filter.isMaxInclusive());
+      return valuesOfMatchingPCR(boundedIterator, pcrsRequested);
     }
 
     // Full scan with range filter applied
@@ -229,6 +219,119 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
   }
 
   /**
+   * Project a bounded index cursor to its posting lists. The cursor already enforced every bound, so
+   * this never touches a key — {@code LazyKeyEntry} keys stay undeserialized.
+   */
+  private static Iterator<NodeReferences> valuesOf(final Iterator<Map.Entry<CASValue, NodeReferences>> entries) {
+    // CloseForwardingIterator, not a bare Iterator: the underlying ChunkAggregatingIterator is
+    // AutoCloseable and documents that an abandoned scan MUST route through close(), because
+    // nothing else will. Erasing that here is what made the contract unreachable for every
+    // short-circuiting consumer (a positional predicate, fn:head, an early-exit filter).
+    return new CloseForwardingIterator(entries) {
+      @Override
+      public NodeReferences next() {
+        return entries.next().getValue();
+      }
+    };
+  }
+
+  /**
+   * Projects an entry iterator to its values while forwarding {@link AutoCloseable#close()} to the
+   * source when the source has one. Subclasses supply {@link #next()}.
+   */
+  abstract class CloseForwardingIterator implements Iterator<NodeReferences>, AutoCloseable {
+    private final Iterator<Map.Entry<CASValue, NodeReferences>> source;
+
+    CloseForwardingIterator(final Iterator<Map.Entry<CASValue, NodeReferences>> source) {
+      this.source = requireNonNull(source);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return source.hasNext();
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (source instanceof AutoCloseable closeable) {
+        closeable.close();
+      }
+    }
+  }
+
+  /**
+   * {@link #valuesOf} plus a per-entry path-class-record check, for the case where the requested PCRs
+   * could not be resolved up front and the index may hold several.
+   */
+  private static Iterator<NodeReferences> valuesOfMatchingPCR(
+      final Iterator<Map.Entry<CASValue, NodeReferences>> entries, final Set<Long> pcrs) {
+    // Unbox once, up front: the membership test runs per entry and Set<Long>#contains(long) boxes
+    // on every call. A PCR set holds one entry per indexed path, so a linear scan over a
+    // cache-resident long[] beats hashing it.
+    final long[] acceptedPCRs = new long[pcrs.size()];
+    int i = 0;
+    for (final Long pcr : pcrs) {
+      acceptedPCRs[i++] = pcr;
+    }
+    return new Iterator<>() {
+      private @Nullable NodeReferences next;
+
+      @Override
+      public boolean hasNext() {
+        if (next != null) {
+          return true;
+        }
+        while (entries.hasNext()) {
+          final Map.Entry<CASValue, NodeReferences> entry = entries.next();
+          if (containsPCR(acceptedPCRs, pathNodeKeyOf(entry))) {
+            next = entry.getValue();
+            return true;
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public NodeReferences next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        final NodeReferences result = next;
+        next = null;
+        return result;
+      }
+    };
+  }
+
+  /**
+   * The entry's path class record, without materializing its key where possible. The HOT readers emit
+   * {@link AbstractHOTIndexReader.RawKeyBytes} entries, whose serialized key already begins with the
+   * sign-flipped pathNodeKey — so this is an eight-byte read plus an XOR, against a full UTF-8 decode
+   * and four allocations per entry for {@code getKey()}. Any other entry shape falls back to the key
+   * itself.
+   */
+  private static long pathNodeKeyOf(final Map.Entry<CASValue, NodeReferences> entry) {
+    if (entry instanceof AbstractHOTIndexReader.RawKeyBytes raw && raw.rawKeyLength() >= Long.BYTES) {
+      return CASKeySerializer.pathNodeKeyAt(raw.rawKeyBytes(), 0);
+    }
+    final CASValue key = entry.getKey();
+    if (key == null) {
+      throw new IllegalStateException("index entry carries neither raw key bytes nor a decodable key");
+    }
+    return key.getPathNodeKey();
+  }
+
+  /** Primitive membership test over a tiny, unsorted PCR array — no boxing, no hashing. */
+  private static boolean containsPCR(final long[] acceptedPCRs, final long pcr) {
+    for (int i = 0, n = acceptedPCRs.length; i < n; i++) {
+      if (acceptedPCRs[i] == pcr) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Open HOT-based CAS index with filter.
    */
   private Iterator<NodeReferences> openHOTIndexWithFilter(StorageEngineReader storageEngineReader, IndexDef indexDef,
@@ -269,108 +372,42 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
         return Collections.emptyIterator();
       }
 
-      // With at most one PCR possible in the index and exactly that one requested, per-entry PCR
-      // checks are redundant — every entry carries it. If the single available PCR is NOT the
-      // requested one, no entry can match at all. Only an empty pcrsAvailable (PCR resolution
-      // came back empty) keeps the per-entry check. Skipping the check matters because the
-      // reader's entries deserialize their key lazily: a scan that never asks for the key never
-      // decodes a CASValue.
+      // If the single PCR the summary can resolve is NOT the requested one, no entry can match at
+      // all. Note this only ever SHORT-CIRCUITS a scan; it is never grounds for skipping the
+      // per-entry PCR check on a cursor that survives it, because the summary describes the query
+      // revision while the index holds every revision's postings (see the one-sided branch below).
       if (pcrsAvailable.size() == 1 && !pcrsRequested.containsAll(pcrsAvailable)) {
         return Collections.emptyIterator();
       }
-      final boolean pcrCheckPerEntry = pcrsAvailable.isEmpty();
 
-      // Range queries: use reader.iteratorFrom() for efficient starting position
-      if (mode == SearchMode.GREATER || mode == SearchMode.GREATER_OR_EQUAL) {
-        // Start from the key and iterate forward
-        Iterator<Map.Entry<CASValue, NodeReferences>> rangeIter = reader.iteratorFrom(value);
-
-        return new Iterator<>() {
-          private NodeReferences next = null;
-          private boolean skipFirst = (mode == SearchMode.GREATER); // Skip exact match for GREATER
-
-          @Override
-          public boolean hasNext() {
-            if (next != null) {
-              return true;
-            }
-            while (rangeIter.hasNext()) {
-              Map.Entry<CASValue, NodeReferences> entry = rangeIter.next();
-
-              // For GREATER mode, skip an exact match — only the FIRST emitted group can equal
-              // the probe (logical keys are unique and arrive in ascending order).
-              if (skipFirst) {
-                skipFirst = false;
-                if (entry.getKey().compareTo(value) == 0) {
-                  continue;
-                }
-              }
-
-              if (pcrCheckPerEntry && !pcrsRequested.contains(entry.getKey().getPathNodeKey())) {
-                continue;
-              }
-
-              next = entry.getValue();
-              return true;
-            }
-            return false;
-          }
-
-          @Override
-          public NodeReferences next() {
-            if (!hasNext()) {
-              throw new NoSuchElementException();
-            }
-            NodeReferences result = next;
-            next = null;
-            return result;
-          }
+      // Range queries: a bounded cursor seeks straight to the bound and stops at it. Inclusivity is
+      // the cursor's job (see the range-filter path above for why positional trimming is wrong), and
+      // with the PCR check hoisted out nothing in these scans deserializes a key at all. Same
+      // content-type gate as the range-filter path: byte order decides these bounds, so a type whose
+      // key bytes are its raw lexical form must use the typed comparison in the full scan instead.
+      if (CASKeySerializer.isByteOrderPreserving(indexDef.getContentType())) {
+        final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIter = switch (mode) {
+          case GREATER, GREATER_OR_EQUAL -> reader.iteratorFrom(value, mode == SearchMode.GREATER_OR_EQUAL);
+          case LOWER, LOWER_OR_EQUAL -> reader.iteratorTo(value, mode == SearchMode.LOWER_OR_EQUAL);
+          default -> null;
         };
+        if (rangeIter != null) {
+          // The PCR check is UNCONDITIONAL on these cursors, exactly as on the one-sided branch of
+          // openHOTIndexWithRangeFilter — see the reasoning there. Both of these are one-sided by
+          // construction, so only ONE end pins the PCR prefix and the open end runs straight into a
+          // neighbouring pathNodeKey's key range: `iteratorFrom` keeps going into every higher PCR,
+          // and `iteratorTo` starts at the first key of the index, below every lower one. Skipping
+          // the check when the path summary reports a single PCR (the old `pcrCheckPerEntry`
+          // shortcut) is unsound for the same reason it is unsound there: the summary describes the
+          // paths at the QUERY revision, while the index holds whatever every revision put there,
+          // so a path node dropped and re-created leaves stale postings under its old pathNodeKey —
+          // living precisely at the open end. The check reads the PCR in place and never
+          // materializes a key, so it is cheap.
+          return valuesOfMatchingPCR(rangeIter, pcrsRequested);
+        }
       }
-
-      if (mode == SearchMode.LOWER || mode == SearchMode.LOWER_OR_EQUAL) {
-        // Bounded cursor: stops AT the probe's composite ceiling instead of scanning the whole
-        // index and filtering. Every emitted key is <= value by construction; only LOWER (strict)
-        // must reject the equal group, and only the LAST emitted group can be it.
-        final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIter = reader.iteratorTo(value);
-        final boolean strict = mode == SearchMode.LOWER;
-
-        return new Iterator<>() {
-          private NodeReferences next = null;
-
-          @Override
-          public boolean hasNext() {
-            if (next != null) {
-              return true;
-            }
-            while (rangeIter.hasNext()) {
-              Map.Entry<CASValue, NodeReferences> entry = rangeIter.next();
-
-              if (strict && !rangeIter.hasNext() && entry.getKey().compareTo(value) == 0) {
-                continue;
-              }
-
-              if (pcrCheckPerEntry && !pcrsRequested.contains(entry.getKey().getPathNodeKey())) {
-                continue;
-              }
-
-              next = entry.getValue();
-              return true;
-            }
-            return false;
-          }
-
-          @Override
-          public NodeReferences next() {
-            if (!hasNext()) {
-              throw new NoSuchElementException();
-            }
-            NodeReferences result = next;
-            next = null;
-            return result;
-          }
-        };
-      }
+      // Not byte-order-preserving (or an EQUAL probe): fall through to the full scan below, which
+      // compares typed atomics via CASFilterRange#inRange.
     }
 
     // Fall back to full scan with filter (when no specific PCR or no atomic key)

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -413,25 +413,27 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
    */
   private static @Nullable NodeReferences exactMatches(final StorageEngineReader storageEngineReader,
       final NodeReferences candidates, final Atomic wanted, final Type contentType) {
-    final byte[] wantedBytes = wanted.stringValue().getBytes(StandardCharsets.UTF_8);
-    // Which comparison to use is a property of the INDEX, not of the candidate's node kind. A numeric
-    // index stores its values through a narrowing encoder, and the SAME logical number reaches the
-    // re-check as a NumericValueNode in JSON and as raw lexical bytes in XML — so dispatching on the
-    // node would compare "19.990" against "19.99" for the XML case and drop a row that matches.
-    // Hoisted out of the loop as well: it is the same for every candidate, and the sibling
-    // wantedBytes was already hoisted for exactly that reason.
-    final BigDecimal wantedNumber = CASKeySerializer.isNumericFamily(contentType)
+    if (storageEngineReader.hasTrxIntentLog()) {
+      return candidates; // writer-backed: cannot be shadowed, and must not be borrowed — see above
+    }
+    // ONE type dispatch, not two. isNumericFamily walks Type#instanceOf's parent chain, which
+    // getTypeId's own comment calls a pointer chase worth ordering by frequency, and the answer is
+    // loop-invariant. Two calls also coupled the branches by convention alone: editing one to a
+    // different type would have silently changed what the null check below meant.
+    final boolean numeric = CASKeySerializer.isNumericFamily(contentType);
+    final BigDecimal wantedNumber = numeric
         ? parseOrNull(wanted.stringValue())
         : null;
-    if (CASKeySerializer.isNumericFamily(contentType) && wantedNumber == null) {
+    if (numeric && wantedNumber == null) {
       // A numeric probe that is not a finite number — NaN or an infinity. The encoder canonicalizes
       // NaN onto a real value's key, so the seek's posting list is other values entirely; and XQuery
       // gives NaN no equals, so the answer is empty rather than that posting list.
       return null;
     }
-    if (storageEngineReader.hasTrxIntentLog()) {
-      return candidates; // writer-backed: cannot be shadowed, and must not be borrowed — see above
-    }
+    // Built only where it is read. matchesExactly consults it on the lexical path, and on the
+    // numeric path only to short-circuit an exact byte hit, so a numeric index still needs it — but
+    // a writer-backed reader, which returned above, now allocates neither this nor the BigDecimal.
+    final byte[] wantedBytes = wanted.stringValue().getBytes(StandardCharsets.UTF_8);
     final long candidateCount = candidates.cardinality();
     // GROWN, not sized from the cardinality. A posting list is unbounded — a value shared by a
     // 246-byte prefix across millions of documents is exactly what drives a probe into this method —
@@ -493,16 +495,24 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
    */
   private static boolean matchesExactly(final DataRecord record, final byte[] wantedBytes,
       final @Nullable BigDecimal wantedNumber) {
+    // BYTES FIRST, on both paths, because byte-identical settles a match either way and this runs
+    // once per candidate. The numeric branch below allocates a String and a BigDecimal per candidate
+    // and then parses a decimal, while the overwhelmingly common case is that the stored lexical
+    // bytes are exactly the probe's — so the vectorized Arrays.equals answers nearly every candidate
+    // and the decimal machinery is left for the case it exists to handle, where 1.50 must still match
+    // a probe of 1.5.
+    if (record instanceof final ValueNode valueNode && Arrays.equals(valueNode.getRawValue(), wantedBytes)) {
+      return true;
+    }
     if (wantedNumber != null) {
-      // Numeric index: compare NUMBERS, whatever shape the node stores them in. 1.50 and 1.5 are the
-      // same value and must both match a probe of 1.5; a lexical comparison would drop one of them.
+      // Numeric index: compare NUMBERS, whatever shape the node stores them in. The same logical
+      // number reaches here as a NumericValueNode in JSON and as raw lexical bytes in XML, and 1.50
+      // and 1.5 are one value — a byte comparison alone would drop rows for both reasons.
       final BigDecimal stored = storedNumber(record);
       return stored == null || stored.compareTo(wantedNumber) == 0;
     }
-    if (record instanceof final ValueNode valueNode) {
-      return Arrays.equals(valueNode.getRawValue(), wantedBytes);
-    }
-    return true;
+    // A lexical index whose bytes did not match is a non-match; anything this cannot read is KEPT.
+    return !(record instanceof ValueNode);
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndex.java
@@ -21,6 +21,7 @@ import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.settings.Fixed;
 import io.brackit.query.atomic.Atomic;
 import io.sirix.index.path.summary.PathSummaryReader;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -125,6 +126,60 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
     final HOTIndexReader<CASValue> reader =
         HOTIndexReader.create(storageEngineReader, CASKeySerializer.INSTANCE, indexDef.getType(), indexDef.getID());
 
+    // Bounded-cursor fast path: with exactly one PCR and both bounds present, the logical range
+    // is ONE contiguous composite-key range — CAS keys serialize PCR-major, so every composite
+    // between (min@pcr) and (max@pcr) carries that PCR and no per-entry PCR check is needed at
+    // all. The cursor seeks to the lower bound and stops at the upper bound, and thanks to the
+    // reader's lazy entry keys nothing in this loop deserializes a CASValue except the at-most-two
+    // boundary groups an exclusive bound must trim: the equal-to-min group can only be the FIRST
+    // emitted and the equal-to-max group only the LAST (logical keys are unique).
+    if (filter != null && filter.getPCRs().size() == 1 && filter.getMin() != null && filter.getMax() != null) {
+      final long pcr = filter.getPCRs().iterator().next();
+      final CASValue minValue = new CASValue(filter.getMin(), indexDef.getContentType(), pcr);
+      final CASValue maxValue = new CASValue(filter.getMax(), indexDef.getContentType(), pcr);
+      final boolean skipMin = !filter.isMinInclusive();
+      final boolean skipMax = !filter.isMaxInclusive();
+      final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIterator = reader.range(minValue, maxValue);
+
+      return new Iterator<>() {
+        private @Nullable NodeReferences next = null;
+        private boolean atFirst = true;
+
+        @Override
+        public boolean hasNext() {
+          if (next != null) {
+            return true;
+          }
+          while (rangeIterator.hasNext()) {
+            final Map.Entry<CASValue, NodeReferences> entry = rangeIterator.next();
+            final boolean atLast = !rangeIterator.hasNext();
+            if (atFirst) {
+              atFirst = false;
+              if (skipMin && entry.getKey().compareTo(minValue) == 0) {
+                continue;
+              }
+            }
+            if (skipMax && atLast && entry.getKey().compareTo(maxValue) == 0) {
+              continue;
+            }
+            next = entry.getValue();
+            return true;
+          }
+          return false;
+        }
+
+        @Override
+        public NodeReferences next() {
+          if (!hasNext()) {
+            throw new NoSuchElementException();
+          }
+          final NodeReferences result = next;
+          next = null;
+          return result;
+        }
+      };
+    }
+
     // Full scan with range filter applied
     final Iterator<Map.Entry<CASValue, NodeReferences>> entryIterator = reader.iterator();
     final CASFilterRange rangeFilter = filter;
@@ -214,6 +269,17 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
         return Collections.emptyIterator();
       }
 
+      // With at most one PCR possible in the index and exactly that one requested, per-entry PCR
+      // checks are redundant — every entry carries it. If the single available PCR is NOT the
+      // requested one, no entry can match at all. Only an empty pcrsAvailable (PCR resolution
+      // came back empty) keeps the per-entry check. Skipping the check matters because the
+      // reader's entries deserialize their key lazily: a scan that never asks for the key never
+      // decodes a CASValue.
+      if (pcrsAvailable.size() == 1 && !pcrsRequested.containsAll(pcrsAvailable)) {
+        return Collections.emptyIterator();
+      }
+      final boolean pcrCheckPerEntry = pcrsAvailable.isEmpty();
+
       // Range queries: use reader.iteratorFrom() for efficient starting position
       if (mode == SearchMode.GREATER || mode == SearchMode.GREATER_OR_EQUAL) {
         // Start from the key and iterate forward
@@ -230,17 +296,61 @@ public interface CASIndex<B, L extends ChangeListener, R extends NodeReadOnlyTrx
             }
             while (rangeIter.hasNext()) {
               Map.Entry<CASValue, NodeReferences> entry = rangeIter.next();
-              CASValue key = entry.getKey();
 
-              // For GREATER mode, skip exact match
-              if (skipFirst && key.compareTo(value) == 0) {
+              // For GREATER mode, skip an exact match — only the FIRST emitted group can equal
+              // the probe (logical keys are unique and arrive in ascending order).
+              if (skipFirst) {
                 skipFirst = false;
+                if (entry.getKey().compareTo(value) == 0) {
+                  continue;
+                }
+              }
+
+              if (pcrCheckPerEntry && !pcrsRequested.contains(entry.getKey().getPathNodeKey())) {
                 continue;
               }
-              skipFirst = false;
 
-              // Check PCR
-              if (!pcrsRequested.isEmpty() && !pcrsRequested.contains(key.getPathNodeKey())) {
+              next = entry.getValue();
+              return true;
+            }
+            return false;
+          }
+
+          @Override
+          public NodeReferences next() {
+            if (!hasNext()) {
+              throw new NoSuchElementException();
+            }
+            NodeReferences result = next;
+            next = null;
+            return result;
+          }
+        };
+      }
+
+      if (mode == SearchMode.LOWER || mode == SearchMode.LOWER_OR_EQUAL) {
+        // Bounded cursor: stops AT the probe's composite ceiling instead of scanning the whole
+        // index and filtering. Every emitted key is <= value by construction; only LOWER (strict)
+        // must reject the equal group, and only the LAST emitted group can be it.
+        final Iterator<Map.Entry<CASValue, NodeReferences>> rangeIter = reader.iteratorTo(value);
+        final boolean strict = mode == SearchMode.LOWER;
+
+        return new Iterator<>() {
+          private NodeReferences next = null;
+
+          @Override
+          public boolean hasNext() {
+            if (next != null) {
+              return true;
+            }
+            while (rangeIter.hasNext()) {
+              Map.Entry<CASValue, NodeReferences> entry = rangeIter.next();
+
+              if (strict && !rangeIter.hasNext() && entry.getKey().compareTo(value) == 0) {
+                continue;
+              }
+
+              if (pcrCheckPerEntry && !pcrsRequested.contains(entry.getKey().getPathNodeKey())) {
                 continue;
               }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
@@ -6,6 +6,7 @@ import io.sirix.exception.SirixIOException;
 import io.sirix.exception.SirixRuntimeException;
 import io.sirix.index.AtomicUtil;
 import io.sirix.index.SearchMode;
+import io.sirix.index.hot.HOTBulkIndexLoader;
 import io.sirix.index.hot.HOTIndexWriter;
 import io.sirix.index.redblacktree.RBTreeReader;
 import io.sirix.index.redblacktree.RBTreeWriter;
@@ -26,6 +27,7 @@ import io.brackit.query.jdm.Type;
 import io.brackit.query.util.path.Path;
 import io.brackit.query.util.path.PathException;
 import io.sirix.index.path.summary.PathSummaryReader;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +51,17 @@ public final class CASIndexBuilder {
   private final Type type;
   private final boolean useHOT;
 
+  /** Path-class records covered by {@link #paths}, resolved lazily on the first indexed node. */
+  private @Nullable LongSet resolvedPCRs;
+
+  /**
+   * Bulk loader for the HOT backend, non-{@code null} exactly when this builder starts against an
+   * empty index tree — the normal "create an index over an already-shredded revision" case. Every
+   * entry is collected and the trie is materialised once in {@link #finish()}; see
+   * {@link HOTBulkIndexLoader} for why that is not the same cost as n incremental inserts.
+   */
+  private final @Nullable HOTBulkIndexLoader<CASValue> bulkLoader;
+
   /**
    * Constructor with RBTree writer (legacy path).
    */
@@ -60,6 +73,7 @@ public final class CASIndexBuilder {
     this.hotWriter = null;
     this.type = type;
     this.useHOT = false;
+    this.bulkLoader = null;
   }
 
   /**
@@ -73,11 +87,15 @@ public final class CASIndexBuilder {
     this.hotWriter = hotWriter;
     this.type = type;
     this.useHOT = true;
+    // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into
+    // it, so an index that already holds entries (a rebuild over a populated definition) keeps
+    // the incremental path.
+    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
   }
 
   public VisitResult process(final ImmutableNode node, final long pathNodeKey) {
     try {
-      if (paths.isEmpty() || pathSummaryReader.getPCRsForPaths(paths).contains(pathNodeKey)) {
+      if (matchesIndexedPath(pathNodeKey)) {
         final Str strValue = switch (node) {
           case ImmutableValueNode immutableValueNode -> new Str(immutableValueNode.getValue());
           case ImmutableNumberNode immutableNumberNode -> new Str(String.valueOf(immutableNumberNode.getValue()));
@@ -117,6 +135,27 @@ public final class CASIndexBuilder {
     return VisitResultType.CONTINUE;
   }
 
+  /**
+   * Whether {@code pathNodeKey} is one of the path-class records this index covers. An empty path
+   * configuration means "index every path".
+   *
+   * <p>The resolved PCR set is computed once and reused: the builder runs a single traversal of an
+   * already-shredded revision, so the path summary cannot gain nodes underneath it, and
+   * {@link PathSummaryReader#getPCRsForPaths(java.util.Collection)} allocates and fills a fresh
+   * {@code LongOpenHashSet} on every call — once per value node, on the build hot path.</p>
+   */
+  private boolean matchesIndexedPath(final long pathNodeKey) {
+    if (paths.isEmpty()) {
+      return true;
+    }
+    LongSet pcrs = resolvedPCRs;
+    if (pcrs == null) {
+      pcrs = pathSummaryReader.getPCRsForPaths(paths);
+      resolvedPCRs = pcrs;
+    }
+    return pcrs.contains(pathNodeKey);
+  }
+
   private void processRBTree(final ImmutableNode node, final CASValue value) throws SirixIOException {
     assert rbTreeWriter != null;
     final Optional<NodeReferences> textReferences = rbTreeWriter.get(value, SearchMode.EQUAL);
@@ -127,13 +166,33 @@ public final class CASIndexBuilder {
     }
   }
 
+  /**
+   * Add {@code node} to {@code value}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one
+   * ({@code HOTLeafPage#mergeWithNodeRefs}), so adding one reference needs neither a read-back of
+   * the stored references nor a re-insert of them. Doing so made building an index quadratic in
+   * the number of nodes sharing a value: the n-th occurrence of a value range-scanned that value's
+   * chunks and then re-inserted all n-1 node keys already stored, each through a full trie descent
+   * — on a corpus where a value repeats k times, k(k+1)/2 slot writes instead of k.</p>
+   */
   private void processHOT(final ImmutableNode node, final CASValue value) throws SirixIOException {
     assert hotWriter != null;
-    NodeReferences existingRefs = hotWriter.get(value, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(node, existingRefs, value);
+    if (bulkLoader != null) {
+      bulkLoader.add(value, node.getNodeKey());
     } else {
-      setNodeReferencesHOT(node, new NodeReferences(), value);
+      hotWriter.indexNodeKey(value, node.getNodeKey());
+    }
+  }
+
+  /**
+   * Materialise everything the traversal collected. Must be called exactly once, after the
+   * document traversal that feeds {@link #process} has finished; a no-op unless this builder is
+   * bulk-loading.
+   */
+  public void finish() {
+    if (bulkLoader != null) {
+      bulkLoader.flush();
     }
   }
 
@@ -143,9 +202,4 @@ public final class CASIndexBuilder {
     rbTreeWriter.index(value, references.addNodeKey(node.getNodeKey()), RBTreeReader.MoveCursor.NO_MOVE);
   }
 
-  private void setNodeReferencesHOT(final ImmutableNode node, final NodeReferences references, final CASValue value)
-      throws SirixIOException {
-    assert hotWriter != null;
-    hotWriter.index(value, references.addNodeKey(node.getNodeKey()), RBTreeReader.MoveCursor.NO_MOVE);
-  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
@@ -22,6 +22,7 @@ import io.sirix.node.json.ObjectNamedStringNode;
 import io.sirix.settings.Constants;
 import io.sirix.utils.LogWrapper;
 import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Type;
 import io.brackit.query.util.path.Path;
@@ -110,10 +111,19 @@ public final class CASIndexBuilder {
           case null, default -> throw new IllegalStateException("Value not supported.");
         };
 
+        // KEEP the conversion, do not merely validate with it. Storing the raw Str while the query
+        // side casts its probe to the content type gave the serializer TWO shapes for one logical
+        // value, and every reconciliation it grew for that was a bug: xs:boolean read a Str through
+        // effective-boolean-value and mapped true and false onto one key, xs:float parsed the Str as
+        // a double while the probe narrowed through float, and an out-of-range xs:integer saturated
+        // on this side while the probe wrapped. One shape per type makes that class of defect
+        // unrepresentable rather than fixed case by case.
+        Atomic typedValue = strValue;
         boolean isOfType = false;
         try {
-          if (type != Type.STR)
-            AtomicUtil.toType(strValue, type);
+          if (type != Type.STR) {
+            typedValue = AtomicUtil.toType(strValue, type);
+          }
           isOfType = true;
         } catch (final SirixRuntimeException e) {
           LOGGER.debug("Value '{}' is not of type {}, skipping CAS index entry for node {}", strValue, type,
@@ -121,7 +131,7 @@ public final class CASIndexBuilder {
         }
 
         if (isOfType) {
-          final CASValue value = new CASValue(strValue, type, pathNodeKey);
+          final CASValue value = new CASValue(typedValue, type, pathNodeKey);
           if (useHOT) {
             processHOT(node, value);
           } else {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
@@ -90,7 +90,9 @@ public final class CASIndexBuilder {
     // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into
     // it, so an index that already holds entries (a rebuild over a populated definition) keeps
     // the incremental path.
-    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
+    this.bulkLoader = hotWriter.isEmptyTree()
+        ? hotWriter.createBulkLoader()
+        : null;
   }
 
   public VisitResult process(final ImmutableNode node, final long pathNodeKey) {
@@ -101,10 +103,8 @@ public final class CASIndexBuilder {
           case ImmutableNumberNode immutableNumberNode -> new Str(String.valueOf(immutableNumberNode.getValue()));
           case ImmutableBooleanNode immutableBooleanNode -> new Str(String.valueOf(immutableBooleanNode.getValue()));
           // Fused kinds carry primitive values inline.
-          case ObjectNamedNumberNode namedNum ->
-            new Str(String.valueOf(namedNum.getValue()));
-          case ObjectNamedBooleanNode namedBool ->
-            new Str(String.valueOf(namedBool.getValue()));
+          case ObjectNamedNumberNode namedNum -> new Str(String.valueOf(namedNum.getValue()));
+          case ObjectNamedBooleanNode namedBool -> new Str(String.valueOf(namedBool.getValue()));
           case ObjectNamedStringNode namedStr ->
             new Str(new String(namedStr.getRawValue(), Constants.DEFAULT_ENCODING));
           case null, default -> throw new IllegalStateException("Value not supported.");
@@ -116,8 +116,8 @@ public final class CASIndexBuilder {
             AtomicUtil.toType(strValue, type);
           isOfType = true;
         } catch (final SirixRuntimeException e) {
-          LOGGER.debug("Value '{}' is not of type {}, skipping CAS index entry for node {}",
-              strValue, type, node.getNodeKey(), e);
+          LOGGER.debug("Value '{}' is not of type {}, skipping CAS index entry for node {}", strValue, type,
+              node.getNodeKey(), e);
         }
 
         if (isOfType) {
@@ -139,10 +139,12 @@ public final class CASIndexBuilder {
    * Whether {@code pathNodeKey} is one of the path-class records this index covers. An empty path
    * configuration means "index every path".
    *
-   * <p>The resolved PCR set is computed once and reused: the builder runs a single traversal of an
+   * <p>
+   * The resolved PCR set is computed once and reused: the builder runs a single traversal of an
    * already-shredded revision, so the path summary cannot gain nodes underneath it, and
    * {@link PathSummaryReader#getPCRsForPaths(java.util.Collection)} allocates and fills a fresh
-   * {@code LongOpenHashSet} on every call — once per value node, on the build hot path.</p>
+   * {@code LongOpenHashSet} on every call — once per value node, on the build hot path.
+   * </p>
    */
   private boolean matchesIndexedPath(final long pathNodeKey) {
     if (paths.isEmpty()) {
@@ -169,12 +171,14 @@ public final class CASIndexBuilder {
   /**
    * Add {@code node} to {@code value}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one
-   * ({@code HOTLeafPage#mergeWithNodeRefs}), so adding one reference needs neither a read-back of
-   * the stored references nor a re-insert of them. Doing so made building an index quadratic in
-   * the number of nodes sharing a value: the n-th occurrence of a value range-scanned that value's
-   * chunks and then re-inserted all n-1 node keys already stored, each through a full trie descent
-   * — on a corpus where a value repeats k times, k(k+1)/2 slot writes instead of k.</p>
+   * <p>
+   * A HOT slot write is an OR-merge of the incoming bitmap into the stored one
+   * ({@code HOTLeafPage#mergeWithNodeRefs}), so adding one reference needs neither a read-back of the
+   * stored references nor a re-insert of them. Doing so made building an index quadratic in the
+   * number of nodes sharing a value: the n-th occurrence of a value range-scanned that value's chunks
+   * and then re-inserted all n-1 node keys already stored, each through a full trie descent — on a
+   * corpus where a value repeats k times, k(k+1)/2 slot writes instead of k.
+   * </p>
    */
   private void processHOT(final ImmutableNode node, final CASValue value) throws SirixIOException {
     assert hotWriter != null;
@@ -186,9 +190,8 @@ public final class CASIndexBuilder {
   }
 
   /**
-   * Materialise everything the traversal collected. Must be called exactly once, after the
-   * document traversal that feeds {@link #process} has finished; a no-op unless this builder is
-   * bulk-loading.
+   * Materialise everything the traversal collected. Must be called exactly once, after the document
+   * traversal that feeds {@link #process} has finished; a no-op unless this builder is bulk-loading.
    */
   public void finish() {
     if (bulkLoader != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
@@ -109,8 +109,7 @@ public final class CASIndexListener {
       AtomicUtil.toType(value, type);
       isOfType = true;
     } catch (final SirixRuntimeException e) {
-      logger.debug("Value '{}' is not of type {}, skipping CAS index insert for node {}",
-          value, type, nodeKey, e);
+      logger.debug("Value '{}' is not of type {}, skipping CAS index insert for node {}", value, type, nodeKey, e);
     }
 
     if (isOfType) {
@@ -136,10 +135,12 @@ public final class CASIndexListener {
   /**
    * Add {@code nodeKey} to {@code indexValue}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
-   * already recorded for {@code indexValue} need neither be read back nor re-inserted — doing so
-   * cost one range scan plus one full trie descent per already-stored node key, making a bulk
-   * insert of k nodes sharing a value quadratic in k.</p>
+   * <p>
+   * A HOT slot write OR-merges the incoming bitmap into the stored one, so the references already
+   * recorded for {@code indexValue} need neither be read back nor re-inserted — doing so cost one
+   * range scan plus one full trie descent per already-stored node key, making a bulk insert of k
+   * nodes sharing a value quadratic in k.
+   * </p>
    */
   private void insertHOT(final long nodeKey, final CASValue indexValue) {
     assert hotWriter != null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
@@ -133,14 +133,17 @@ public final class CASIndexListener {
     }
   }
 
+  /**
+   * Add {@code nodeKey} to {@code indexValue}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
+   * already recorded for {@code indexValue} need neither be read back nor re-inserted — doing so
+   * cost one range scan plus one full trie descent per already-stored node key, making a bulk
+   * insert of k nodes sharing a value quadratic in k.</p>
+   */
   private void insertHOT(final long nodeKey, final CASValue indexValue) {
     assert hotWriter != null;
-    NodeReferences existingRefs = hotWriter.get(indexValue, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(nodeKey, new NodeReferences(existingRefs.getNodeKeys()), indexValue);
-    } else {
-      setNodeReferencesHOT(nodeKey, new NodeReferences(), indexValue);
-    }
+    hotWriter.indexNodeKey(indexValue, nodeKey);
   }
 
   private void setNodeReferencesRBTree(final long nodeKey, final NodeReferences references, final CASValue indexValue) {
@@ -148,8 +151,4 @@ public final class CASIndexListener {
     rbTreeWriter.index(indexValue, references.addNodeKey(nodeKey), RBTreeReader.MoveCursor.NO_MOVE);
   }
 
-  private void setNodeReferencesHOT(final long nodeKey, final NodeReferences references, final CASValue indexValue) {
-    assert hotWriter != null;
-    hotWriter.index(indexValue, references.addNodeKey(nodeKey), RBTreeReader.MoveCursor.NO_MOVE);
-  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexListener.java
@@ -12,6 +12,7 @@ import io.sirix.index.redblacktree.keyvalue.CASValue;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
 import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Str;
 import io.brackit.query.jdm.Type;
 import io.brackit.query.util.path.Path;
@@ -88,7 +89,14 @@ public final class CASIndexListener {
       }
       case DELETE -> {
         if (paths.isEmpty() || pathSummaryReader.getPCRsForPaths(paths).contains(pathNodeKey)) {
-          CASValue casValue = new CASValue(value, this.type, pathNodeKey);
+          // Converted exactly as insert() converts, because the two must build the SAME key or the
+          // delete misses the entry it is meant to remove. A value that does not convert was never
+          // indexed, so there is nothing to remove and skipping is right.
+          final Atomic typedValue = toTypedOrNull(value, nodeKey);
+          if (typedValue == null) {
+            return;
+          }
+          final CASValue casValue = new CASValue(typedValue, this.type, pathNodeKey);
           if (useHOT) {
             assert hotWriter != null;
             hotWriter.remove(casValue, nodeKey);
@@ -103,17 +111,37 @@ public final class CASIndexListener {
     }
   }
 
-  private void insert(final long nodeKey, final long pathNodeKey, final Str value) throws SirixIOException {
-    boolean isOfType = false;
-    try {
-      AtomicUtil.toType(value, type);
-      isOfType = true;
-    } catch (final SirixRuntimeException e) {
-      logger.debug("Value '{}' is not of type {}, skipping CAS index insert for node {}", value, type, nodeKey, e);
+  /**
+   * {@code value} as the index's content type, or {@code null} when it is not of that type.
+   *
+   * <p>
+   * The conversion is KEPT rather than discarded, so the stored key is built from the same shape the
+   * query side probes with — see {@code CASIndexBuilder#process} for the three bugs the two-shape
+   * arrangement produced.
+   * </p>
+   *
+   * @param value the node's lexical value
+   * @param nodeKey the node, for the diagnostic only
+   * @return the typed value, or {@code null} to skip this node
+   */
+  private @Nullable Atomic toTypedOrNull(final Str value, final long nodeKey) {
+    if (type == Type.STR) {
+      return value;
     }
+    try {
+      return AtomicUtil.toType(value, type);
+    } catch (final SirixRuntimeException e) {
+      logger.debug("Value '{}' is not of type {}, skipping CAS index entry for node {}", value, type, nodeKey, e);
+      return null;
+    }
+  }
+
+  private void insert(final long nodeKey, final long pathNodeKey, final Str value) throws SirixIOException {
+    final Atomic typedValue = toTypedOrNull(value, nodeKey);
+    final boolean isOfType = typedValue != null;
 
     if (isOfType) {
-      final CASValue indexValue = new CASValue(value, type, pathNodeKey);
+      final CASValue indexValue = new CASValue(typedValue, type, pathNodeKey);
       if (useHOT) {
         insertHOT(nodeKey, indexValue);
       } else {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/json/JsonCASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/json/JsonCASIndexBuilder.java
@@ -3,6 +3,7 @@ package io.sirix.index.cas.json;
 import io.sirix.access.trx.node.json.AbstractJsonNodeVisitor;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.visitor.VisitResult;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.cas.CASIndexBuilder;
 import io.sirix.node.NodeKind;
 import io.sirix.node.immutable.json.ImmutableArrayNode;
@@ -21,7 +22,7 @@ import io.sirix.node.json.ObjectNamedStringNode;
  *
  * @author Johannes Lichtenberger
  */
-final class JsonCASIndexBuilder extends AbstractJsonNodeVisitor {
+final class JsonCASIndexBuilder extends AbstractJsonNodeVisitor implements IndexBuildFinalizer {
 
   private final CASIndexBuilder indexBuilderDelegate;
 
@@ -70,6 +71,11 @@ final class JsonCASIndexBuilder extends AbstractJsonNodeVisitor {
   @Override
   public VisitResult visit(final ObjectNamedBooleanNode node) {
     return indexBuilderDelegate.process(node, node.getPathNodeKey());
+  }
+
+  @Override
+  public void finishIndexBuild() {
+    indexBuilderDelegate.finish();
   }
 
   private long getPathClassRecord(ImmutableNode node) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/xml/XmlCASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/xml/XmlCASIndexBuilder.java
@@ -3,6 +3,7 @@ package io.sirix.index.cas.xml;
 import io.sirix.api.visitor.VisitResult;
 import io.sirix.api.xml.XmlNodeReadOnlyTrx;
 import io.sirix.access.trx.node.xml.AbstractXmlNodeVisitor;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.cas.CASIndexBuilder;
 import io.sirix.node.immutable.xml.ImmutableAttributeNode;
 import io.sirix.node.immutable.xml.ImmutableText;
@@ -13,7 +14,7 @@ import io.sirix.node.immutable.xml.ImmutableText;
  * @author Johannes Lichtenberger
  *
  */
-final class XmlCASIndexBuilder extends AbstractXmlNodeVisitor {
+final class XmlCASIndexBuilder extends AbstractXmlNodeVisitor implements IndexBuildFinalizer {
 
   private final CASIndexBuilder mIndexBuilderDelegate;
 
@@ -41,6 +42,11 @@ final class XmlCASIndexBuilder extends AbstractXmlNodeVisitor {
         : mRtx.getNameNode().getPathNodeKey();
 
     return mIndexBuilderDelegate.process(node, PCR);
+  }
+
+  @Override
+  public void finishIndexBuild() {
+    mIndexBuilderDelegate.finish();
   }
 
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntComparator;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Accumulating bulk loader for a HOT secondary index that is being built from scratch.
+ *
+ * <p>Building an index over an already-shredded revision is a bulk load, not a sequence of
+ * updates: every {@code (key, nodeKey)} pair is known before the first byte is written. Feeding
+ * them through the incremental-insert path one at a time makes the trie pay that path's machinery
+ * — a descent, a merge-vs-branch decision and, whenever a fold leaves a node malformed, a scoped
+ * {@link HOTBulkBuilder} rebuild of the touched subtree — per entry. The rebuilds are what hurt:
+ * each is {@code O(subtree)}, and a build of n entries triggers them in proportion to n, so index
+ * construction grows super-linearly.</p>
+ *
+ * <p>This loader instead collects the pairs, sorts them once, folds the node keys that share a
+ * chunk slot into one Roaring bitmap, and hands the result to {@link HOTBulkBuilder#build} — a
+ * single {@code Θ(n)} construction whose output is invariant-clean by construction, so no
+ * self-heal ever runs. The tree it produces is the tree the incremental path converges to.</p>
+ *
+ * <h2>Layout</h2>
+ * <p>Keys live in one growable byte arena addressed by {@code (start, length)} pairs rather than
+ * in a {@code byte[]} per entry: an index build over millions of nodes would otherwise pay a
+ * 16-byte object header and a separate allocation for every key. Node keys live in a parallel
+ * {@code long[]}. Sorting permutes an {@code int[]} of entry ids, never the payload.</p>
+ *
+ * <h2>Memory</h2>
+ * <p>A bulk load is not streaming: the whole entry set is resident until {@link #flush()} hands it
+ * to the builder, which is the price of a single-pass canonical construction. The arena layout
+ * keeps that to roughly {@code n × (key bytes + 16)} while accumulating; {@code flush} then
+ * materialises one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot. The buffers are
+ * dropped as soon as the tree is spliced.</p>
+ *
+ * <h2>Threading</h2>
+ * <p>Not thread-safe; a loader belongs to the single traversal that feeds it.</p>
+ *
+ * <p>Subclasses supply the key encoding only — {@link HOTBulkIndexLoader} for object keys
+ * (CAS, NAME), {@link HOTLongBulkIndexLoader} for the PATH index's primitive long keys, which
+ * would otherwise box once per indexed node.</p>
+ *
+ * @author Johannes Lichtenberger
+ */
+abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOTLongBulkIndexLoader {
+
+  /** Initial arena capacity in bytes — grown by doubling. */
+  private static final int INITIAL_ARENA_BYTES = 64 * 1024;
+
+  /** Initial entry capacity — grown by doubling. */
+  private static final int INITIAL_ENTRIES = 1024;
+
+  /**
+   * Upper bound on one serialized composite key. Mirrors {@link HOTIndexWriter}'s thread-local key
+   * buffer: the largest CAS prefix (10-byte header + 246 value bytes) plus the 4-byte chunkIdx
+   * trailer, rounded up for headroom. PATH's composite key is a fixed 12 bytes.
+   */
+  private static final int MAX_COMPOSITE_KEY_BYTES = 512;
+
+  /** The index whose root this loader replaces on {@link #flush()}. */
+  private final AbstractHOTIndexWriter<?> writer;
+
+  /** Composite key bytes, back to back. */
+  private byte[] arena = new byte[INITIAL_ARENA_BYTES];
+
+  /** Bytes used in {@link #arena}. */
+  private int arenaLength;
+
+  /** Start offset in {@link #arena} of entry {@code i}. */
+  private int[] keyStart = new int[INITIAL_ENTRIES];
+
+  /** Length in {@link #arena} of entry {@code i}'s composite key. */
+  private int[] keyLength = new int[INITIAL_ENTRIES];
+
+  /** The node key of entry {@code i}. */
+  private long[] nodeKeys = new long[INITIAL_ENTRIES];
+
+  /** Number of accumulated entries. */
+  private int count;
+
+  /** Set once {@link #flush()} has run, so a second flush cannot re-splice the tree. */
+  private boolean flushed;
+
+  AbstractHOTBulkIndexLoader(final AbstractHOTIndexWriter<?> writer) {
+    this.writer = requireNonNull(writer, "writer");
+  }
+
+  /**
+   * Make room for one more composite key and hand back the arena to serialize into. The write
+   * must start at {@link #arenaOffset()} and be committed with {@link #commitKey(int, long)}.
+   *
+   * @param nodeKey the node key the key being written belongs to; validated here so a subclass
+   *        never serializes a key it would have to roll back
+   * @return the arena, guaranteed to have {@link #MAX_COMPOSITE_KEY_BYTES} free from
+   *         {@link #arenaOffset()}
+   */
+  final byte[] reserveKeySpace(final long nodeKey) {
+    if (flushed) {
+      throw new IllegalStateException("Bulk loader already flushed");
+    }
+    AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
+
+    if (arenaLength + MAX_COMPOSITE_KEY_BYTES > arena.length) {
+      arena = Arrays.copyOf(arena, Math.max(arena.length << 1, arenaLength + MAX_COMPOSITE_KEY_BYTES));
+    }
+    if (count == keyStart.length) {
+      final int newCapacity = keyStart.length << 1;
+      keyStart = Arrays.copyOf(keyStart, newCapacity);
+      keyLength = Arrays.copyOf(keyLength, newCapacity);
+      nodeKeys = Arrays.copyOf(nodeKeys, newCapacity);
+    }
+    return arena;
+  }
+
+  /** Offset in the reserved arena at which the next composite key must be written. */
+  final int arenaOffset() {
+    return arenaLength;
+  }
+
+  /** Record the key just written at {@link #arenaOffset()} as belonging to {@code nodeKey}. */
+  final void commitKey(final int length, final long nodeKey) {
+    keyStart[count] = arenaLength;
+    keyLength[count] = length;
+    nodeKeys[count] = nodeKey;
+    arenaLength += length;
+    count++;
+  }
+
+  /** Number of {@code (key, nodeKey)} pairs accumulated so far. */
+  public final int size() {
+    return count;
+  }
+
+  /**
+   * Build the trie from everything accumulated and splice it in as the index's root.
+   *
+   * <p>A no-op when nothing was accumulated — the empty tree the index was initialized with stays
+   * in place. After this call the loader is spent.</p>
+   */
+  public final void flush() {
+    if (flushed) {
+      throw new IllegalStateException("Bulk loader already flushed");
+    }
+    flushed = true;
+    if (count == 0) {
+      return;
+    }
+
+    final int[] order = new int[count];
+    for (int i = 0; i < count; i++) {
+      order[i] = i;
+    }
+    // Composite key first, node key second. Grouping below relies on equal keys being adjacent,
+    // and the node-key tiebreak makes this a total order, so the permutation is deterministic
+    // even though quicksort is not stable. The comparator only reads, so sorting in parallel is
+    // safe; fastutil runs small inputs sequentially anyway.
+    final IntComparator byKeyThenNodeKey = (a, b) -> {
+      final int cmp = Arrays.compareUnsigned(arena, keyStart[a], keyStart[a] + keyLength[a], arena,
+          keyStart[b], keyStart[b] + keyLength[b]);
+      return cmp != 0 ? cmp : Long.compare(nodeKeys[a], nodeKeys[b]);
+    };
+    IntArrays.parallelQuickSort(order, byKeyThenNodeKey);
+
+    final List<HOTBulkBuilder.Entry> entries = new ArrayList<>();
+    int groupStart = 0;
+    while (groupStart < count) {
+      int groupEnd = groupStart + 1;
+      while (groupEnd < count && sameKey(order[groupStart], order[groupEnd])) {
+        groupEnd++;
+      }
+      entries.add(toEntry(order, groupStart, groupEnd));
+      groupStart = groupEnd;
+    }
+
+    writer.spliceBulkBuiltRoot(entries);
+    releaseBuffers();
+  }
+
+  private boolean sameKey(final int a, final int b) {
+    return keyLength[a] == keyLength[b] && Arrays.compareUnsigned(arena, keyStart[a],
+        keyStart[a] + keyLength[a], arena, keyStart[b], keyStart[b] + keyLength[b]) == 0;
+  }
+
+  /**
+   * Fold {@code order[from..to)} — all entries sharing one composite key — into a single
+   * {@link HOTBulkBuilder.Entry}. A chunk slot stores the low 16 bits of each node key; the high
+   * bits are already carried by the key's chunkIdx trailer.
+   */
+  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to) {
+    final int representative = order[from];
+    final byte[] key =
+        Arrays.copyOfRange(arena, keyStart[representative], keyStart[representative] + keyLength[representative]);
+
+    final Roaring64Bitmap bits = new Roaring64Bitmap();
+    for (int i = from; i < to; i++) {
+      bits.add(nodeKeys[order[i]] & 0xFFFFL);
+    }
+    bits.runOptimize();
+    return new HOTBulkBuilder.Entry(key, NodeReferencesSerializer.serialize(NodeReferences.owning(bits)));
+  }
+
+  /** Drop the accumulation buffers — a spent loader must not pin an index-sized arena. */
+  private void releaseBuffers() {
+    arena = new byte[0];
+    keyStart = new int[0];
+    keyLength = new int[0];
+    nodeKeys = new long[0];
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
@@ -73,14 +73,6 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /** Initial entry capacity — grown by doubling. */
   private static final int INITIAL_ENTRIES = 1024;
 
-  /**
-   * Upper bound on one serialized composite key, and hence the tail of a block that is left unused
-   * rather than split a key across two blocks. Mirrors {@link HOTIndexWriter}'s thread-local key
-   * buffer: the largest CAS prefix (10-byte header + 246 value bytes) plus the 4-byte chunkIdx
-   * trailer, rounded up for headroom. PATH's composite key is a fixed 12 bytes.
-   */
-  private static final int MAX_COMPOSITE_KEY_BYTES = 512;
-
   /** The index whose root this loader replaces on {@link #flush()}. */
   private final AbstractHOTIndexWriter<?> writer;
 
@@ -114,6 +106,9 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /** Number of accumulated entries. */
   private int count;
 
+  /** Bytes {@link #reserveKeySpace} last promised the caller, and {@link #commitKey} holds it to. */
+  private int reservedKeyBytes;
+
   /** Set once {@link #flush()} has run, so a second flush cannot re-splice the tree. */
   private boolean flushed;
 
@@ -129,16 +124,25 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
    *
    * @param nodeKey the node key the key being written belongs to; validated here so a subclass
    *        never serializes a key it would have to roll back
-   * @return the current block, guaranteed to have {@link #MAX_COMPOSITE_KEY_BYTES} free from
+   * @param maxKeyBytes the caller's own upper bound on what it is about to write. Taken BEFORE the
+   *        write, because the length a serializer <em>returns</em> arrives too late — by then a key
+   *        larger than the room available has already been written past it
+   * @return the current block, guaranteed to have {@code maxKeyBytes} free from
    *         {@link #blockOffset()}
+   * @throws IllegalStateException if a single key cannot fit a block at all
    */
-  final byte[] reserveKeySpace(final long nodeKey) {
+  final byte[] reserveKeySpace(final long nodeKey, final int maxKeyBytes) {
     if (flushed) {
       throw new IllegalStateException("Bulk loader already flushed");
     }
     AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
+    if (maxKeyBytes <= 0 || maxKeyBytes > BLOCK_BYTES) {
+      throw new IllegalStateException(
+          "Composite index key of up to " + maxKeyBytes + " bytes does not fit a " + BLOCK_BYTES + "-byte key block");
+    }
+    reservedKeyBytes = maxKeyBytes;
 
-    if (currentBlockOffset + MAX_COMPOSITE_KEY_BYTES > BLOCK_BYTES) {
+    if (currentBlockOffset + maxKeyBytes > BLOCK_BYTES) {
       if (blockCount == blocks.length) {
         blocks = Arrays.copyOf(blocks, blocks.length << 1);
       }
@@ -167,18 +171,18 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /**
    * Record the key just written at {@link #blockOffset()} as belonging to {@code nodeKey}.
    *
-   * <p>Checked, not asserted: {@link #reserveKeySpace} only guarantees
-   * {@link #MAX_COMPOSITE_KEY_BYTES} of room, so a serializer that ran past that has written into
-   * the tail of the block and must not be allowed to look like it succeeded.</p>
+   * <p>Checked, not asserted: {@link #reserveKeySpace} guarantees only what the caller asked for,
+   * so a serializer that under-reported its own bound has written into whatever followed the
+   * reservation and must not be allowed to look like it succeeded.</p>
    *
    * @param length bytes the subclass wrote
    * @param nodeKey the node key the written composite key belongs to
-   * @throws IllegalStateException if {@code length} is outside the reserved range
+   * @throws IllegalStateException if {@code length} is outside the reservation
    */
   final void commitKey(final int length, final long nodeKey) {
-    if (length <= 0 || length > MAX_COMPOSITE_KEY_BYTES) {
-      throw new IllegalStateException(
-          "Composite index key of " + length + " bytes exceeds the " + MAX_COMPOSITE_KEY_BYTES + "-byte maximum");
+    if (length <= 0 || length > reservedKeyBytes) {
+      throw new IllegalStateException("Composite index key of " + length
+          + " bytes overran the " + reservedKeyBytes + " bytes its serializer reserved");
     }
     keyPos[count] = ((long) currentBlockIndex << BLOCK_SHIFT) | currentBlockOffset;
     keyLength[count] = length;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
@@ -3,7 +3,6 @@
  */
 package io.sirix.index.hot;
 
-import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
@@ -26,22 +25,30 @@ import static java.util.Objects.requireNonNull;
  * construction grows super-linearly.</p>
  *
  * <p>This loader instead collects the pairs, sorts them once, folds the node keys that share a
- * chunk slot into one Roaring bitmap, and hands the result to {@link HOTBulkBuilder#build} — a
- * single {@code Θ(n)} construction whose output is invariant-clean by construction, so no
- * self-heal ever runs. The tree it produces is the tree the incremental path converges to.</p>
+ * chunk slot into one payload, and hands the result to {@link HOTBulkBuilder#build} — a single
+ * {@code Θ(n)} construction whose output is invariant-clean by construction, so no self-heal ever
+ * runs. The tree it produces is the tree the incremental path converges to.</p>
  *
  * <h2>Layout</h2>
- * <p>Keys live in one growable byte arena addressed by {@code (start, length)} pairs rather than
- * in a {@code byte[]} per entry: an index build over millions of nodes would otherwise pay a
- * 16-byte object header and a separate allocation for every key. Node keys live in a parallel
- * {@code long[]}. Sorting permutes an {@code int[]} of entry ids, never the payload.</p>
+ * <p>Composite keys live in a chain of fixed-size byte blocks, addressed by a packed
+ * {@code (block, offset)} {@code long} plus a length; node keys live in a parallel {@code long[]}.
+ * Neither a {@code byte[]} per key (a 16-byte header and a separate allocation per indexed node)
+ * nor one growable arena (whose doubling copies a hundreds-of-megabytes array, needs twice that
+ * live at the moment of growth, and cannot address past {@code Integer.MAX_VALUE} at all). Sorting
+ * permutes an {@code int[]} of entry ids, never the payload.</p>
+ *
+ * <h2>Allocation</h2>
+ * <p>{@link #reserveKeySpace}/{@link #commitKey} allocate nothing per entry — only a fresh block
+ * every {@value #BLOCK_BYTES} bytes and an amortized index-array growth. {@link #flush()} then
+ * allocates exactly what {@link HOTBulkBuilder}'s input contract requires: one key array, one
+ * payload array and one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot, in an
+ * exactly pre-sized list. The per-slot node-key run is gathered into a reusable buffer and
+ * serialized straight from it, so no bitmap is built below the packed threshold.</p>
  *
  * <h2>Memory</h2>
  * <p>A bulk load is not streaming: the whole entry set is resident until {@link #flush()} hands it
- * to the builder, which is the price of a single-pass canonical construction. The arena layout
- * keeps that to roughly {@code n × (key bytes + 16)} while accumulating; {@code flush} then
- * materialises one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot. The buffers are
- * dropped as soon as the tree is spliced.</p>
+ * to the builder, which is the price of a single-pass canonical construction. That comes to
+ * roughly {@code n × (key bytes + 20)}. The buffers are dropped as soon as the tree is spliced.</p>
  *
  * <h2>Threading</h2>
  * <p>Not thread-safe; a loader belongs to the single traversal that feeds it.</p>
@@ -54,14 +61,21 @@ import static java.util.Objects.requireNonNull;
  */
 abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOTLongBulkIndexLoader {
 
-  /** Initial arena capacity in bytes — grown by doubling. */
-  private static final int INITIAL_ARENA_BYTES = 64 * 1024;
+  /** Size of one key block. A power of two so the packed position splits with shift and mask. */
+  private static final int BLOCK_BYTES = 1 << 20;
+
+  /** Bits of a packed position that address within a block. */
+  private static final int BLOCK_SHIFT = 20;
+
+  /** Mask of the in-block offset of a packed position. */
+  private static final int BLOCK_MASK = BLOCK_BYTES - 1;
 
   /** Initial entry capacity — grown by doubling. */
   private static final int INITIAL_ENTRIES = 1024;
 
   /**
-   * Upper bound on one serialized composite key. Mirrors {@link HOTIndexWriter}'s thread-local key
+   * Upper bound on one serialized composite key, and hence the tail of a block that is left unused
+   * rather than split a key across two blocks. Mirrors {@link HOTIndexWriter}'s thread-local key
    * buffer: the largest CAS prefix (10-byte header + 246 value bytes) plus the 4-byte chunkIdx
    * trailer, rounded up for headroom. PATH's composite key is a fixed 12 bytes.
    */
@@ -70,16 +84,28 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /** The index whose root this loader replaces on {@link #flush()}. */
   private final AbstractHOTIndexWriter<?> writer;
 
-  /** Composite key bytes, back to back. */
-  private byte[] arena = new byte[INITIAL_ARENA_BYTES];
+  /**
+   * Key blocks; a key never straddles two of them. A plain array rather than a {@code List}
+   * because {@link #compareKeys} runs in the sort's inner loop.
+   */
+  private byte[][] blocks = new byte[8][];
 
-  /** Bytes used in {@link #arena}. */
-  private int arenaLength;
+  /** Number of allocated entries in {@link #blocks}. */
+  private int blockCount;
 
-  /** Start offset in {@link #arena} of entry {@code i}. */
-  private int[] keyStart = new int[INITIAL_ENTRIES];
+  /** The block {@link #reserveKeySpace} currently writes into. */
+  private byte[] currentBlock;
 
-  /** Length in {@link #arena} of entry {@code i}'s composite key. */
+  /** Index of {@link #currentBlock} in {@link #blocks}. */
+  private int currentBlockIndex;
+
+  /** Bytes used in {@link #currentBlock}. */
+  private int currentBlockOffset;
+
+  /** Packed {@code (blockIndex << BLOCK_SHIFT) | offset} of entry {@code i}'s composite key. */
+  private long[] keyPos = new long[INITIAL_ENTRIES];
+
+  /** Length of entry {@code i}'s composite key. */
   private int[] keyLength = new int[INITIAL_ENTRIES];
 
   /** The node key of entry {@code i}. */
@@ -93,16 +119,18 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
 
   AbstractHOTBulkIndexLoader(final AbstractHOTIndexWriter<?> writer) {
     this.writer = requireNonNull(writer, "writer");
+    currentBlock = new byte[BLOCK_BYTES];
+    blocks[blockCount++] = currentBlock;
   }
 
   /**
-   * Make room for one more composite key and hand back the arena to serialize into. The write
-   * must start at {@link #arenaOffset()} and be committed with {@link #commitKey(int, long)}.
+   * Make room for one more composite key and hand back the block to serialize into. The write must
+   * start at {@link #blockOffset()} and be committed with {@link #commitKey(int, long)}.
    *
    * @param nodeKey the node key the key being written belongs to; validated here so a subclass
    *        never serializes a key it would have to roll back
-   * @return the arena, guaranteed to have {@link #MAX_COMPOSITE_KEY_BYTES} free from
-   *         {@link #arenaOffset()}
+   * @return the current block, guaranteed to have {@link #MAX_COMPOSITE_KEY_BYTES} free from
+   *         {@link #blockOffset()}
    */
   final byte[] reserveKeySpace(final long nodeKey) {
     if (flushed) {
@@ -110,29 +138,52 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
     }
     AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
 
-    if (arenaLength + MAX_COMPOSITE_KEY_BYTES > arena.length) {
-      arena = Arrays.copyOf(arena, Math.max(arena.length << 1, arenaLength + MAX_COMPOSITE_KEY_BYTES));
+    if (currentBlockOffset + MAX_COMPOSITE_KEY_BYTES > BLOCK_BYTES) {
+      if (blockCount == blocks.length) {
+        blocks = Arrays.copyOf(blocks, blocks.length << 1);
+      }
+      currentBlock = new byte[BLOCK_BYTES];
+      currentBlockIndex = blockCount;
+      blocks[blockCount++] = currentBlock;
+      currentBlockOffset = 0;
     }
-    if (count == keyStart.length) {
-      final int newCapacity = keyStart.length << 1;
-      keyStart = Arrays.copyOf(keyStart, newCapacity);
+    if (count == keyLength.length) {
+      final int newCapacity = keyLength.length << 1;
+      if (newCapacity < 0) {
+        throw new IllegalStateException("Bulk index build exceeds " + keyLength.length + " entries");
+      }
+      keyPos = Arrays.copyOf(keyPos, newCapacity);
       keyLength = Arrays.copyOf(keyLength, newCapacity);
       nodeKeys = Arrays.copyOf(nodeKeys, newCapacity);
     }
-    return arena;
+    return currentBlock;
   }
 
-  /** Offset in the reserved arena at which the next composite key must be written. */
-  final int arenaOffset() {
-    return arenaLength;
+  /** Offset in the reserved block at which the next composite key must be written. */
+  final int blockOffset() {
+    return currentBlockOffset;
   }
 
-  /** Record the key just written at {@link #arenaOffset()} as belonging to {@code nodeKey}. */
+  /**
+   * Record the key just written at {@link #blockOffset()} as belonging to {@code nodeKey}.
+   *
+   * <p>Checked, not asserted: {@link #reserveKeySpace} only guarantees
+   * {@link #MAX_COMPOSITE_KEY_BYTES} of room, so a serializer that ran past that has written into
+   * the tail of the block and must not be allowed to look like it succeeded.</p>
+   *
+   * @param length bytes the subclass wrote
+   * @param nodeKey the node key the written composite key belongs to
+   * @throws IllegalStateException if {@code length} is outside the reserved range
+   */
   final void commitKey(final int length, final long nodeKey) {
-    keyStart[count] = arenaLength;
+    if (length <= 0 || length > MAX_COMPOSITE_KEY_BYTES) {
+      throw new IllegalStateException(
+          "Composite index key of " + length + " bytes exceeds the " + MAX_COMPOSITE_KEY_BYTES + "-byte maximum");
+    }
+    keyPos[count] = ((long) currentBlockIndex << BLOCK_SHIFT) | currentBlockOffset;
     keyLength[count] = length;
     nodeKeys[count] = nodeKey;
-    arenaLength += length;
+    currentBlockOffset += length;
     count++;
   }
 
@@ -153,6 +204,7 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
     }
     flushed = true;
     if (count == 0) {
+      releaseBuffers();
       return;
     }
 
@@ -160,25 +212,39 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
     for (int i = 0; i < count; i++) {
       order[i] = i;
     }
-    // Composite key first, node key second. Grouping below relies on equal keys being adjacent,
-    // and the node-key tiebreak makes this a total order, so the permutation is deterministic
-    // even though quicksort is not stable. The comparator only reads, so sorting in parallel is
-    // safe; fastutil runs small inputs sequentially anyway.
+    // Composite key first, node key second. Grouping below relies on equal keys being adjacent and
+    // on each group's node keys being ascending, which is also what the packed payload wants. The
+    // node-key tiebreak makes this a total order, so the permutation is deterministic even though
+    // quicksort is not stable. The comparator only reads, so sorting in parallel is safe; fastutil
+    // runs small inputs sequentially anyway.
     final IntComparator byKeyThenNodeKey = (a, b) -> {
-      final int cmp = Arrays.compareUnsigned(arena, keyStart[a], keyStart[a] + keyLength[a], arena,
-          keyStart[b], keyStart[b] + keyLength[b]);
+      final int cmp = compareKeys(a, b);
       return cmp != 0 ? cmp : Long.compare(nodeKeys[a], nodeKeys[b]);
     };
     IntArrays.parallelQuickSort(order, byKeyThenNodeKey);
 
-    final List<HOTBulkBuilder.Entry> entries = new ArrayList<>();
+    // One counting pass so the entry list is allocated at its exact size rather than doubled into
+    // place — at index scale those copies move hundreds of megabytes of references.
+    int distinct = 1;
+    for (int i = 1; i < count; i++) {
+      if (compareKeys(order[i - 1], order[i]) != 0) {
+        distinct++;
+      }
+    }
+
+    final List<HOTBulkBuilder.Entry> entries = new ArrayList<>(distinct);
+    final Roaring64Bitmap payloadScratch = new Roaring64Bitmap();
+    long[] runScratch = new long[64];
     int groupStart = 0;
     while (groupStart < count) {
       int groupEnd = groupStart + 1;
-      while (groupEnd < count && sameKey(order[groupStart], order[groupEnd])) {
+      while (groupEnd < count && compareKeys(order[groupStart], order[groupEnd]) == 0) {
         groupEnd++;
       }
-      entries.add(toEntry(order, groupStart, groupEnd));
+      if (groupEnd - groupStart > runScratch.length) {
+        runScratch = new long[Math.max(runScratch.length << 1, groupEnd - groupStart)];
+      }
+      entries.add(toEntry(order, groupStart, groupEnd, runScratch, payloadScratch));
       groupStart = groupEnd;
     }
 
@@ -186,33 +252,55 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
     releaseBuffers();
   }
 
-  private boolean sameKey(final int a, final int b) {
-    return keyLength[a] == keyLength[b] && Arrays.compareUnsigned(arena, keyStart[a],
-        keyStart[a] + keyLength[a], arena, keyStart[b], keyStart[b] + keyLength[b]) == 0;
+  /** Unsigned byte comparison of the composite keys of entries {@code a} and {@code b}. */
+  private int compareKeys(final int a, final int b) {
+    final long posA = keyPos[a];
+    final long posB = keyPos[b];
+    final byte[] blockA = blocks[(int) (posA >>> BLOCK_SHIFT)];
+    final byte[] blockB = blocks[(int) (posB >>> BLOCK_SHIFT)];
+    final int offA = (int) (posA & BLOCK_MASK);
+    final int offB = (int) (posB & BLOCK_MASK);
+    return Arrays.compareUnsigned(blockA, offA, offA + keyLength[a], blockB, offB, offB + keyLength[b]);
   }
 
   /**
    * Fold {@code order[from..to)} — all entries sharing one composite key — into a single
    * {@link HOTBulkBuilder.Entry}. A chunk slot stores the low 16 bits of each node key; the high
    * bits are already carried by the key's chunkIdx trailer.
+   *
+   * <p>The run is ascending by node key and may repeat one (a visitor is free to offer the same
+   * node under the same key twice — {@code JsonPathIndexBuilder} does for a fused named array),
+   * so equal neighbours collapse as the run is gathered. That also satisfies
+   * {@link HOTBulkBuilder}'s distinct-key precondition, since a repeated pair would otherwise
+   * become a second entry with an identical key.</p>
    */
-  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to) {
+  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to,
+      final long[] runScratch, final Roaring64Bitmap payloadScratch) {
     final int representative = order[from];
-    final byte[] key =
-        Arrays.copyOfRange(arena, keyStart[representative], keyStart[representative] + keyLength[representative]);
+    final long pos = keyPos[representative];
+    final byte[] block = blocks[(int) (pos >>> BLOCK_SHIFT)];
+    final int offset = (int) (pos & BLOCK_MASK);
+    final byte[] key = Arrays.copyOfRange(block, offset, offset + keyLength[representative]);
 
-    final Roaring64Bitmap bits = new Roaring64Bitmap();
+    int run = 0;
     for (int i = from; i < to; i++) {
-      bits.add(nodeKeys[order[i]] & 0xFFFFL);
+      final long bit16 = nodeKeys[order[i]] & 0xFFFFL;
+      if (run == 0 || runScratch[run - 1] != bit16) {
+        runScratch[run++] = bit16;
+      }
     }
-    bits.runOptimize();
-    return new HOTBulkBuilder.Entry(key, NodeReferencesSerializer.serialize(NodeReferences.owning(bits)));
+    return new HOTBulkBuilder.Entry(key,
+        NodeReferencesSerializer.serializeAscendingRun(runScratch, 0, run, payloadScratch));
   }
 
-  /** Drop the accumulation buffers — a spent loader must not pin an index-sized arena. */
+  /** Drop the accumulation buffers — a spent loader must not pin an index-sized key arena. */
   private void releaseBuffers() {
-    arena = new byte[0];
-    keyStart = new int[0];
+    blocks = new byte[0][];
+    blockCount = 0;
+    currentBlock = null;
+    currentBlockIndex = 0;
+    currentBlockOffset = 0;
+    keyPos = new long[0];
     keyLength = new int[0];
     nodeKeys = new long[0];
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTBulkIndexLoader.java
@@ -16,46 +16,60 @@ import static java.util.Objects.requireNonNull;
 /**
  * Accumulating bulk loader for a HOT secondary index that is being built from scratch.
  *
- * <p>Building an index over an already-shredded revision is a bulk load, not a sequence of
- * updates: every {@code (key, nodeKey)} pair is known before the first byte is written. Feeding
- * them through the incremental-insert path one at a time makes the trie pay that path's machinery
- * — a descent, a merge-vs-branch decision and, whenever a fold leaves a node malformed, a scoped
+ * <p>
+ * Building an index over an already-shredded revision is a bulk load, not a sequence of updates:
+ * every {@code (key, nodeKey)} pair is known before the first byte is written. Feeding them through
+ * the incremental-insert path one at a time makes the trie pay that path's machinery — a descent, a
+ * merge-vs-branch decision and, whenever a fold leaves a node malformed, a scoped
  * {@link HOTBulkBuilder} rebuild of the touched subtree — per entry. The rebuilds are what hurt:
  * each is {@code O(subtree)}, and a build of n entries triggers them in proportion to n, so index
- * construction grows super-linearly.</p>
+ * construction grows super-linearly.
+ * </p>
  *
- * <p>This loader instead collects the pairs, sorts them once, folds the node keys that share a
- * chunk slot into one payload, and hands the result to {@link HOTBulkBuilder#build} — a single
+ * <p>
+ * This loader instead collects the pairs, sorts them once, folds the node keys that share a chunk
+ * slot into one payload, and hands the result to {@link HOTBulkBuilder#build} — a single
  * {@code Θ(n)} construction whose output is invariant-clean by construction, so no self-heal ever
- * runs. The tree it produces is the tree the incremental path converges to.</p>
+ * runs. The tree it produces is the tree the incremental path converges to.
+ * </p>
  *
  * <h2>Layout</h2>
- * <p>Composite keys live in a chain of fixed-size byte blocks, addressed by a packed
+ * <p>
+ * Composite keys live in a chain of fixed-size byte blocks, addressed by a packed
  * {@code (block, offset)} {@code long} plus a length; node keys live in a parallel {@code long[]}.
  * Neither a {@code byte[]} per key (a 16-byte header and a separate allocation per indexed node)
  * nor one growable arena (whose doubling copies a hundreds-of-megabytes array, needs twice that
  * live at the moment of growth, and cannot address past {@code Integer.MAX_VALUE} at all). Sorting
- * permutes an {@code int[]} of entry ids, never the payload.</p>
+ * permutes an {@code int[]} of entry ids, never the payload.
+ * </p>
  *
  * <h2>Allocation</h2>
- * <p>{@link #reserveKeySpace}/{@link #commitKey} allocate nothing per entry — only a fresh block
- * every {@value #BLOCK_BYTES} bytes and an amortized index-array growth. {@link #flush()} then
- * allocates exactly what {@link HOTBulkBuilder}'s input contract requires: one key array, one
- * payload array and one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot, in an
- * exactly pre-sized list. The per-slot node-key run is gathered into a reusable buffer and
- * serialized straight from it, so no bitmap is built below the packed threshold.</p>
+ * <p>
+ * {@link #reserveKeySpace}/{@link #commitKey} allocate nothing per entry — only a fresh block every
+ * {@value #BLOCK_BYTES} bytes and an amortized index-array growth. {@link #flush()} then allocates
+ * exactly what {@link HOTBulkBuilder}'s input contract requires: one key array, one payload array
+ * and one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot, in an exactly pre-sized
+ * list. The per-slot node-key run is gathered into a reusable buffer and serialized straight from
+ * it, so no bitmap is built below the packed threshold.
+ * </p>
  *
  * <h2>Memory</h2>
- * <p>A bulk load is not streaming: the whole entry set is resident until {@link #flush()} hands it
- * to the builder, which is the price of a single-pass canonical construction. That comes to
- * roughly {@code n × (key bytes + 20)}. The buffers are dropped as soon as the tree is spliced.</p>
+ * <p>
+ * A bulk load is not streaming: the whole entry set is resident until {@link #flush()} hands it to
+ * the builder, which is the price of a single-pass canonical construction. That comes to roughly
+ * {@code n × (key bytes + 20)}. The buffers are dropped as soon as the tree is spliced.
+ * </p>
  *
  * <h2>Threading</h2>
- * <p>Not thread-safe; a loader belongs to the single traversal that feeds it.</p>
+ * <p>
+ * Not thread-safe; a loader belongs to the single traversal that feeds it.
+ * </p>
  *
- * <p>Subclasses supply the key encoding only — {@link HOTBulkIndexLoader} for object keys
- * (CAS, NAME), {@link HOTLongBulkIndexLoader} for the PATH index's primitive long keys, which
- * would otherwise box once per indexed node.</p>
+ * <p>
+ * Subclasses supply the key encoding only — {@link HOTBulkIndexLoader} for object keys (CAS, NAME),
+ * {@link HOTLongBulkIndexLoader} for the PATH index's primitive long keys, which would otherwise
+ * box once per indexed node.
+ * </p>
  *
  * @author Johannes Lichtenberger
  */
@@ -77,8 +91,8 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   private final AbstractHOTIndexWriter<?> writer;
 
   /**
-   * Key blocks; a key never straddles two of them. A plain array rather than a {@code List}
-   * because {@link #compareKeys} runs in the sort's inner loop.
+   * Key blocks; a key never straddles two of them. A plain array rather than a {@code List} because
+   * {@link #compareKeys} runs in the sort's inner loop.
    */
   private byte[][] blocks = new byte[8][];
 
@@ -122,8 +136,8 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
    * Make room for one more composite key and hand back the block to serialize into. The write must
    * start at {@link #blockOffset()} and be committed with {@link #commitKey(int, long)}.
    *
-   * @param nodeKey the node key the key being written belongs to; validated here so a subclass
-   *        never serializes a key it would have to roll back
+   * @param nodeKey the node key the key being written belongs to; validated here so a subclass never
+   *        serializes a key it would have to roll back
    * @param maxKeyBytes the caller's own upper bound on what it is about to write. Taken BEFORE the
    *        write, because the length a serializer <em>returns</em> arrives too late — by then a key
    *        larger than the room available has already been written past it
@@ -171,9 +185,11 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /**
    * Record the key just written at {@link #blockOffset()} as belonging to {@code nodeKey}.
    *
-   * <p>Checked, not asserted: {@link #reserveKeySpace} guarantees only what the caller asked for,
-   * so a serializer that under-reported its own bound has written into whatever followed the
-   * reservation and must not be allowed to look like it succeeded.</p>
+   * <p>
+   * Checked, not asserted: {@link #reserveKeySpace} guarantees only what the caller asked for, so a
+   * serializer that under-reported its own bound has written into whatever followed the reservation
+   * and must not be allowed to look like it succeeded.
+   * </p>
    *
    * @param length bytes the subclass wrote
    * @param nodeKey the node key the written composite key belongs to
@@ -181,8 +197,8 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
    */
   final void commitKey(final int length, final long nodeKey) {
     if (length <= 0 || length > reservedKeyBytes) {
-      throw new IllegalStateException("Composite index key of " + length
-          + " bytes overran the " + reservedKeyBytes + " bytes its serializer reserved");
+      throw new IllegalStateException("Composite index key of " + length + " bytes overran the " + reservedKeyBytes
+          + " bytes its serializer reserved");
     }
     keyPos[count] = ((long) currentBlockIndex << BLOCK_SHIFT) | currentBlockOffset;
     keyLength[count] = length;
@@ -199,8 +215,10 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
   /**
    * Build the trie from everything accumulated and splice it in as the index's root.
    *
-   * <p>A no-op when nothing was accumulated — the empty tree the index was initialized with stays
-   * in place. After this call the loader is spent.</p>
+   * <p>
+   * A no-op when nothing was accumulated — the empty tree the index was initialized with stays in
+   * place. After this call the loader is spent.
+   * </p>
    */
   public final void flush() {
     if (flushed) {
@@ -223,7 +241,9 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
     // runs small inputs sequentially anyway.
     final IntComparator byKeyThenNodeKey = (a, b) -> {
       final int cmp = compareKeys(a, b);
-      return cmp != 0 ? cmp : Long.compare(nodeKeys[a], nodeKeys[b]);
+      return cmp != 0
+          ? cmp
+          : Long.compare(nodeKeys[a], nodeKeys[b]);
     };
     IntArrays.parallelQuickSort(order, byKeyThenNodeKey);
 
@@ -269,17 +289,19 @@ abstract sealed class AbstractHOTBulkIndexLoader permits HOTBulkIndexLoader, HOT
 
   /**
    * Fold {@code order[from..to)} — all entries sharing one composite key — into a single
-   * {@link HOTBulkBuilder.Entry}. A chunk slot stores the low 16 bits of each node key; the high
-   * bits are already carried by the key's chunkIdx trailer.
+   * {@link HOTBulkBuilder.Entry}. A chunk slot stores the low 16 bits of each node key; the high bits
+   * are already carried by the key's chunkIdx trailer.
    *
-   * <p>The run is ascending by node key and may repeat one (a visitor is free to offer the same
-   * node under the same key twice — {@code JsonPathIndexBuilder} does for a fused named array),
-   * so equal neighbours collapse as the run is gathered. That also satisfies
-   * {@link HOTBulkBuilder}'s distinct-key precondition, since a repeated pair would otherwise
-   * become a second entry with an identical key.</p>
+   * <p>
+   * The run is ascending by node key and may repeat one (a visitor is free to offer the same node
+   * under the same key twice — {@code JsonPathIndexBuilder} does for a fused named array), so equal
+   * neighbours collapse as the run is gathered. That also satisfies {@link HOTBulkBuilder}'s
+   * distinct-key precondition, since a repeated pair would otherwise become a second entry with an
+   * identical key.
+   * </p>
    */
-  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to,
-      final long[] runScratch, final Roaring64Bitmap payloadScratch) {
+  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to, final long[] runScratch,
+      final Roaring64Bitmap payloadScratch) {
     final int representative = order[from];
     final long pos = keyPos[representative];
     final byte[] block = blocks[(int) (pos >>> BLOCK_SHIFT)];

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -200,8 +200,8 @@ public abstract class AbstractHOTIndexReader<K> {
         }
         return accumulator.toNodeReferencesAndReset();
       }
-      throw new IllegalStateException("HOT: chunk walk failed stamp validation on every one of " + MAX_TORN_WALK_RETRIES
-          + " attempts — sustained allocator thrashing");
+      throw new IllegalStateException("HOT: chunk walk failed stamp validation on every one of "
+          + HOTTrieReader.MAX_STAMP_RETRIES + " attempts — sustained allocator thrashing");
     } finally {
       accumulator.reset(); // no-op on the success path; drops partial state if the walk threw
       trie.close(); // clears the reader's leaf snapshot + path; the object stays reusable
@@ -210,12 +210,6 @@ public abstract class AbstractHOTIndexReader<K> {
     }
   }
 
-  /**
-   * Bound on whole-walk retries after a torn read poisoned an aggregate. Each retry races eviction
-   * independently on freshly reloaded copies, so consecutive failures imply allocator thrashing, not
-   * a logic error.
-   */
-  private static final int MAX_TORN_WALK_RETRIES = 64;
 
   /**
    * Get the storage engine reader.
@@ -258,7 +252,7 @@ public abstract class AbstractHOTIndexReader<K> {
    */
   private volatile @Nullable PageReference cachedRootReference;
 
-  protected @Nullable PageReference getRootReference() {
+  public @Nullable PageReference getRootReference() {
     PageReference root = cachedRootReference;
     if (root != null) {
       return root;
@@ -771,7 +765,7 @@ public abstract class AbstractHOTIndexReader<K> {
 
     /** Bounded torn-recovery: refresh the cursor's leaf and let the caller re-evaluate in place. */
     private void recoverTorn(final int round) {
-      cursor.recoverTorn(round);
+      cursor.recoverTorn(round, "HOT chunk aggregation");
     }
 
     private void checkTornBound(final int round) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -154,7 +154,7 @@ public abstract class AbstractHOTIndexReader<K> {
       // torn batch poisons the accumulator, so recovery is wholesale: reset and re-walk from a
       // fresh lower-bound descent. Content per PageReference is immutable, so every retry
       // re-derives the identical result.
-      for (int walkAttempt = 0; walkAttempt < MAX_TORN_WALK_RETRIES; walkAttempt++) {
+      for (int walkAttempt = 0; walkAttempt < HOTTrieReader.MAX_STAMP_RETRIES; walkAttempt++) {
         accumulator.reset();
         final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
         HOTLeafPage leaf = lowerBound.leaf;
@@ -771,14 +771,12 @@ public abstract class AbstractHOTIndexReader<K> {
 
     /** Bounded torn-recovery: refresh the cursor's leaf and let the caller re-evaluate in place. */
     private void recoverTorn(final int round) {
-      checkTornBound(round);
-      cursor.refreshLeaf();
+      cursor.recoverTorn(round);
     }
 
     private void checkTornBound(final int round) {
-      if (round > MAX_TORN_WALK_RETRIES) {
-        throw new IllegalStateException("HOT: chunk aggregation failed stamp validation on " + MAX_TORN_WALK_RETRIES
-            + " consecutive rounds — sustained allocator thrashing");
+      if (round > HOTTrieReader.MAX_STAMP_RETRIES) {
+        throw HOTTrieReader.stampRetriesExhausted("HOT chunk aggregation");
       }
     }
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -76,16 +76,26 @@ public abstract class AbstractHOTIndexReader<K> {
   protected final int indexNumber;
 
   /**
-   * Pooled trie reader for point-lookup chunk walks: constructing a {@link HOTTrieReader} allocates
-   * its path-stack arrays, which on the lookup path was per-call garbage. One instance is parked here
-   * between calls ({@link HOTTrieReader#close()} drops the leaf snapshot and clears the path but
-   * keeps the object reusable). Handed out via {@link AtomicReference#getAndSet} so concurrent
-   * lookups through the same reader instance stay correct — a loser simply constructs a fresh one.
+   * The mutable state one point-lookup chunk walk needs: a trie reader (whose construction allocates
+   * path-stack arrays) and a chunk accumulator (whose construction allocates a key array). They are
+   * pooled as ONE object rather than two because the pool handoff is atomic and the atomics are not
+   * free — the profile put the pair of {@code getAndSet}/{@code compareAndSet} at 4.6% of a point
+   * lookup, and a walk never wants one without the other.
+   *
+   * @param trie the reader for the descent and the leaf-to-leaf walk
+   * @param accumulator the merge target for the walk's chunk payloads
    */
-  private final AtomicReference<HOTTrieReader> pooledTrieReader = new AtomicReference<>();
+  private record ChunkWalkState(HOTTrieReader trie, NodeReferencesSerializer.ChunkAccumulator accumulator) {
+  }
 
-  /** Pooled chunk accumulator for the lookup walk — same handoff discipline as the trie reader. */
-  private final AtomicReference<NodeReferencesSerializer.ChunkAccumulator> pooledAccumulator = new AtomicReference<>();
+  /**
+   * Pooled per-walk state: constructing it is per-call garbage on the lookup path, so one instance is
+   * parked here between calls ({@link HOTTrieReader#close()} drops the leaf snapshot and clears the
+   * path but keeps the object reusable). Handed out via {@link AtomicReference#getAndSet} so
+   * concurrent lookups through the same reader instance stay correct — a loser simply constructs a
+   * fresh one, and only one walk can ever hold a given instance.
+   */
+  private final AtomicReference<ChunkWalkState> pooledWalkState = new AtomicReference<>();
 
   /**
    * Protected constructor.
@@ -139,14 +149,13 @@ public abstract class AbstractHOTIndexReader<K> {
     System.arraycopy(prefixBuf, 0, fromBytes, 0, prefixLen);
     HOTKeySerializer.writeChunkIdxBE(fromBytes, prefixLen, 0);
 
-    HOTTrieReader trie = pooledTrieReader.getAndSet(null);
-    if (trie == null) {
-      trie = new HOTTrieReader(storageEngineReader);
-    }
-    NodeReferencesSerializer.ChunkAccumulator accumulator = pooledAccumulator.getAndSet(null);
-    if (accumulator == null) {
-      accumulator = new NodeReferencesSerializer.ChunkAccumulator();
-    }
+    final ChunkWalkState pooled = pooledWalkState.getAndSet(null);
+    final ChunkWalkState state = pooled != null
+        ? pooled
+        : new ChunkWalkState(new HOTTrieReader(storageEngineReader),
+            new NodeReferencesSerializer.ChunkAccumulator());
+    final HOTTrieReader trie = state.trie();
+    final NodeReferencesSerializer.ChunkAccumulator accumulator = state.accumulator();
     try {
       // The whole walk runs against UNPINNED leaves under optimistic stamps: each leaf's read
       // batch — the per-slot prefix compares, the chunkIdx reads, the payload merges — is
@@ -249,8 +258,7 @@ public abstract class AbstractHOTIndexReader<K> {
     } finally {
       accumulator.reset(); // no-op on the success path; drops partial state if the walk threw
       trie.close(); // clears the reader's leaf snapshot + path; the object stays reusable
-      pooledTrieReader.compareAndSet(null, trie);
-      pooledAccumulator.compareAndSet(null, accumulator);
+      pooledWalkState.compareAndSet(null, state);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -268,6 +268,66 @@ public abstract class AbstractHOTIndexReader<K> {
   protected abstract @Nullable K deserializeKey(byte[] buffer, int offset, int length);
 
   /**
+   * {@link Map.Entry} whose key deserializes on first {@link #getKey()} — the chunk-aggregating
+   * iterators emit these so value-only consumers never pay key materialization at all. The unfiltered
+   * CAS {@code openIndex} path, for one, iterates the whole index and reads ONLY {@code getValue()}:
+   * with eager keys that was one decoded atomic + key object per logical entry, all garbage.
+   * Immutable ({@link #setValue} throws), {@code equals}/{@code hashCode} follow the
+   * {@link Map.Entry} contract (and therefore force the key).
+   */
+  protected final class LazyKeyEntry implements Map.Entry<K, NodeReferences> {
+    private final byte[] keyBytes;
+    private final int keyLen;
+    private final NodeReferences refs;
+    private @Nullable K key;
+    private boolean keyDeserialized;
+
+    protected LazyKeyEntry(final byte[] keyBytes, final int keyLen, final NodeReferences refs) {
+      this.keyBytes = keyBytes;
+      this.keyLen = keyLen;
+      this.refs = refs;
+    }
+
+    @Override
+    public @Nullable K getKey() {
+      if (!keyDeserialized) {
+        key = deserializeKey(keyBytes, 0, keyLen);
+        keyDeserialized = true;
+      }
+      return key;
+    }
+
+    @Override
+    public NodeReferences getValue() {
+      return refs;
+    }
+
+    @Override
+    public NodeReferences setValue(final NodeReferences value) {
+      throw new UnsupportedOperationException("immutable index entry");
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof Map.Entry<?, ?> other)) {
+        return false;
+      }
+      final K k = getKey();
+      return (k == null
+          ? other.getKey() == null
+          : k.equals(other.getKey())) && refs.equals(other.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+      final K k = getKey();
+      return (k == null
+          ? 0
+          : k.hashCode()) ^ refs.hashCode();
+    }
+  }
+
+  /**
    * Compare two serialized keys.
    *
    * @param key1 first key bytes

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -175,8 +175,8 @@ public abstract class AbstractHOTIndexReader<K> {
   protected abstract int serializeKey(K key, byte[] buffer, int offset);
 
   /**
-   * Upper bound, in bytes, on what {@link #serializeKey} writes for {@code key}, so callers can
-   * size the buffer before the write rather than discover the overflow after it.
+   * Upper bound, in bytes, on what {@link #serializeKey} writes for {@code key}, so callers can size
+   * the buffer before the write rather than discover the overflow after it.
    *
    * @param key the key about to be serialized
    * @return a value {@code >=} the length {@code serializeKey} will return
@@ -306,26 +306,29 @@ public abstract class AbstractHOTIndexReader<K> {
   /**
    * Range iterator over HOT entries.
    *
-   * <p><strong>Implementation note (lower-bound primitive missing in Sirix's HOT).</strong> A
-   * navigate-to-fromKey range scan via {@link HOTRangeCursor} returns wrong results for
-   * non-existent fromKeys on this Sirix HOT implementation: {@code HOTTrieReader.navigateToLeaf}
-   * does PEXT-based exact-or-best-guess routing and does NOT implement a true lower-bound
-   * primitive over the lex order. For an existing key it lands correctly; for a non-existent
-   * key (the common range-scan case, e.g. {@code GREATER_OR_EQUAL 2500}) it may land in a leaf
-   * whose entries are NOT lex-greater than fromKey, and walking forward from there visits keys
-   * in HOT-trie-order rather than lex order — verified empirically by
-   * {@code HOTMultiLayerIndirectPageTest.testCrossTransactionWriteAfterSplitPreservesEntries}
-   * (range &ge; 2500 returned 4489 instead of 2501).
+   * <p>
+   * <strong>Implementation note (lower-bound primitive missing in Sirix's HOT).</strong> A
+   * navigate-to-fromKey range scan via {@link HOTRangeCursor} returns wrong results for non-existent
+   * fromKeys on this Sirix HOT implementation: {@code HOTTrieReader.navigateToLeaf} does PEXT-based
+   * exact-or-best-guess routing and does NOT implement a true lower-bound primitive over the lex
+   * order. For an existing key it lands correctly; for a non-existent key (the common range-scan
+   * case, e.g. {@code GREATER_OR_EQUAL 2500}) it may land in a leaf whose entries are NOT lex-greater
+   * than fromKey, and walking forward from there visits keys in HOT-trie-order rather than lex order
+   * — verified empirically by
+   * {@code HOTMultiLayerIndirectPageTest.testCrossTransactionWriteAfterSplitPreservesEntries} (range
+   * &ge; 2500 returned 4489 instead of 2501).
    *
-   * <p>The HOT paper / Binna 2018 reference implementation in C++ does provide a proper
-   * lower_bound iterator; Sirix's HOT does not yet expose one. Until that primitive lands, the
-   * correct fallback is leftmost-and-filter — start at {@code navigateToLeftmostLeaf}, walk
-   * every leaf via the parent stack, skip entries before {@code fromBytes}. {@code O(total
+   * <p>
+   * The HOT paper / Binna 2018 reference implementation in C++ does provide a proper lower_bound
+   * iterator; Sirix's HOT does not yet expose one. Until that primitive lands, the correct fallback
+   * is leftmost-and-filter — start at {@code navigateToLeftmostLeaf}, walk every leaf via the parent
+   * stack, skip entries before {@code fromBytes}. {@code O(total
    * trie entries)} per query, but correct on every key shape (chunked PROJECTION-style keys,
    * composite CAS path-value pairs, etc.).
    *
-   * <p>If/when {@code HOTTrieReader} gains a true lower-bound navigation, this iterator can be
-   * rewritten to use it; the current implementation pins the correct semantics.
+   * <p>
+   * If/when {@code HOTTrieReader} gains a true lower-bound navigation, this iterator can be rewritten
+   * to use it; the current implementation pins the correct semantics.
    */
   protected class RangeIterator implements Iterator<Map.Entry<K, NodeReferences>> {
     private final byte[] fromBytes;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.index.hot;
 
+import io.sirix.access.trx.page.HOTRangeCursor;
 import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
@@ -38,8 +39,10 @@ import io.sirix.page.NamePage;
 import io.sirix.page.PageReference;
 import io.sirix.page.PathPage;
 import io.sirix.page.RevisionRootPage;
+import io.sirix.page.ValidTimeIndexPage;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -59,7 +62,7 @@ import static java.util.Objects.requireNonNull;
  * <ul>
  * <li>Thread-local byte buffers for key serialization</li>
  * <li>No Optional - uses @Nullable returns</li>
- * <li>Lock-free reads with guard management</li>
+ * <li>Lock-free reads via optimistic stamp validation — leaves stay evictable, no pins</li>
  * <li>Pre-allocated traversal arrays via {@link HOTTrieReader}</li>
  * </ul>
  *
@@ -75,7 +78,7 @@ public abstract class AbstractHOTIndexReader<K> {
   /**
    * Pooled trie reader for point-lookup chunk walks: constructing a {@link HOTTrieReader} allocates
    * its path-stack arrays, which on the lookup path was per-call garbage. One instance is parked here
-   * between calls ({@link HOTTrieReader#close()} releases the leaf guard and clears the path but
+   * between calls ({@link HOTTrieReader#close()} drops the leaf snapshot and clears the path but
    * keeps the object reusable). Handed out via {@link AtomicReference#getAndSet} so concurrent
    * lookups through the same reader instance stay correct — a loser simply constructs a fresh one.
    */
@@ -110,8 +113,8 @@ public abstract class AbstractHOTIndexReader<K> {
    * Zero-copy by construction: slot filtering reads off the leaf via
    * {@link HOTLeafPage#compareKeyPrefix} / {@link HOTLeafPage#getKeyLength}, the chunkIdx via
    * {@link HOTLeafPage#readKeyIntBE}, and the chunk payload merges straight from slot memory via
-   * {@link NodeReferencesSerializer#mergeChunkInto} — no key or value is ever materialized. The trie
-   * reader is pooled across calls.
+   * {@link NodeReferencesSerializer.ChunkAccumulator#addChunk} — no key or value is ever
+   * materialized. The trie reader is pooled across calls.
    *
    * @param prefixBuf buffer holding the serialized logical key
    * @param prefixLen serialized length of the logical key
@@ -124,6 +127,14 @@ public abstract class AbstractHOTIndexReader<K> {
       return null;
     }
     final int compositeLen = prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES;
+    // The seek key must be an EXACTLY-sized array, so it is built fresh rather than appended to the
+    // caller's oversized buffer in place. Not an oversight: the whole descent takes the search key's
+    // length from the array itself — HOTLeafPage.compareKeyWithBound reads bound.length and
+    // DiscriminativeBitComputer.computeDifferingBit reads both operands' lengths — so handing it a
+    // 512-byte thread-local buffer means "a 512-byte key padded with zeros", which routes and
+    // verifies against the wrong key and silently misses stored entries (measured: 13% of point
+    // lookups). Removing this allocation needs a length-parameterized HOTTrieReader.lowerBound, not
+    // a buffer trick.
     final byte[] fromBytes = new byte[compositeLen];
     System.arraycopy(prefixBuf, 0, fromBytes, 0, prefixLen);
     HOTKeySerializer.writeChunkIdxBE(fromBytes, prefixLen, 0);
@@ -137,33 +148,74 @@ public abstract class AbstractHOTIndexReader<K> {
       accumulator = new NodeReferencesSerializer.ChunkAccumulator();
     }
     try {
-      final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
-      HOTLeafPage leaf = lowerBound.leaf;
-      int idx = lowerBound.indexInLeaf;
-      walk: while (leaf != null) {
-        final int entryCount = leaf.getEntryCount();
-        while (idx < entryCount) {
-          final int cmp = leaf.compareKeyPrefix(idx, prefixBuf, prefixLen);
-          if (cmp > 0) {
-            break walk;
+      // The whole walk runs against UNPINNED leaves under optimistic stamps: each leaf's read
+      // batch — the per-slot prefix compares, the chunkIdx reads, the payload merges — is
+      // validated once before its outcome (stop, or advance to the next leaf) takes effect. A
+      // torn batch poisons the accumulator, so recovery is wholesale: reset and re-walk from a
+      // fresh lower-bound descent. Content per PageReference is immutable, so every retry
+      // re-derives the identical result.
+      for (int walkAttempt = 0; walkAttempt < MAX_TORN_WALK_RETRIES; walkAttempt++) {
+        accumulator.reset();
+        final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
+        HOTLeafPage leaf = lowerBound.leaf;
+        int idx = lowerBound.indexInLeaf;
+        boolean torn = false;
+        while (leaf != null) {
+          boolean stop = false;
+          try {
+            final int entryCount = leaf.getEntryCount();
+            while (idx < entryCount) {
+              final int cmp = leaf.compareKeyPrefix(idx, prefixBuf, prefixLen);
+              if (cmp > 0) {
+                stop = true;
+                break;
+              }
+              if (cmp == 0 && leaf.getKeyLength(idx) == compositeLen) {
+                final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
+                if (!accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16, trie)) {
+                  torn = true;
+                  break;
+                }
+              }
+              idx++;
+            }
+          } catch (RuntimeException e) {
+            if (trie.validateCurrentLeaf()) {
+              throw e; // stable bytes — genuine corruption, not a torn read
+            }
+            torn = true;
           }
-          if (cmp == 0 && leaf.getKeyLength(idx) == compositeLen) {
-            final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-            accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
+          if (torn || !trie.validateCurrentLeaf()) {
+            torn = true;
+            break;
           }
-          idx++;
+          if (stop) {
+            break;
+          }
+          leaf = trie.advanceToNextLeaf();
+          idx = 0;
         }
-        leaf = trie.advanceToNextLeaf();
-        idx = 0;
+        if (torn) {
+          continue;
+        }
+        return accumulator.toNodeReferencesAndReset();
       }
-      return accumulator.toNodeReferencesAndReset();
+      throw new IllegalStateException("HOT: chunk walk failed stamp validation on every one of " + MAX_TORN_WALK_RETRIES
+          + " attempts — sustained allocator thrashing");
     } finally {
       accumulator.reset(); // no-op on the success path; drops partial state if the walk threw
-      trie.close(); // releases the leaf guard + clears the path; the object stays reusable
+      trie.close(); // clears the reader's leaf snapshot + path; the object stays reusable
       pooledTrieReader.compareAndSet(null, trie);
       pooledAccumulator.compareAndSet(null, accumulator);
     }
   }
+
+  /**
+   * Bound on whole-walk retries after a torn read poisoned an aggregate. Each retry races eviction
+   * independently on freshly reloaded copies, so consecutive failures imply allocator thrashing, not
+   * a logic error.
+   */
+  private static final int MAX_TORN_WALK_RETRIES = 64;
 
   /**
    * Get the storage engine reader.
@@ -204,7 +256,7 @@ public abstract class AbstractHOTIndexReader<K> {
    * resolves fresh per call — an in-flight commit can replace the index page and its child
    * references.
    */
-  private @Nullable PageReference cachedRootReference;
+  private volatile @Nullable PageReference cachedRootReference;
 
   protected @Nullable PageReference getRootReference() {
     PageReference root = cachedRootReference;
@@ -243,7 +295,7 @@ public abstract class AbstractHOTIndexReader<K> {
         yield namePage.getOrCreateReference(indexNumber);
       }
       case VALIDTIME -> {
-        final io.sirix.page.ValidTimeIndexPage vtPage = storageEngineReader.getValidTimeIndexPage(rootPage);
+        final ValidTimeIndexPage vtPage = storageEngineReader.getValidTimeIndexPage(rootPage);
         if (vtPage == null || indexNumber >= vtPage.getReferencesCount()) {
           yield null;
         }
@@ -253,19 +305,9 @@ public abstract class AbstractHOTIndexReader<K> {
     };
   }
 
-  /**
-   * Navigate to the leaf page containing the key. Uses {@link HOTTrieReader} for proper tree
-   * traversal.
-   *
-   * @param rootRef the root reference
-   * @param key the search key bytes
-   * @return the leaf page, or null if not found
-   */
-  protected @Nullable HOTLeafPage navigateToLeaf(PageReference rootRef, byte[] key) {
-    try (var trieReader = new HOTTrieReader(storageEngineReader)) {
-      return trieReader.navigateToLeaf(rootRef, key);
-    }
-  }
+  // navigateToLeaf(rootRef, key) was removed: no caller anywhere, and under optimistic stamps a
+  // bare unpinned leaf with no validation contract attached is exactly the API shape that invites
+  // silent torn reads. Leaf access goes through the validated walk/iterator primitives above.
 
   /**
    * Serialize a key to bytes.
@@ -297,6 +339,19 @@ public abstract class AbstractHOTIndexReader<K> {
   protected abstract @Nullable K deserializeKey(byte[] buffer, int offset, int length);
 
   /**
+   * A {@link Map.Entry} that can hand out the entry's serialized key without materializing it, so a
+   * per-entry filter that only needs a fixed-offset field (the CAS path class record, say) can read
+   * it in place instead of paying a full key deserialization per entry.
+   */
+  public interface RawKeyBytes {
+    /** Buffer holding the serialized logical key; valid for {@code [0, rawKeyLength())}. */
+    byte[] rawKeyBytes();
+
+    /** Length of the serialized logical key inside {@link #rawKeyBytes()}. */
+    int rawKeyLength();
+  }
+
+  /**
    * {@link Map.Entry} whose key deserializes on first {@link #getKey()} — the chunk-aggregating
    * iterators emit these so value-only consumers never pay key materialization at all. The unfiltered
    * CAS {@code openIndex} path, for one, iterates the whole index and reads ONLY {@code getValue()}:
@@ -304,7 +359,7 @@ public abstract class AbstractHOTIndexReader<K> {
    * Immutable ({@link #setValue} throws), {@code equals}/{@code hashCode} follow the
    * {@link Map.Entry} contract (and therefore force the key).
    */
-  protected final class LazyKeyEntry implements Map.Entry<K, NodeReferences> {
+  protected final class LazyKeyEntry implements Map.Entry<K, NodeReferences>, RawKeyBytes {
     private final byte[] keyBytes;
     private final int keyLen;
     private final NodeReferences refs;
@@ -315,6 +370,16 @@ public abstract class AbstractHOTIndexReader<K> {
       this.keyBytes = keyBytes;
       this.keyLen = keyLen;
       this.refs = refs;
+    }
+
+    @Override
+    public byte[] rawKeyBytes() {
+      return keyBytes;
+    }
+
+    @Override
+    public int rawKeyLength() {
+      return keyLen;
     }
 
     @Override
@@ -357,19 +422,6 @@ public abstract class AbstractHOTIndexReader<K> {
   }
 
   /**
-   * Compare two serialized keys.
-   *
-   * @param key1 first key bytes
-   * @param offset1 offset in first key
-   * @param length1 length of first key
-   * @param key2 second key bytes
-   * @param offset2 offset in second key
-   * @param length2 length of second key
-   * @return negative if key1 < key2, zero if equal, positive if key1 > key2
-   */
-  protected abstract int compareKeys(byte[] key1, int offset1, int length1, byte[] key2, int offset2, int length2);
-
-  /**
    * Get the thread-local key buffer.
    *
    * @return the key buffer
@@ -384,37 +436,135 @@ public abstract class AbstractHOTIndexReader<K> {
   protected abstract void setKeyBuffer(byte[] newBuffer);
 
   /**
-   * Create an iterator over all entries in the HOT index.
+   * Iterate every logical entry in the index.
+   *
+   * <p>
+   * Abstract because "all entries" is a per-reader notion: with chunked-bitmap storage one logical
+   * entry spans several slots, so every concrete reader answers with a
+   * {@link ChunkAggregatingIterator} over an unbounded range rather than a per-slot walk.
    *
    * @return iterator over all key-value pairs
    */
-  public Iterator<Map.Entry<K, NodeReferences>> iterator() {
-    return new HOTLeafIterator();
+  public abstract Iterator<Map.Entry<K, NodeReferences>> iterator();
+
+  /**
+   * Serialize {@code key} into a right-sized array, growing the shared buffer first when the key
+   * needs more room than it has. Sizing BEFORE the write is the point: checking the returned length
+   * afterwards is too late, the overrun has already happened. Range constructors need the bytes to
+   * outlive the shared buffer (two bounds are live at once), hence the copy — once per cursor, never
+   * per entry.
+   *
+   * @param key the key to serialize
+   * @return the serialized bytes, exactly {@code serializeKey}'s length
+   */
+  protected final byte[] serializeKeyToArray(final K key) {
+    requireNonNull(key, "key");
+    byte[] buffer = getKeyBuffer();
+    final int required = maxSerializedKeyLength(key);
+    if (required > buffer.length) {
+      buffer = new byte[required];
+      setKeyBuffer(buffer);
+    }
+    final int length = serializeKey(key, buffer, 0);
+    return Arrays.copyOf(buffer, length);
+  }
+
+  /** {@code prefix ‖ chunkIdx_be4} — a composite bound for the range cursor. */
+  private static byte[] compositeBound(final byte[] prefix, final int chunkIdx) {
+    requireNonNull(prefix, "prefix");
+    final byte[] composite = new byte[prefix.length + HOTKeySerializer.CHUNK_IDX_BYTES];
+    System.arraycopy(prefix, 0, composite, 0, prefix.length);
+    HOTKeySerializer.writeChunkIdxBE(composite, prefix.length, chunkIdx);
+    return composite;
   }
 
   /**
-   * Iterator over all entries in a HOT index, handling tree navigation.
+   * Iterator over logical entries in a bounded composite-key range, grouping the chunk slots of one
+   * logical key into a single {@link Map.Entry}. Shared by every HOT reader — the object-key
+   * (CAS/NAME) and primitive-long (PATH) readers differ only in {@link #deserializeKey}, which
+   * {@link LazyKeyEntry} already routes through.
+   *
+   * <h2>Why bounds are checked here and not by the caller</h2>
+   * <p>
+   * The cursor's composite bounds are a coarse <em>byte</em> window, not the logical key range: index
+   * keys are not prefix-free (a CAS string value is raw UTF-8 with no terminator), so the upper
+   * composite {@code serialize(max) ‖ 0xFFFFFFFF} also covers every key that byte-extends {@code max}
+   * — "carpet" sorts below the ceiling built for "car". Callers that trimmed bounds positionally
+   * afterwards (skip the first group if it equals min, the last if it equals max) were wrong twice
+   * over: they let prefix-extensions through, and the equal group need not be first or last. The
+   * exact bound test therefore lives here, comparing each group's LOGICAL key bytes (composite minus
+   * the chunk trailer) against the serialized bound — at most two {@link Arrays#compareUnsigned} per
+   * emitted group, and no key deserialization, so {@link LazyKeyEntry}'s laziness survives.
+   *
+   * <p>
+   * Out-of-range groups are skipped rather than terminating the sweep, because the path-stack forward
+   * walk is not strictly lex-monotonic across sibling subtrees (see {@link #lowerBoundKey}); the
+   * composite ceiling still bounds the scan.
    */
-  protected class HOTLeafIterator implements Iterator<Map.Entry<K, NodeReferences>> {
-    private @Nullable HOTLeafPage currentLeaf;
-    private int currentIndex;
-    private Map.@Nullable Entry<K, NodeReferences> nextEntry;
+  protected final class ChunkAggregatingIterator implements Iterator<Map.Entry<K, NodeReferences>>, AutoCloseable {
     private final @Nullable HOTTrieReader trieReader;
-    private final @Nullable PageReference rootRef;
+    private final @Nullable HOTRangeCursor cursor;
+    /**
+     * Serialized logical lower bound, or {@code null} for unbounded. Doubles as the cheap per-slot
+     * pre-filter that suppresses the lex-residue the PEXT-routed seek can leave at the head of the
+     * sweep: HOT sibling subtrees can have overlapping lex ranges (a bit that varies at the parent
+     * level and inside a sibling's subtree cannot be a parent disc bit, so it lives deeper), which
+     * makes the forward walk non-monotonic in the small.
+     */
+    private final byte @Nullable [] lowerBoundKey;
+    private final boolean lowerInclusive;
+    /** Serialized logical upper bound, or {@code null} for unbounded. */
+    private final byte @Nullable [] upperBoundKey;
+    private final boolean upperInclusive;
+    /** Per-iterator chunk accumulator, reset per logical group. */
+    private final NodeReferencesSerializer.ChunkAccumulator accumulator =
+        new NodeReferencesSerializer.ChunkAccumulator();
+    private Map.@Nullable Entry<K, NodeReferences> nextEntry;
+    private boolean closed;
 
-    protected HOTLeafIterator() {
-      this.rootRef = getRootReference();
-      if (rootRef != null) {
-        this.trieReader = new HOTTrieReader(storageEngineReader);
-        // Navigate to leftmost leaf
-        this.currentLeaf = trieReader.navigateToLeftmostLeaf(rootRef);
-      } else {
+    /**
+     * @param lowerBoundKey serialized logical lower bound, or {@code null} for unbounded
+     * @param lowerInclusive whether {@code lowerBoundKey} itself is in range
+     * @param upperBoundKey serialized logical upper bound, or {@code null} for unbounded
+     * @param upperInclusive whether {@code upperBoundKey} itself is in range
+     */
+    ChunkAggregatingIterator(final byte @Nullable [] lowerBoundKey, final boolean lowerInclusive,
+        final byte @Nullable [] upperBoundKey, final boolean upperInclusive) {
+      this.lowerBoundKey = lowerBoundKey;
+      this.lowerInclusive = lowerInclusive;
+      this.upperBoundKey = upperBoundKey;
+      this.upperInclusive = upperInclusive;
+      final PageReference rootRef = getRootReference();
+      if (rootRef == null) {
+        // Empty trie — no entries.
         this.trieReader = null;
-        // Fallback to simple case
-        this.currentLeaf = storageEngineReader.getHOTLeafPage(indexType, indexNumber);
+        this.cursor = null;
+        this.nextEntry = null;
+        return;
       }
-      this.currentIndex = 0;
-      advance();
+      // The cursor's byte window is DERIVED here rather than passed in, so it can never disagree
+      // with the logical bounds — the invariant `fromComposite == lowerBoundKey ‖ chunk0` is what
+      // lets slotWithinBounds skip the inclusive lower-bound compare. An unbounded lower end is
+      // null, not an empty array: HOTRangeCursor only takes its deterministic navigateToLeftmostLeaf
+      // branch on null, and an empty array instead routes through a PEXT descent on an all-zero
+      // partial key plus a never-firing bound compare per entry for the whole sweep.
+      final byte[] fromComposite = lowerBoundKey == null
+          ? null
+          : compositeBound(lowerBoundKey, 0);
+      final byte[] toComposite = upperBoundKey == null
+          ? null
+          : compositeBound(upperBoundKey, 0xFFFFFFFF);
+      this.trieReader = new HOTTrieReader(storageEngineReader);
+      // range() is INSIDE the try: its constructor descends, so an exception thrown there would
+      // otherwise strand a half-built iterator nothing can reach — this catch routes it through
+      // closeQuietly so the reader and cursor are torn down.
+      try {
+        this.cursor = trieReader.range(rootRef, fromComposite, toComposite);
+        advance();
+      } catch (RuntimeException | Error e) {
+        closeQuietly();
+        throw e;
+      }
     }
 
     @Override
@@ -427,154 +577,209 @@ public abstract class AbstractHOTIndexReader<K> {
       if (nextEntry == null) {
         throw new NoSuchElementException();
       }
-      Map.Entry<K, NodeReferences> result = nextEntry;
-      advance();
+      final Map.Entry<K, NodeReferences> result = nextEntry;
+      try {
+        advance();
+      } catch (RuntimeException | Error e) {
+        closeQuietly();
+        throw e;
+      }
       return result;
     }
 
-    private void advance() {
-      nextEntry = null;
-      while (currentLeaf != null) {
-        if (currentIndex < currentLeaf.getEntryCount()) {
-          byte[] keyBytes = currentLeaf.getKey(currentIndex);
-          byte[] valueBytes = currentLeaf.getValue(currentIndex);
-          currentIndex++;
+    /**
+     * Tear down the cursor and the trie reader. Idempotent, and safe to call at any point: an abandoned
+     * scan MUST route here, because nothing else will — exhaustion and a throw close themselves, but a
+     * consumer that simply stops pulling (a limit, a short-circuiting predicate) would otherwise keep
+     * the leaf object and path stack reachable for the iterator's lifetime.
+     */
+    @Override
+    public void close() {
+      closeQuietly();
+    }
 
-          if (!NodeReferencesSerializer.isTombstone(valueBytes, 0, valueBytes.length)) {
-            K key = deserializeKey(keyBytes, 0, keyBytes.length);
-            NodeReferences refs = NodeReferencesSerializer.deserialize(valueBytes);
-            if (key != null && refs != null) {
-              nextEntry = Map.entry(key, refs);
-              return;
-            }
-          }
-        } else {
-          // No more entries in current leaf - try to advance to next leaf
-          currentIndex = 0;
-          if (trieReader != null) {
-            currentLeaf = trieReader.advanceToNextLeaf();
-          } else {
-            currentLeaf = null;
-          }
-        }
+    /** Idempotent: exhaustion, abandonment and a throw all route here. */
+    private void closeQuietly() {
+      if (closed) {
+        return;
       }
-
-      // Clean up trie reader when done
-      if (trieReader != null && currentLeaf == null) {
+      closed = true;
+      // Drop the pending entry too: hasNext() is `nextEntry != null`, so leaving it set after a
+      // throw would let a caller that catches and keeps draining receive the same group twice and
+      // then re-enter the cursor after it was closed.
+      nextEntry = null;
+      if (cursor != null) {
+        cursor.close();
+      }
+      if (trieReader != null) {
         trieReader.close();
       }
     }
-  }
 
-  /**
-   * Range iterator over HOT entries.
-   *
-   * <p>
-   * <strong>Implementation note (lower-bound primitive missing in Sirix's HOT).</strong> A
-   * navigate-to-fromKey range scan via {@link HOTRangeCursor} returns wrong results for non-existent
-   * fromKeys on this Sirix HOT implementation: {@code HOTTrieReader.navigateToLeaf} does PEXT-based
-   * exact-or-best-guess routing and does NOT implement a true lower-bound primitive over the lex
-   * order. For an existing key it lands correctly; for a non-existent key (the common range-scan
-   * case, e.g. {@code GREATER_OR_EQUAL 2500}) it may land in a leaf whose entries are NOT lex-greater
-   * than fromKey, and walking forward from there visits keys in HOT-trie-order rather than lex order
-   * — verified empirically by
-   * {@code HOTMultiLayerIndirectPageTest.testCrossTransactionWriteAfterSplitPreservesEntries} (range
-   * &ge; 2500 returned 4489 instead of 2501).
-   *
-   * <p>
-   * The HOT paper / Binna 2018 reference implementation in C++ does provide a proper lower_bound
-   * iterator; Sirix's HOT does not yet expose one. Until that primitive lands, the correct fallback
-   * is leftmost-and-filter — start at {@code navigateToLeftmostLeaf}, walk every leaf via the parent
-   * stack, skip entries before {@code fromBytes}. {@code O(total
-   * trie entries)} per query, but correct on every key shape (chunked PROJECTION-style keys,
-   * composite CAS path-value pairs, etc.).
-   *
-   * <p>
-   * If/when {@code HOTTrieReader} gains a true lower-bound navigation, this iterator can be rewritten
-   * to use it; the current implementation pins the correct semantics.
-   */
-  protected class RangeIterator implements Iterator<Map.Entry<K, NodeReferences>> {
-    private final byte[] fromBytes;
-    private final byte @Nullable [] toBytes; // null means no upper bound
-    private @Nullable HOTLeafPage currentLeaf;
-    private int currentIndex;
-    private Map.@Nullable Entry<K, NodeReferences> nextEntry;
-    private final @Nullable HOTTrieReader trieReader;
-
-    protected RangeIterator(byte[] fromBytes, byte @Nullable [] toBytes) {
-      this.fromBytes = fromBytes;
-      this.toBytes = toBytes;
-
-      PageReference rootRef = getRootReference();
-      if (rootRef != null) {
-        this.trieReader = new HOTTrieReader(storageEngineReader);
-        this.currentLeaf = trieReader.navigateToLeftmostLeaf(rootRef);
-      } else {
-        this.trieReader = null;
-        this.currentLeaf = storageEngineReader.getHOTLeafPage(indexType, indexNumber);
+    /**
+     * Whether the slot's logical key (composite minus the chunk trailer) lies inside both bounds, read
+     * straight off the leaf. Zero-copy on purpose: the composite ceiling is wider than the logical
+     * range (index keys are not prefix-free), so a bounded scan visits groups it must reject, and
+     * rejecting them here means {@link HOTLeafPage#getKey} is only ever paid for a group that is
+     * actually emitted.
+     */
+    private boolean slotWithinBounds(final HOTLeafPage leaf, final int idx) {
+      final byte[] lower = lowerBoundKey;
+      // Only the EXCLUSIVE case needs a logical compare. The cursor's seek bound is
+      // `lower ‖ chunk0` (derived in the constructor, so they cannot drift apart) and
+      // HOTRangeCursor#isOutOfRange rejects every slot below it on every step — and
+      // `composite >= lower ‖ 0` is exactly `logical >= lower`, since the composite is the logical
+      // key followed by the chunk trailer. So for an inclusive lower bound this compare could only
+      // ever repeat the cursor's answer, once per slot, over the whole sweep.
+      if (lower != null && !lowerInclusive) {
+        if (leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES, lower, lower.length) <= 0) {
+          return false;
+        }
       }
-
-      this.currentIndex = 0;
-      advance();
-    }
-
-    @Override
-    public boolean hasNext() {
-      return nextEntry != null;
-    }
-
-    @Override
-    public Map.Entry<K, NodeReferences> next() {
-      if (nextEntry == null) {
-        throw new NoSuchElementException();
+      final byte[] upper = upperBoundKey;
+      if (upper != null) {
+        final int cmp = leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES, upper, upper.length);
+        return cmp < 0 || (cmp == 0 && upperInclusive);
       }
-      Map.Entry<K, NodeReferences> result = nextEntry;
-      advance();
-      return result;
+      return true;
     }
 
     private void advance() {
+      // Cleared up front, not just on the exits: a throw out of the loop below (corrupt slot
+      // payload) must not leave a stale entry behind for hasNext() to report.
       nextEntry = null;
-      while (currentLeaf != null) {
-        if (currentIndex < currentLeaf.getEntryCount()) {
-          byte[] key = currentLeaf.getKey(currentIndex);
-
-          if (toBytes != null && compareKeys(key, 0, key.length, toBytes, 0, toBytes.length) >= 0) {
-            currentLeaf = null;
-            break;
-          }
-
-          if (compareKeys(key, 0, key.length, fromBytes, 0, fromBytes.length) < 0) {
-            currentIndex++;
+      if (cursor == null) {
+        return;
+      }
+      while (true) {
+        // Head skip: move past slots that cannot start a group. Every skip/stop decision reads
+        // the UNPINNED leaf and is validated before it takes effect; a torn read re-evaluates
+        // the SAME slot on a refreshed copy — cursor position is derived only from validated
+        // decisions, so it survives the reload.
+        int tornRounds = 0;
+        while (cursor.hasNext()) {
+          final HOTLeafPage leaf = cursor.currentLeafPage();
+          final int idx = cursor.currentEntryIndex();
+          final boolean skip;
+          try {
+            // <=, not <: a composite of exactly CHUNK_IDX_BYTES carries a ZERO-length logical key, which
+            // would emit an entry whose deserializeKey reads past the buffer. Such a slot is not a
+            // well-formed chunk composite either way.
+            skip = leaf.getKeyLength(idx) <= HOTKeySerializer.CHUNK_IDX_BYTES || !slotWithinBounds(leaf, idx);
+          } catch (RuntimeException e) {
+            if (cursor.validateLeaf()) {
+              throw e; // stable bytes — genuine corruption, not a torn read
+            }
+            recoverTorn(++tornRounds);
             continue;
           }
+          if (!cursor.validateLeaf()) {
+            recoverTorn(++tornRounds);
+            continue;
+          }
+          tornRounds = 0;
+          if (!skip) {
+            break;
+          }
+          cursor.advance();
+        }
+        if (!cursor.hasNext()) {
+          closeQuietly(); // an empty or fully-rejected sweep must release its resources too
+          return;
+        }
 
-          byte[] value = currentLeaf.getValue(currentIndex);
-          currentIndex++;
-
-          if (!NodeReferencesSerializer.isTombstone(value, 0, value.length)) {
-            K deserializedKey = deserializeKey(key, 0, key.length);
-            NodeReferences refs = NodeReferencesSerializer.deserialize(value);
-            if (deserializedKey != null && refs != null) {
-              nextEntry = Map.entry(deserializedKey, refs);
-              return;
+        // Materialize the group's composite key ONCE — it doubles as the logical-key bytes for
+        // deserializeKey at emit. Only in-bounds groups ever get here. The copy is validated
+        // before anything derives from it: it names the group for the merge compares below, for
+        // the emitted entry, and for the re-seek target when a torn read voids the merge.
+        byte[] groupComposite = null;
+        while (groupComposite == null) {
+          final byte[] candidate;
+          try {
+            candidate = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
+          } catch (RuntimeException e) {
+            if (cursor.validateLeaf()) {
+              throw e;
             }
+            recoverTorn(++tornRounds);
+            continue;
           }
-        } else {
-          currentIndex = 0;
-          if (trieReader != null) {
-            currentLeaf = trieReader.advanceToNextLeaf();
-          } else {
-            currentLeaf = null;
+          if (!cursor.validateLeaf()) {
+            recoverTorn(++tornRounds);
+            continue;
           }
+          if (candidate == null) {
+            // getKey() returns null for a slot the slot table does not address — and the stamp
+            // just validated, so this is storage corruption, reported rather than dereferenced
+            // into an opaque NullPointerException.
+            throw new IllegalStateException(
+                "HOT leaf slot " + cursor.currentEntryIndex() + " does not address a readable key");
+          }
+          groupComposite = candidate;
+        }
+        final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
+        final int compositeLen = groupComposite.length;
+
+        // Merge the group's chunk slots. A torn read voids the WHOLE aggregate (the merge writes
+        // into the accumulator as it goes), so recovery is wholesale: reset the accumulator,
+        // re-seek the group's first slot by its validated composite, and re-merge from scratch.
+        group: for (int groupAttempt = 0;; groupAttempt++) {
+          checkTornBound(groupAttempt);
+          while (cursor.hasNext()) {
+            final HOTLeafPage leaf = cursor.currentLeafPage();
+            final int idx = cursor.currentEntryIndex();
+            final boolean groupEnd;
+            try {
+              groupEnd =
+                  leaf.getKeyLength(idx) != compositeLen || leaf.compareKeyPrefix(idx, groupComposite, prefixLen) != 0;
+              if (!groupEnd) {
+                final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
+                if (!accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16, trieReader)) {
+                  accumulator.reset();
+                  cursor.restartAtComposite(groupComposite);
+                  continue group;
+                }
+              }
+            } catch (RuntimeException e) {
+              if (cursor.validateLeaf()) {
+                throw e;
+              }
+              accumulator.reset();
+              cursor.restartAtComposite(groupComposite);
+              continue group;
+            }
+            if (!cursor.validateLeaf()) {
+              accumulator.reset();
+              cursor.restartAtComposite(groupComposite);
+              continue group;
+            }
+            if (groupEnd) {
+              break;
+            }
+            cursor.advance();
+          }
+          break;
+        }
+
+        final NodeReferences groupRefs = accumulator.toNodeReferencesAndReset();
+        if (groupRefs != null) {
+          nextEntry = new LazyKeyEntry(groupComposite, prefixLen, groupRefs);
+          return;
         }
       }
+    }
 
-      if (trieReader != null && currentLeaf == null) {
-        trieReader.close();
+    /** Bounded torn-recovery: refresh the cursor's leaf and let the caller re-evaluate in place. */
+    private void recoverTorn(final int round) {
+      checkTornBound(round);
+      cursor.refreshLeaf();
+    }
+
+    private void checkTornBound(final int round) {
+      if (round > MAX_TORN_WALK_RETRIES) {
+        throw new IllegalStateException("HOT: chunk aggregation failed stamp validation on " + MAX_TORN_WALK_RETRIES
+            + " consecutive rounds — sustained allocator thrashing");
       }
     }
   }
-
 }
-

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -38,7 +38,6 @@ import io.sirix.page.PageReference;
 import io.sirix.page.PathPage;
 import io.sirix.page.RevisionRootPage;
 import org.jspecify.annotations.Nullable;
-import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -81,6 +80,9 @@ public abstract class AbstractHOTIndexReader<K> {
    */
   private final AtomicReference<HOTTrieReader> pooledTrieReader = new AtomicReference<>();
 
+  /** Pooled chunk accumulator for the lookup walk — same handoff discipline as the trie reader. */
+  private final AtomicReference<NodeReferencesSerializer.ChunkAccumulator> pooledAccumulator = new AtomicReference<>();
+
   /**
    * Protected constructor.
    *
@@ -112,10 +114,10 @@ public abstract class AbstractHOTIndexReader<K> {
    *
    * @param prefixBuf buffer holding the serialized logical key
    * @param prefixLen serialized length of the logical key
-   * @return the merged logical bitmap, or {@code null} when no chunk holds a live reference
+   * @return the reassembled references — compact for small results — or {@code null} when no chunk
+   *         holds a live reference
    */
-  protected final @Nullable Roaring64Bitmap collectChunksViaLowerBoundWalk(final byte[] prefixBuf,
-      final int prefixLen) {
+  protected final @Nullable NodeReferences collectChunksViaLowerBoundWalk(final byte[] prefixBuf, final int prefixLen) {
     final PageReference rootRef = getRootReference();
     if (rootRef == null) {
       return null;
@@ -129,7 +131,10 @@ public abstract class AbstractHOTIndexReader<K> {
     if (trie == null) {
       trie = new HOTTrieReader(storageEngineReader);
     }
-    Roaring64Bitmap merged = null;
+    NodeReferencesSerializer.ChunkAccumulator accumulator = pooledAccumulator.getAndSet(null);
+    if (accumulator == null) {
+      accumulator = new NodeReferencesSerializer.ChunkAccumulator();
+    }
     try {
       final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
       HOTLeafPage leaf = lowerBound.leaf;
@@ -143,18 +148,20 @@ public abstract class AbstractHOTIndexReader<K> {
           }
           if (cmp == 0 && leaf.getKeyLength(idx) == compositeLen) {
             final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-            merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
+            accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
           }
           idx++;
         }
         leaf = trie.advanceToNextLeaf();
         idx = 0;
       }
+      return accumulator.toNodeReferencesAndReset();
     } finally {
+      accumulator.reset(); // no-op on the success path; drops partial state if the walk threw
       trie.close(); // releases the leaf guard + clears the path; the object stays reusable
       pooledTrieReader.compareAndSet(null, trie);
+      pooledAccumulator.compareAndSet(null, accumulator);
     }
-    return merged;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -156,10 +156,54 @@ public abstract class AbstractHOTIndexReader<K> {
       // re-derives the identical result.
       for (int walkAttempt = 0; walkAttempt < HOTTrieReader.MAX_STAMP_RETRIES; walkAttempt++) {
         accumulator.reset();
-        final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
-        HOTLeafPage leaf = lowerBound.leaf;
-        int idx = lowerBound.indexInLeaf;
+        // FAST PATH: a point lookup needs the first slot at-or-after `prefix ‖ chunk0`, which is
+        // usually just where the PEXT descent lands — the seek key differs from the stored ones
+        // only in the 4-byte chunk trailer, so they route together unless a discriminative bit
+        // falls inside it. Measured on the 33K-key movies index: the descent is ~71 ns while the
+        // full lowerBound is ~346 ns, because the latter additionally verifies the landing, may
+        // peek the successor leaf, and on a miss re-descends the whole trie comparing per-child
+        // first keys (each of which is itself a leftmost descent).
+        //
+        // Correctness: the fast path is taken ONLY when the landing leaf actually resolves the
+        // question — either it holds a slot carrying the prefix, or it proves the prefix is
+        // absent by holding a key that sorts strictly past it. Anything else (the seek runs off
+        // the end of the leaf, or the landing is lexically off-subtree) falls through to the full
+        // lowerBound, which keeps every guarantee it had.
+        HOTLeafPage leaf = null;
+        int idx = 0;
         boolean torn = false;
+        final HOTLeafPage landing = trie.navigateToLeaf(rootRef, fromBytes);
+        if (landing != null) {
+          try {
+            final int entryCount = landing.getEntryCount();
+            final int found = landing.findEntry(fromBytes);
+            final int insertion = found >= 0
+                ? found
+                : -(found + 1);
+            if (insertion < entryCount) {
+              // The landing answers the seek: either this slot carries the prefix (walk from
+              // here) or it sorts past it (the prefix has no chunks at all).
+              leaf = landing;
+              idx = insertion;
+            }
+          } catch (RuntimeException e) {
+            if (trie.validateCurrentLeaf()) {
+              throw e;
+            }
+            torn = true;
+          }
+          if (!torn && !trie.validateCurrentLeaf()) {
+            torn = true;
+          }
+        }
+        if (torn) {
+          continue;
+        }
+        if (leaf == null) {
+          final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
+          leaf = lowerBound.leaf;
+          idx = lowerBound.indexInLeaf;
+        }
         while (leaf != null) {
           boolean stop = false;
           try {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -38,10 +38,12 @@ import io.sirix.page.PageReference;
 import io.sirix.page.PathPage;
 import io.sirix.page.RevisionRootPage;
 import org.jspecify.annotations.Nullable;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
 
@@ -71,6 +73,15 @@ public abstract class AbstractHOTIndexReader<K> {
   protected final int indexNumber;
 
   /**
+   * Pooled trie reader for point-lookup chunk walks: constructing a {@link HOTTrieReader} allocates
+   * its path-stack arrays, which on the lookup path was per-call garbage. One instance is parked here
+   * between calls ({@link HOTTrieReader#close()} releases the leaf guard and clears the path but
+   * keeps the object reusable). Handed out via {@link AtomicReference#getAndSet} so concurrent
+   * lookups through the same reader instance stay correct — a loser simply constructs a fresh one.
+   */
+  private final AtomicReference<HOTTrieReader> pooledTrieReader = new AtomicReference<>();
+
+  /**
    * Protected constructor.
    *
    * @param storageEngineReader the storage engine reader
@@ -81,6 +92,69 @@ public abstract class AbstractHOTIndexReader<K> {
     this.storageEngineReader = requireNonNull(storageEngineReader);
     this.indexType = requireNonNull(indexType);
     this.indexNumber = indexNumber;
+  }
+
+  /**
+   * Point-lookup chunk collection shared by the CAS/NAME and PATH readers: seek
+   * {@code lowerBound(prefix ‖ chunk0)} and walk forward, merging every slot whose composite key is
+   * exactly {@code prefix ‖ chunkIdx}, until the first key whose leading {@code prefixLen} bytes
+   * exceed the prefix — lex order makes that stop authoritative, every later key exceeds it too.
+   * Entries that merely EXTEND the prefix (longer logical keys sharing its bytes) are skipped, not
+   * stopped on: their composites sort between this prefix's chunk slots whenever their next byte is
+   * below the chunk trailer's.
+   *
+   * <p>
+   * Zero-copy by construction: slot filtering reads off the leaf via
+   * {@link HOTLeafPage#compareKeyPrefix} / {@link HOTLeafPage#getKeyLength}, the chunkIdx via
+   * {@link HOTLeafPage#readKeyIntBE}, and the chunk payload merges straight from slot memory via
+   * {@link NodeReferencesSerializer#mergeChunkInto} — no key or value is ever materialized. The trie
+   * reader is pooled across calls.
+   *
+   * @param prefixBuf buffer holding the serialized logical key
+   * @param prefixLen serialized length of the logical key
+   * @return the merged logical bitmap, or {@code null} when no chunk holds a live reference
+   */
+  protected final @Nullable Roaring64Bitmap collectChunksViaLowerBoundWalk(final byte[] prefixBuf,
+      final int prefixLen) {
+    final PageReference rootRef = getRootReference();
+    if (rootRef == null) {
+      return null;
+    }
+    final int compositeLen = prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES;
+    final byte[] fromBytes = new byte[compositeLen];
+    System.arraycopy(prefixBuf, 0, fromBytes, 0, prefixLen);
+    HOTKeySerializer.writeChunkIdxBE(fromBytes, prefixLen, 0);
+
+    HOTTrieReader trie = pooledTrieReader.getAndSet(null);
+    if (trie == null) {
+      trie = new HOTTrieReader(storageEngineReader);
+    }
+    Roaring64Bitmap merged = null;
+    try {
+      final HOTTrieReader.LowerBoundResult lowerBound = trie.lowerBound(rootRef, fromBytes);
+      HOTLeafPage leaf = lowerBound.leaf;
+      int idx = lowerBound.indexInLeaf;
+      walk: while (leaf != null) {
+        final int entryCount = leaf.getEntryCount();
+        while (idx < entryCount) {
+          final int cmp = leaf.compareKeyPrefix(idx, prefixBuf, prefixLen);
+          if (cmp > 0) {
+            break walk;
+          }
+          if (cmp == 0 && leaf.getKeyLength(idx) == compositeLen) {
+            final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
+            merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
+          }
+          idx++;
+        }
+        leaf = trie.advanceToNextLeaf();
+        idx = 0;
+      }
+    } finally {
+      trie.close(); // releases the leaf guard + clears the path; the object stays reusable
+      pooledTrieReader.compareAndSet(null, trie);
+    }
+    return merged;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -175,6 +175,15 @@ public abstract class AbstractHOTIndexReader<K> {
   protected abstract int serializeKey(K key, byte[] buffer, int offset);
 
   /**
+   * Upper bound, in bytes, on what {@link #serializeKey} writes for {@code key}, so callers can
+   * size the buffer before the write rather than discover the overflow after it.
+   *
+   * @param key the key about to be serialized
+   * @return a value {@code >=} the length {@code serializeKey} will return
+   */
+  protected abstract int maxSerializedKeyLength(K key);
+
+  /**
    * Deserialize a key from bytes.
    *
    * @param buffer the buffer to read from

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -30,8 +30,11 @@ package io.sirix.index.hot;
 import io.sirix.access.trx.page.HOTRangeCursor;
 import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
-import io.sirix.api.StorageEngineWriter;
+import io.sirix.cache.BufferManager;
+import io.sirix.cache.HOTLookupCache;
+import io.sirix.cache.HOTLookupKey;
 import io.sirix.index.IndexType;
+import io.sirix.index.SearchMode;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.CASPage;
 import io.sirix.page.HOTLeafPage;
@@ -40,12 +43,15 @@ import io.sirix.page.PageReference;
 import io.sirix.page.PathPage;
 import io.sirix.page.RevisionRootPage;
 import io.sirix.page.ValidTimeIndexPage;
+import io.sirix.utils.LogWrapper;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNull;
@@ -70,6 +76,9 @@ import static java.util.Objects.requireNonNull;
  * @author Johannes Lichtenberger
  */
 public abstract class AbstractHOTIndexReader<K> {
+
+  /** Only ever used to report a refused memoization, which nothing else surfaces. */
+  private static final LogWrapper LOGGER = new LogWrapper(LoggerFactory.getLogger(AbstractHOTIndexReader.class));
 
   protected final StorageEngineReader storageEngineReader;
   protected final IndexType indexType;
@@ -98,6 +107,47 @@ public abstract class AbstractHOTIndexReader<K> {
   private final AtomicReference<ChunkWalkState> pooledWalkState = new AtomicReference<>();
 
   /**
+   * The session's memoized point lookups, or {@code null} when this reader must not use them.
+   *
+   * <p>
+   * Null for a WRITER-backed reader, and the reason is the same one that makes the cache free of an
+   * invalidation protocol: entries are keyed by revision number and a committed revision's index
+   * content is immutable, but an uncommitted transaction mutates the index UNDER a revision number
+   * that is already a key here. A writer consulting the cache could therefore read its own
+   * pre-modification answer back. It is exactly the distinction {@link #getRootReference} already
+   * draws for the memoized root reference.
+   * </p>
+   */
+  private final @Nullable HOTLookupCache lookupCache;
+
+  /**
+   * Whether the backing reader resolves pages through a transaction intent log.
+   *
+   * <p>
+   * Captured once because it decides BOTH memoizations this class performs — the point-lookup cache
+   * above and {@link #getRootReference}'s cached root — and they must never drift apart: an
+   * intent-log reader resolves uncommitted pages under an already-committed revision number, so
+   * either memoization would pin or serve content an in-flight commit can still replace.
+   * </p>
+   */
+  private final boolean usesTrxIntentLog;
+
+  /**
+   * The reader's snapshot coordinates, captured once.
+   *
+   * <p>
+   * Each of the three accessors runs {@code assertNotClosed()} and the last dereferences the revision
+   * root page, so reading them per lookup put three guarded virtual calls on the hot path for values
+   * that cannot change over a reader's lifetime.
+   * </p>
+   */
+  private final long databaseId;
+
+  private final long resourceId;
+
+  private final int revisionNumber;
+
+  /**
    * Protected constructor.
    *
    * @param storageEngineReader the storage engine reader
@@ -108,6 +158,213 @@ public abstract class AbstractHOTIndexReader<K> {
     this.storageEngineReader = requireNonNull(storageEngineReader);
     this.indexType = requireNonNull(indexType);
     this.indexNumber = indexNumber;
+    // hasTrxIntentLog() rather than `instanceof StorageEngineWriter`: the writer hands out a plain
+    // NodeStorageEngineReader carrying its intent log (StorageEngineWriter#getStorageEngineReader),
+    // which is NOT a StorageEngineWriter yet resolves uncommitted pages under an already-committed
+    // revision number. Nothing constructs an index reader over one today, but one call would poison
+    // that revision process-wide; the intent-log test is exactly the property that matters.
+    //
+    // Taken straight off the reader's own buffer manager: routing through getResourceSession() is
+    // the longer way round to the very same object, and would have meant a new method on the public
+    // ResourceSession interface for a cache that is not per-resource at all.
+    this.usesTrxIntentLog = storageEngineReader.hasTrxIntentLog();
+    // DEGRADE, never throw. Before memoization an index reader needed nothing but a
+    // StorageEngineReader, so requiring a wired-up buffer manager here would turn a working index
+    // open into an NPE from a constructor for any reader that has none — a test double, a forwarding
+    // decorator, an embedded wiring path. Missing infrastructure is a reason to skip the cache, not
+    // to fail the read; the two branches below are the same "no cache" outcome as a writer-backed
+    // reader, which is the behaviour that shipped before this class memoized anything.
+    final HOTLookupCache sessionCache;
+    if (usesTrxIntentLog) {
+      sessionCache = null;
+    } else {
+      final BufferManager bufferManager = storageEngineReader.getBufferManager();
+      sessionCache = bufferManager == null
+          ? null
+          : bufferManager.getHOTLookupCache();
+    }
+    this.databaseId = storageEngineReader.getDatabaseId();
+    this.resourceId = storageEngineReader.getResourceId();
+    this.revisionNumber = storageEngineReader.getRevisionNumber();
+    // A disabled cache is treated as no cache at all. Otherwise every lookup still built two keys,
+    // copied the key bytes and drained the whole posting list into a long[] only to have put()
+    // refuse it — which also meant maxEntries=0 did not actually measure the uncached path.
+    //
+    // databaseId == 0 disables it too, and that one is a correctness guard rather than a
+    // micro-optimisation: ResourceConfiguration#getDatabaseId returns 0 when no DatabaseConfiguration
+    // was attached, real ids are random POSITIVE longs, and resource ids restart at 0 in every
+    // database — so an unattached configuration would file two unrelated databases under the same
+    // (0, 0, revision, ...) slice of a JVM-GLOBAL table and answer one resource's lookup with
+    // another's posting list. Every production open path attaches one; this is what makes that a
+    // property the cache enforces rather than one it assumes.
+    this.lookupCache = sessionCache != null && sessionCache.isEnabled() && databaseId != 0L
+        ? sessionCache
+        : null;
+  }
+
+  /**
+   * Sentinel array length marking a memoized ABSENT key.
+   *
+   * <p>
+   * A present key always has at least one node key — {@code collectChunksViaLowerBoundWalk} returns
+   * {@code null} rather than an empty result — so zero length is free to mean "asked before, not
+   * there". Worth memoizing precisely because a miss is the EXPENSIVE case: an absent key cannot be
+   * answered by the landing-leaf fast path and falls through to the full lower bound, which
+   * re-descends the trie comparing per-child first keys.
+   * </p>
+   */
+  private static final long[] ABSENT = new long[0];
+
+  /**
+   * Reject a search mode a memoized point lookup cannot answer.
+   *
+   * <p>
+   * ONE copy, in the class that owns {@link #pointLookup}, rather than one per {@code get} overload:
+   * the invariant belongs to the cache key — {@link HOTLookupKey} does not carry the mode, so a
+   * mode-sensitive answer would be served across modes — and a subclass that adds an overload must
+   * inherit the guard rather than remember to restate it.
+   * </p>
+   *
+   * @param mode the caller's search mode
+   * @throws IllegalArgumentException if {@code mode} is anything but {@link SearchMode#EQUAL}
+   */
+  protected static void requireEqualMode(final SearchMode mode) {
+    if (mode != SearchMode.EQUAL) {
+      throw new IllegalArgumentException("get supports only SearchMode.EQUAL, got " + mode + "; use the range cursors");
+    }
+  }
+
+  /** Borrowing cache key over the caller's serialization buffer — see {@code HOTLookupKey.probe}. */
+  private HOTLookupKey probeKey(final byte[] keyBuf, final int keyLen) {
+    return HOTLookupKey.probe(databaseId, resourceId, revisionNumber, indexType, indexNumber, keyBuf, 0, keyLen);
+  }
+
+  /**
+   * Answer a point lookup for {@code keyBuf[0, keyLen)}, memoizing the result for this revision.
+   *
+   * <p>
+   * The whole point of the cache: for a committed revision the walk below is deterministic, so
+   * repeating it for a key already asked about is pure CPU waste. On a miss the freshly computed
+   * answer is admitted — including the absent case — subject to
+   * {@link HOTLookupCache#MAX_CACHED_NODE_KEYS}.
+   * </p>
+   *
+   * @param keyBuf buffer holding the serialized logical key
+   * @param keyLen serialized length of the key
+   * @return the references for the key, or {@code null} when it has none
+   */
+  protected final @Nullable NodeReferences pointLookup(final byte[] keyBuf, final int keyLen) {
+    // Unconditionally, not as a side effect of building a probe key: HOTLookupKey.probe runs the
+    // identical checkFromIndexSize, so without this the SAME malformed (keyBuf, keyLen) is diagnosed
+    // or waved through depending on whether a cache happens to be configured — a writer-backed
+    // reader or sirix.hotLookupCache.maxEntries=0 took the unchecked path.
+    Objects.checkFromIndexSize(0, keyLen, requireNonNull(keyBuf, "keyBuf").length);
+    final HOTLookupCache cache = lookupCache;
+    if (cache == null) {
+      return computePointLookup(keyBuf, keyLen);
+    }
+    // ONE key object, hashed ONCE, reused for the probe and for the admission. Building it per phase
+    // instead cost three allocations and three full passes over the key bytes on every miss — and a
+    // miss is the path that must not end up slower than the walk the cache exists to avoid.
+    final HOTLookupKey probe = probeKey(keyBuf, keyLen);
+    final long[] hit = cache.get(probe);
+    if (hit != null) {
+      // A fresh NodeReferences over a COPY per hit. Both halves are load-bearing: the class is
+      // mutable and getNodeKeys() hands out the live set, so sharing the cached instance would turn
+      // "every lookup returns a fresh object" into an aliasing contract the first mutating consumer
+      // would break for everyone else — and `hit` is the cache's own stored array, which a consumer
+      // must never be handed a reference to.
+      return hit.length == 0
+          ? null
+          : NodeReferences.copyOfSortedUnchecked(hit);
+    }
+    // Snapshot the key bytes BEFORE the walk, not after it. `probe` BORROWS the caller's reusable
+    // serialization buffer and froze its hash at construction, while computePointLookup below is an
+    // overridable extension point running on the same thread with that very buffer in reach —
+    // serializeKeyToArray writes into it in place whenever the key fits. Copying afterwards would
+    // file the entry under hash(bytes-before-the-walk) while carrying bytes-after: a slot no probe
+    // can ever match, or — on a 32-bit hash collision — one that answers a different logical key.
+    // The copy costs one byte[] per miss even when the answer turns out too large to admit, which is
+    // the rare case; nothing on today's walk path rewrites the buffer, but the ordering is what makes
+    // that a property of this method rather than of every future override.
+    final HOTLookupKey owned = probe.owned();
+    // Captured BEFORE the walk reads a single page, and handed back at admission. An invalidation
+    // sweep that overlaps this walk bumps the generation, so the answer below — which may have been
+    // built from pages the sweep is discarding — is refused rather than resurrected under a revision
+    // number truncateTo is about to re-issue over different content. Ordering the sweep's own steps
+    // cannot achieve this; see HOTLookupCache#generation.
+    final long generation = cache.generation();
+    final NodeReferences computed = computePointLookup(keyBuf, keyLen);
+    memoize(cache, owned, computed, generation);
+    return computed;
+  }
+
+  /**
+   * Compute a point lookup without consulting or populating the cache. Overridden where a reader has
+   * a fallback beyond the chunk walk.
+   *
+   * @param keyBuf buffer holding the serialized logical key
+   * @param keyLen serialized length of the key
+   * @return the references for the key, or {@code null} when it has none
+   */
+  protected @Nullable NodeReferences computePointLookup(final byte[] keyBuf, final int keyLen) {
+    return collectChunksViaLowerBoundWalk(keyBuf, keyLen);
+  }
+
+  /**
+   * Admit a freshly computed answer, absent results included.
+   *
+   * @param cache the cache to admit into
+   * @param key the OWNING key, copied off the probe before the walk ran — see {@link #pointLookup}
+   * @param computed the answer, or {@code null} when the key has none
+   * @param generation the cache's sweep generation, read before the answer was computed
+   */
+  private static void memoize(final HOTLookupCache cache, final HOTLookupKey key,
+      final @Nullable NodeReferences computed, final long generation) {
+    if (computed == null) {
+      cache.put(key, ABSENT, generation);
+      return;
+    }
+    // Gate BEFORE exporting, so an oversized posting list is never materialized here.
+    if (computed.cardinality() > HOTLookupCache.MAX_CACHED_NODE_KEYS) {
+      return; // too big to be worth copying on every hit — see MAX_CACHED_NODE_KEYS
+    }
+    // Sized and filled by ONE read of the representation. Sizing from cardinality() and then filling
+    // through forEachNodeKey is two independent reads, and a disagreement between them yields a
+    // TRUNCATED posting list that is indistinguishable from a complete one — the failure this cache
+    // must never produce, since a wrong answer here is served silently for the rest of the revision.
+    // The bound itself is re-checked by put(), which refuses an oversized array outright, so there is
+    // no second length test here: the gate above exists to avoid MATERIALIZING a huge posting list,
+    // not to enforce the bound twice.
+    final long[] nodeKeys = computed.toSortedArray();
+    // A zero-length array is the ABSENT sentinel, so a non-null-but-empty result must NOT be stored:
+    // it would come back as null on the next hit, and NameIndex/PathIndex distinguish those two
+    // outcomes. Both producers guarantee non-empty today (the accumulator returns null for an empty
+    // result rather than an empty NodeReferences), but computePointLookup is overridable and the
+    // sentinel makes the invariant load-bearing, so it is checked here rather than assumed.
+    if (nodeKeys.length == 0) {
+      return;
+    }
+    // The ordering contract is enforced HERE, once per array ever cached, rather than by
+    // NodeReferences.copyOfSortedUnchecked on every hit — the hit path would re-derive a property of an
+    // immutable array it had already established, at up to MAX_CACHED_NODE_KEYS serial unsigned
+    // comparisons a time. Not dropped, because copyOfSortedUnchecked's own javadoc explains why an
+    // assert is
+    // not enough: an out-of-order run makes contains()'s unsigned binary search report present node
+    // keys as absent, with no exception anywhere.
+    //
+    // REFUSED, not thrown. Memoization is an optimization the caller never asked for, so a run this
+    // cannot admit must cost a recomputation and nothing else — the same bargain the class makes for
+    // an evicted entry. Throwing instead would fail a query that had already
+    // computed its answer, and only on the configurations where a HOTLookupCache exists: the same
+    // lookup would keep succeeding on a writer-backed reader, under EmptyBufferManager, or with the
+    // cache sized to zero. That is the configuration-dependent diagnosis this read path is written to
+    // avoid, and it would be reached with the result in hand.
+    if (!NodeReferences.isSortedAscending(nodeKeys)) {
+      LOGGER.warn("Refusing to memoize a posting list that is not strictly ascending unsigned; key={}", key);
+      return;
+    }
+    cache.put(key, nodeKeys, generation);
   }
 
   /**
@@ -152,8 +409,7 @@ public abstract class AbstractHOTIndexReader<K> {
     final ChunkWalkState pooled = pooledWalkState.getAndSet(null);
     final ChunkWalkState state = pooled != null
         ? pooled
-        : new ChunkWalkState(new HOTTrieReader(storageEngineReader),
-            new NodeReferencesSerializer.ChunkAccumulator());
+        : new ChunkWalkState(new HOTTrieReader(storageEngineReader), new NodeReferencesSerializer.ChunkAccumulator());
     final HOTTrieReader trie = state.trie();
     final NodeReferencesSerializer.ChunkAccumulator accumulator = state.accumulator();
     try {
@@ -310,7 +566,11 @@ public abstract class AbstractHOTIndexReader<K> {
       return root;
     }
     root = resolveRootReference();
-    if (root != null && !(storageEngineReader instanceof StorageEngineWriter)) {
+    // The SAME captured predicate as lookupCache, so the two memoization decisions cannot drift: a
+    // reader carrying a transaction intent log resolves uncommitted pages, so memoizing its root
+    // reference would pin a chain an in-flight commit can replace. (`instanceof StorageEngineWriter`
+    // missed the plain reader the writer hands out over its own intent log.)
+    if (root != null && !usesTrxIntentLog) {
       cachedRootReference = root; // benign race: resolution is idempotent for a snapshot
     }
     return root;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexReader.java
@@ -29,6 +29,7 @@ package io.sirix.index.hot;
 
 import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
+import io.sirix.api.StorageEngineWriter;
 import io.sirix.index.IndexType;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.CASPage;
@@ -196,7 +197,28 @@ public abstract class AbstractHOTIndexReader<K> {
    *
    * @return the root page reference, or null if not found
    */
+  /**
+   * Root reference, memoized after the first resolution for read-only snapshots: the chain
+   * {@code RevisionRootPage -> index page -> child reference} is immutable for a committed revision,
+   * yet the profile showed every point lookup re-walking it (~16% of a hit). A writer-backed reader
+   * resolves fresh per call — an in-flight commit can replace the index page and its child
+   * references.
+   */
+  private @Nullable PageReference cachedRootReference;
+
   protected @Nullable PageReference getRootReference() {
+    PageReference root = cachedRootReference;
+    if (root != null) {
+      return root;
+    }
+    root = resolveRootReference();
+    if (root != null && !(storageEngineReader instanceof StorageEngineWriter)) {
+      cachedRootReference = root; // benign race: resolution is idempotent for a snapshot
+    }
+    return root;
+  }
+
+  private @Nullable PageReference resolveRootReference() {
     final RevisionRootPage rootPage = storageEngineReader.getActualRevisionRootPage();
     return switch (indexType) {
       case PATH -> {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -52,8 +52,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static java.util.Objects.requireNonNull;
@@ -1055,6 +1058,9 @@ public abstract class AbstractHOTIndexWriter<K> {
     }
 
     selfHealScope = null; // set by registerFreshSubtree iff this dispatch splices a subtree
+    lastDispatchHandler = merge
+        ? "merge"
+        : "branch";
     final boolean structurallyChanged = merge
         ? mergeIntoLeaf(navResult, keyBuf, keyLen, valueBuf, valueLen, keySlice)
         : branchAboveLeaf(navResult, analysis, keySlice, valueBuf, valueLen);
@@ -1146,6 +1152,7 @@ public abstract class AbstractHOTIndexWriter<K> {
       }
       for (final HOTMalformedSubtreeDetector.MalformedSubtree m : malformed) {
         STRUCTURAL_SELFHEAL_REBUILD.incrementAndGet();
+        HEAL_TALLY.computeIfAbsent(m.invariant() + "|" + lastDispatchHandler, k -> new AtomicLong()).incrementAndGet();
         rebuildExistingSubtree(m.reference());
       }
     }
@@ -1269,6 +1276,38 @@ public abstract class AbstractHOTIndexWriter<K> {
         return null;
       }
       cur = indirect.getChildReference(0);
+      if (cur == null) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * The last (lex-greatest) key of the subtree at {@code ref}, by rightmost descent — the true
+   * maximum when the subtree is internally ordered, which is what the propagation boundary check
+   * needs (a genuinely disordered subtree is the detector's to flag, not this walk's).
+   */
+  private byte @Nullable [] lastKeyOfSubtree(@Nullable PageReference ref) {
+    if (ref == null) {
+      return null;
+    }
+    PageReference cur = ref;
+    for (int depth = 0; depth <= MAX_PATH_DEPTH; depth++) {
+      final Page page = resolveHOTPageForTraversal(cur);
+      if (page == null) {
+        return null;
+      }
+      if (page instanceof HOTLeafPage leaf) {
+        final int n = leaf.getEntryCount();
+        return n == 0
+            ? null
+            : leaf.getKey(n - 1);
+      }
+      if (!(page instanceof HOTIndirectPage indirect) || indirect.getNumChildren() == 0) {
+        return null;
+      }
+      cur = indirect.getChildReference(indirect.getNumChildren() - 1);
       if (cur == null) {
         return null;
       }
@@ -1504,19 +1543,15 @@ public abstract class AbstractHOTIndexWriter<K> {
    * Direction 1 outcome counter -- how often the C2 catch sub-inserts vs falls back to scoped
    * rebuild. Useful for empirical hit-rate measurement; never read by the writer.
    */
-  public static final java.util.concurrent.atomic.AtomicLong DIRECTION_ONE_SUBINSERT =
-      new java.util.concurrent.atomic.AtomicLong();
-  public static final java.util.concurrent.atomic.AtomicLong DIRECTION_ONE_FALLBACK =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong DIRECTION_ONE_SUBINSERT = new AtomicLong();
+  public static final AtomicLong DIRECTION_ONE_FALLBACK = new AtomicLong();
 
   /**
    * Issue B outcome counters -- how often handleOffPathOverflow succeeds vs falls back to the
    * caller's whole-index self-heal. Plan §4.3.
    */
-  public static final java.util.concurrent.atomic.AtomicLong OFF_PATH_OVERFLOW_OK =
-      new java.util.concurrent.atomic.AtomicLong();
-  public static final java.util.concurrent.atomic.AtomicLong OFF_PATH_OVERFLOW_FALLBACK =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong OFF_PATH_OVERFLOW_OK = new AtomicLong();
+  public static final AtomicLong OFF_PATH_OVERFLOW_FALLBACK = new AtomicLong();
 
   /**
    * Stage 3c (docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md §12) -- how often the scoped
@@ -1524,23 +1559,22 @@ public abstract class AbstractHOTIndexWriter<K> {
    * increment per ancestor refreshed). A high count means Stage 3c stopped a cascade that the
    * original behaviour would have grown into a depth-0 whole rebuild.
    */
-  public static final java.util.concurrent.atomic.AtomicLong REBUILD_HEIGHT_ESCALATION_AVOIDED =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong REBUILD_HEIGHT_ESCALATION_AVOIDED = new AtomicLong();
   /**
-   * Stage 3c defensive arm -- the new partial would break I7 (ascending, distinct partials); the
-   * propagation falls back to a scoped rebuild at the ancestor's depth instead of an in-place
-   * re-encode. Should stay near zero in practice (the C2-firing descent already picked a slot for K,
-   * so the new partial slots into the same ordering).
+   * Stage 3c defensive arm -- the rebuilt slot's key range collides with a sibling's (the Direction-1
+   * shape: subset routing admitted a key the lex order does not), so the propagation falls back to a
+   * scoped rebuild at the ancestor's depth instead of an in-place re-encode. Stored partials are
+   * never touched by the propagation (Stage 5: a sparse partial is the slot's position in the block
+   * trie, invariant under content growth), so sibling ORDER is the only property a content change can
+   * break on the way up. Should stay near zero in practice.
    */
-  public static final java.util.concurrent.atomic.AtomicLong REBUILD_PROPAGATION_I7_FALLBACK =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong REBUILD_PROPAGATION_ORDER_FALLBACK = new AtomicLong();
   /**
    * Total invocations of {@link #rebuildSubtree} (any depth, any caller). With
    * {@link #REBUILD_HEIGHT_ESCALATION_AVOIDED} reports both how often a rebuild occurred and how
    * often Stage 3c's propagation re-encoded at least one ancestor.
    */
-  public static final java.util.concurrent.atomic.AtomicLong REBUILD_SUBTREE_CALLED =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong REBUILD_SUBTREE_CALLED = new AtomicLong();
 
 
   /**
@@ -1764,6 +1798,7 @@ public abstract class AbstractHOTIndexWriter<K> {
 
     // Step 3: re-point N's reference at its parent + register fresh subtree.
     navResult.pathRefs()[pathDepth - 1].setPage(newN);
+    lastDispatchHandler = "h:merge-integrate";
     registerFreshSubtree(navResult.pathRefs()[pathDepth - 1]);
     OFF_PATH_OVERFLOW_OK.incrementAndGet();
     return true;
@@ -1819,12 +1854,13 @@ public abstract class AbstractHOTIndexWriter<K> {
       return false;
     }
 
+    lastDispatchHandler = "h:merge-offpath";
     registerFreshSubtree(result.touchedRef());
     if (Boolean.getBoolean("hot.diag.postHandlerValidate")) {
-      final java.util.List<HOTMalformedSubtreeDetector.MalformedSubtree> defects =
+      final List<HOTMalformedSubtreeDetector.MalformedSubtree> defects =
           HOTMalformedSubtreeDetector.detect(navResult.pathRefs()[0], this::resolveHOTPageForTraversal);
-      final java.util.HashSet<String> seen = new java.util.HashSet<>(4096);
-      final java.util.ArrayList<String> duplicates = new java.util.ArrayList<>();
+      final HashSet<String> seen = new HashSet<>(4096);
+      final ArrayList<String> duplicates = new ArrayList<>();
       collectKeysForI1(navResult.pathRefs()[0].getPage(), seen, duplicates);
       System.err.println("[POST-HANDLER-FULL-N] depth=" + pathDepth + " defects=" + defects + " duplicates="
           + duplicates.size() + (duplicates.isEmpty()
@@ -1838,12 +1874,12 @@ public abstract class AbstractHOTIndexWriter<K> {
   /**
    * Diagnostic helper — walk the subtree rooted at {@code page} and collect duplicate stored keys.
    */
-  private void collectKeysForI1(io.sirix.page.interfaces.Page page, java.util.HashSet<String> seen,
-      java.util.ArrayList<String> duplicates) {
+  private void collectKeysForI1(io.sirix.page.interfaces.Page page, HashSet<String> seen,
+      ArrayList<String> duplicates) {
     if (page instanceof io.sirix.page.HOTLeafPage leaf) {
       final int count = leaf.getEntryCount();
       for (int i = 0; i < count; i++) {
-        final String h = java.util.HexFormat.of().formatHex(leaf.getKey(i));
+        final String h = HexFormat.of().formatHex(leaf.getKey(i));
         if (!seen.add(h)) {
           duplicates.add(h);
         }
@@ -1911,6 +1947,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     final HOTIncrementalInsert.IntegrationResult result =
         HOTIncrementalInsert.integrate(navResult.pathNodes(), buildSpineRefs(navResult), navResult.pathChildIndices(),
             navResult.pathDepth(), biNode, revision, pageKeyAllocator);
+    lastDispatchHandler = "h:merge-offpath-fullN";
     registerFreshSubtree(result.touchedRef());
     return true;
   }
@@ -2013,6 +2050,7 @@ public abstract class AbstractHOTIndexWriter<K> {
           return false; // I8-unsafe combo-add -> canonical rebuildSubtree(insertDepth)
         }
         pathRefs[insertDepth].setPage(newNode);
+        lastDispatchHandler = "h:combo-site1";
         registerFreshSubtree(pathRefs[insertDepth]);
         return true;
       } catch (IllegalArgumentException c2Collision) {
@@ -2025,6 +2063,7 @@ public abstract class AbstractHOTIndexWriter<K> {
         // whole-index self-heal).
         comboLeaf.close();
         if (isDirectionOneI8Safe(navResult, insertDepth, analysis.affectedChildIndex(), keySlice)) {
+          lastDispatchHandler = "h:d1-subinsert";
           DIRECTION_ONE_SUBINSERT.incrementAndGet();
           return subInsertAt(node.getChildReference(analysis.affectedChildIndex()), keySlice, keySlice.length,
               valueSlice, valueSlice.length);
@@ -2072,6 +2111,7 @@ public abstract class AbstractHOTIndexWriter<K> {
         ensurePathChildrenLoaded(pathNodes);
         final HOTIncrementalInsert.IntegrationResult result = HOTIncrementalInsert.integrate(pathNodes,
             buildSpineRefs(navResult), childSlots, insertDepth, biNode, revision, pageKeyAllocator);
+        lastDispatchHandler = "h:integrate-existing-bit";
         registerFreshSubtree(result.touchedRef());
         return true;
       }
@@ -2114,6 +2154,7 @@ public abstract class AbstractHOTIndexWriter<K> {
             return false; // I8-unsafe combo-add -> canonical rebuildSubtree(insertDepth)
           }
           pathRefs[insertDepth + 1].setPage(newChild);
+          lastDispatchHandler = "h:combo-site3";
           registerFreshSubtree(pathRefs[insertDepth + 1]);
           return true;
         } catch (IllegalArgumentException collisionOrPrecondition) {
@@ -2124,6 +2165,7 @@ public abstract class AbstractHOTIndexWriter<K> {
           // (docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md §11 iteration 4).
           comboLeaf.close();
           if (isDirectionOneI8Safe(navResult, insertDepth + 1, childEntryIndex, keySlice)) {
+            lastDispatchHandler = "h:d1-subinsert";
             DIRECTION_ONE_SUBINSERT.incrementAndGet();
             return subInsertAt(child.getChildReference(childEntryIndex), keySlice, keySlice.length, valueSlice,
                 valueSlice.length);
@@ -2160,9 +2202,36 @@ public abstract class AbstractHOTIndexWriter<K> {
       // Fall back to the canonical rebuild instead of the lossy pairing.
       if (navResult.leaf().isBitConstantAtAbsBit(beta) != (1 - betaValue)) {
         keyLeaf.close();
+        if (strandDischargeSplitIntegrate(navResult, keySlice, valueSlice)) {
+          return true;
+        }
+        lastDispatchHandler = "h:strand-pairleaf";
         leafScopedRebuild(navResult, keySlice, valueSlice); // strandable keys are the descended leaf's
         STRAND_LEAF_REBUILD.incrementAndGet();
         return true;
+      }
+      // Direction-1-dual pre-guard: the pair keeps the leaf's slot, so K becomes the slot's new
+      // minimum (betaValue == 0) or maximum (betaValue == 1). Subset routing brought K here, but
+      // subset routing does not imply lex position — if K falls outside the slot's boundary with
+      // its neighbour, the pairing would break I8/I12 (the shape the impossibility analysis
+      // proves no local primitive fixes). Detect it BEFORE splicing and take the canonical
+      // rebuild instead of manufacturing a violation for the detector to repair.
+      if (pathDepth > 0) {
+        final HOTIndirectPage pairParent = pathNodes[pathDepth - 1];
+        final int leafSlot = childSlots[pathDepth - 1];
+        if (betaValue == 0 && leafSlot > 0) {
+          final byte[] prevLast = lastKeyOfSubtree(pairParent.getChildReference(leafSlot - 1));
+          if (prevLast != null && Arrays.compareUnsigned(prevLast, keySlice) >= 0) {
+            keyLeaf.close();
+            return false; // K sorts at or below the previous sibling: canonical rebuildSubtree
+          }
+        } else if (betaValue == 1 && leafSlot + 1 < pairParent.getNumChildren()) {
+          final byte[] nextFirst = firstKeyOfSubtree(pairParent.getChildReference(leafSlot + 1));
+          if (nextFirst != null && Arrays.compareUnsigned(keySlice, nextFirst) >= 0) {
+            keyLeaf.close();
+            return false; // K sorts at or above the next sibling: canonical rebuildSubtree
+          }
+        }
       }
       final PageReference leafRef = swizzle(navResult.leaf());
       final HOTIncrementalInsert.BiNode biNode = betaValue == 1
@@ -2171,6 +2240,7 @@ public abstract class AbstractHOTIndexWriter<K> {
       ensurePathChildrenLoaded(pathNodes);
       final HOTIncrementalInsert.IntegrationResult result = HOTIncrementalInsert.integrate(pathNodes,
           buildSpineRefs(navResult), childSlots, pathDepth, biNode, revision, pageKeyAllocator);
+      lastDispatchHandler = "h:pair-leaf";
       registerFreshSubtree(result.touchedRef());
       return true;
     }
@@ -2194,6 +2264,7 @@ public abstract class AbstractHOTIndexWriter<K> {
           return false; // I8-unsafe combo-add -> canonical rebuildSubtree(insertDepth)
         }
         pathRefs[childDepth].setPage(newChild);
+        lastDispatchHandler = "h:boundary-addentry";
         registerFreshSubtree(pathRefs[childDepth]);
         return true;
       }
@@ -2218,6 +2289,7 @@ public abstract class AbstractHOTIndexWriter<K> {
       ensurePathChildrenLoaded(pathNodes);
       final HOTIncrementalInsert.IntegrationResult result = HOTIncrementalInsert.integrate(pathNodes,
           buildSpineRefs(navResult), childSlots, childDepth, biNode, revision, pageKeyAllocator);
+      lastDispatchHandler = "h:wrap-full";
       registerFreshSubtree(result.touchedRef());
       return true;
     }
@@ -2237,6 +2309,7 @@ public abstract class AbstractHOTIndexWriter<K> {
       return false; // I8-unsafe combo-add -> canonical rebuildSubtree(insertDepth)
     }
     pathRefs[insertDepth].setPage(newNode);
+    lastDispatchHandler = "h:fold-multi";
     registerFreshSubtree(pathRefs[insertDepth]);
     return true;
   }
@@ -2268,6 +2341,7 @@ public abstract class AbstractHOTIndexWriter<K> {
         swizzle(keyLeaf), revision, pageKeyAllocator);
     final HOTIncrementalInsert.IntegrationResult result = HOTIncrementalInsert.integrate(navResult.pathNodes(),
         buildSpineRefs(navResult), navResult.pathChildIndices(), insertDepth, biNode, revision, pageKeyAllocator);
+    lastDispatchHandler = "h:branch-integrate";
     registerFreshSubtree(result.touchedRef());
     return true;
   }
@@ -2432,6 +2506,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     // 4. Integrate the split BiNode at insertDepth — the standard capacity cascade.
     final HOTIncrementalInsert.IntegrationResult result = HOTIncrementalInsert.integrate(navResult.pathNodes(),
         buildSpineRefs(navResult), navResult.pathChildIndices(), insertDepth, split, revision, pageKeyAllocator);
+    lastDispatchHandler = "h:combo-site2-fold";
     registerFreshSubtree(result.touchedRef());
     return true;
   }
@@ -2549,6 +2624,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     reattachSegmentRefs(rebuilt, segmentRefs);
     final PageReference subtreeRef = navResult.pathRefs()[safeDepth];
     subtreeRef.setPage(rebuilt);
+    lastDispatchHandler = "h:rebuildSubtree";
     registerFreshSubtree(subtreeRef);
 
     // Plan §12 Stage 3c (A): propagate the rebuilt subtree's height + (if firstKey changed)
@@ -2571,6 +2647,23 @@ public abstract class AbstractHOTIndexWriter<K> {
     storageEngineWriter.getLog().releaseOrphanedHOTLeaves(staleLeafRefs);
   }
 
+  /**
+   * Heal attribution: per-{@code (invariant|dispatch handler)} tally of detector heals, keyed
+   * {@code "I5|h:merge-integrate"}-style. Only touched when a heal actually fires (rare by design),
+   * so the hot path pays nothing beyond the {@link #lastDispatchHandler} field store. This is the
+   * instrumentation that attributed 91% of all heals to the spine propagation's dense-partial
+   * recompute (plan doc, Stage 5) — kept so a future regression is attributable the same day it
+   * lands.
+   */
+  public static final ConcurrentHashMap<String, AtomicLong> HEAL_TALLY = new ConcurrentHashMap<>();
+
+  /**
+   * The structural handler that produced the tree state a subsequent heal repairs — the attribution
+   * key half of {@link #HEAL_TALLY}. Written as a constant-string field store at each dispatch site;
+   * read only when a heal fires.
+   */
+  protected String lastDispatchHandler = "?";
+
   /** Disable hook for the post-dispatch structural self-heal (default ON — correctness first). */
   private static final boolean SELFHEAL_STRUCTURAL = !Boolean.getBoolean("hot.selfheal.structural.disable");
   /**
@@ -2579,8 +2672,7 @@ public abstract class AbstractHOTIndexWriter<K> {
    * canonical rebuild. Distinct from {@link #BRANCH_I8_UNSAFE_REBUILD} (the pre-commit combo-add
    * guard) — this is the defense-in-depth backstop that covers the merge/integrate handlers too.
    */
-  public static final java.util.concurrent.atomic.AtomicLong STRUCTURAL_SELFHEAL_REBUILD =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong STRUCTURAL_SELFHEAL_REBUILD = new AtomicLong();
 
   /**
    * Defense-in-depth backstop after a structural change: walk {@code keySlice}'s <em>current</em>
@@ -2649,21 +2741,25 @@ public abstract class AbstractHOTIndexWriter<K> {
    * the insert depth (off-path / multi-leaf / BiNode-wrap source — the minimal correct scope when K
    * and the strandable keys occupy different node slots).
    */
-  public static final java.util.concurrent.atomic.AtomicLong STRAND_LEAF_REBUILD =
-      new java.util.concurrent.atomic.AtomicLong();
-  public static final java.util.concurrent.atomic.AtomicLong STRAND_FULL_FALLBACK =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong STRAND_LEAF_REBUILD = new AtomicLong();
+  /**
+   * Strands discharged canonically: the descended leaf held keys on both sides of the branch bit, so
+   * the union {@code leaf ∪ {K}} was split at its own key-set MSDB and the BiNode integrated at the
+   * leaf's depth — Binna's insert, leaving no straddled leaf behind (unlike the
+   * {@link #leafScopedRebuild} splice, which keeps the union in the leaf's slot and thereby
+   * re-attracts the strand guard on later inserts).
+   */
+  public static final AtomicLong STRAND_SPLIT_INTEGRATE = new AtomicLong();
+  public static final AtomicLong STRAND_FULL_FALLBACK = new AtomicLong();
   /** Off-path strands discharged by the two-leaf migration ({@link #tryTwoLeafMigration}). */
-  public static final java.util.concurrent.atomic.AtomicLong STRAND_TWO_LEAF_MIGRATE =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong STRAND_TWO_LEAF_MIGRATE = new AtomicLong();
   /**
    * Branch combo-adds discharged by the canonical {@link #rebuildSubtree} because the partial-sorted
    * new slot is structurally malformed ({@link #nodeStructurallyMalformed} — typically the I7≡I8
    * first-key-order divergence under multi-value leaves). Bounded like the Direction-1 fallback; a
    * runaway count signals a workload stressing off-path-bit reordering.
    */
-  public static final java.util.concurrent.atomic.AtomicLong BRANCH_I8_UNSAFE_REBUILD =
-      new java.util.concurrent.atomic.AtomicLong();
+  public static final AtomicLong BRANCH_I8_UNSAFE_REBUILD = new AtomicLong();
 
   /**
    * Surgical strand discharge ({@code O(one leaf + path)}). When a branch-add stranding guard fires
@@ -2679,6 +2775,64 @@ public abstract class AbstractHOTIndexWriter<K> {
    * descended leaf's slot, so rebuilding {@code leaf ∪ {K}} and re-splicing there preserves routing
    * and re-discriminates them straddle-free (Fact R1). 99%+ of strands (empirically) hit this path.
    */
+  /**
+   * Canonical strand discharge — Binna's insert applied to a leaf that spans the branch bit. The
+   * strand state ("the descended leaf holds keys on both sides of {@code beta}") means the canonical
+   * R(S) cut runs <em>through</em> the leaf: the union {@code leaf ∪ {K}} splits at its own key-set
+   * MSDB into two complete R(S) halves (Fact R1), and the resulting BiNode integrates at the leaf's
+   * depth exactly as a full-leaf overflow does. Both primitives are the merge path's — the single
+   * most exercised pipeline in this writer.
+   *
+   * <p>
+   * Contrast with {@link #leafScopedRebuild}: that splice keeps the whole union in the leaf's slot,
+   * which routes correctly (the slot's sparse partial is untouched and every key subset-matches it)
+   * but leaves a leaf spanning a bit above its cut point — a shape the strand guard fires on again
+   * for every later key branching at that bit. The split removes the shape, so the guard goes quiet.
+   *
+   * <p>
+   * The integrate cascade is pre-checked ({@link #canIntegrateBiNodeCleanly}) <em>before</em> the
+   * split allocates pages, so a {@code false} return leaves no half-built state and no leaked pages;
+   * the caller falls back to the splice. An exception escaping {@code integrate} after a clean
+   * pre-check is a real bug, exactly as on the merge path, and propagates.
+   *
+   * @return {@code true} iff the strand was discharged canonically
+   */
+  private boolean strandDischargeSplitIntegrate(LeafNavigationResult navResult, byte[] keySlice, byte[] valueSlice) {
+    final HOTLeafPage leaf = navResult.leaf();
+    if (!leaf.canSplit()) {
+      return false;
+    }
+    // The union's MSDB, from its extremes: leaf entries are lex-sorted (I2), so the union's min
+    // and max are min/max of (firstKey, lastKey, K). Computable without building the union.
+    final byte[] leafFirst = leaf.getFirstKey();
+    final byte[] leafLast = leaf.getKey(leaf.getEntryCount() - 1);
+    if (leafFirst == null || leafLast == null) {
+      return false;
+    }
+    final byte[] unionMin = Arrays.compareUnsigned(keySlice, leafFirst) < 0
+        ? keySlice
+        : leafFirst;
+    final byte[] unionMax = Arrays.compareUnsigned(keySlice, leafLast) > 0
+        ? keySlice
+        : leafLast;
+    final int unionMsdb = HOTBulkBuilder.msdb(unionMin, unionMax);
+    if (!canIntegrateBiNodeCleanly(navResult.pathNodes(), navResult.pathChildIndices(), navResult.pathDepth(),
+        unionMsdb)) {
+      return false;
+    }
+    final int revision = storageEngineWriter.getRevisionNumber();
+    final HOTIncrementalInsert.BiNode biNode =
+        HOTIncrementalInsert.splitLeafPage(leaf, keySlice, valueSlice, revision, indexType, pageKeyAllocator);
+    ensurePathChildrenLoaded(navResult.pathNodes());
+    lastDispatchHandler = "h:strand-split-integrate";
+    final HOTIncrementalInsert.IntegrationResult result =
+        HOTIncrementalInsert.integrate(navResult.pathNodes(), buildSpineRefs(navResult), navResult.pathChildIndices(),
+            navResult.pathDepth(), biNode, revision, pageKeyAllocator);
+    registerFreshSubtree(result.touchedRef());
+    STRAND_SPLIT_INTEGRATE.incrementAndGet();
+    return true;
+  }
+
   private boolean dischargeStrandViaLeafRebuild(LeafNavigationResult navResult, HOTIndirectPage oldNode,
       HOTIndirectPage newNode, int nodeDepth, byte[] keySlice, byte[] valueSlice) {
     final int newSlot = newNode.findChildIndex(keySlice);
@@ -2688,6 +2842,10 @@ public abstract class AbstractHOTIndexWriter<K> {
     }
     // (a) On-path: strandable keys confined to the descended leaf -> O(one leaf + path).
     if (strandConfinedToLeaf(oldNode, newNode, newSlot, keySlice, navResult.leaf().getPageKey())) {
+      if (strandDischargeSplitIntegrate(navResult, keySlice, valueSlice)) {
+        return true;
+      }
+      lastDispatchHandler = "h:strand-leafrebuild-b";
       leafScopedRebuild(navResult, keySlice, valueSlice);
       STRAND_LEAF_REBUILD.incrementAndGet();
       return true;
@@ -2745,9 +2903,9 @@ public abstract class AbstractHOTIndexWriter<K> {
     if (!(sourceLeafPage instanceof HOTLeafPage sourceLeaf) || sourceLeaf.getPageKey() != sourceLeafPageKey) {
       return false; // source slot is not the single source leaf
     }
-    final java.util.HashSet<String> strandSet = new java.util.HashSet<>(strandKeys.size() * 2);
+    final HashSet<String> strandSet = new HashSet<>(strandKeys.size() * 2);
     for (final byte[] k : strandKeys) {
-      strandSet.add(java.util.HexFormat.of().formatHex(k));
+      strandSet.add(HexFormat.of().formatHex(k));
     }
     // This two-leaf migration extracts keys/values only and discards the source leaf. Rather
     // than route the side map across the two rebuilt leaves, decline: the caller's canonical
@@ -2759,7 +2917,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     final List<HOTBulkBuilder.Entry> remaining = new ArrayList<>(sourceLeaf.getEntryCount());
     for (int i = 0; i < sourceLeaf.getEntryCount(); i++) {
       final byte[] k = sourceLeaf.getKey(i);
-      if (strandSet.contains(java.util.HexFormat.of().formatHex(k))) {
+      if (strandSet.contains(HexFormat.of().formatHex(k))) {
         childEntries.add(new HOTBulkBuilder.Entry(k, sourceLeaf.getValue(i)));
       } else {
         remaining.add(new HOTBulkBuilder.Entry(k, sourceLeaf.getValue(i)));
@@ -2803,6 +2961,7 @@ public abstract class AbstractHOTIndexWriter<K> {
       }
 
       navResult.pathRefs()[nodeDepth].setPage(candidate);
+      lastDispatchHandler = "h:twoleaf-migrate";
       registerFreshSubtree(navResult.pathRefs()[nodeDepth]);
       if (nodeDepth > 0) {
         propagateRebuildUpSpine(navResult, nodeDepth, keySlice, valueSlice);
@@ -2904,6 +3063,7 @@ public abstract class AbstractHOTIndexWriter<K> {
 
     if (pathDepth == 0) { // the leaf is the whole index root
       navResult.leafRef().setPage(miniRoot);
+      lastDispatchHandler = "h:leafrebuild-root";
       registerFreshSubtree(navResult.leafRef());
       return;
     }
@@ -2912,11 +3072,12 @@ public abstract class AbstractHOTIndexWriter<K> {
     final PageReference oldLeafRef = navResult.leafRef();
     final PageReference newRef = swizzle(miniRoot);
     parent.setChildReference(leafSlot, newRef);
+    lastDispatchHandler = "h:leafrebuild-splice";
     registerFreshSubtree(newRef);
     // Reuse the scoped-rebuild spine propagation: treat the leaf level as rebuiltDepth=pathDepth so
     // it refreshes the parent's height + the leaf-slot partial (and recurses on an I7 collision).
     propagateRebuildUpSpine(navResult, pathDepth, keySlice, valueSlice);
-    storageEngineWriter.getLog().releaseOrphanedHOTLeaves(java.util.List.of(oldLeafRef));
+    storageEngineWriter.getLog().releaseOrphanedHOTLeaves(List.of(oldLeafRef));
   }
 
   /**
@@ -2962,23 +3123,28 @@ public abstract class AbstractHOTIndexWriter<K> {
   }
 
   /**
-   * Plan §12 Stage 3c -- propagate a scoped {@link #rebuildSubtree}'s effects up the spine via
-   * in-place re-encoding. At each ancestor from {@code rebuiltDepth - 1} down to 0:
+   * Plan §12 Stage 3c (partials-verbatim since Stage 5) -- propagate a scoped
+   * {@link #rebuildSubtree}'s effects up the spine via in-place re-encoding. At each ancestor from
+   * {@code rebuiltDepth - 1} down to 0:
    *
    * <ul>
    * <li>Recompute the ancestor's height as {@code 1 + max(child.height)} -- HOT heights are max-based
    * ({@link HOTBulkBuilder#assembleIndirect}); a single rebuilt slot's new height only matters if
    * it's the (possibly tied) maximum.</li>
-   * <li>If the rebuilt subtree's leftmost key changed (only when the rebuilt slot is 0), recompute
-   * the slot's sparse partial via {@link HOTIndirectPage#computeDensePartialKey}.</li>
-   * <li>Stop early if both are unchanged -- the propagation hit a stable ancestor.</li>
-   * <li>If the new partial would break I7 (must stay strictly between the prev/next sibling
-   * partials), fall back to a scoped {@link #rebuildSubtree} at this ancestor's depth. The recursive
-   * call re-enters this propagation; the cascade is at most {@code rebuiltDepth} levels.</li>
-   * <li>Otherwise re-encode the ancestor with the same children + disc bits, just an updated height
-   * (and partial for the rebuilt slot if changed). The ancestor's child references are shared with
-   * the prior version; only the rebuilt slot already points at fresh content via the swizzled
-   * {@link PageReference}.</li>
+   * <li>Keep every stored partial verbatim -- a sparse partial is the slot's position in the
+   * ancestor's block trie (off-path bits zero by convention), invariant under content growth of the
+   * subtree behind it. Recomputing it from the subtree's new first key stamps off-path bits and was
+   * the mass producer of I4/I5 heals (plan doc, Stage 5).</li>
+   * <li>Check the one property a content change can break: sibling key ORDER (I8/I12). Compare the
+   * rebuilt slot's extremes against its neighbours'; on a violation fall back to a scoped
+   * {@link #rebuildSubtree} at this ancestor's depth (the recursive call re-enters this propagation;
+   * the cascade is at most {@code rebuiltDepth} levels). The check runs at the immediate parent and
+   * continues upward only while the changed slot sits at its block's edge -- interior slots absorb
+   * the change locally.</li>
+   * <li>Stop early once neither the height nor an edge boundary can change further up.</li>
+   * <li>On a height change re-encode the ancestor with the same children + disc bits + partials, just
+   * an updated height. The ancestor's child references are shared with the prior version; only the
+   * rebuilt slot already points at fresh content via the swizzled {@link PageReference}.</li>
    * </ul>
    *
    * <p>
@@ -2993,6 +3159,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     final int[] childSlots = navResult.pathChildIndices();
     final int revision = storageEngineWriter.getRevisionNumber();
 
+    boolean boundaryRelevant = true;
     for (int ancestorDepth = rebuiltDepth - 1; ancestorDepth >= 0; ancestorDepth--) {
       final HOTIndirectPage ancestor = pathNodes[ancestorDepth];
       final int rebuiltSlot = childSlots[ancestorDepth];
@@ -3014,44 +3181,62 @@ public abstract class AbstractHOTIndexWriter<K> {
 
       // The rebuilt slot's PageReference is the same instance the ancestor holds in its
       // children array, so ancestor.getChildReference(rebuiltSlot) already sees the fresh
-      // subtree -- only the encoded partial may need refreshing.
-      final byte[] newSlotFirstKey = firstKeyOfSubtree(ancestor.getChildReference(rebuiltSlot));
-      final int oldSlotPartial = ancestor.getPartialKey(rebuiltSlot);
-      final int newSlotPartial = newSlotFirstKey != null
-          ? ancestor.computeDensePartialKey(newSlotFirstKey)
-          : oldSlotPartial;
-
+      // subtree. The slot's STORED PARTIAL is deliberately left untouched: a sparse partial
+      // encodes the slot's path through the ancestor's block trie — a position, not a content
+      // fingerprint — and the rebuilt subtree holds the same key set (plus a key that
+      // subset-routed through this very slot), so its position is unchanged. The previous
+      // shape recomputed the partial as densePK(new firstKey), which stamps the first key's
+      // values at OFF-PATH mask bits into an encoding whose off-path bits must be zero
+      // (Binna's sparse-path convention) — on this branch's attribution run that single line
+      // manufactured 1,151 I5 and 80 I4 violations per 36K-insert shred, ~91% of every
+      // self-heal the detector had to discharge.
+      //
+      // What a content change CAN legitimately break is sibling ORDER (I8/I12): the rebuilt
+      // subtree's minimum may have dropped below the previous sibling's maximum (the
+      // Direction-1 shape) — subset routing admits keys the lex order does not. That is a
+      // boundary property, checked as such; a violation falls back to the canonical scoped
+      // rebuild at this ancestor's depth, the Theorem-4 discharge for genuine firings.
       final boolean heightChanged = newAncestorHeight != ancestor.getHeight();
-      final boolean partialChanged = newSlotPartial != oldSlotPartial;
 
-      if (!heightChanged && !partialChanged) {
-        return; // Stable -- propagation complete.
-      }
-
-      // I7 (partials strictly ascending) safety: a new partial must stay between the prev/next
-      // sibling partials. A violation falls back to a scoped rebuild at this ancestor's depth
-      // -- still smaller than the original always-cascade-when-height-changes behaviour.
-      if (partialChanged) {
+      if (boundaryRelevant) {
+        final byte[] slotFirst = firstKeyOfSubtree(ancestor.getChildReference(rebuiltSlot));
+        final byte[] prevLast = rebuiltSlot > 0
+            ? lastKeyOfSubtree(ancestor.getChildReference(rebuiltSlot - 1))
+            : null;
+        final byte[] slotLast = rebuiltSlot + 1 < numChildren
+            ? lastKeyOfSubtree(ancestor.getChildReference(rebuiltSlot))
+            : null;
+        final byte[] nextFirst = rebuiltSlot + 1 < numChildren
+            ? firstKeyOfSubtree(ancestor.getChildReference(rebuiltSlot + 1))
+            : null;
         final boolean leftViolated =
-            rebuiltSlot > 0 && Integer.compareUnsigned(ancestor.getPartialKey(rebuiltSlot - 1), newSlotPartial) >= 0;
-        final boolean rightViolated = rebuiltSlot + 1 < numChildren
-            && Integer.compareUnsigned(newSlotPartial, ancestor.getPartialKey(rebuiltSlot + 1)) >= 0;
+            prevLast != null && slotFirst != null && Arrays.compareUnsigned(prevLast, slotFirst) >= 0;
+        final boolean rightViolated =
+            slotLast != null && nextFirst != null && Arrays.compareUnsigned(slotLast, nextFirst) >= 0;
         if (leftViolated || rightViolated) {
-          REBUILD_PROPAGATION_I7_FALLBACK.incrementAndGet();
+          REBUILD_PROPAGATION_ORDER_FALLBACK.incrementAndGet();
           rebuildSubtree(navResult, ancestorDepth, keySlice, valueSlice);
           return;
         }
+        // The slot's extremes can influence the NEXT ancestor's boundaries only while the
+        // changed slot is the edge of this block (the subtree minimum propagates from slot 0,
+        // the maximum from the last slot); interior slots absorb the change here.
+        boundaryRelevant = rebuiltSlot == 0 || rebuiltSlot == numChildren - 1;
       }
 
-      // Re-encode the ancestor: same disc bits + children, updated height + possibly one
-      // partial. assembleIndirect picks the SingleMask/MultiMask layout to match the disc
-      // bits exactly as the original encoding -- the new page's mask is identical so routing
-      // is invariant-preserving.
+      if (!heightChanged && !boundaryRelevant) {
+        return; // Stable -- propagation complete.
+      }
+      if (!heightChanged) {
+        continue; // Order verified at this level; only the edge-propagation continues upward.
+      }
+
+      // Re-encode the ancestor: same disc bits + children + partials, updated height only.
+      // assembleIndirect picks the SingleMask/MultiMask layout to match the disc bits exactly
+      // as the original encoding -- the new page's mask is identical so routing is
+      // invariant-preserving.
       final int[] discBits = HOTIncrementalInsert.discriminativeBits(ancestor);
       final int[] partials = ancestor.getPartialKeysRef().clone();
-      if (partialChanged) {
-        partials[rebuiltSlot] = newSlotPartial;
-      }
       final PageReference[] children = new PageReference[numChildren];
       for (int i = 0; i < numChildren; i++) {
         children[i] = ancestor.getChildReference(i);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -613,8 +613,8 @@ public abstract class AbstractHOTIndexWriter<K> {
 
   /**
    * Cap on a permitted nodeKey for chunked-bitmap storage. The chunkIdx is stored as a 32-bit
-   * big-endian unsigned int trailer; with {@code chunkIdx = (int)(nodeKey >>> 16)} this gives a
-   * full 48-bit nodeKey range — well above any practical Sirix dataset.
+   * big-endian unsigned int trailer; with {@code chunkIdx = (int)(nodeKey >>> 16)} this gives a full
+   * 48-bit nodeKey range — well above any practical Sirix dataset.
    */
   static final long MAX_NODE_KEY = (1L << 48) - 1L;
 
@@ -622,8 +622,7 @@ public abstract class AbstractHOTIndexWriter<K> {
    * Reject a node key the chunked-bitmap encoding cannot represent.
    *
    * @param nodeKey the node key to validate
-   * @throws IllegalArgumentException if {@code nodeKey} is negative or exceeds
-   *         {@link #MAX_NODE_KEY}
+   * @throws IllegalArgumentException if {@code nodeKey} is negative or exceeds {@link #MAX_NODE_KEY}
    */
   static void checkNodeKeyRange(final long nodeKey) {
     if (nodeKey < 0L) {
@@ -638,9 +637,11 @@ public abstract class AbstractHOTIndexWriter<K> {
   /**
    * Whether the index tree currently holds no entry at all.
    *
-   * <p>True exactly for a freshly initialized index: its root reference resolves to the single
-   * empty leaf {@code createHOT*IndexTree} planted. An indirect root only exists once a leaf has
-   * split, so it always covers at least one entry.</p>
+   * <p>
+   * True exactly for a freshly initialized index: its root reference resolves to the single empty
+   * leaf {@code createHOT*IndexTree} planted. An indirect root only exists once a leaf has split, so
+   * it always covers at least one entry.
+   * </p>
    */
   public final boolean isEmptyTree() {
     if (rootReference == null) {
@@ -652,10 +653,12 @@ public abstract class AbstractHOTIndexWriter<K> {
   /**
    * Replace the whole index tree with one bulk-built from {@code sortedEntries}.
    *
-   * <p>Splices exactly like the scoped {@link #rebuildExistingSubtree} does, but at the root and
-   * from externally supplied entries: {@link HOTBulkBuilder} output is invariant-clean by
-   * construction (foundation Theorem 1), so no self-heal is needed afterwards. Registering the
-   * fresh subtree also re-puts the root reference, which closes the empty leaf it displaces.</p>
+   * <p>
+   * Splices exactly like the scoped {@link #rebuildExistingSubtree} does, but at the root and from
+   * externally supplied entries: {@link HOTBulkBuilder} output is invariant-clean by construction
+   * (foundation Theorem 1), so no self-heal is needed afterwards. Registering the fresh subtree also
+   * re-puts the root reference, which closes the empty leaf it displaces.
+   * </p>
    *
    * @param sortedEntries entries sorted strictly ascending by unsigned key, with no duplicates
    * @throws IllegalStateException if the tree is not empty — the bulk build replaces rather than
@@ -670,8 +673,8 @@ public abstract class AbstractHOTIndexWriter<K> {
       throw new IllegalStateException(
           "Bulk load requires an empty " + indexType + " index tree (index " + indexNumber + ')');
     }
-    final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(sortedEntries,
-        storageEngineWriter.getRevisionNumber(), indexType, pageKeyAllocator);
+    final HOTBulkBuilder.BuildResult built =
+        HOTBulkBuilder.build(sortedEntries, storageEngineWriter.getRevisionNumber(), indexType, pageKeyAllocator);
     rootReference.setPage(built.rootPage());
     registerFreshSubtree(rootReference);
   }
@@ -1130,10 +1133,21 @@ public abstract class AbstractHOTIndexWriter<K> {
     if (scope == null) {
       return;
     }
-    final var malformed = HOTMalformedSubtreeDetector.detect(scope, this::resolveHOTPageForTraversal);
-    for (final HOTMalformedSubtreeDetector.MalformedSubtree m : malformed) {
-      STRUCTURAL_SELFHEAL_REBUILD.incrementAndGet();
-      rebuildExistingSubtree(m.reference());
+    // Iterate to a fixed point. The detector's I8/I12 checks read a child's extremes off its edge
+    // descents, which only report the truth once the child itself is clean — so a node judged in
+    // the same round as a malformed descendant may have passed on stale extremes. A discharge is a
+    // canonical rebuild (never itself malformed), so each round only ever surfaces nodes ABOVE the
+    // previous round's repairs: the loop terminates within the scope's height, and the common case
+    // — detect finds nothing — still runs exactly one pass, as before.
+    for (int round = 0; round <= MAX_PATH_DEPTH; round++) {
+      final var malformed = HOTMalformedSubtreeDetector.detect(scope, this::resolveHOTPageForTraversal);
+      if (malformed.isEmpty()) {
+        return;
+      }
+      for (final HOTMalformedSubtreeDetector.MalformedSubtree m : malformed) {
+        STRUCTURAL_SELFHEAL_REBUILD.incrementAndGet();
+        rebuildExistingSubtree(m.reference());
+      }
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -936,7 +936,8 @@ public abstract class AbstractHOTIndexWriter<K> {
       // a scoped rebuild. Amortized cheap: runs once per CONSOLIDATION_INTERVAL inserts, the same
       // O(subtree) cadence as the sweep it guards.
       if (SELFHEAL_STRUCTURAL) {
-        detectAndHeal(navResult.pathRefs()[0]);
+        lastDispatchHandler = "h:consolidate-sweep";
+        detectAndHeal(navResult.pathRefs()[0], keySlice);
       }
       if (localize && consBefore == null) {
         i8ProbeReport("consolidate", keySlice, consCntBefore);
@@ -1076,10 +1077,10 @@ public abstract class AbstractHOTIndexWriter<K> {
     // I3/I4/I7/I8/I11. A mutation only malforms nodes it touched, so scoping the O(subtree)
     // walk to selfHealScope is sound and bounded (not a from-root scan).
     // (2) healStructuralViolationOnPath covers the ANCESTORS above the touched subtree: their
-    // blocks are unmodified (I5 preserved), but the touched subtree's firstKey may have
-    // shifted, so re-verify the cheap ordering invariants (I4/I7/I8) up the spine.
+    // blocks are unmodified (I5 preserved), but the touched subtree's key range may have
+    // shifted, so re-verify the cheap ordering invariants (I4/I7/I8/I12) up the spine.
     if (structurallyChanged && SELFHEAL_STRUCTURAL) {
-      detectAndHeal(selfHealScope);
+      detectAndHeal(selfHealScope, keySlice);
       healStructuralViolationOnPath(keySlice);
     }
   }
@@ -1120,7 +1121,7 @@ public abstract class AbstractHOTIndexWriter<K> {
     selfHealScope = null;
     final boolean structurallyChanged = branchAboveLeaf(navResult, analysis, keySlice, valueBuf, valueLen);
     if (structurallyChanged && SELFHEAL_STRUCTURAL) {
-      detectAndHeal(selfHealScope);
+      detectAndHeal(selfHealScope, keySlice);
       healStructuralViolationOnPath(keySlice);
     }
     return true;
@@ -1135,7 +1136,7 @@ public abstract class AbstractHOTIndexWriter<K> {
    * invariants. {@code scope} is the just-spliced subtree root, so the detector cost is bounded by
    * the mutation's footprint, and the rebuild is Θ(n)-optimal (foundation Theorem 4).
    */
-  private void detectAndHeal(@Nullable PageReference scope) {
+  private void detectAndHeal(@Nullable PageReference scope, byte[] keySlice) {
     if (scope == null) {
       return;
     }
@@ -1153,6 +1154,15 @@ public abstract class AbstractHOTIndexWriter<K> {
       for (final HOTMalformedSubtreeDetector.MalformedSubtree m : malformed) {
         STRUCTURAL_SELFHEAL_REBUILD.incrementAndGet();
         HEAL_TALLY.computeIfAbsent(m.invariant() + "|" + lastDispatchHandler, k -> new AtomicLong()).incrementAndGet();
+        if (Boolean.getBoolean("hot.diag.healDump")) {
+          final Page malformedPage = resolveHOTPageForTraversal(m.reference());
+          final int height = malformedPage instanceof HOTIndirectPage hi
+              ? hi.getHeight()
+              : 0;
+          System.err.println("[healdump] inv=" + m.invariant() + " handler=" + lastDispatchHandler + " round=" + round
+              + " height=" + height + " atScopeRoot=" + (m.reference() == scope) + " K="
+              + HexFormat.of().formatHex(keySlice) + " detail=" + m.detail());
+        }
         rebuildExistingSubtree(m.reference());
       }
     }
@@ -1356,13 +1366,15 @@ public abstract class AbstractHOTIndexWriter<K> {
   }
 
   /**
-   * Cheap single-node structural check covering the three O(children)-class invariants that a
-   * combo-add / fold can break under multi-value leaves: I4 (smallest stored partial must be 0 —
-   * Binna's "first mask always zero"), I7 (stored partials strictly ascending), and I8 (children
-   * ordered by ascending subtree first-key). Returns {@code true} on the first violation. The
-   * expensive I5 constancy walk is intentionally excluded here (the post-dispatch
-   * {@link #detectAndHeal} runs the full detector incl. I5); these three are O(children) /
-   * O(children×height). Used as a pre-commit combo-add guard (the first-key-order complement to the
+   * Cheap single-node structural check covering the O(children)-class invariants that a combo-add /
+   * fold can break under multi-value leaves: I4 (smallest stored partial must be 0 — Binna's "first
+   * mask always zero"), I7 (stored partials strictly ascending), I8 (children ordered by ascending
+   * subtree first-key), and I12 (consecutive children's key RANGES must not interleave — first-key
+   * order alone misses a preceding sibling whose subtree spans past the next child's start, the shape
+   * every residual combo-fold heal turned out to be). Returns {@code true} on the first violation.
+   * The expensive I5 constancy walk is intentionally excluded here (the post-dispatch
+   * {@link #detectAndHeal} runs the full detector incl. I5); these are O(children) /
+   * O(children×height). Used as a pre-commit combo-add guard (the ordering complement to the
    * routing-only {@link #branchAddStrandsExisting}, discharging via the I8-clean canonical
    * {@link #rebuildSubtree}) and as the post-dispatch path probe
    * ({@link #healStructuralViolationOnPath}). Sufficient as a single-node scan because a fold leaves
@@ -1386,15 +1398,24 @@ public abstract class AbstractHOTIndexWriter<K> {
       }
     }
     byte[] previousFirstKey = null;
+    byte[] previousLastKey = null;
     for (int i = 0; i < n; i++) {
-      final byte[] firstKey = firstKeyOfSubtree(candidate.getChildReference(i));
+      final PageReference childRef = candidate.getChildReference(i);
+      final byte[] firstKey = firstKeyOfSubtree(childRef);
       if (firstKey == null) {
         continue;
       }
       if (previousFirstKey != null && Arrays.compareUnsigned(previousFirstKey, firstKey) >= 0) {
         return true; // I8: children not ordered by first-key
       }
+      if (previousLastKey != null && Arrays.compareUnsigned(previousLastKey, firstKey) >= 0) {
+        return true; // I12: the preceding sibling's range reaches into this child's
+      }
       previousFirstKey = firstKey;
+      final byte[] lastKey = lastKeyOfSubtree(childRef);
+      if (lastKey != null) {
+        previousLastKey = lastKey;
+      }
     }
     return false;
   }
@@ -2192,15 +2213,34 @@ public abstract class AbstractHOTIndexWriter<K> {
       // BiNode on beta and integrate at the leaf's depth. The leaf needs a fresh reference:
       // integrate's materialize cases re-point the leaf's own spine slot, and aliasing it would
       // make a page its own descendant (a cycle).
-      if (!canIntegrateBiNodeCleanly(pathNodes, childSlots, pathDepth, beta)) {
-        keyLeaf.close();
-        return false;
-      }
-      // Multi-entry-leaf stranding guard ([[hot-multientry-leaf-quirks]] #1): pairing puts the
-      // whole descended leaf on beta's (1-betaValue) side. If the leaf straddles beta (holds a
-      // key with beta==betaValue), that key would route to K's leaf without migrating -> dup.
-      // Fall back to the canonical rebuild instead of the lossy pairing.
-      if (navResult.leaf().isBitConstantAtAbsBit(beta) != (1 - betaValue)) {
+      //
+      // Canonical-cut guard. Binna's BiNode pairing at beta IS the R(S) recursion step only when
+      // beta is the MSDB of the union {leaf ∪ K} — single-TID leaves satisfy that by
+      // construction, but a multi-value leaf buckets keys across bits the trie never
+      // discriminated, so its internal spread can reach a bit MORE significant than beta (beta
+      // is computed against the leaf's discriminated prefix, not its content). Two disqualifying
+      // shapes, both discharged by splitting the leaf at the union's own MSDB (the strand
+      // discharge — the same R(S) cut, taken at the right bit):
+      // (a) the leaf straddles beta itself (holds a key with beta==betaValue) — pairing would
+      // re-route that key to K's leaf without migrating it (cross-leaf dup);
+      // (b) the leaf's spread crosses a bit above beta — bit-constancy at beta still holds, yet
+      // the union's true MSDB lies inside the leaf, so pairing puts K lex-inside the leaf's
+      // range (13 of the 19 residual detector heals attributed here as I8/I12 at the
+      // integrated node before this guard existed).
+      final HOTLeafPage pairLeaf = navResult.leaf();
+      final byte[] pairLeafFirst = pairLeaf.getFirstKey();
+      final byte[] pairLeafLast = pairLeaf.getEntryCount() > 0
+          ? pairLeaf.getKey(pairLeaf.getEntryCount() - 1)
+          : null;
+      final boolean canonicalCut = pairLeafFirst != null && pairLeafLast != null
+          && HOTBulkBuilder.msdb(Arrays.compareUnsigned(keySlice, pairLeafFirst) < 0
+              ? keySlice
+              : pairLeafFirst,
+              Arrays.compareUnsigned(keySlice, pairLeafLast) > 0
+                  ? keySlice
+                  : pairLeafLast) == beta
+          && pairLeaf.isBitConstantAtAbsBit(beta) == 1 - betaValue;
+      if (!canonicalCut) {
         keyLeaf.close();
         if (strandDischargeSplitIntegrate(navResult, keySlice, valueSlice)) {
           return true;
@@ -2209,6 +2249,10 @@ public abstract class AbstractHOTIndexWriter<K> {
         leafScopedRebuild(navResult, keySlice, valueSlice); // strandable keys are the descended leaf's
         STRAND_LEAF_REBUILD.incrementAndGet();
         return true;
+      }
+      if (!canIntegrateBiNodeCleanly(pathNodes, childSlots, pathDepth, beta)) {
+        keyLeaf.close();
+        return false;
       }
       // Direction-1-dual pre-guard: the pair keeps the leaf's slot, so K becomes the slot's new
       // minimum (betaValue == 0) or maximum (betaValue == 1). Subset routing brought K here, but
@@ -2668,7 +2712,7 @@ public abstract class AbstractHOTIndexWriter<K> {
   private static final boolean SELFHEAL_STRUCTURAL = !Boolean.getBoolean("hot.selfheal.structural.disable");
   /**
    * Post-dispatch structural self-heals: a structural fold (combo-add / integrate / off-path-
-   * overflow) left a node on the insert path malformed (I4/I7/I8) and was discharged by a scoped
+   * overflow) left a node on the insert path malformed (I4/I7/I8/I12) and was discharged by a scoped
    * canonical rebuild. Distinct from {@link #BRANCH_I8_UNSAFE_REBUILD} (the pre-commit combo-add
    * guard) — this is the defense-in-depth backstop that covers the merge/integrate handlers too.
    */
@@ -2677,11 +2721,11 @@ public abstract class AbstractHOTIndexWriter<K> {
   /**
    * Defense-in-depth backstop after a structural change: walk {@code keySlice}'s <em>current</em>
    * descent path from the root and, at the shallowest indirect that is structurally malformed
-   * (I4/I7/I8 — {@link #nodeStructurallyMalformed}), discharge by a canonical scoped rebuild of that
-   * node's subtree ({@link #rebuildExistingSubtree}). Rebuilding the shallowest violator subsumes any
-   * malformed descendant (Binna Lemma 3). A fold can only malform nodes on the inserted key's path,
-   * so this O(height × children) walk is necessary and sufficient — and far cheaper than a from-root
-   * scan or the corruption-prone whole-index rebuild (Stage 3c).
+   * (I4/I7/I8/I12 — {@link #nodeStructurallyMalformed}), discharge by a canonical scoped rebuild of
+   * that node's subtree ({@link #rebuildExistingSubtree}). Rebuilding the shallowest violator
+   * subsumes any malformed descendant (Binna Lemma 3). A fold can only malform nodes on the inserted
+   * key's path, so this O(height × children) walk is necessary and sufficient — and far cheaper than
+   * a from-root scan or the corruption-prone whole-index rebuild (Stage 3c).
    */
   private void healStructuralViolationOnPath(byte[] keySlice) {
     PageReference cur = rootReference;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -612,6 +612,47 @@ public abstract class AbstractHOTIndexWriter<K> {
   }
 
   /**
+   * Whether the index tree currently holds no entry at all.
+   *
+   * <p>True exactly for a freshly initialized index: its root reference resolves to the single
+   * empty leaf {@code createHOT*IndexTree} planted. An indirect root only exists once a leaf has
+   * split, so it always covers at least one entry.</p>
+   */
+  public final boolean isEmptyTree() {
+    if (rootReference == null) {
+      return false;
+    }
+    return resolveHOTPageForTraversal(rootReference) instanceof HOTLeafPage leaf && leaf.getEntryCount() == 0;
+  }
+
+  /**
+   * Replace the whole index tree with one bulk-built from {@code sortedEntries}.
+   *
+   * <p>Splices exactly like the scoped {@link #rebuildExistingSubtree} does, but at the root and
+   * from externally supplied entries: {@link HOTBulkBuilder} output is invariant-clean by
+   * construction (foundation Theorem 1), so no self-heal is needed afterwards. Registering the
+   * fresh subtree also re-puts the root reference, which closes the empty leaf it displaces.</p>
+   *
+   * @param sortedEntries entries sorted strictly ascending by unsigned key, with no duplicates
+   * @throws IllegalStateException if the tree is not empty — the bulk build replaces rather than
+   *         merges, so any pre-existing entry would be dropped
+   */
+  final void spliceBulkBuiltRoot(final List<HOTBulkBuilder.Entry> sortedEntries) {
+    requireNonNull(sortedEntries, "sortedEntries");
+    if (sortedEntries.isEmpty()) {
+      return;
+    }
+    if (!isEmptyTree()) {
+      throw new IllegalStateException(
+          "Bulk load requires an empty " + indexType + " index tree (index " + indexNumber + ')');
+    }
+    final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(sortedEntries,
+        storageEngineWriter.getRevisionNumber(), indexType, pageKeyAllocator);
+    rootReference.setPage(built.rootPage());
+    registerFreshSubtree(rootReference);
+  }
+
+  /**
    * Build immutable navigation result by trimming reusable path buffers.
    */
   private LeafNavigationResult buildNavigationResult(final HOTLeafPage leaf, final PageReference leafRef,

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -1166,6 +1166,37 @@ public abstract class AbstractHOTIndexWriter<K> {
         rebuildExistingSubtree(m.reference());
       }
     }
+    // Every round is spent, so the LAST round's rebuilds have not been re-checked yet. Verify them
+    // before declaring failure: reporting from inside the loop marked a run unresolved that the very
+    // rebuilds it was about to perform went on to fix.
+    if (HOTMalformedSubtreeDetector.detect(scope, this::resolveHOTPageForTraversal).isEmpty()) {
+      return;
+    }
+
+    // Still malformed after every round. The per-defect discharge is converging too slowly (or
+    // oscillating, if a child page resolves in one round and not the next), so escalate to the one
+    // operation that cannot itself be malformed: rebuild the WHOLE scope canonically.
+    LOG.warn("HOT self-heal did not converge in {} rounds; rebuilding the whole scope canonically.",
+        MAX_PATH_DEPTH + 1);
+    STRUCTURAL_SELFHEAL_REBUILD.incrementAndGet();
+    rebuildExistingSubtree(scope);
+
+    final var residual = HOTMalformedSubtreeDetector.detect(scope, this::resolveHOTPageForTraversal);
+    if (residual.isEmpty()) {
+      return;
+    }
+
+    // A canonical rebuild left defects behind, so the trie cannot be repaired by this machinery at
+    // all. Committing anyway would persist an index whose bounded range scans truncate at the first
+    // out-of-order leaf and silently return partial answers — for good, since committed pages are
+    // never revisited. Fail the transaction instead; every caller runs inside doIndex, before commit.
+    SELFHEAL_UNRESOLVED.incrementAndGet();
+    final String detail = String.format(
+        "HOT self-heal could not repair the index: %d subtree(s) still malformed after %d rounds and a "
+            + "canonical scope rebuild (first: %s — %s).",
+        residual.size(), MAX_PATH_DEPTH + 1, residual.getFirst().invariant(), residual.getFirst().detail());
+    LOG.error(detail);
+    throw new IllegalStateException(detail);
   }
 
   /**
@@ -1412,9 +1443,14 @@ public abstract class AbstractHOTIndexWriter<K> {
         return true; // I12: the preceding sibling's range reaches into this child's
       }
       previousFirstKey = firstKey;
-      final byte[] lastKey = lastKeyOfSubtree(childRef);
-      if (lastKey != null) {
-        previousLastKey = lastKey;
+      if (i < n - 1) {
+        // Only a PRECEDING sibling's maximum is ever compared, so the last child's rightmost
+        // descent (O(height) page resolutions plus a key materialization) would be pure waste on
+        // a guard that runs at every combo/fold site and every level of the path probe.
+        final byte[] lastKey = lastKeyOfSubtree(childRef);
+        if (lastKey != null) {
+          previousLastKey = lastKey;
+        }
       }
     }
     return false;
@@ -1895,9 +1931,8 @@ public abstract class AbstractHOTIndexWriter<K> {
   /**
    * Diagnostic helper — walk the subtree rooted at {@code page} and collect duplicate stored keys.
    */
-  private void collectKeysForI1(io.sirix.page.interfaces.Page page, HashSet<String> seen,
-      ArrayList<String> duplicates) {
-    if (page instanceof io.sirix.page.HOTLeafPage leaf) {
+  private void collectKeysForI1(Page page, HashSet<String> seen, ArrayList<String> duplicates) {
+    if (page instanceof HOTLeafPage leaf) {
       final int count = leaf.getEntryCount();
       for (int i = 0; i < count; i++) {
         final String h = HexFormat.of().formatHex(leaf.getKey(i));
@@ -1907,10 +1942,10 @@ public abstract class AbstractHOTIndexWriter<K> {
       }
     } else if (page instanceof HOTIndirectPage indirect) {
       for (int i = 0; i < indirect.getNumChildren(); i++) {
-        final io.sirix.page.PageReference ref = indirect.getChildReference(i);
+        final PageReference ref = indirect.getChildReference(i);
         if (ref == null)
           continue;
-        final io.sirix.page.interfaces.Page child = resolveHOTPageForTraversal(ref);
+        final Page child = resolveHOTPageForTraversal(ref);
         if (child != null) {
           collectKeysForI1(child, seen, duplicates);
         }
@@ -2717,6 +2752,13 @@ public abstract class AbstractHOTIndexWriter<K> {
    * guard) — this is the defense-in-depth backstop that covers the merge/integrate handlers too.
    */
   public static final AtomicLong STRUCTURAL_SELFHEAL_REBUILD = new AtomicLong();
+
+  /**
+   * Times {@link #detectAndHeal} exhausted its round budget with defects still standing. Must stay
+   * zero; a non-zero value means an index was committed that the detector still considers malformed,
+   * and the accompanying ERROR log names the first offender.
+   */
+  public static final AtomicLong SELFHEAL_UNRESOLVED = new AtomicLong();
 
   /**
    * Defense-in-depth backstop after a structural change: walk {@code keySlice}'s <em>current</em>
@@ -3558,9 +3600,12 @@ public abstract class AbstractHOTIndexWriter<K> {
    * HFT-grade: at most O(pathDepth * pathMaskBits * leafEntries) per call. Single allocation per call
    * (the owned-bits and values arrays).
    */
-  protected void populateLeafOwnedBitsFromPath(io.sirix.page.HOTLeafPage leaf,
-      io.sirix.page.HOTIndirectPage[] pathNodes, int pathDepth) {
-    if (leaf == null || pathDepth <= 0) {
+  protected void populateLeafOwnedBitsFromPath(final HOTLeafPage leaf, final HOTIndirectPage[] pathNodes,
+      final int pathDepth) {
+    if (leaf == null) {
+      return; // nothing to populate — the guard used to dereference the very null it tested
+    }
+    if (pathDepth <= 0) {
       leaf.setAncestorOwnedBits(new int[0], new byte[0]);
       return;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AbstractHOTIndexWriter.java
@@ -612,6 +612,30 @@ public abstract class AbstractHOTIndexWriter<K> {
   }
 
   /**
+   * Cap on a permitted nodeKey for chunked-bitmap storage. The chunkIdx is stored as a 32-bit
+   * big-endian unsigned int trailer; with {@code chunkIdx = (int)(nodeKey >>> 16)} this gives a
+   * full 48-bit nodeKey range — well above any practical Sirix dataset.
+   */
+  static final long MAX_NODE_KEY = (1L << 48) - 1L;
+
+  /**
+   * Reject a node key the chunked-bitmap encoding cannot represent.
+   *
+   * @param nodeKey the node key to validate
+   * @throws IllegalArgumentException if {@code nodeKey} is negative or exceeds
+   *         {@link #MAX_NODE_KEY}
+   */
+  static void checkNodeKeyRange(final long nodeKey) {
+    if (nodeKey < 0L) {
+      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
+    }
+    if (nodeKey > MAX_NODE_KEY) {
+      throw new IllegalArgumentException(
+          "nodeKey " + nodeKey + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
+    }
+  }
+
+  /**
    * Whether the index tree currently holds no entry at all.
    *
    * <p>True exactly for a freshly initialized index: its root reference resolves to the single

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
@@ -31,21 +31,35 @@ final class AsciiKeyBytes {
   /**
    * Whether the first {@code upTo} chars of {@code s} are all US-ASCII.
    *
+   * <p>
+   * HFT: accumulates every char into one {@code int} and tests the accumulator once, instead of
+   * branching per char. The branchless form is a plain OR reduction over the string's backing array,
+   * which C2 can unroll and vectorize; the early-exit form cannot be, and this loop runs once per
+   * key serialized. Chars are non-negative, so an accumulator below {@code 0x80} proves every
+   * contributing char was.
+   *
    * @param s the string
    * @param upTo number of leading chars to test; must not exceed {@code s.length()}
    * @return {@code true} if every one of them is below {@code 0x80}
    */
   static boolean isAsciiPrefix(final String s, final int upTo) {
+    int accumulator = 0;
     for (int i = 0; i < upTo; i++) {
-      if (s.charAt(i) >= 0x80) {
-        return false;
-      }
+      accumulator |= s.charAt(i);
     }
-    return true;
+    return accumulator < 0x80;
   }
 
   /**
    * Write the first {@code n} chars of {@code s} as one byte each.
+   *
+   * <p>
+   * HFT: {@link String#getBytes(int, int, byte[], int)} writes exactly the low byte of each char —
+   * the same bytes this used to produce with a {@code charAt} loop — but for a Latin-1-coded string,
+   * which every ASCII string is, it bottoms out in {@code System.arraycopy} over the backing array
+   * rather than one bounds-checked store per char. Deprecated since 1.1 for being charset-blind,
+   * which is precisely the contract wanted here: the caller has already established that the first
+   * {@code n} chars are ASCII, so truncation to eight bits is lossless.
    *
    * @param s the string, whose first {@code n} chars must be US-ASCII
    * @param n number of chars to write
@@ -53,10 +67,9 @@ final class AsciiKeyBytes {
    * @param offset offset to write at
    * @return {@code n}, the number of bytes written
    */
+  @SuppressWarnings("deprecation")
   static int writeAsciiPrefix(final String s, final int n, final byte[] dest, final int offset) {
-    for (int i = 0; i < n; i++) {
-      dest[offset + i] = (byte) s.charAt(i);
-    }
+    s.getBytes(0, n, dest, offset);
     return n;
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
@@ -6,15 +6,19 @@ package io.sirix.index.hot;
 /**
  * Writes the US-ASCII prefix of a {@link String} straight into a key buffer.
  *
- * <p>Index keys are built one per indexed node, so {@code String.getBytes(UTF_8)} on that path is a
+ * <p>
+ * Index keys are built one per indexed node, so {@code String.getBytes(UTF_8)} on that path is a
  * {@code byte[]} per node that exists only to be copied into the destination and dropped. Field
- * names and the overwhelming majority of indexed values are ASCII, where UTF-8 is one byte per
- * char and the intermediate array buys nothing.</p>
+ * names and the overwhelming majority of indexed values are ASCII, where UTF-8 is one byte per char
+ * and the intermediate array buys nothing.
+ * </p>
  *
- * <p>Callers check {@link #isAsciiPrefix} first and fall back to {@code getBytes} otherwise, so
- * this never has to reproduce UTF-8's multi-byte forms or {@code getBytes}' replacement of
- * unpaired surrogates — the bytes are identical to the prefix {@code getBytes} would have
- * produced, by construction.</p>
+ * <p>
+ * Callers check {@link #isAsciiPrefix} first and fall back to {@code getBytes} otherwise, so this
+ * never has to reproduce UTF-8's multi-byte forms or {@code getBytes}' replacement of unpaired
+ * surrogates — the bytes are identical to the prefix {@code getBytes} would have produced, by
+ * construction.
+ * </p>
  *
  * @author Johannes Lichtenberger
  */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
@@ -34,8 +34,8 @@ final class AsciiKeyBytes {
    * <p>
    * HFT: accumulates every char into one {@code int} and tests the accumulator once, instead of
    * branching per char. The branchless form is a plain OR reduction over the string's backing array,
-   * which C2 can unroll and vectorize; the early-exit form cannot be, and this loop runs once per
-   * key serialized. Chars are non-negative, so an accumulator below {@code 0x80} proves every
+   * which C2 can unroll and vectorize; the early-exit form cannot be, and this loop runs once per key
+   * serialized. Chars are non-negative, so an accumulator below {@code 0x80} proves every
    * contributing char was.
    *
    * @param s the string

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/AsciiKeyBytes.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+/**
+ * Writes the US-ASCII prefix of a {@link String} straight into a key buffer.
+ *
+ * <p>Index keys are built one per indexed node, so {@code String.getBytes(UTF_8)} on that path is a
+ * {@code byte[]} per node that exists only to be copied into the destination and dropped. Field
+ * names and the overwhelming majority of indexed values are ASCII, where UTF-8 is one byte per
+ * char and the intermediate array buys nothing.</p>
+ *
+ * <p>Callers check {@link #isAsciiPrefix} first and fall back to {@code getBytes} otherwise, so
+ * this never has to reproduce UTF-8's multi-byte forms or {@code getBytes}' replacement of
+ * unpaired surrogates — the bytes are identical to the prefix {@code getBytes} would have
+ * produced, by construction.</p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class AsciiKeyBytes {
+
+  private AsciiKeyBytes() {
+    throw new AssertionError("no instances");
+  }
+
+  /**
+   * Whether the first {@code upTo} chars of {@code s} are all US-ASCII.
+   *
+   * @param s the string
+   * @param upTo number of leading chars to test; must not exceed {@code s.length()}
+   * @return {@code true} if every one of them is below {@code 0x80}
+   */
+  static boolean isAsciiPrefix(final String s, final int upTo) {
+    for (int i = 0; i < upTo; i++) {
+      if (s.charAt(i) >= 0x80) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Write the first {@code n} chars of {@code s} as one byte each.
+   *
+   * @param s the string, whose first {@code n} chars must be US-ASCII
+   * @param n number of chars to write
+   * @param dest destination buffer
+   * @param offset offset to write at
+   * @return {@code n}, the number of bytes written
+   */
+  static int writeAsciiPrefix(final String s, final int n, final byte[] dest, final int offset) {
+    for (int i = 0; i < n; i++) {
+      dest[offset + i] = (byte) s.charAt(i);
+    }
+    return n;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -52,7 +52,8 @@ import static java.util.Objects.requireNonNull;
  * <h2>Order Preservation</h2>
  * <ul>
  * <li><b>pathNodeKey:</b> XOR with sign bit for unsigned byte comparison</li>
- * <li><b>Integer values:</b> sign-flipped two's-complement (lossless for the full 64-bit range)</li>
+ * <li><b>Integer values:</b> sign-flipped two's-complement (lossless for the full 64-bit
+ * range)</li>
  * <li><b>Floating-point values:</b> IEEE 754 order-preserving encoding</li>
  * <li><b>String values:</b> UTF-8 (already lexicographically ordered)</li>
  * </ul>
@@ -130,9 +131,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
 
   /**
    * A CAS key is a 10-byte header plus a value region the encoders bound themselves: 8 bytes for
-   * every numeric family, 1 for a boolean, and at most {@link #MAX_STRING_VALUE_BYTES} for a
-   * string, which {@link #encodeAtomicOrderPreserving} truncates to. So the bound is a constant
-   * and no key of any type can exceed it.
+   * every numeric family, 1 for a boolean, and at most {@link #MAX_STRING_VALUE_BYTES} for a string,
+   * which {@link #encodeAtomicOrderPreserving} truncates to. So the bound is a constant and no key of
+   * any type can exceed it.
    */
   @Override
   public int maxSerializedLength(final CASValue key) {
@@ -270,11 +271,11 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * lossless, order-preserving 8-byte big-endian key.
    *
    * <p>
-   * The signed 64-bit value is sign-flipped (XOR with the sign bit) so that unsigned byte
-   * comparison matches signed numeric order. Unlike {@link #encodeNumericOrderPreserving}, the
-   * value is not routed through {@code double}, so integers above 2<sup>53</sup> keep full
-   * precision. The encoding is exact for the entire signed 64-bit range; xs:integer magnitudes
-   * beyond {@code Long} range are narrowed by {@link Numeric#longValue()}.
+   * The signed 64-bit value is sign-flipped (XOR with the sign bit) so that unsigned byte comparison
+   * matches signed numeric order. Unlike {@link #encodeNumericOrderPreserving}, the value is not
+   * routed through {@code double}, so integers above 2<sup>53</sup> keep full precision. The encoding
+   * is exact for the entire signed 64-bit range; xs:integer magnitudes beyond {@code Long} range are
+   * narrowed by {@link Numeric#longValue()}.
    * </p>
    */
   private int encodeIntegerOrderPreserving(Atomic value, byte[] dest, int offset) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -28,11 +28,16 @@
 package io.sirix.index.hot;
 
 import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.Numeric;
 import io.brackit.query.jdm.Type;
 import io.sirix.index.InstantKeyCodec;
 import io.sirix.index.redblacktree.keyvalue.CASValue;
+import org.jspecify.annotations.Nullable;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
@@ -69,6 +74,11 @@ import static java.util.Objects.requireNonNull;
  */
 public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
 
+  // The xs:boolean, xs:float and out-of-range xs:integer encodings all changed here, so a HOT CAS
+  // index written by an older build holds keys this one will not seek to. Nothing to migrate: all
+  // three were returning wrong answers, so such an index holds no correct data to preserve. Delete
+  // and rebuild any local scratch resource that predates this.
+
   /**
    * Sign-flip constant for order-preserving encoding of signed longs.
    */
@@ -90,19 +100,25 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * the typed {@code CASFilterRange#inRange} comparison order them chronologically.
    *
    * <p>
-   * The stored VALUE is the raw lexical form (the string branch of
-   * {@link #encodeAtomicOrderPreserving}), and {@link #isByteOrderPreserving} deliberately reports
-   * {@code false} for them, so every range query is decided by that typed comparison and never by a
-   * byte-bounded cursor. An id is emphatically NOT a claim of byte-orderability — see the predicate's
-   * javadoc.
+   * The stored VALUE is {@link InstantKeyCodec}'s fixed-width binary instant, whose byte order IS
+   * chronological order, so {@link #isByteOrderPreserving} reports {@code true} for them and range
+   * queries take the bounded cursor. That was not always so — see the history block below, which
+   * records what an earlier lexical encoding got wrong and what any replacement must preserve. Note
+   * that an id is still emphatically NOT a claim of byte-orderability: the two questions are
+   * separate, and {@code xs:duration} carries no id and is not byte-ordered.
    * </p>
    */
   private static final short TYPE_DATETIME = 8;
   private static final short TYPE_DATE = 9;
   private static final short TYPE_TIME = 10;
 
-  // These were briefly stored through a BINARY instant codec on this branch. That was wrong and is
-  // reverted to the lexical form. Measured against brackit's own comparison semantics:
+  // HISTORY, kept because the failure modes below are easy to reintroduce. An EARLIER binary instant
+  // codec on this branch had all of the defects listed here; the current InstantKeyCodec does not,
+  // and CASKeySerializerEdgeCaseTest.Instants asserts the two properties that matter (distinct values
+  // keep distinct keys, and byte order agrees with brackit's compareTo) rather than trusting this
+  // note. Do NOT read the list below as a description of the shipped encoder — it is a description of
+  // what an instant encoding must avoid. Measured against brackit's own comparison semantics, the
+  // earlier attempt failed as follows:
   // * xs:date — canonicalizing to UTC moves the offset into a time-of-day that xs:date cannot
   // hold (brackit's Date.getHours() is always 0), so the residue is dropped and
   // xs:date("2020-01-01+02:00") encoded to the SAME 10 bytes as xs:date("2019-12-31Z"),
@@ -113,11 +129,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   // * mixed timezoned/untimezoned values collided, and brackit orders that pair inconsistently
   // (it reports "less" in BOTH directions), so no byte encoding can agree with it.
   // Colliding keys are the fatal part: two distinct values sharing one CAS key merge their posting
-  // lists, which corrupts equality lookups and deletes, not just ranges. The lexical form is
-  // injective, so it is what gets stored; chronological ORDER comes from the typed
-  // CASFilterRange#inRange comparison, which isByteOrderPreserving=false routes every instant range
-  // query through. That gate is the actual fix for the original defect — a byte-bounded cursor
-  // deciding instant ranges on lexical bytes and silently dropping records.
+  // lists, which corrupts equality lookups and deletes, not just ranges — strictly worse than a
+  // mis-ordered range, which costs only the range. Any future change to InstantKeyCodec must keep
+  // the codec INJECTIVE first and order-preserving second, in that priority.
 
   private static final short TYPE_OTHER = 0;
 
@@ -233,6 +247,12 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    */
   static final int MAX_STRING_VALUE_BYTES = 246;
 
+  /** {@code Long.MIN_VALUE} as a decimal, for the saturating integer parse. */
+  private static final BigDecimal LONG_MIN = BigDecimal.valueOf(Long.MIN_VALUE);
+
+  /** {@code Long.MAX_VALUE} as a decimal, for the saturating integer parse. */
+  private static final BigDecimal LONG_MAX = BigDecimal.valueOf(Long.MAX_VALUE);
+
   /**
    * Encodes an atomic value in order-preserving format.
    *
@@ -253,12 +273,20 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
         // Integer family (xs:integer and subtypes): lossless 64-bit encoding, not double.
         return encodeIntegerOrderPreserving(value, dest, offset);
       case TYPE_DOUBLE:
-      case TYPE_FLOAT:
       case TYPE_DECIMAL:
-        return encodeNumericOrderPreserving(value, dest, offset);
+        return encodeNumericOrderPreserving(value, dest, offset, false);
+      case TYPE_FLOAT:
+        // Rounded to float precision FIRST, because the two sides of an xs:float index reach this
+        // method in different shapes and must land on one key. CASIndexBuilder stores every value as
+        // a Str, so the stored side takes the parse branch below and yields Double.parseDouble("1.1")
+        // = 1.1d; ScanCASIndex cast the probe to the content type, so the probe side arrives as a Flt
+        // and yields (double) 1.1f = 1.100000023841858. Those are different keys, so `eq 1.1` on an
+        // xs:float index found nothing at all. Narrowing both through float makes them agree, and it
+        // is also the precision the index claims to hold — decodeAtomic already hands back Flt.
+        return encodeNumericOrderPreserving(value, dest, offset, true);
       case TYPE_BOOLEAN:
         // Boolean: 0 for false, 1 for true (already ordered)
-        dest[offset] = value.booleanValue()
+        dest[offset] = booleanValueOf(value)
             ? (byte) 1
             : (byte) 0;
         return 1;
@@ -272,10 +300,10 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
         final String str = value.stringValue();
         // Truncate to fit buffer (preserves lexicographic ordering for prefixes)
         final int cap = Math.min(dest.length - offset, MAX_STRING_VALUE_BYTES);
-      // A value is serialized once per indexed node, so the ASCII case — which is very nearly all
-      // of them — writes straight into dest instead of through a throwaway byte[]. One ASCII char
-      // is one UTF-8 byte, so the bytes and the truncation point are identical either way; only
-      // the leading `cap` chars have to be ASCII, since anything beyond them is truncated away.
+        // A value is serialized once per indexed node, so the ASCII case — which is very nearly all
+        // of them — writes straight into dest instead of through a throwaway byte[]. One ASCII char
+        // is one UTF-8 byte, so the bytes and the truncation point are identical either way; only
+        // the leading `cap` chars have to be ASCII, since anything beyond them is truncated away.
         final int asciiLen = Math.min(str.length(), cap);
         if (AsciiKeyBytes.isAsciiPrefix(str, asciiLen)) {
           return AsciiKeyBytes.writeAsciiPrefix(str, asciiLen, dest, offset);
@@ -300,7 +328,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * <li>Negative values: XOR all bits</li>
    * </ul>
    */
-  private int encodeNumericOrderPreserving(Atomic value, byte[] dest, int offset) {
+  private int encodeNumericOrderPreserving(Atomic value, byte[] dest, int offset, boolean roundToFloat) {
     double d;
     if (value instanceof Numeric numeric) {
       d = numeric.doubleValue();
@@ -312,6 +340,12 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
         // Can't parse as number - treat as 0 (or could throw)
         d = 0.0;
       }
+    }
+
+    if (roundToFloat) {
+      // Before the NaN canonicalization, so a value that is finite as a double but overflows float
+      // becomes an infinity here and keeps its own key rather than colliding with NaN's.
+      d = (float) d;
     }
 
     // Canonicalize NaN to sort last
@@ -358,14 +392,20 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   private int encodeIntegerOrderPreserving(Atomic value, byte[] dest, int offset) {
     final long v;
     if (value instanceof Numeric numeric) {
-      v = numeric.longValue();
+      v = saturatingLong(numeric);
     } else {
       // Value is a string representation of an integer - parse it.
       long parsed;
       try {
         parsed = Long.parseLong(value.stringValue().trim());
       } catch (NumberFormatException e) {
-        parsed = 0L;
+        // NOT zero. xs:integer is unbounded, so a literal beyond Long's range is a perfectly legal
+        // index value that Long.parseLong refuses — and mapping it to 0 put it on the key for zero,
+        // in the MIDDLE of the key space, where `eq 0` returned it and every range query placed it on
+        // the wrong side of every bound. Saturating keeps it at the end of the key space it actually
+        // belongs to, so ordering survives; only two values that both overflow the same end share a
+        // key, which narrowsNumeric reports as lossy so the caller re-checks.
+        parsed = saturatingLong(value.stringValue());
       }
       v = parsed;
     }
@@ -386,20 +426,98 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   }
 
   /**
+   * {@code value} as an {@code xs:boolean}, NOT as its effective boolean value.
+   *
+   * <p>
+   * {@link Atomic#booleanValue()} is XQuery's EBV, and on a {@link Str} the EBV is "is the string
+   * non-empty" — so it answers {@code true} for {@code "false"} just as readily as for
+   * {@code "true"}. {@code CASIndexBuilder} stores every indexed value as a {@code Str}, so calling
+   * it here mapped EVERY boolean in the index onto byte 1: {@code true} and {@code false} shared one
+   * key and one posting list, while a probe — which {@code ScanCASIndex} casts to the content type,
+   * giving a real {@link Bool} — encoded {@code false} to byte 0 and matched nothing at all.
+   * </p>
+   *
+   * @param value the atomic being serialized
+   * @return its boolean value, {@code false} for any lexical form that is not {@code true} or
+   *         {@code 1}
+   */
+  private static boolean booleanValueOf(final Atomic value) {
+    if (value instanceof final Bool bool) {
+      return bool.booleanValue();
+    }
+    // The xs:boolean lexical space is exactly these four spellings; anything else is not of the type
+    // and CASIndexBuilder's AtomicUtil#toType probe would already have rejected the node.
+    final String lexical = value.stringValue().trim();
+    return "true".equals(lexical) || "1".equals(lexical);
+  }
+
+  /**
+   * {@code numeric} as a {@code long}, clamped to the {@code long} range rather than wrapped.
+   *
+   * <p>
+   * BOTH sides of an integer index must clamp the same way, and this is the side that is easy to
+   * miss. {@link Numeric#longValue()} is exact for the primitive-backed types but WRAPS for brackit's
+   * arbitrary-precision {@code Int}, whose implementation is {@code BigDecimal#longValue()}: 2^63
+   * comes back as {@code Long.MIN_VALUE} and 2^70 as {@code 0}. Saturating only the lexical side —
+   * which is the side {@code CASIndexBuilder} always takes, since it stores every value as a
+   * {@code Str} — while the probe side wrapped was WORSE than both wrapping: the stored value landed
+   * at one end of the key space and the probe at the other, so an equality query that used to match
+   * (both sides collapsing onto zero) began missing entirely.
+   * </p>
+   *
+   * @param numeric the value being encoded
+   * @return the clamped value
+   */
+  private static long saturatingLong(final Numeric numeric) {
+    // Fast path: these wrap a primitive, so longValue() is exact and costs a field read. The careful
+    // path below allocates, but only for a magnitude past int range, and the STORED side never
+    // reaches it at all.
+    if (numeric instanceof Int32 || numeric instanceof Int64) {
+      return numeric.longValue();
+    }
+    return saturatingLong(numeric.stringValue());
+  }
+
+  /**
+   * {@code lexical} as a {@code long}, clamped to the {@code long} range rather than wrapped or
+   * zeroed.
+   *
+   * @param lexical the integer literal
+   * @return the clamped value, or {@code 0} when {@code lexical} is not a number at all
+   */
+  private static long saturatingLong(final String lexical) {
+    try {
+      final BigDecimal exact = new BigDecimal(lexical.trim());
+      if (exact.compareTo(LONG_MIN) <= 0) {
+        return Long.MIN_VALUE;
+      }
+      if (exact.compareTo(LONG_MAX) >= 0) {
+        return Long.MAX_VALUE;
+      }
+      return exact.longValue();
+    } catch (final NumberFormatException e) {
+      return 0L;
+    }
+  }
+
+  /**
    * Whether the serialized key's unsigned BYTE order is the type's own value order — i.e. whether a
    * bounded byte-range cursor may decide a range query for this content type at all.
    *
    * <p>
    * True for the families {@link #encodeAtomicOrderPreserving} encodes deliberately: the integer
-   * family, the floating-point family, {@code xs:decimal}, {@code xs:boolean} and {@code xs:string}.
+   * family, the floating-point family, {@code xs:decimal}, {@code xs:boolean}, {@code xs:string} —
+   * and the instant family, which {@link InstantKeyCodec} stores as a fixed-width BINARY instant
+   * whose byte order is chronological order.
+   *
+   * <p>
    * FALSE for everything else, which falls through to that method's string branch and is stored as
-   * its raw lexical form: {@code xs:dateTime}, {@code xs:date}, {@code xs:time} and
-   * {@code xs:duration} all order textually there, which is not chronological order. Text order puts
-   * {@code "…T12:00:00.5Z"} below {@code "…T12:00:00Z"} ({@code '.'} &lt; {@code 'Z'}) and mixes
-   * timezone spellings arbitrarily ({@code '+'}, {@code '-'} &lt; {@code 'Z'}), so a byte-bounded
-   * scan silently drops matching records. Callers must fall back to a typed
-   * {@link io.sirix.index.cas.CASFilterRange#inRange} comparison for those — which is exactly what a
-   * {@code false} answer here makes {@code CASIndex} do.
+   * its raw lexical form. {@code xs:duration} is the family that matters there: lexical text order is
+   * not duration order, so a byte-bounded scan would silently drop matching records, and callers fall
+   * back to a typed {@link io.sirix.index.cas.CASFilterRange#inRange} comparison — which is exactly
+   * what a {@code false} answer here makes {@code CASIndex} do. The instant family was in this
+   * paragraph while it was stored lexically; it is not any more, and the block comment at the top of
+   * this class records what that encoding got wrong.
    *
    * <p>
    * <b>This predicate is deliberately NOT "does the type have an id".</b> Those are different
@@ -417,6 +535,252 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     final short id = getTypeId(type);
     return id == TYPE_STRING || id == TYPE_BOOLEAN || id == TYPE_DOUBLE || id == TYPE_FLOAT || id == TYPE_INTEGER
         || id == TYPE_DECIMAL || id == TYPE_DATETIME || id == TYPE_DATE || id == TYPE_TIME;
+  }
+
+  /**
+   * Whether a numeric probe survives its encoder unchanged.
+   *
+   * <p>
+   * The numeric encoders are fixed-width but NOT lossless: {@code encodeIntegerOrderPreserving}
+   * narrows through {@code Numeric#longValue()} and {@code encodeNumericOrderPreserving} funnels
+   * decimals through {@code double}, so values that differ past the encoder's precision share one key
+   * and one merged posting list. The test is a round trip rather than a range check — encode the
+   * value the way the serializer will and ask whether it comes back equal — because that is exactly
+   * the property the seek depends on, and it needs no per-type precision arithmetic.
+   * </p>
+   *
+   * @param value the probe
+   * @param id the encoder that will be used
+   * @return {@code true} when the encoding cannot distinguish {@code value} from other values
+   */
+  private static boolean narrowsNumeric(final Atomic value, final short id) {
+    if (!(value instanceof final Numeric numeric)) {
+      // A non-numeric atomic under a numeric index: the encoders fall back to 0 rather than failing,
+      // so every such probe collapses onto the key for zero.
+      return true;
+    }
+    if (id == TYPE_FLOAT) {
+      // NARROWED to float by the encoder, so this is NOT the "the encoder is the double" case below.
+      // Two distinct doubles that round to one float share a key: a probe of 1.10000001 lands on
+      // stored 1.1's key, and every double above Float.MAX_VALUE collapses onto +Infinity's. Nothing
+      // casts the probe on the way in — CASIndex builds its CASValue from whatever atomic the caller
+      // passed — so a Dbl or Str probe reaches the float encoder unchanged and must be re-checked
+      // unless it survives the narrowing exactly.
+      final double d = numeric.doubleValue();
+      return Double.isNaN(d) || (double) (float) d != d;
+    }
+    if (id == TYPE_DOUBLE) {
+      // For these two the encoder IS the double, so the key round-trips by construction:
+      // encodeNumericOrderPreserving stores numeric.doubleValue() verbatim, a float widens to double
+      // exactly, and equality on an xs:double/xs:float index is therefore double equality. Only NaN
+      // loses anything, because the encoder canonicalizes it onto Double.MAX_VALUE's key. Infinities
+      // are NOT saturated — encodeNumericOrderPreserving touches only NaN, so they keep their own
+      // distinct bit patterns and round-trip like any other value.
+      //
+      // Testing these through the decimal round trip below reported very nearly every value lossy:
+      // "0.1" does not compare equal to 0.1000000000000000055511151231257827021181583404541015625,
+      // so only dyadic rationals (0.5, 2.0) came back false. That sent every double/float EQUALITY
+      // query through exactMatches' per-candidate document re-read, and every double/float RANGE
+      // query off the bounded byte cursor into the O(index) typed full scan — a large regression on
+      // exactly the indexes this predicate was added to keep correct.
+      return Double.isNaN(numeric.doubleValue());
+    }
+    if (id != TYPE_INTEGER) {
+      // xs:decimal: UNCONDITIONALLY lossy, and the round-trip test that used to stand here was
+      // unsound rather than merely expensive. It asked "is the PROBE exactly a double", but the
+      // collision that matters is between the probe's key and a STORED value's key, and the probe
+      // cannot see the stored values. A probe of 0.5 IS exactly a double and was reported lossless,
+      // so the re-check was switched off — while a stored 0.5000000000000000001 encodes to that same
+      // double and came back as a hit for `eq 0.5`. Answering true for every decimal is sound, and no
+      // slower in practice: the old test already said true for every non-dyadic literal, which is
+      // essentially every price and measurement anyone indexes.
+      //
+      // This costs the EQUALITY path a re-check and nothing else. The range gates deliberately do not
+      // consult this predicate for the numeric families, because their fallback re-derived its
+      // comparison value from the very same narrowed key — see CASIndex#openHOTIndexWithRangeFilter.
+      return true;
+    }
+    // Lossless across the whole signed 64-bit range and SATURATING outside it, so a probe inside the
+    // range can only be reported lossy by genuinely being outside it. Two values collide only when
+    // both overflow the same end, and this round trip catches exactly that.
+    final BigDecimal exact;
+    try {
+      exact = new BigDecimal(numeric.stringValue());
+    } catch (final NumberFormatException e) {
+      // Not a decimal literal at all (a special value, or a lexical form BigDecimal declines), so
+      // nothing here can prove the encoding keeps it apart from its neighbours.
+      return true;
+    }
+    final long encoded = saturatingLong(numeric);
+    if (encoded == Long.MAX_VALUE || encoded == Long.MIN_VALUE) {
+      // The saturation sentinels are shared: every value past the range collapses onto them, and so
+      // does the genuine Long.MAX_VALUE/MIN_VALUE. Saturating keeps ORDER (which zeroing destroyed)
+      // but cannot keep the values apart, so these two keys are the one place an integer index needs
+      // the re-check. Every other integer round-trips exactly and pays nothing.
+      return true;
+    }
+    return exact.compareTo(BigDecimal.valueOf(encoded)) != 0;
+  }
+
+  /**
+   * Whether serializing {@code value} under {@code type} loses information, so that a byte-exact seek
+   * on the resulting key answers with a SUPERSET of the values that actually match.
+   *
+   * <p>
+   * For the lexical family the rule is "does this type reach the TRUNCATING branch", NOT "is this
+   * type a string". {@link #encodeAtomicOrderPreserving} switches on the type id and has no
+   * {@link #TYPE_OTHER} case, so every type {@link #getTypeId} does not recognise —
+   * {@code xs:anyURI}, {@code xs:untypedAtomic}, {@code xs:duration}, {@code xs:hexBinary},
+   * {@code xs:QName}, and anything else a user names through {@code jn:create-cas-index} — falls into
+   * {@code default:}, the string encoder, and is capped at {@link #MAX_STRING_VALUE_BYTES} exactly as
+   * a string is. Testing for {@link #TYPE_STRING} alone left that whole family answering with an
+   * unchecked superset. A caller that seeks on a key this reports {@code true} for must re-check its
+   * hits against the real values, because nothing in the index can separate them.
+   * </p>
+   *
+   * <p>
+   * <b>Truncation is not the only way a CAS key loses information</b>, and the two are reported
+   * differently. Numeric NARROWING is detected by {@link #narrowsNumeric} and reported here:
+   * {@link #encodeNumericOrderPreserving} routes {@code xs:decimal} through {@code doubleValue()} and
+   * {@link #encodeIntegerOrderPreserving} narrows through {@code longValue()}, so values differing
+   * past the encoder's precision share one key and one posting list. The re-check a {@code true}
+   * answer triggers in {@code CASIndex} is TYPED — it picks a numeric or a byte comparison from the
+   * INDEX's content type rather than from the candidate's node kind — so it closes the narrowing case
+   * as well as the truncation one. Dispatching on the node instead is what made a numeric index over
+   * XML compare {@code "1.50"} against {@code "1.5"} lexically and drop the row.
+   * </p>
+   *
+   * <p>
+   * RANGE callers must not consult this predicate; they want {@link #truncates}. Numeric narrowing is
+   * monotone, so a bounded cursor still places every stored key correctly against the bound, and the
+   * O(index) fallback a {@code true} answer used to trigger re-derived its comparison value from the
+   * very same narrowed key — the identical answer at vastly higher cost.
+   * </p>
+   *
+   * <p>
+   * <b>The boundary is {@code >=}, not {@code >}</b>, and the difference is a real over-match rather
+   * than a rounding preference. A value measuring EXACTLY {@link #MAX_STRING_VALUE_BYTES} is itself
+   * stored losslessly, but the encoder caps every LONGER value at the same 246 bytes, so a 250-byte
+   * stored value sharing that prefix produces a byte-identical key of identical length — and the
+   * chunk walk filters on the composite length, so nothing downstream separates them either. At
+   * exactly the cap the seek is therefore GUARANTEED to over-match, which is precisely where a
+   * {@code >} test switched the caller's re-check off.
+   * </p>
+   *
+   * @param value the atomic being probed for, may be {@code null}
+   * @param type the index's declared content type
+   * @return {@code true} when the key cannot distinguish {@code value} from other values
+   */
+  public static boolean losesInformation(final @Nullable Atomic value, final Type type) {
+    if (value == null) {
+      return false;
+    }
+    final short id = getTypeId(requireNonNull(type, "type"));
+    if (id == TYPE_INTEGER || id == TYPE_DECIMAL || id == TYPE_DOUBLE || id == TYPE_FLOAT) {
+      return narrowsNumeric(value, id);
+    }
+    return truncates(value, id);
+  }
+
+  /**
+   * Whether {@code type} is encoded by one of the NARROWING numeric encoders.
+   *
+   * <p>
+   * The distinction a value re-check needs: for these types the same logical number can be stored as
+   * a {@code NumericValueNode} (JSON) or as raw lexical bytes (XML), and two lexically different
+   * forms — {@code 1.50} and {@code 1.5} — are the same value. A re-check that compared bytes would
+   * drop one of them.
+   * </p>
+   *
+   * @param type the index's declared content type
+   * @return {@code true} for the integer, decimal, double and float families
+   */
+  public static boolean isNumericFamily(final Type type) {
+    final short id = getTypeId(requireNonNull(type, "type"));
+    return id == TYPE_INTEGER || id == TYPE_DECIMAL || id == TYPE_DOUBLE || id == TYPE_FLOAT;
+  }
+
+  /**
+   * Whether serializing {@code value} under {@code type} TRUNCATES it — the lexical half of
+   * {@link #losesInformation}, reported on its own because the two halves need opposite remedies.
+   *
+   * <p>
+   * A truncated bound breaks the bounded cursor's ordering, and no re-derivation from the stored key
+   * can repair it, because the bytes the encoder dropped are not in the index either. Numeric
+   * narrowing is different: the encoder is monotone, so the cursor still places every stored key
+   * correctly against the bound, and a caller that reacts to narrowing by abandoning the cursor pays
+   * an O(index) scan to reach exactly the same answer. Range callers therefore consult THIS, not
+   * {@link #losesInformation}.
+   * </p>
+   *
+   * @param value the bound being serialized, may be {@code null}
+   * @param type the index's declared content type
+   * @return {@code true} when the encoder caps {@code value} at {@link #MAX_STRING_VALUE_BYTES}
+   */
+  public static boolean truncates(final @Nullable Atomic value, final Type type) {
+    if (value == null) {
+      return false;
+    }
+    return truncates(value, getTypeId(requireNonNull(type, "type")));
+  }
+
+  private static boolean truncates(final Atomic value, final short id) {
+    if (id != TYPE_STRING && id != TYPE_OTHER) {
+      return false;
+    }
+    final String str = value.stringValue();
+    // Cheap bounds first — this runs once per equality query, but the UTF-8 measurement below walks
+    // the string and there is no reason to do it for the ~every value that is obviously short.
+    // One char is at least one UTF-8 byte, so a char count at or past the cap already settles it;
+    // and no char exceeds three UTF-8 bytes (a surrogate PAIR is four bytes across two chars, i.e.
+    // two per char), so a char count under a third of the cap settles the other direction.
+    final int chars = str.length();
+    if (chars >= MAX_STRING_VALUE_BYTES) {
+      return true;
+    }
+    // ORDER-DEPENDENT, and the dependence is the point: the test above caps `chars` below 246, so
+    // the product below cannot overflow. Removing it — on the reasoning that utf8Length subsumes it
+    // — would let `chars * 3` go negative for a string past ~715M chars, and a negative product
+    // satisfies `< MAX_STRING_VALUE_BYTES`, reporting a gigabyte-long value as losslessly
+    // representable and switching the caller's re-check off for exactly the value that needs it.
+    // STRICT `<`, matching the `>=` boundary: 82 three-byte chars measure exactly 246, which
+    // collides, so the short-circuit must not claim it is safe.
+    if (chars * 3 < MAX_STRING_VALUE_BYTES) {
+      return false;
+    }
+    return utf8Length(str) >= MAX_STRING_VALUE_BYTES;
+  }
+
+  /**
+   * UTF-8 length of {@code str}, counted without encoding it.
+   *
+   * <p>
+   * An UNPAIRED surrogate is counted as three bytes while {@code String.getBytes(UTF_8)} — what the
+   * serializer actually calls — substitutes a single {@code '?'}. The error is one-directional (this
+   * never under-counts), so truncation is never MISSED; it can only be over-reported, which costs the
+   * caller a re-check it did not need. Counting the substitution instead would make this method's
+   * answer depend on the JDK's malformed-input policy rather than on the string.
+   * </p>
+   *
+   * @param str the string to measure
+   * @return its length in UTF-8 bytes, never below what the serializer writes
+   */
+  private static int utf8Length(final String str) {
+    int length = 0;
+    for (int i = 0, n = str.length(); i < n; i++) {
+      final char c = str.charAt(i);
+      if (c < 0x80) {
+        length += 1;
+      } else if (c < 0x800) {
+        length += 2;
+      } else if (Character.isHighSurrogate(c) && i + 1 < n && Character.isLowSurrogate(str.charAt(i + 1))) {
+        length += 4;
+        i++;
+      } else {
+        length += 3;
+      }
+    }
+    return length;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -569,9 +569,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * {@link #normalizedDecimalString}, which is what makes it usable as a fast path there. Stripping
    * {@code k} trailing zeros takes precision {@code p} to {@code p - k} and scale {@code s} to
    * {@code s - k}; working the three cases below through that substitution — including the
-   * transitions where stripping moves a value from one case to another — the stripped length is
-   * never the greater. So a caller may conclude "it fits" from this alone, and need fall back to
-   * formatting only where this says the value might not.
+   * transitions where stripping moves a value from one case to another — the stripped length is never
+   * the greater. So a caller may conclude "it fits" from this alone, and need fall back to formatting
+   * only where this says the value might not.
    * </p>
    *
    * @param exact the value

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -30,9 +30,13 @@ package io.sirix.index.hot;
 import io.brackit.query.QueryException;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Dbl;
+import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.Flt;
 import io.brackit.query.atomic.Int32;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.Numeric;
+import io.brackit.query.atomic.Str;
 import io.brackit.query.expr.Cast;
 import io.brackit.query.jdm.Type;
 import io.sirix.index.InstantKeyCodec;
@@ -484,13 +488,13 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       // and the double prefix already carries whatever the encoder could represent.
       return written;
     }
-    final byte[] suffix = normalizedDecimalBytes(exact);
+    final String suffix = normalizedDecimalString(exact);
     // One byte held back for the terminator, which is not optional — see below.
     final int room = Math.min(dest.length - offset - written, MAX_DECIMAL_SUFFIX_BYTES) - 1;
     if (room < 0) {
       return written;
     }
-    final int length = Math.min(suffix.length, room);
+    final int length = Math.min(suffix.length(), room);
     final boolean negative = exact.signum() < 0;
     // SIGN-DEPENDENT complement and terminator, and both halves are load-bearing.
     //
@@ -506,10 +510,15 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     // digits, '.' and '-' (0x2D..0x39); complemented that is 0xC6..0xD2, and neither 0x00 nor 0xFF
     // can occur in either range. The alphabet is restricted enough that the terminator is
     // unambiguous by construction rather than by convention.
+    //
+    // Narrowed from the String's chars rather than through getBytes(US_ASCII), which is the same
+    // bytes without the intermediate array: that alphabet is single-byte in ASCII by construction,
+    // so the cast cannot lose anything the encoder would have kept.
     for (int i = 0; i < length; i++) {
+      final byte b = (byte) suffix.charAt(i);
       dest[offset + written + i] = negative
-          ? (byte) ~suffix[i]
-          : suffix[i];
+          ? (byte) ~b
+          : b;
     }
     dest[offset + written + length] = negative
         ? (byte) 0xFF
@@ -524,6 +533,15 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * @return the exact value, or {@code null}
    */
   private static @Nullable BigDecimal exactDecimalOrNull(final Atomic value) {
+    // An xs:decimal probe already HOLDS the BigDecimal, and this is the hot path for it: both the
+    // encoder and losesInformation land here on every decimal equality query. Formatting it to a
+    // String and re-parsing that String allocated four objects and ran a full decimal parse to
+    // arrive back at the value it started from. Taking the field directly is the same value —
+    // Dec#stringValue is that BigDecimal's own canonical lexical form, so the round trip was
+    // identity by construction.
+    if (value instanceof Dec dec) {
+      return dec.decimalValue();
+    }
     try {
       return new BigDecimal(value.stringValue().trim());
     } catch (final NumberFormatException e) {
@@ -532,14 +550,47 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   }
 
   /**
-   * The canonical bytes of {@code exact}, with trailing zeros stripped so that equal values produce
+   * The canonical text of {@code exact}, with trailing zeros stripped so that equal values produce
    * equal bytes. ASCII by construction — a plain decimal string has no character outside it.
    *
    * @param exact the value
-   * @return its normalized bytes
+   * @return its normalized form
    */
-  private static byte[] normalizedDecimalBytes(final BigDecimal exact) {
-    return exact.stripTrailingZeros().toPlainString().getBytes(StandardCharsets.US_ASCII);
+  private static String normalizedDecimalString(final BigDecimal exact) {
+    return exact.stripTrailingZeros().toPlainString();
+  }
+
+  /**
+   * The length {@link BigDecimal#toPlainString()} would produce for {@code exact}, derived from its
+   * precision and scale rather than by formatting it.
+   *
+   * <p>
+   * Exact for the value as given, and therefore an UPPER BOUND on the length of
+   * {@link #normalizedDecimalString}, which is what makes it usable as a fast path there. Stripping
+   * {@code k} trailing zeros takes precision {@code p} to {@code p - k} and scale {@code s} to
+   * {@code s - k}; working the three cases below through that substitution — including the
+   * transitions where stripping moves a value from one case to another — the stripped length is
+   * never the greater. So a caller may conclude "it fits" from this alone, and need fall back to
+   * formatting only where this says the value might not.
+   * </p>
+   *
+   * @param exact the value
+   * @return the number of characters its plain form would occupy
+   */
+  private static int plainDecimalLength(final BigDecimal exact) {
+    final int precision = exact.precision();
+    final int scale = exact.scale();
+    // scale <= 0: the digits followed by -scale zeros. 0 < scale < precision: a point inserted
+    // among the digits. scale >= precision: "0." then scale digits, of which scale - precision are
+    // leading zeros.
+    final int digits = scale <= 0
+        ? precision - scale
+        : (precision > scale
+            ? precision + 1
+            : scale + 2);
+    return exact.signum() < 0
+        ? digits + 1
+        : digits;
   }
 
   /**
@@ -810,7 +861,18 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       // allocation here is paid by a query that is genuinely ambiguous rather than by every price
       // lookup.
       final BigDecimal exact = exactDecimalOrNull(value);
-      return exact == null || normalizedDecimalBytes(exact).length > MAX_DECIMAL_SUFFIX_BYTES - 1;
+      if (exact == null) {
+        return true;
+      }
+      // Only a LENGTH is wanted here, so formatting the value to get one was the whole cost of this
+      // check on every decimal equality query — the second full normalization per query, after the
+      // encoder's. plainDecimalLength bounds it from precision and scale without allocating, and the
+      // bound is exact for the unstripped form, so a value comfortably inside the budget (which is
+      // every decimal anyone actually indexes — the limit is ~237 significant digits) settles it in
+      // arithmetic. The formatting survives only where the bound cannot decide, which is where the
+      // key genuinely may not be injective and a re-check was going to be paid for anyway.
+      return plainDecimalLength(exact) > MAX_DECIMAL_SUFFIX_BYTES - 1
+          && normalizedDecimalString(exact).length() > MAX_DECIMAL_SUFFIX_BYTES - 1;
     }
     if (id != TYPE_INTEGER) {
       // xs:decimal: UNCONDITIONALLY lossy, and the round-trip test that used to stand here was
@@ -1117,7 +1179,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
           | ((long) (bytes[offset + 4] & 0xFF) << 24) | ((long) (bytes[offset + 5] & 0xFF) << 16)
           | ((long) (bytes[offset + 6] & 0xFF) << 8) | ((long) (bytes[offset + 7] & 0xFF));
       long longValue = bits ^ SIGN_FLIP;
-      return new io.brackit.query.atomic.Int64(longValue);
+      return new Int64(longValue);
     } else if (type.isNumeric()) {
       // Decode IEEE 754 order-preserving format (xs:double, xs:float, xs:decimal)
       long bits = ((long) (bytes[offset] & 0xFF) << 56) | ((long) (bytes[offset + 1] & 0xFF) << 48)
@@ -1151,20 +1213,20 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
                 ? (byte) ~raw
                 : raw;
           }
-          return new io.brackit.query.atomic.Dec(new BigDecimal(new String(plain, StandardCharsets.US_ASCII)));
+          return new Dec(new BigDecimal(new String(plain, StandardCharsets.US_ASCII)));
         }
-        return new io.brackit.query.atomic.Dec(java.math.BigDecimal.valueOf(d));
+        return new Dec(BigDecimal.valueOf(d));
       } else if (type.instanceOf(Type.FLO)) {
-        return new io.brackit.query.atomic.Flt((float) d);
+        return new Flt((float) d);
       } else {
-        return new io.brackit.query.atomic.Dbl(d);
+        return new Dbl(d);
       }
     } else if (type.instanceOf(Type.BOOL)) {
-      return new io.brackit.query.atomic.Bool(bytes[offset] == 1);
+      return new Bool(bytes[offset] == 1);
     } else {
       // String
       String str = new String(bytes, offset, length, StandardCharsets.UTF_8);
-      return new io.brackit.query.atomic.Str(str);
+      return new Str(str);
     }
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -85,6 +85,17 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   private static final long SIGN_FLIP = 0x8000_0000_0000_0000L;
 
   /**
+   * The key every NaN encodes to: above every real value, and reachable by no real value.
+   *
+   * <p>
+   * Reversing the sign-flip on it gives {@code 0x7FFF_FFFF_FFFF_FFFF}, itself a NaN bit pattern, so
+   * no finite double and neither infinity can land here — {@code +Infinity}, the largest real value,
+   * encodes to {@code 0xFFF0_0000_0000_0000}.
+   * </p>
+   */
+  private static final long NAN_KEY_BITS = 0xFFFF_FFFF_FFFF_FFFFL;
+
+  /**
    * Type IDs for stable serialization (independent of Type.ordinal()).
    */
   private static final short TYPE_STRING = 1;
@@ -273,8 +284,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
         // Integer family (xs:integer and subtypes): lossless 64-bit encoding, not double.
         return encodeIntegerOrderPreserving(value, dest, offset);
       case TYPE_DOUBLE:
-      case TYPE_DECIMAL:
         return encodeNumericOrderPreserving(value, dest, offset, false);
+      case TYPE_DECIMAL:
+        return encodeDecimalOrderPreserving(value, dest, offset);
       case TYPE_FLOAT:
         // Rounded to float precision FIRST, because the two sides of an xs:float index reach this
         // method in different shapes and must land on one key. CASIndexBuilder stores every value as
@@ -349,11 +361,6 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       d = (float) d;
     }
 
-    // Canonicalize NaN to sort last
-    if (Double.isNaN(d)) {
-      d = Double.MAX_VALUE;
-    }
-
     // Collapse -0.0 onto +0.0, and note this is a CORRECTNESS fix, not tidiness. The sign-flip below
     // branches on the VALUE (`d >= 0`), and `-0.0 >= 0` is true in Java while
     // doubleToLongBits(-0.0) has the sign bit SET — so -0.0 took the positive branch and XORed to
@@ -368,6 +375,25 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       d = 0.0;
     }
 
+    if (Double.isNaN(d)) {
+      // NaN gets a key of its OWN, above every real value. It used to be canonicalized onto
+      // Double.MAX_VALUE, which MERGED its posting list with that of a real, indexable number — the
+      // failure this class's own history note calls the fatal one, because a shared key corrupts
+      // equality and deletes rather than merely mis-ordering a range. A stored NaN made
+      // `eq 1.7976931348623157E308` return it, and deleting one entry disturbed the other's list.
+      //
+      // All-ones is safe as that key precisely because the sign-flip below is a bijection: reversing
+      // it gives 0x7FFF_FFFF_FFFF_FFFF, itself a NaN bit pattern, so no finite value and neither
+      // infinity can produce it (+Infinity, the largest real, encodes to 0xFFF0_...). Every NaN
+      // payload collapses onto this one key, which is what makes the encoding a function.
+      //
+      // decodeAtomic needs no change: reversing all-ones yields a NaN bit pattern and hands back NaN.
+      // Note this does NOT make `eq NaN` answer with those rows — XQuery gives NaN no equals, which
+      // CASIndex#exactMatches enforces separately.
+      writeBigEndian(NAN_KEY_BITS, dest, offset);
+      return 8;
+    }
+
     long bits = Double.doubleToLongBits(d);
 
     // Order-preserving transformation:
@@ -380,6 +406,21 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     }
 
     // Write big-endian
+    writeBigEndian(bits, dest, offset);
+
+    return 8;
+  }
+
+
+  /**
+   * Write {@code bits} big-endian at {@code offset}. One definition, because the byte-shift ladder
+   * appeared verbatim in each fixed-width encoder and a transposed shift there is invisible.
+   *
+   * @param bits the already order-transformed value
+   * @param dest destination buffer
+   * @param offset offset to write at
+   */
+  private static void writeBigEndian(final long bits, final byte[] dest, final int offset) {
     dest[offset] = (byte) (bits >>> 56);
     dest[offset + 1] = (byte) (bits >>> 48);
     dest[offset + 2] = (byte) (bits >>> 40);
@@ -388,8 +429,115 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     dest[offset + 5] = (byte) (bits >>> 16);
     dest[offset + 6] = (byte) (bits >>> 8);
     dest[offset + 7] = (byte) bits;
+  }
 
-    return 8;
+
+  /** Bytes a decimal's exact suffix may use: the value budget minus the 8-byte double prefix. */
+  private static final int MAX_DECIMAL_SUFFIX_BYTES = MAX_STRING_VALUE_BYTES - Long.BYTES;
+
+  /**
+   * Encodes {@code xs:decimal} as an order-preserving double FOLLOWED BY the exact value.
+   *
+   * <p>
+   * The double alone is what the encoder used to write, and it is why every decimal equality query
+   * had to re-read the candidate documents: two decimals differing past double precision collapsed
+   * onto one key, so the seek could only ever answer with candidates. That re-check opened a second
+   * {@code StorageEngineReader} and read one record per posting, turning an O(log n) descent into
+   * O(|posting list|) random reads on the most common query shape there is.
+   * </p>
+   *
+   * <p>
+   * Appending the exact value makes the key INJECTIVE, so equality is decided by the seek alone and
+   * {@code narrowsNumeric} can answer {@code false} — the re-check disappears from the hot path and
+   * survives only for a decimal too long to fit, which {@link #MAX_DECIMAL_SUFFIX_BYTES} bounds at
+   * ~238 significant digits.
+   * </p>
+   *
+   * <p>
+   * NORMALIZED, and that is the subtle part: {@code stripTrailingZeros().toPlainString()} so that
+   * {@code 1.50} and {@code 1.5} produce identical bytes. They are the same value and MUST share a
+   * key; a bare {@code toString()} would give them different suffixes and {@code eq 1.5} would stop
+   * finding a stored {@code 1.50} — trading the old over-match for a missing row, which is the worse
+   * failure.
+   * </p>
+   *
+   * <p>
+   * ORDERING is unchanged where it was ever right: the double prefix dominates the comparison, so
+   * byte order still follows value order between different doubles. WITHIN one double — values
+   * differing past ~17 significant digits — the suffix decides, and that is not value order. It was
+   * not value order before either: those values shared a single key, so a bound falling among them
+   * was already arbitrary. The error stays sub-ULP; what changes is that equality became exact.
+   * </p>
+   *
+   * @param value the decimal
+   * @param dest destination buffer
+   * @param offset offset to write at
+   * @return number of bytes written
+   */
+  private int encodeDecimalOrderPreserving(final Atomic value, final byte[] dest, final int offset) {
+    final int written = encodeNumericOrderPreserving(value, dest, offset, false);
+    final BigDecimal exact = exactDecimalOrNull(value);
+    if (exact == null) {
+      // NaN, an infinity, or a lexical form BigDecimal declines: there is no exact value to append,
+      // and the double prefix already carries whatever the encoder could represent.
+      return written;
+    }
+    final byte[] suffix = normalizedDecimalBytes(exact);
+    // One byte held back for the terminator, which is not optional — see below.
+    final int room = Math.min(dest.length - offset - written, MAX_DECIMAL_SUFFIX_BYTES) - 1;
+    if (room < 0) {
+      return written;
+    }
+    final int length = Math.min(suffix.length, room);
+    final boolean negative = exact.signum() < 0;
+    // SIGN-DEPENDENT complement and terminator, and both halves are load-bearing.
+    //
+    // Within one double the suffix decides the order, and a plain byte compare gets NEGATIVES
+    // backwards: "-0.5" is a prefix of "-0.5000000000000000001", so the length tiebreak in
+    // HOTLeafPage#compareKeyPrefixPart sorts the shorter first — while numerically -0.5 is the
+    // GREATER of the two. Complementing the payload flips the digit comparison, and the terminator
+    // flips the length tiebreak with it: 0xFF for a negative outranks any complemented digit, 0x00
+    // for a positive falls below any plain one, so under both signs "ends sooner" lands on the
+    // correct side.
+    //
+    // No escaping is needed, which is what makes this cheap. A normalized plain decimal is ASCII
+    // digits, '.' and '-' (0x2D..0x39); complemented that is 0xC6..0xD2, and neither 0x00 nor 0xFF
+    // can occur in either range. The alphabet is restricted enough that the terminator is
+    // unambiguous by construction rather than by convention.
+    for (int i = 0; i < length; i++) {
+      dest[offset + written + i] = negative
+          ? (byte) ~suffix[i]
+          : suffix[i];
+    }
+    dest[offset + written + length] = negative
+        ? (byte) 0xFF
+        : 0;
+    return written + length + 1;
+  }
+
+  /**
+   * {@code value} as an exact decimal, or {@code null} when it is not one.
+   *
+   * @param value the atomic
+   * @return the exact value, or {@code null}
+   */
+  private static @Nullable BigDecimal exactDecimalOrNull(final Atomic value) {
+    try {
+      return new BigDecimal(value.stringValue().trim());
+    } catch (final NumberFormatException e) {
+      return null;
+    }
+  }
+
+  /**
+   * The canonical bytes of {@code exact}, with trailing zeros stripped so that equal values produce
+   * equal bytes. ASCII by construction — a plain decimal string has no character outside it.
+   *
+   * @param exact the value
+   * @return its normalized bytes
+   */
+  private static byte[] normalizedDecimalBytes(final BigDecimal exact) {
+    return exact.stripTrailingZeros().toPlainString().getBytes(StandardCharsets.US_ASCII);
   }
 
   /**
@@ -428,14 +576,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     // Sign-flip so unsigned byte order matches signed numeric order.
     final long bits = v ^ SIGN_FLIP;
 
-    dest[offset] = (byte) (bits >>> 56);
-    dest[offset + 1] = (byte) (bits >>> 48);
-    dest[offset + 2] = (byte) (bits >>> 40);
-    dest[offset + 3] = (byte) (bits >>> 32);
-    dest[offset + 4] = (byte) (bits >>> 24);
-    dest[offset + 5] = (byte) (bits >>> 16);
-    dest[offset + 6] = (byte) (bits >>> 8);
-    dest[offset + 7] = (byte) bits;
+    writeBigEndian(bits, dest, offset);
 
     return 8;
   }
@@ -655,6 +796,19 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       // query off the bounded byte cursor into the O(index) typed full scan — a large regression on
       // exactly the indexes this predicate was added to keep correct.
       return Double.isNaN(numeric.doubleValue());
+    }
+    if (id == TYPE_DECIMAL) {
+      // EXACT by construction now — encodeDecimalOrderPreserving appends the normalized value after
+      // the double, so two distinct decimals cannot share a key and the seek settles equality on its
+      // own. This used to answer true unconditionally, which put every decimal `eq` through a second
+      // StorageEngineReader and a document read per posting.
+      //
+      // The one case left is a decimal whose normalized form does not FIT, which collapses onto its
+      // prefix exactly as an over-long string does. Bounded at ~238 significant digits, so the
+      // allocation here is paid by a query that is genuinely ambiguous rather than by every price
+      // lookup.
+      final BigDecimal exact = exactDecimalOrNull(value);
+      return exact == null || normalizedDecimalBytes(exact).length > MAX_DECIMAL_SUFFIX_BYTES - 1;
     }
     if (id != TYPE_INTEGER) {
       // xs:decimal: UNCONDITIONALLY lossy, and the round-trip test that used to stand here was
@@ -949,6 +1103,21 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
 
       // Return the appropriate type based on the stored type
       if (type.instanceOf(Type.DEC)) {
+        if (length > Long.BYTES + 1) {
+          // The exact value the encoder appended, so this round-trips instead of handing back the
+          // double's shortest decimal form. CASFilterRange#inRange then compares the real value.
+          // Undoes the sign-dependent complement and drops the terminator the encoder reserved.
+          final int suffixLength = length - Long.BYTES - 1;
+          final boolean negative = (bytes[offset + length - 1] & 0xFF) == 0xFF;
+          final byte[] plain = new byte[suffixLength];
+          for (int i = 0; i < suffixLength; i++) {
+            final byte raw = bytes[offset + Long.BYTES + i];
+            plain[i] = negative
+                ? (byte) ~raw
+                : raw;
+          }
+          return new io.brackit.query.atomic.Dec(new BigDecimal(new String(plain, StandardCharsets.US_ASCII)));
+        }
         return new io.brackit.query.atomic.Dec(java.math.BigDecimal.valueOf(d));
       } else if (type.instanceOf(Type.FLO)) {
         return new io.brackit.query.atomic.Flt((float) d);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -30,9 +30,11 @@ package io.sirix.index.hot;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Numeric;
 import io.brackit.query.jdm.Type;
+import io.sirix.index.InstantKeyCodec;
 import io.sirix.index.redblacktree.keyvalue.CASValue;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -81,7 +83,45 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   private static final short TYPE_FLOAT = 4;
   private static final short TYPE_INTEGER = 5;
   private static final short TYPE_DECIMAL = 7;
+
+  /**
+   * The instant family. These carry real ids so the content type ROUND-TRIPS — {@code CASValue} then
+   * reports {@code xs:dateTime} rather than {@code xs:string} on the way back out, which is what lets
+   * the typed {@code CASFilterRange#inRange} comparison order them chronologically.
+   *
+   * <p>
+   * The stored VALUE is the raw lexical form (the string branch of
+   * {@link #encodeAtomicOrderPreserving}), and {@link #isByteOrderPreserving} deliberately reports
+   * {@code false} for them, so every range query is decided by that typed comparison and never by a
+   * byte-bounded cursor. An id is emphatically NOT a claim of byte-orderability — see the predicate's
+   * javadoc.
+   * </p>
+   */
+  private static final short TYPE_DATETIME = 8;
+  private static final short TYPE_DATE = 9;
+  private static final short TYPE_TIME = 10;
+
+  // These were briefly stored through a BINARY instant codec on this branch. That was wrong and is
+  // reverted to the lexical form. Measured against brackit's own comparison semantics:
+  // * xs:date — canonicalizing to UTC moves the offset into a time-of-day that xs:date cannot
+  // hold (brackit's Date.getHours() is always 0), so the residue is dropped and
+  // xs:date("2020-01-01+02:00") encoded to the SAME 10 bytes as xs:date("2019-12-31Z"),
+  // which compareTo reports as different values.
+  // * xs:time — the reference-date comparison (1972-12-31) carries a ±1-day rollover that
+  // xs:time cannot hold (Time.getDay() is always 0), so byte order came out INVERTED against
+  // compareTo for any non-UTC offset.
+  // * mixed timezoned/untimezoned values collided, and brackit orders that pair inconsistently
+  // (it reports "less" in BOTH directions), so no byte encoding can agree with it.
+  // Colliding keys are the fatal part: two distinct values sharing one CAS key merge their posting
+  // lists, which corrupts equality lookups and deletes, not just ranges. The lexical form is
+  // injective, so it is what gets stored; chronological ORDER comes from the typed
+  // CASFilterRange#inRange comparison, which isByteOrderPreserving=false routes every instant range
+  // query through. That gate is the actual fix for the original defect — a byte-bounded cursor
+  // deciding instant ranges on lexical bytes and silently dropping records.
+
   private static final short TYPE_OTHER = 0;
+
+
 
   /**
    * Singleton instance (stateless, thread-safe).
@@ -120,13 +160,15 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       offset += encodeAtomicOrderPreserving(atomicValue, type, dest, offset);
     }
 
-    int bytesWritten = offset - start;
-    if (bytesWritten == 10) {
-      // Only header, no value - shouldn't happen for valid CASValue
+    if (atomicValue == null) {
       throw new IllegalArgumentException("CASValue has no atomic value");
     }
 
-    return bytesWritten;
+    // NOT an error when the value region is empty: the empty string encodes to zero bytes, and a
+    // bare 10-byte header is its correct key — it sorts below every non-empty value of the same
+    // type, which is exactly right. Rejecting a zero-length region instead made `$x >= ""` throw
+    // out of the reader and would have made indexing a `""` value throw out of the writer.
+    return offset - start;
   }
 
   /**
@@ -138,6 +180,27 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   @Override
   public int maxSerializedLength(final CASValue key) {
     return HEADER_BYTES + MAX_STRING_VALUE_BYTES;
+  }
+
+  /**
+   * The path class record of a serialized CAS key, read in place. The pathNodeKey is the first eight
+   * bytes, big-endian and sign-flipped, so this is one unaligned-style read plus an XOR — no
+   * {@link CASValue}, no atomic, no UTF-8 decode. Exists because the per-entry PCR filter used to go
+   * through {@link #deserialize}, which materializes the whole key just to look at its first eight
+   * bytes.
+   *
+   * @param bytes buffer holding a serialized CAS key
+   * @param offset offset of the key within {@code bytes}
+   * @return the key's pathNodeKey
+   */
+  public static long pathNodeKeyAt(final byte[] bytes, final int offset) {
+    requireNonNull(bytes, "bytes");
+    Objects.checkFromIndexSize(offset, Long.BYTES, bytes.length);
+    final long signFlipped = ((long) (bytes[offset] & 0xFF) << 56) | ((long) (bytes[offset + 1] & 0xFF) << 48)
+        | ((long) (bytes[offset + 2] & 0xFF) << 40) | ((long) (bytes[offset + 3] & 0xFF) << 32)
+        | ((long) (bytes[offset + 4] & 0xFF) << 24) | ((long) (bytes[offset + 5] & 0xFF) << 16)
+        | ((long) (bytes[offset + 6] & 0xFF) << 8) | (bytes[offset + 7] & 0xFF);
+    return signFlipped ^ SIGN_FLIP;
   }
 
   @Override
@@ -191,6 +254,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
           ? (byte) 1
           : (byte) 0;
       return 1;
+    } else if (InstantKeyCodec.isInstantType(type)) {
+      // The absolute instant, so byte order is chronological order — see InstantKeyCodec.
+      return InstantKeyCodec.encode(value, type, dest, offset);
     } else {
       // String: UTF-8 is already lexicographically ordered
       final String str = value.stringValue();
@@ -309,10 +375,52 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   }
 
   /**
+   * Whether the serialized key's unsigned BYTE order is the type's own value order — i.e. whether a
+   * bounded byte-range cursor may decide a range query for this content type at all.
+   *
+   * <p>
+   * True for the families {@link #encodeAtomicOrderPreserving} encodes deliberately: the integer
+   * family, the floating-point family, {@code xs:decimal}, {@code xs:boolean} and {@code xs:string}.
+   * FALSE for everything else, which falls through to that method's string branch and is stored as
+   * its raw lexical form: {@code xs:dateTime}, {@code xs:date}, {@code xs:time} and
+   * {@code xs:duration} all order textually there, which is not chronological order. Text order puts
+   * {@code "…T12:00:00.5Z"} below {@code "…T12:00:00Z"} ({@code '.'} &lt; {@code 'Z'}) and mixes
+   * timezone spellings arbitrarily ({@code '+'}, {@code '-'} &lt; {@code 'Z'}), so a byte-bounded
+   * scan silently drops matching records. Callers must fall back to a typed
+   * {@link io.sirix.index.cas.CASFilterRange#inRange} comparison for those — which is exactly what a
+   * {@code false} answer here makes {@code CASIndex} do.
+   *
+   * <p>
+   * <b>This predicate is deliberately NOT "does the type have an id".</b> Those are different
+   * questions, and fusing them is how the instant family briefly ended up on the byte-bounded fast
+   * path with an encoding that was not order-preserving (see the burned-id note at the top of this
+   * class). A type gets {@code true} here only when its encoder is known to preserve order.
+   *
+   * @param type the index's content type
+   * @return {@code true} iff byte order over the encoded value equals value order
+   */
+  public static boolean isByteOrderPreserving(final Type type) {
+    if (type == null) {
+      return false;
+    }
+    final short id = getTypeId(type);
+    return id == TYPE_STRING || id == TYPE_BOOLEAN || id == TYPE_DOUBLE || id == TYPE_FLOAT || id == TYPE_INTEGER
+        || id == TYPE_DECIMAL || id == TYPE_DATETIME || id == TYPE_DATE || id == TYPE_TIME;
+  }
+
+  /**
    * Gets a stable type ID for serialization.
    */
   private static short getTypeId(Type type) {
-    if (type.instanceOf(Type.STR)) {
+    // The instant family first: none of these is a subtype of the families below, but checking them
+    // up front keeps the mapping obvious.
+    if (type.instanceOf(Type.DATI)) {
+      return TYPE_DATETIME;
+    } else if (type.instanceOf(Type.DATE)) {
+      return TYPE_DATE;
+    } else if (type.instanceOf(Type.TIME)) {
+      return TYPE_TIME;
+    } else if (type.instanceOf(Type.STR)) {
       return TYPE_STRING;
     } else if (type.instanceOf(Type.BOOL)) {
       return TYPE_BOOLEAN;
@@ -342,6 +450,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       case TYPE_FLOAT -> Type.FLO;
       case TYPE_INTEGER -> Type.LON;
       case TYPE_DECIMAL -> Type.DEC;
+      case TYPE_DATETIME -> Type.DATI;
+      case TYPE_DATE -> Type.DATE;
+      case TYPE_TIME -> Type.TIME;
       default -> Type.STR; // Fallback
     };
   }
@@ -350,6 +461,9 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * Decodes an atomic value from bytes.
    */
   private static Atomic decodeAtomic(byte[] bytes, int offset, int length, Type type) {
+    if (InstantKeyCodec.isInstantType(type)) {
+      return InstantKeyCodec.decode(bytes, offset, length, type);
+    }
     if (type.instanceOf(Type.INR)) {
       // Integer family: reverse the lossless 64-bit sign-flipped encoding.
       long bits = ((long) (bytes[offset] & 0xFF) << 56) | ((long) (bytes[offset + 1] & 0xFF) << 48)

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -157,7 +157,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     // 3. Value (order-preserving encoding)
     Atomic atomicValue = key.getAtomicValue();
     if (atomicValue != null) {
-      offset += encodeAtomicOrderPreserving(atomicValue, type, dest, offset);
+      offset += encodeAtomicOrderPreserving(atomicValue, type, typeId, dest, offset);
     }
 
     if (atomicValue == null) {
@@ -242,38 +242,49 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * @param offset offset to write at
    * @return number of bytes written
    */
-  private int encodeAtomicOrderPreserving(Atomic value, Type type, byte[] dest, int offset) {
-    if (type.instanceOf(Type.INR)) {
-      // Integer family (xs:integer and subtypes): lossless 64-bit encoding, not double.
-      return encodeIntegerOrderPreserving(value, dest, offset);
-    } else if (type.isNumeric()) {
-      return encodeNumericOrderPreserving(value, dest, offset);
-    } else if (type.instanceOf(Type.BOOL)) {
-      // Boolean: 0 for false, 1 for true (already ordered)
-      dest[offset] = value.booleanValue()
-          ? (byte) 1
-          : (byte) 0;
-      return 1;
-    } else if (InstantKeyCodec.isInstantType(type)) {
-      // The absolute instant, so byte order is chronological order — see InstantKeyCodec.
-      return InstantKeyCodec.encode(value, type, dest, offset);
-    } else {
-      // String: UTF-8 is already lexicographically ordered
-      final String str = value.stringValue();
-      // Truncate to fit buffer (preserves lexicographic ordering for prefixes)
-      final int cap = Math.min(dest.length - offset, MAX_STRING_VALUE_BYTES);
+  private int encodeAtomicOrderPreserving(Atomic value, Type type, short typeId, byte[] dest, int offset) {
+    // Dispatch on the id the caller already computed, NOT by re-walking the type hierarchy.
+    // Type.instanceOf is a parent-pointer chase, and this method used to redo the whole ladder that
+    // getTypeId had just walked -- so every key paid the dispatch twice. A switch over the id is a
+    // tableswitch: no chain walks at all. Measured on the string CAS path, where serializing a key
+    // cost MORE than the entire PEXT descent it feeds (134 ns against 79 ns).
+    switch (typeId) {
+      case TYPE_INTEGER:
+        // Integer family (xs:integer and subtypes): lossless 64-bit encoding, not double.
+        return encodeIntegerOrderPreserving(value, dest, offset);
+      case TYPE_DOUBLE:
+      case TYPE_FLOAT:
+      case TYPE_DECIMAL:
+        return encodeNumericOrderPreserving(value, dest, offset);
+      case TYPE_BOOLEAN:
+        // Boolean: 0 for false, 1 for true (already ordered)
+        dest[offset] = value.booleanValue()
+            ? (byte) 1
+            : (byte) 0;
+        return 1;
+      case TYPE_DATETIME:
+      case TYPE_DATE:
+      case TYPE_TIME:
+        // The absolute instant, so byte order is chronological order — see InstantKeyCodec.
+        return InstantKeyCodec.encode(value, type, dest, offset);
+      default: {
+        // String: UTF-8 is already lexicographically ordered
+        final String str = value.stringValue();
+        // Truncate to fit buffer (preserves lexicographic ordering for prefixes)
+        final int cap = Math.min(dest.length - offset, MAX_STRING_VALUE_BYTES);
       // A value is serialized once per indexed node, so the ASCII case — which is very nearly all
       // of them — writes straight into dest instead of through a throwaway byte[]. One ASCII char
       // is one UTF-8 byte, so the bytes and the truncation point are identical either way; only
       // the leading `cap` chars have to be ASCII, since anything beyond them is truncated away.
-      final int asciiLen = Math.min(str.length(), cap);
-      if (AsciiKeyBytes.isAsciiPrefix(str, asciiLen)) {
-        return AsciiKeyBytes.writeAsciiPrefix(str, asciiLen, dest, offset);
+        final int asciiLen = Math.min(str.length(), cap);
+        if (AsciiKeyBytes.isAsciiPrefix(str, asciiLen)) {
+          return AsciiKeyBytes.writeAsciiPrefix(str, asciiLen, dest, offset);
+        }
+        final byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
+        final int maxLen = Math.min(utf8.length, cap);
+        System.arraycopy(utf8, 0, dest, offset, maxLen);
+        return maxLen;
       }
-      final byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
-      final int maxLen = Math.min(utf8.length, cap);
-      System.arraycopy(utf8, 0, dest, offset, maxLen);
-      return maxLen;
     }
   }
 
@@ -412,15 +423,13 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * Gets a stable type ID for serialization.
    */
   private static short getTypeId(Type type) {
-    // The instant family first: none of these is a subtype of the families below, but checking them
-    // up front keeps the mapping obvious.
-    if (type.instanceOf(Type.DATI)) {
-      return TYPE_DATETIME;
-    } else if (type.instanceOf(Type.DATE)) {
-      return TYPE_DATE;
-    } else if (type.instanceOf(Type.TIME)) {
-      return TYPE_TIME;
-    } else if (type.instanceOf(Type.STR)) {
+    // Ordered by FREQUENCY, not taxonomy. Type.instanceOf walks the parent chain, so every test that
+    // fails before the right one costs a pointer chase -- and this runs once per key serialized, on
+    // the insert path and on every lookup's probe. Putting the instant family first (which reads
+    // more tidily) made every string key pay three failing walks before reaching its own branch.
+    // The one ordering constraint that is NOT about frequency: xs:integer must be tested before
+    // xs:decimal, since integers are decimals but need the lossless 64-bit encoding.
+    if (type.instanceOf(Type.STR)) {
       return TYPE_STRING;
     } else if (type.instanceOf(Type.BOOL)) {
       return TYPE_BOOLEAN;
@@ -433,6 +442,12 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       // Checked before xs:decimal because xs:integer instanceOf xs:decimal is true,
       // yet integers use the lossless 64-bit encoding, not the IEEE-754 double encoding.
       return TYPE_INTEGER;
+    } else if (type.instanceOf(Type.DATI)) {
+      return TYPE_DATETIME;
+    } else if (type.instanceOf(Type.DATE)) {
+      return TYPE_DATE;
+    } else if (type.instanceOf(Type.TIME)) {
+      return TYPE_TIME;
     } else if (type.instanceOf(Type.DEC)) {
       return TYPE_DECIMAL;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -328,7 +328,8 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * <li>Negative values: XOR all bits</li>
    * </ul>
    */
-  private int encodeNumericOrderPreserving(Atomic value, byte[] dest, int offset, boolean roundToFloat) {
+  private int encodeNumericOrderPreserving(final Atomic value, final byte[] dest, final int offset,
+      final boolean roundToFloat) {
     double d;
     if (value instanceof Numeric numeric) {
       d = numeric.doubleValue();
@@ -351,6 +352,20 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     // Canonicalize NaN to sort last
     if (Double.isNaN(d)) {
       d = Double.MAX_VALUE;
+    }
+
+    // Collapse -0.0 onto +0.0, and note this is a CORRECTNESS fix, not tidiness. The sign-flip below
+    // branches on the VALUE (`d >= 0`), and `-0.0 >= 0` is true in Java while
+    // doubleToLongBits(-0.0) has the sign bit SET — so -0.0 took the positive branch and XORed to
+    // 0x0000000000000000, the absolute minimum key, sorting below -Infinity. `eq 0.0` then missed a
+    // stored -0.0, and any range spanning zero silently excluded it.
+    //
+    // Canonicalizing rather than branching on the sign bit is what XQuery asks for: -0.0 eq 0.0 is
+    // TRUE, so the two must share a key. Branching on the bit pattern instead would order them
+    // correctly but give them DISTINCT keys, which would break equality in the other direction.
+    // `d == 0.0` is true for both zeros, so this one comparison catches it.
+    if (d == 0.0) {
+      d = 0.0;
     }
 
     long bits = Double.doubleToLongBits(d);
@@ -514,10 +529,10 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * FALSE for everything else, which falls through to that method's string branch and is stored as
    * its raw lexical form. {@code xs:duration} is the family that matters there: lexical text order is
    * not duration order, so a byte-bounded scan would silently drop matching records, and callers fall
-   * back to a typed {@link io.sirix.index.cas.CASFilterRange#inRange} comparison — which is exactly
-   * what a {@code false} answer here makes {@code CASIndex} do. The instant family was in this
-   * paragraph while it was stored lexically; it is not any more, and the block comment at the top of
-   * this class records what that encoding got wrong.
+   * back to a typed {@code CASFilterRange#inRange} comparison — which is exactly what a {@code false}
+   * answer here makes {@code CASIndex} do. The instant family was in this paragraph while it was
+   * stored lexically; it is not any more, and the block comment at the top of this class records what
+   * that encoding got wrong.
    *
    * <p>
    * <b>This predicate is deliberately NOT "does the type have an id".</b> Those are different
@@ -603,6 +618,14 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     // Lossless across the whole signed 64-bit range and SATURATING outside it, so a probe inside the
     // range can only be reported lossy by genuinely being outside it. Two values collide only when
     // both overflow the same end, and this round trip catches exactly that.
+    if (numeric instanceof Int32 || numeric instanceof Int64) {
+      // Primitive-backed, so longValue() is exact and the BigDecimal round trip below can only
+      // confirm what the type already guarantees. NOT simply false, though: Long.MAX_VALUE and
+      // Long.MIN_VALUE are the saturation sentinels every out-of-range value collapses onto, so an
+      // Int64 holding one of them genuinely does share its key and still needs the re-check.
+      final long exactly = numeric.longValue();
+      return exactly == Long.MAX_VALUE || exactly == Long.MIN_VALUE;
+    }
     final BigDecimal exact;
     try {
       exact = new BigDecimal(numeric.stringValue());

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -515,6 +515,64 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     }
   }
 
+
+  // ===== Per-type policy, declared ONCE =====
+  //
+  // These three facts about a content type were previously spelled out as four separate disjunction
+  // lists — isByteOrderPreserving, isNumericFamily, losesInformation's numeric test and truncates'
+  // lexical test — and the numeric set was written out twice, verbatim, in two of them. That is drift
+  // waiting to happen: adding a content type meant editing every list in the right way, and missing
+  // one is SILENT. Miss the byte-order list and every range query on the new type degrades to an
+  // O(index) scan; miss the lexical list and an exclusive bound past the string cap drops rows.
+  //
+  // One table instead, and a static check that every id declared above has an entry, so a new type
+  // that forgets its policy fails at class initialization rather than in a query months later.
+  // Encoding and decoding keep their own switches deliberately: both are per-KEY rather than
+  // per-query, and the switch over the id compiles to a tableswitch, which is why
+  // encodeAtomicOrderPreserving stopped re-walking Type#instanceOf in the first place.
+
+  /** Capped at {@link #MAX_STRING_VALUE_BYTES} by the string encoder, so long values share a key. */
+  private static final int LEXICAL = 1;
+
+  /** Encoded by a NARROWING numeric encoder, so distinct values can share a key. */
+  private static final int NUMERIC = 1 << 1;
+
+  /** Unsigned byte order over the encoded value IS the type's value order. */
+  private static final int BYTE_ORDERED = 1 << 2;
+
+  /** Indexed by type id. Index 6 is the burned id and is deliberately absent. */
+  private static final int[] POLICY = new int[TYPE_TIME + 1];
+
+  private static final short BURNED_TYPE_ID = 6;
+
+  static {
+    POLICY[TYPE_OTHER] = LEXICAL; // the string encoder, but lexical order is not its value order
+    POLICY[TYPE_STRING] = LEXICAL | BYTE_ORDERED;
+    POLICY[TYPE_BOOLEAN] = BYTE_ORDERED;
+    POLICY[TYPE_DOUBLE] = NUMERIC | BYTE_ORDERED;
+    POLICY[TYPE_FLOAT] = NUMERIC | BYTE_ORDERED;
+    POLICY[TYPE_INTEGER] = NUMERIC | BYTE_ORDERED;
+    POLICY[TYPE_DECIMAL] = NUMERIC | BYTE_ORDERED;
+    POLICY[TYPE_DATETIME] = BYTE_ORDERED;
+    POLICY[TYPE_DATE] = BYTE_ORDERED;
+    POLICY[TYPE_TIME] = BYTE_ORDERED;
+    for (short id = 0; id < POLICY.length; id++) {
+      if (id != BURNED_TYPE_ID && POLICY[id] == 0) {
+        throw new ExceptionInInitializerError("CAS key type id " + id + " has no policy entry");
+      }
+    }
+  }
+
+  /**
+   * The policy flags for {@code type}.
+   *
+   * @param type the index's content type
+   * @return the {@link #LEXICAL}/{@link #NUMERIC}/{@link #BYTE_ORDERED} mask
+   */
+  private static int policyOf(final Type type) {
+    return POLICY[getTypeId(type)];
+  }
+
   /**
    * Whether the serialized key's unsigned BYTE order is the type's own value order — i.e. whether a
    * bounded byte-range cursor may decide a range query for this content type at all.
@@ -547,9 +605,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     if (type == null) {
       return false;
     }
-    final short id = getTypeId(type);
-    return id == TYPE_STRING || id == TYPE_BOOLEAN || id == TYPE_DOUBLE || id == TYPE_FLOAT || id == TYPE_INTEGER
-        || id == TYPE_DECIMAL || id == TYPE_DATETIME || id == TYPE_DATE || id == TYPE_TIME;
+    return (policyOf(type) & BYTE_ORDERED) != 0;
   }
 
   /**
@@ -699,7 +755,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       return false;
     }
     final short id = getTypeId(requireNonNull(type, "type"));
-    if (id == TYPE_INTEGER || id == TYPE_DECIMAL || id == TYPE_DOUBLE || id == TYPE_FLOAT) {
+    if ((POLICY[id] & NUMERIC) != 0) {
       return narrowsNumeric(value, id);
     }
     return truncates(value, id);
@@ -719,8 +775,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
    * @return {@code true} for the integer, decimal, double and float families
    */
   public static boolean isNumericFamily(final Type type) {
-    final short id = getTypeId(requireNonNull(type, "type"));
-    return id == TYPE_INTEGER || id == TYPE_DECIMAL || id == TYPE_DOUBLE || id == TYPE_FLOAT;
+    return (policyOf(requireNonNull(type, "type")) & NUMERIC) != 0;
   }
 
   /**
@@ -748,7 +803,7 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
   }
 
   private static boolean truncates(final Atomic value, final short id) {
-    if (id != TYPE_STRING && id != TYPE_OTHER) {
+    if ((POLICY[id] & LEXICAL) == 0) {
       return false;
     }
     final String str = value.stringValue();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -178,11 +178,19 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       return 1;
     } else {
       // String: UTF-8 is already lexicographically ordered
-      String str = value.stringValue();
-      byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
+      final String str = value.stringValue();
       // Truncate to fit buffer (preserves lexicographic ordering for prefixes)
-      int maxLen = Math.min(utf8.length, dest.length - offset);
-      maxLen = Math.min(maxLen, MAX_STRING_VALUE_BYTES);
+      final int cap = Math.min(dest.length - offset, MAX_STRING_VALUE_BYTES);
+      // A value is serialized once per indexed node, so the ASCII case — which is very nearly all
+      // of them — writes straight into dest instead of through a throwaway byte[]. One ASCII char
+      // is one UTF-8 byte, so the bytes and the truncation point are identical either way; only
+      // the leading `cap` chars have to be ASCII, since anything beyond them is truncated away.
+      final int asciiLen = Math.min(str.length(), cap);
+      if (AsciiKeyBytes.isAsciiPrefix(str, asciiLen)) {
+        return AsciiKeyBytes.writeAsciiPrefix(str, asciiLen, dest, offset);
+      }
+      final byte[] utf8 = str.getBytes(StandardCharsets.UTF_8);
+      final int maxLen = Math.min(utf8.length, cap);
       System.arraycopy(utf8, 0, dest, offset, maxLen);
       return maxLen;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -27,11 +27,13 @@
  */
 package io.sirix.index.hot;
 
+import io.brackit.query.QueryException;
 import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Bool;
 import io.brackit.query.atomic.Int32;
 import io.brackit.query.atomic.Int64;
 import io.brackit.query.atomic.Numeric;
+import io.brackit.query.expr.Cast;
 import io.brackit.query.jdm.Type;
 import io.sirix.index.InstantKeyCodec;
 import io.sirix.index.redblacktree.keyvalue.CASValue;
@@ -913,6 +915,39 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
       return narrowsNumeric(value, id);
     }
     return truncates(value, id);
+  }
+
+
+  /**
+   * Whether {@code value} is, or can be read as, the index's declared content type.
+   *
+   * <p>
+   * A probe that answers {@code false} matches NOTHING and the caller should say so directly.
+   * {@code CASIndexBuilder} skips any node whose value is not of the declared type, so nothing of
+   * that shape was ever indexed — but the per-type encoders below cannot express "no match" and
+   * instead fall back to {@code 0}, {@code false} or the empty string. That turns a type mismatch
+   * into a WRONG ANSWER rather than an empty one: {@code eq "abc"} on an {@code xs:decimal} index
+   * parses to {@code 0.0} and lands on ZERO's key, so it returns every zero-valued node.
+   * </p>
+   *
+   * @param value the probe, may be {@code null}
+   * @param type the index's declared content type
+   * @return {@code true} when the probe can be encoded as {@code type}
+   */
+  public static boolean isOfType(final @Nullable Atomic value, final Type type) {
+    if (value == null) {
+      return false;
+    }
+    requireNonNull(type, "type");
+    if (value.type() == type) {
+      return true;
+    }
+    try {
+      Cast.cast(null, value, type, false);
+      return true;
+    } catch (final QueryException e) {
+      return false;
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/CASKeySerializer.java
@@ -128,6 +128,17 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     return bytesWritten;
   }
 
+  /**
+   * A CAS key is a 10-byte header plus a value region the encoders bound themselves: 8 bytes for
+   * every numeric family, 1 for a boolean, and at most {@link #MAX_STRING_VALUE_BYTES} for a
+   * string, which {@link #encodeAtomicOrderPreserving} truncates to. So the bound is a constant
+   * and no key of any type can exceed it.
+   */
+  @Override
+  public int maxSerializedLength(final CASValue key) {
+    return HEADER_BYTES + MAX_STRING_VALUE_BYTES;
+  }
+
   @Override
   public CASValue deserialize(byte[] bytes, int offset, int length) {
     // Read path node key (8 bytes)
@@ -149,11 +160,14 @@ public final class CASKeySerializer implements HOTKeySerializer<CASValue> {
     return new CASValue(atomicValue, type, pathNodeKey);
   }
 
+  /** Bytes a key spends before its value: 8 for the pathNodeKey plus 2 for the type id. */
+  static final int HEADER_BYTES = 10;
+
   /**
    * Maximum bytes available for string value encoding. Header is 10 bytes (8 for pathNodeKey + 2 for
    * typeId), buffer is 256 bytes.
    */
-  private static final int MAX_STRING_VALUE_BYTES = 246;
+  static final int MAX_STRING_VALUE_BYTES = 246;
 
   /**
    * Encodes an atomic value in order-preserving format.

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntComparator;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Accumulating bulk loader for a HOT secondary index that is being built from scratch.
+ *
+ * <p>Building an index over an already-shredded revision is a bulk load, not a sequence of
+ * updates: every {@code (key, nodeKey)} pair is known before the first byte is written. Feeding
+ * them through {@link HOTIndexWriter#indexNodeKey} one at a time makes the trie pay the
+ * incremental-insert machinery — a descent, a merge-vs-branch decision and, whenever a fold
+ * leaves a node malformed, a scoped {@link HOTBulkBuilder} rebuild of the touched subtree — per
+ * entry. The rebuilds are what hurt: each is {@code O(subtree)}, and a build of n entries
+ * triggers them in proportion to n, so index construction grows super-linearly.</p>
+ *
+ * <p>This loader instead collects the pairs, sorts them once, folds the node keys that share a
+ * chunk slot into one Roaring bitmap, and hands the result to {@link HOTBulkBuilder#build} — a
+ * single {@code Θ(n)} construction whose output is invariant-clean by construction, so no
+ * self-heal ever runs. The tree it produces is byte-for-byte the tree the incremental path
+ * converges to.</p>
+ *
+ * <h2>Layout</h2>
+ * <p>Keys live in one growable byte arena addressed by {@code (start, length)} pairs rather than
+ * in a {@code byte[]} per entry: an index build over millions of nodes would otherwise pay a
+ * 16-byte object header and a separate allocation for every key. Node keys live in a parallel
+ * {@code long[]}. Sorting permutes an {@code int[]} of entry ids, never the payload.</p>
+ *
+ * <h2>Memory</h2>
+ * <p>A bulk load is not streaming: the whole entry set is resident until {@link #flush()} hands it
+ * to the builder, which is the price of a single-pass canonical construction. The arena layout
+ * keeps that to roughly {@code n × (key bytes + 16)} while accumulating; {@code flush} then
+ * materialises one {@link HOTBulkBuilder.Entry} per <em>distinct</em> chunk slot. The buffers are
+ * dropped as soon as the tree is spliced.</p>
+ *
+ * <h2>Threading</h2>
+ * <p>Not thread-safe; a loader belongs to the single traversal that feeds it.</p>
+ *
+ * @param <K> the logical index key type
+ * @author Johannes Lichtenberger
+ */
+public final class HOTBulkIndexLoader<K extends Comparable<? super K>> {
+
+  /** Initial arena capacity in bytes — grown by doubling. */
+  private static final int INITIAL_ARENA_BYTES = 64 * 1024;
+
+  /** Initial entry capacity — grown by doubling. */
+  private static final int INITIAL_ENTRIES = 1024;
+
+  /**
+   * Upper bound on one serialized composite key. Mirrors {@link HOTIndexWriter}'s thread-local
+   * key buffer: the largest CAS prefix (10-byte header + 246 value bytes) plus the 4-byte
+   * chunkIdx trailer, rounded up for headroom.
+   */
+  private static final int MAX_COMPOSITE_KEY_BYTES = 512;
+
+  private final HOTIndexWriter<K> writer;
+
+  private final HOTKeySerializer<K> keySerializer;
+
+  /** Composite key bytes, back to back. */
+  private byte[] arena = new byte[INITIAL_ARENA_BYTES];
+
+  /** Bytes used in {@link #arena}. */
+  private int arenaLength;
+
+  /** Start offset in {@link #arena} of entry {@code i}. */
+  private int[] keyStart = new int[INITIAL_ENTRIES];
+
+  /** Length in {@link #arena} of entry {@code i}'s composite key. */
+  private int[] keyLength = new int[INITIAL_ENTRIES];
+
+  /** The node key of entry {@code i}. */
+  private long[] nodeKeys = new long[INITIAL_ENTRIES];
+
+  /** Number of accumulated entries. */
+  private int count;
+
+  /** Set once {@link #flush()} has run, so a second flush cannot re-splice the tree. */
+  private boolean flushed;
+
+  HOTBulkIndexLoader(final HOTIndexWriter<K> writer, final HOTKeySerializer<K> keySerializer) {
+    this.writer = requireNonNull(writer, "writer");
+    this.keySerializer = requireNonNull(keySerializer, "keySerializer");
+  }
+
+  /**
+   * Record that {@code nodeKey} belongs to {@code key}'s posting list.
+   *
+   * @param key the logical index key
+   * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
+   */
+  public void add(final K key, final long nodeKey) {
+    requireNonNull(key, "key");
+    if (flushed) {
+      throw new IllegalStateException("Bulk loader already flushed");
+    }
+    HOTIndexWriter.checkNodeKeyRange(nodeKey);
+
+    if (arenaLength + MAX_COMPOSITE_KEY_BYTES > arena.length) {
+      arena = Arrays.copyOf(arena, Math.max(arena.length << 1, arenaLength + MAX_COMPOSITE_KEY_BYTES));
+    }
+    if (count == keyStart.length) {
+      final int newCapacity = keyStart.length << 1;
+      keyStart = Arrays.copyOf(keyStart, newCapacity);
+      keyLength = Arrays.copyOf(keyLength, newCapacity);
+      nodeKeys = Arrays.copyOf(nodeKeys, newCapacity);
+    }
+
+    final int chunkIdx = (int) (nodeKey >>> 16);
+    final int length = keySerializer.serializeWithChunkIdx(key, chunkIdx, arena, arenaLength);
+    keyStart[count] = arenaLength;
+    keyLength[count] = length;
+    nodeKeys[count] = nodeKey;
+    arenaLength += length;
+    count++;
+  }
+
+  /** Number of {@code (key, nodeKey)} pairs accumulated so far. */
+  public int size() {
+    return count;
+  }
+
+  /**
+   * Build the trie from everything accumulated and splice it in as the index's root.
+   *
+   * <p>A no-op when nothing was accumulated — the empty tree the index was initialized with
+   * stays in place. After this call the loader is spent.</p>
+   */
+  public void flush() {
+    if (flushed) {
+      throw new IllegalStateException("Bulk loader already flushed");
+    }
+    flushed = true;
+    if (count == 0) {
+      return;
+    }
+
+    final int[] order = new int[count];
+    for (int i = 0; i < count; i++) {
+      order[i] = i;
+    }
+    // Composite key first, node key second. Grouping below relies on equal keys being adjacent,
+    // and the node-key tiebreak makes this a total order, so the permutation is deterministic
+    // even though quicksort is not stable. The comparator only reads, so sorting in parallel is
+    // safe; fastutil runs small inputs sequentially anyway.
+    final IntComparator byKeyThenNodeKey = (a, b) -> {
+      final int cmp = Arrays.compareUnsigned(arena, keyStart[a], keyStart[a] + keyLength[a], arena,
+          keyStart[b], keyStart[b] + keyLength[b]);
+      return cmp != 0 ? cmp : Long.compare(nodeKeys[a], nodeKeys[b]);
+    };
+    IntArrays.parallelQuickSort(order, byKeyThenNodeKey);
+
+    final List<HOTBulkBuilder.Entry> entries = new ArrayList<>();
+    int groupStart = 0;
+    while (groupStart < count) {
+      int groupEnd = groupStart + 1;
+      while (groupEnd < count && sameKey(order[groupStart], order[groupEnd])) {
+        groupEnd++;
+      }
+      entries.add(toEntry(order, groupStart, groupEnd));
+      groupStart = groupEnd;
+    }
+
+    writer.spliceBulkBuiltRoot(entries);
+    releaseBuffers();
+  }
+
+  private boolean sameKey(final int a, final int b) {
+    return keyLength[a] == keyLength[b] && Arrays.compareUnsigned(arena, keyStart[a],
+        keyStart[a] + keyLength[a], arena, keyStart[b], keyStart[b] + keyLength[b]) == 0;
+  }
+
+  /**
+   * Fold {@code order[from..to)} — all entries sharing one composite key — into a single
+   * {@link HOTBulkBuilder.Entry}. A chunk slot stores the low 16 bits of each node key; the high
+   * bits are already carried by the key's chunkIdx trailer.
+   */
+  private HOTBulkBuilder.Entry toEntry(final int[] order, final int from, final int to) {
+    final int representative = order[from];
+    final byte[] key =
+        Arrays.copyOfRange(arena, keyStart[representative], keyStart[representative] + keyLength[representative]);
+
+    final Roaring64Bitmap bits = new Roaring64Bitmap();
+    for (int i = from; i < to; i++) {
+      bits.add(nodeKeys[order[i]] & 0xFFFFL);
+    }
+    bits.runOptimize();
+    return new HOTBulkBuilder.Entry(key, NodeReferencesSerializer.serialize(NodeReferences.owning(bits)));
+  }
+
+  /** Drop the accumulation buffers — a spent loader must not pin an index-sized arena. */
+  private void releaseBuffers() {
+    arena = new byte[0];
+    keyStart = new int[0];
+    keyLength = new int[0];
+    nodeKeys = new long[0];
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
@@ -29,7 +29,8 @@ public final class HOTBulkIndexLoader<K extends Comparable<? super K>> extends A
    */
   public void add(final K key, final long nodeKey) {
     requireNonNull(key, "key");
-    final byte[] block = reserveKeySpace(nodeKey);
+    final byte[] block =
+        reserveKeySpace(nodeKey, keySerializer.maxSerializedLength(key) + HOTKeySerializer.CHUNK_IDX_BYTES);
     final int offset = blockOffset();
     final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), block, offset);
     commitKey(length, nodeKey);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkIndexLoader.java
@@ -29,9 +29,9 @@ public final class HOTBulkIndexLoader<K extends Comparable<? super K>> extends A
    */
   public void add(final K key, final long nodeKey) {
     requireNonNull(key, "key");
-    final byte[] arena = reserveKeySpace(nodeKey);
-    final int offset = arenaOffset();
-    final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), arena, offset);
+    final byte[] block = reserveKeySpace(nodeKey);
+    final int offset = blockOffset();
+    final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), block, offset);
     commitKey(length, nodeKey);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -27,7 +27,6 @@
  */
 package io.sirix.index.hot;
 
-import io.sirix.access.trx.page.HOTRangeCursor;
 import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.index.IndexType;
@@ -42,7 +41,6 @@ import org.roaringbitmap.longlong.Roaring64Bitmap;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import static java.util.Objects.requireNonNull;
 
@@ -68,11 +66,27 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
 
   /**
    * Thread-local buffer for key serialization. Sized to fit the largest CAS prefix (10-byte header +
-   * {@code MAX_STRING_VALUE_BYTES = 246}) PLUS {@link HOTKeySerializer#CHUNK_IDX_BYTES} (= 4)
-   * chunkIdx trailer; rounded to 512 for headroom. Mirrors {@link HOTIndexWriter#KEY_BUFFER}'s sizing
-   * to avoid 4-byte overflow on max-length string CAS values.
+   * {@code MAX_STRING_VALUE_BYTES = 246}), rounded to 512 for headroom. Only the LOGICAL key is ever
+   * written here — the chunkIdx trailer is appended into a right-sized seek array by
+   * {@link AbstractHOTIndexReader#collectChunksViaLowerBoundWalk}, never in place, because the trie
+   * descent takes the search key's length from the array it is handed.
    */
   private static final ThreadLocal<byte[]> KEY_BUFFER = ThreadLocal.withInitial(() -> new byte[512]);
+
+  /**
+   * Whether a lookup miss retries with the O(index) leftmost leaf walk. Resolved once at class load
+   * (it was a synchronized system-Properties lookup on every miss).
+   *
+   * <p>
+   * Historically this was ON by default and switched off via
+   * {@code hot.cas.leftmostfallback.disable}; it is now opt-in through
+   * {@code hot.cas.leftmostfallback.enable}, because the writer enforces I8/I12 pre-commit and the
+   * walk costs a whole-index scan on EVERY miss (~2.5 ms against ~2 us for the primary path on a
+   * 33K-key index). The retired {@code .disable} property is deliberately NOT consulted: reading it
+   * would make {@code .disable=false} — the value that used to mean "leave the default alone" —
+   * silently turn the whole-index scan back on.
+   */
+  private static final boolean LEFTMOST_FALLBACK_ENABLED = Boolean.getBoolean("hot.cas.leftmostfallback.enable");
 
   private final HOTKeySerializer<K> keySerializer;
 
@@ -118,7 +132,7 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    *
    * @param key the logical index key
    * @param mode reserved (only {@code EQUAL} is meaningful for {@code get}); range modes go via
-   *        {@link #range(Comparable, Comparable)} / {@link #iteratorFrom(Comparable)}
+   *        {@link #range(Comparable, Comparable)} / {@link #iteratorFrom(Comparable, boolean)}
    * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
    */
   public @Nullable NodeReferences get(K key, SearchMode mode) {
@@ -146,22 +160,16 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
       return collected;
     }
 
-    Roaring64Bitmap merged = null;
-    {
-      if (Boolean.getBoolean("hot.cas.leftmostfallback.enable")) {
-        // Historical Phase 7v retry, now OPT-IN: a full leaf-walk scan robust against
-        // non-lex-order leaves, for tries written before the writer enforced I8/I12 (the
-        // byte-10 encoder discontinuity era). It costs a whole-index walk on EVERY miss —
-        // measured at ~2.5 ms against ~1 µs for the primary path on a 33K-key index — so a
-        // lookup miss must not pay it by default now that the writer's invariants are
-        // guarded pre-commit and detector-verified.
-        final PageReference rootRef = getRootReference();
-        if (rootRef != null) {
-          merged = collectViaLeafWalk(rootRef, prefixBuf, prefixLen);
-        }
-      }
+    if (!LEFTMOST_FALLBACK_ENABLED) {
+      return null;
     }
-
+    // Phase 7v retry for tries written before the writer enforced I8/I12: a full leaf-walk scan
+    // robust against non-lex-order leaves.
+    final PageReference rootRef = getRootReference();
+    if (rootRef == null) {
+      return null;
+    }
+    final Roaring64Bitmap merged = collectViaLeafWalk(rootRef, prefixBuf, prefixLen);
     if (merged == null || merged.isEmpty()) {
       return null;
     }
@@ -175,18 +183,51 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    * entries) per call; only triggered on miss.
    */
   private @Nullable Roaring64Bitmap collectViaLeafWalk(PageReference rootRef, byte[] prefixBuf, int prefixLen) {
+    final int compositeLen = prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES;
     Roaring64Bitmap merged = null;
     try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader())) {
       HOTLeafPage leaf = reader.navigateToLeftmostLeaf(rootRef);
+      int tornRounds = 0;
       while (leaf != null) {
-        final int entryCount = leaf.getEntryCount();
-        for (int idx = 0; idx < entryCount; idx++) {
-          final byte[] composite = leaf.getKey(idx);
-          if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-              || Arrays.compareUnsigned(composite, 0, prefixLen, prefixBuf, 0, prefixLen) != 0) {
+        int idx = 0;
+        while (true) {
+          // One entry's read batch (or the end-of-leaf decision) against the UNPINNED leaf,
+          // validated before any effect: the chunk copy reaches the deserializer and the merge
+          // only after its bytes are proven stable, so `merged` never absorbs torn state and
+          // recovery is a same-position re-read on a refreshed copy.
+          boolean leafDone = false;
+          byte[] composite = null;
+          byte[] chunkBytes = null;
+          try {
+            if (idx >= leaf.getEntryCount()) {
+              leafDone = true;
+            } else {
+              final byte[] candidate = leaf.getKey(idx);
+              if (candidate != null && candidate.length == compositeLen
+                  && Arrays.compareUnsigned(candidate, 0, prefixLen, prefixBuf, 0, prefixLen) == 0) {
+                composite = candidate;
+                chunkBytes = leaf.getValue(idx);
+              }
+            }
+          } catch (RuntimeException e) {
+            if (reader.validateCurrentLeaf()) {
+              throw e; // stable bytes — genuine corruption, not a torn read
+            }
+            leaf = refreshTornLeaf(reader, ++tornRounds);
             continue;
           }
-          merged = mergeChunk(merged, leaf, idx, composite);
+          if (!reader.validateCurrentLeaf()) {
+            leaf = refreshTornLeaf(reader, ++tornRounds);
+            continue;
+          }
+          tornRounds = 0;
+          if (leafDone) {
+            break;
+          }
+          if (chunkBytes != null) {
+            merged = mergeChunk(merged, composite, chunkBytes);
+          }
+          idx++;
         }
         leaf = reader.advanceToNextLeaf();
       }
@@ -194,10 +235,22 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
     return merged;
   }
 
-  private @Nullable Roaring64Bitmap mergeChunk(@Nullable Roaring64Bitmap merged, HOTLeafPage leaf, int idx,
-      byte[] composite) {
-    final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-    final byte[] chunkBytes = leaf.getValue(idx);
+  /** Bounded torn-read recovery: reload the current leaf in place and re-adopt the fresh copy. */
+  private static HOTLeafPage refreshTornLeaf(final HOTTrieReader reader, final int round) {
+    if (round > 64) {
+      throw new IllegalStateException(
+          "HOT leaf walk failed stamp validation on 64 consecutive rounds — sustained allocator thrashing");
+    }
+    if (!reader.refreshCurrentLeaf()) {
+      throw new IllegalStateException("HOT leaf walk: evicted leaf could not be reloaded through its PageReference");
+    }
+    return reader.currentLeafPage();
+  }
+
+  /** Merge one VALIDATED chunk payload copy into the accumulator bitmap. */
+  private @Nullable Roaring64Bitmap mergeChunk(@Nullable Roaring64Bitmap merged, byte[] composite, byte[] chunkBytes) {
+    // Unsigned, as everywhere else the chunk trailer is expanded.
+    final long chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length) & 0xFFFFFFFFL;
     if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
       return merged;
     }
@@ -209,7 +262,7 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
     if (merged == null) {
       merged = new Roaring64Bitmap();
     }
-    final long high = ((long) chunkIdx) << 16;
+    final long high = chunkIdx << 16;
     final LongIterator bIt = chunkBitmap.getLongIterator();
     while (bIt.hasNext()) {
       merged.add(high | (bIt.next() & 0xFFFFL));
@@ -218,226 +271,63 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * Create a range iterator over logical entries with keys in {@code [fromKey, toKey]}.
-   *
-   * <p>
-   * Composite-key range scan with chunk grouping. Walks composite keys
-   * {@code [(fromKey, 0), (toKey, 0xFFFFFFFF)]} and groups consecutive same-prefix slots into one
-   * logical {@link Map.Entry}{@code <K, NodeReferences>} — chunks of one prefix lex-cluster because
-   * composite keys share prefix bytes and the chunkIdx_be4 trailer determines order within that
-   * range.
-   * </p>
+   * Create a range iterator over logical entries with keys in {@code [fromKey, toKey]}, both
+   * inclusive.
    *
    * @param fromKey start key (inclusive)
    * @param toKey end key (inclusive)
    */
   public Iterator<Map.Entry<K, NodeReferences>> range(K fromKey, K toKey) {
-    requireNonNull(fromKey);
-    requireNonNull(toKey);
-
-    byte[] keyBuf = getKeyBuffer();
-    int fromLen = serializeKey(fromKey, keyBuf, 0);
-    byte[] fromPrefix = Arrays.copyOf(keyBuf, fromLen);
-    int toLen = serializeKey(toKey, keyBuf, 0);
-    byte[] toPrefix = Arrays.copyOf(keyBuf, toLen);
-
-    final byte[] fromComposite = new byte[fromLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(fromPrefix, 0, fromComposite, 0, fromLen);
-    HOTKeySerializer.writeChunkIdxBE(fromComposite, fromLen, 0);
-
-    final byte[] toComposite = new byte[toLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(toPrefix, 0, toComposite, 0, toLen);
-    HOTKeySerializer.writeChunkIdxBE(toComposite, toLen, 0xFFFFFFFF);
-
-    return new ChunkAggregatingIterator(fromComposite, toComposite, fromPrefix);
+    return range(fromKey, toKey, true, true);
   }
 
   /**
-   * Create an iterator that starts from {@code fromKey} (inclusive) with no upper bound. Used for
-   * {@code GREATER} / {@code GREATER_OR_EQUAL} CAS queries.
+   * Create a range iterator over logical entries between {@code fromKey} and {@code toKey} with
+   * explicit bound inclusivity.
+   *
+   * <p>
+   * Inclusivity is enforced by the cursor itself, on each group's logical key bytes — see
+   * {@link ChunkAggregatingIterator}. Callers must NOT post-filter positionally: index keys are not
+   * prefix-free, so the composite byte window is wider than the logical range.
+   *
+   * @param fromKey start key
+   * @param toKey end key
+   * @param fromInclusive whether {@code fromKey} itself is in range
+   * @param toInclusive whether {@code toKey} itself is in range
    */
+  public Iterator<Map.Entry<K, NodeReferences>> range(K fromKey, K toKey, boolean fromInclusive, boolean toInclusive) {
+    requireNonNull(fromKey);
+    requireNonNull(toKey);
+    final byte[] fromPrefix = serializeKeyToArray(fromKey);
+    final byte[] toPrefix = serializeKeyToArray(toKey);
+    return new ChunkAggregatingIterator(fromPrefix, fromInclusive, toPrefix, toInclusive);
+  }
+
   /**
    * Iterate every logical entry in the index. Overrides the abstract base's per-slot iterator — with
    * chunked-bitmap storage, "all entries" means one logical {@link Map.Entry} per prefix, not per
-   * chunk slot. Implemented by walking the entire composite-key range with no bounds and grouping
-   * consecutive same-prefix slots.
+   * chunk slot.
    */
   @Override
   public Iterator<Map.Entry<K, NodeReferences>> iterator() {
-    return new ChunkAggregatingIterator(new byte[0], null, null);
+    return new ChunkAggregatingIterator(null, true, null, true);
   }
 
-  public Iterator<Map.Entry<K, NodeReferences>> iteratorFrom(K fromKey) {
+  /**
+   * Iterate every logical entry above {@code fromKey}, inclusive or not. Used for {@code GREATER} /
+   * {@code GREATER_OR_EQUAL} CAS queries.
+   */
+  public Iterator<Map.Entry<K, NodeReferences>> iteratorFrom(K fromKey, boolean inclusive) {
     requireNonNull(fromKey);
-
-    byte[] keyBuf = getKeyBuffer();
-    int fromLen = serializeKey(fromKey, keyBuf, 0);
-    byte[] fromPrefix = Arrays.copyOf(keyBuf, fromLen);
-
-    final byte[] fromComposite = new byte[fromLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(fromPrefix, 0, fromComposite, 0, fromLen);
-    HOTKeySerializer.writeChunkIdxBE(fromComposite, fromLen, 0);
-
-    return new ChunkAggregatingIterator(fromComposite, null, fromPrefix);
+    final byte[] fromPrefix = serializeKeyToArray(fromKey);
+    return new ChunkAggregatingIterator(fromPrefix, inclusive, null, true);
   }
 
-  /**
-   * Iterate every logical entry with key {@code <= toKey}: a from-the-start cursor bounded above by
-   * {@code toKey}'s composite ceiling. The LESS / LESS_OR_EQUAL CAS scans use this so the cursor
-   * STOPS at the bound instead of scanning the whole index and filtering every entry behind it.
-   */
-  public Iterator<Map.Entry<K, NodeReferences>> iteratorTo(K toKey) {
+  /** Iterate every logical entry below {@code toKey}, inclusive or not. */
+  public Iterator<Map.Entry<K, NodeReferences>> iteratorTo(K toKey, boolean inclusive) {
     requireNonNull(toKey);
-
-    byte[] keyBuf = getKeyBuffer();
-    final int required = maxSerializedKeyLength(toKey);
-    if (required > keyBuf.length) {
-      keyBuf = new byte[required];
-      setKeyBuffer(keyBuf);
-    }
-    final int toLen = serializeKey(toKey, keyBuf, 0);
-    final byte[] toComposite = new byte[toLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(keyBuf, 0, toComposite, 0, toLen);
-    HOTKeySerializer.writeChunkIdxBE(toComposite, toLen, 0xFFFFFFFF);
-
-    return new ChunkAggregatingIterator(new byte[0], toComposite, null);
-  }
-
-  /**
-   * Iterator that walks a chunked composite-key range and groups consecutive same-prefix slots into
-   * logical {@link Map.Entry}{@code <K, NodeReferences>} records.
-   *
-   * <p>
-   * Per group: deserialize each chunk's bitmap, expand bit16 → {@code chunkIdx<<16|bit16}, accumulate
-   * into a fresh {@link Roaring64Bitmap}, then emit. Crosses to the next group when the composite
-   * key's prefix bytes change.
-   * </p>
-   */
-  private final class ChunkAggregatingIterator implements Iterator<Map.Entry<K, NodeReferences>> {
-    private final @Nullable HOTTrieReader trieReader;
-    private final @Nullable HOTRangeCursor cursor;
-    /**
-     * Lex-prefix lower bound. Groups whose prefix is lex-less than {@code fromPrefixFilter} are skipped
-     * during {@link #advance()}. Required because HOT sibling subtrees can have overlapping lex ranges,
-     * so a path-stack forward walk is not strictly lex-monotonic across the whole trie even after the
-     * BE partial-key encoding refactor.
-     *
-     * <p>
-     * The overlap arises whenever a high-order key bit varies at the parent level <em>and</em> varies
-     * within some sibling subtree: HOT can only capture a bit as a parent disc bit when it is constant
-     * in every sibling's subtree (see {@code HOTTrieWriter#computeDiscBits},
-     * {@link HOTTrieWriter#bitConstantValueInSubtree}). Bits that fail that test must live at a deeper
-     * level, which means two sibling subtrees can share <em>some</em> lex prefixes while differing on
-     * lower bits. Forward sweep therefore can emit a leaf in subtree i whose key is lex-less than
-     * {@code fromKey} after the PEXT-routed seek already positioned us beyond it.
-     *
-     * <p>
-     * The filter is a per-entry forward-only prefix compare — it never seeks backwards and never falls
-     * back to a full scan. The cursor still skips the bulk of the trie via the lower-bound seek; this
-     * only suppresses the small interleaving residue at the head of the sweep so
-     * {@code GREATER}/{@code GREATER_OR_EQUAL} CAS semantics are exact.
-     *
-     * <p>
-     * {@code null} disables filtering — used by full-trie iteration ({@link #iterator()}).
-     * </p>
-     */
-    private final byte @Nullable [] fromPrefixFilter;
-    /** Per-iterator chunk accumulator, reset per logical group. */
-    private final NodeReferencesSerializer.ChunkAccumulator accumulator =
-        new NodeReferencesSerializer.ChunkAccumulator();
-    private Map.@Nullable Entry<K, NodeReferences> nextEntry;
-
-    ChunkAggregatingIterator(byte[] fromComposite, byte @Nullable [] toComposite, byte @Nullable [] fromPrefixFilter) {
-      this.fromPrefixFilter = fromPrefixFilter;
-      final PageReference rootRef = getRootReference();
-      if (rootRef == null) {
-        // Empty trie — no entries.
-        this.trieReader = null;
-        this.cursor = null;
-        this.nextEntry = null;
-        return;
-      }
-      this.trieReader = new HOTTrieReader(getStorageEngineReader());
-      this.cursor = trieReader.range(rootRef, fromComposite, toComposite);
-      advance();
-    }
-
-    @Override
-    public boolean hasNext() {
-      return nextEntry != null;
-    }
-
-    @Override
-    public Map.Entry<K, NodeReferences> next() {
-      if (nextEntry == null) {
-        throw new NoSuchElementException();
-      }
-      final Map.Entry<K, NodeReferences> result = nextEntry;
-      advance();
-      if (nextEntry == null) {
-        closeQuietly();
-      }
-      return result;
-    }
-
-    private void closeQuietly() {
-      if (cursor != null) {
-        cursor.close();
-      }
-      if (trieReader != null) {
-        trieReader.close();
-      }
-    }
-
-    private void advance() {
-      if (cursor == null) {
-        nextEntry = null;
-        return;
-      }
-      while (true) {
-        while (cursor.hasNext()) {
-          final HOTLeafPage leaf = cursor.currentLeafPage();
-          final int idx = cursor.currentEntryIndex();
-          if (leaf.getKeyLength(idx) < HOTKeySerializer.CHUNK_IDX_BYTES) {
-            cursor.advance();
-            continue;
-          }
-          if (fromPrefixFilter != null && leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES,
-              fromPrefixFilter, fromPrefixFilter.length) < 0) {
-            cursor.advance();
-            continue;
-          }
-          break;
-        }
-        if (!cursor.hasNext()) {
-          nextEntry = null;
-          return;
-        }
-
-        // Materialize the group's composite key ONCE — it doubles as the logical-key bytes for
-        // deserializeKey at emit. Per-slot filtering below stays zero-copy against it.
-        final byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
-        final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-        final int compositeLen = groupComposite.length;
-
-        while (cursor.hasNext()) {
-          final HOTLeafPage leaf = cursor.currentLeafPage();
-          final int idx = cursor.currentEntryIndex();
-          if (leaf.getKeyLength(idx) != compositeLen || leaf.compareKeyPrefix(idx, groupComposite, prefixLen) != 0) {
-            break;
-          }
-          final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-          accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
-          cursor.advance();
-        }
-
-        final NodeReferences groupRefs = accumulator.toNodeReferencesAndReset();
-        if (groupRefs != null) {
-          nextEntry = new LazyKeyEntry(groupComposite, prefixLen, groupRefs);
-          return;
-        }
-      }
-    }
+    final byte[] toPrefix = serializeKeyToArray(toKey);
+    return new ChunkAggregatingIterator(null, true, toPrefix, inclusive);
   }
 
   @Override
@@ -453,11 +343,6 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   @Override
   protected @Nullable K deserializeKey(byte[] buffer, int offset, int length) {
     return keySerializer.deserialize(buffer, offset, length);
-  }
-
-  @Override
-  protected int compareKeys(byte[] key1, int offset1, int length1, byte[] key2, int offset2, int length2) {
-    return keySerializer.compare(key1, offset1, length1, key2, offset2, length2);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -68,11 +68,10 @@ import static java.util.Objects.requireNonNull;
 public final class HOTIndexReader<K extends Comparable<? super K>> extends AbstractHOTIndexReader<K> {
 
   /**
-   * Thread-local buffer for key serialization. Sized to fit the largest CAS prefix (10-byte
-   * header + {@code MAX_STRING_VALUE_BYTES = 246}) PLUS
-   * {@link HOTKeySerializer#CHUNK_IDX_BYTES} (= 4) chunkIdx trailer; rounded to 512 for headroom.
-   * Mirrors {@link HOTIndexWriter#KEY_BUFFER}'s sizing to avoid 4-byte overflow on max-length
-   * string CAS values.
+   * Thread-local buffer for key serialization. Sized to fit the largest CAS prefix (10-byte header +
+   * {@code MAX_STRING_VALUE_BYTES = 246}) PLUS {@link HOTKeySerializer#CHUNK_IDX_BYTES} (= 4)
+   * chunkIdx trailer; rounded to 512 for headroom. Mirrors {@link HOTIndexWriter#KEY_BUFFER}'s sizing
+   * to avoid 4-byte overflow on max-length string CAS values.
    */
   private static final ThreadLocal<byte[]> KEY_BUFFER = ThreadLocal.withInitial(() -> new byte[512]);
 
@@ -86,8 +85,8 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    * @param indexType the index type (PATH, CAS, NAME)
    * @param indexNumber the index number
    */
-  private HOTIndexReader(StorageEngineReader storageEngineReader, HOTKeySerializer<K> keySerializer, IndexType indexType,
-      int indexNumber) {
+  private HOTIndexReader(StorageEngineReader storageEngineReader, HOTKeySerializer<K> keySerializer,
+      IndexType indexType, int indexNumber) {
     super(storageEngineReader, indexType, indexNumber);
     this.keySerializer = requireNonNull(keySerializer);
   }
@@ -110,15 +109,17 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   /**
    * Reassemble all chunks of {@code key} into one logical {@link NodeReferences}.
    *
-   * <p>Chunked-bitmap storage (Phase 1+2): the logical bitmap for {@code key} is split across
-   * multiple HOT slots, one per chunkIdx = {@code (int)(nodeKey >>> 16)}. This method
-   * range-scans {@code [(prefix, 0), (prefix, 0xFFFFFFFF)]} via Phase 0b's
-   * {@link HOTTrieReader#lowerBound} and merges every chunk's low-16-bit bitmap into a
-   * single 64-bit {@code Roaring64Bitmap}, expanding bit16 → {@code (chunkIdx << 16) | bit16}.</p>
+   * <p>
+   * Chunked-bitmap storage (Phase 1+2): the logical bitmap for {@code key} is split across multiple
+   * HOT slots, one per chunkIdx = {@code (int)(nodeKey >>> 16)}. This method range-scans
+   * {@code [(prefix, 0), (prefix, 0xFFFFFFFF)]} via Phase 0b's {@link HOTTrieReader#lowerBound} and
+   * merges every chunk's low-16-bit bitmap into a single 64-bit {@code Roaring64Bitmap}, expanding
+   * bit16 → {@code (chunkIdx << 16) | bit16}.
+   * </p>
    *
    * @param key the logical index key
    * @param mode reserved (only {@code EQUAL} is meaningful for {@code get}); range modes go via
-   *             {@link #range(Comparable, Comparable)} / {@link #iteratorFrom(Comparable)}
+   *        {@link #range(Comparable, Comparable)} / {@link #iteratorFrom(Comparable)}
    * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
    */
   public @Nullable NodeReferences get(K key, SearchMode mode) {
@@ -156,8 +157,7 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
 
     Roaring64Bitmap merged = collectViaCursor(rootRef, prefixBuf, prefixLen, fromBytes, toBytes);
 
-    if ((merged == null || merged.isEmpty())
-        && !Boolean.getBoolean("hot.cas.leftmostfallback.disable")) {
+    if ((merged == null || merged.isEmpty()) && !Boolean.getBoolean("hot.cas.leftmostfallback.disable")) {
       // Phase 7v retry: the PEXT-routed lowerBound may misroute under I6 violations
       // (writer-side structural bugs from byte-10 encoder discontinuity). Retry with a
       // full leaf-walk scan that's robust against non-lex-order leaves. Only fires when
@@ -171,8 +171,8 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
     return NodeReferences.owning(merged);
   }
 
-  private @Nullable Roaring64Bitmap collectViaCursor(PageReference rootRef, byte[] prefixBuf,
-      int prefixLen, byte[] fromBytes, byte[] toBytes) {
+  private @Nullable Roaring64Bitmap collectViaCursor(PageReference rootRef, byte[] prefixBuf, int prefixLen,
+      byte[] fromBytes, byte[] toBytes) {
     Roaring64Bitmap merged = null;
     try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader());
         HOTRangeCursor cursor = reader.range(rootRef, fromBytes, toBytes)) {
@@ -193,13 +193,12 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * Phase 7v fallback: walk every leaf in the trie (left-to-right traversal order, NOT lex order
-   * — robust against I8 violations), filter each entry by exact prefix match. Used only when the
+   * Phase 7v fallback: walk every leaf in the trie (left-to-right traversal order, NOT lex order —
+   * robust against I8 violations), filter each entry by exact prefix match. Used only when the
    * primary PEXT-routed cursor returns 0 chunks for a key that is in fact stored. O(total trie
    * entries) per call; only triggered on miss.
    */
-  private @Nullable Roaring64Bitmap collectViaLeafWalk(PageReference rootRef, byte[] prefixBuf,
-      int prefixLen) {
+  private @Nullable Roaring64Bitmap collectViaLeafWalk(PageReference rootRef, byte[] prefixBuf, int prefixLen) {
     Roaring64Bitmap merged = null;
     try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader())) {
       HOTLeafPage leaf = reader.navigateToLeftmostLeaf(rootRef);
@@ -219,8 +218,8 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
     return merged;
   }
 
-  private @Nullable Roaring64Bitmap mergeChunk(@Nullable Roaring64Bitmap merged, HOTLeafPage leaf,
-      int idx, byte[] composite) {
+  private @Nullable Roaring64Bitmap mergeChunk(@Nullable Roaring64Bitmap merged, HOTLeafPage leaf, int idx,
+      byte[] composite) {
     final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
     final byte[] chunkBytes = leaf.getValue(idx);
     if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
@@ -245,14 +244,16 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   /**
    * Create a range iterator over logical entries with keys in {@code [fromKey, toKey]}.
    *
-   * <p>Composite-key range scan with chunk grouping. Walks composite keys
+   * <p>
+   * Composite-key range scan with chunk grouping. Walks composite keys
    * {@code [(fromKey, 0), (toKey, 0xFFFFFFFF)]} and groups consecutive same-prefix slots into one
-   * logical {@link Map.Entry}{@code <K, NodeReferences>} — chunks of one prefix lex-cluster
-   * because composite keys share prefix bytes and the chunkIdx_be4 trailer determines order
-   * within that range.</p>
+   * logical {@link Map.Entry}{@code <K, NodeReferences>} — chunks of one prefix lex-cluster because
+   * composite keys share prefix bytes and the chunkIdx_be4 trailer determines order within that
+   * range.
+   * </p>
    *
    * @param fromKey start key (inclusive)
-   * @param toKey   end key (inclusive)
+   * @param toKey end key (inclusive)
    */
   public Iterator<Map.Entry<K, NodeReferences>> range(K fromKey, K toKey) {
     requireNonNull(fromKey);
@@ -276,14 +277,14 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * Create an iterator that starts from {@code fromKey} (inclusive) with no upper bound. Used
-   * for {@code GREATER} / {@code GREATER_OR_EQUAL} CAS queries.
+   * Create an iterator that starts from {@code fromKey} (inclusive) with no upper bound. Used for
+   * {@code GREATER} / {@code GREATER_OR_EQUAL} CAS queries.
    */
   /**
-   * Iterate every logical entry in the index. Overrides the abstract base's per-slot iterator —
-   * with chunked-bitmap storage, "all entries" means one logical {@link Map.Entry} per prefix,
-   * not per chunk slot. Implemented by walking the entire composite-key range with no bounds
-   * and grouping consecutive same-prefix slots.
+   * Iterate every logical entry in the index. Overrides the abstract base's per-slot iterator — with
+   * chunked-bitmap storage, "all entries" means one logical {@link Map.Entry} per prefix, not per
+   * chunk slot. Implemented by walking the entire composite-key range with no bounds and grouping
+   * consecutive same-prefix slots.
    */
   @Override
   public Iterator<Map.Entry<K, NodeReferences>> iterator() {
@@ -305,42 +306,47 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * Iterator that walks a chunked composite-key range and groups consecutive same-prefix slots
-   * into logical {@link Map.Entry}{@code <K, NodeReferences>} records.
+   * Iterator that walks a chunked composite-key range and groups consecutive same-prefix slots into
+   * logical {@link Map.Entry}{@code <K, NodeReferences>} records.
    *
-   * <p>Per group: deserialize each chunk's bitmap, expand bit16 → {@code chunkIdx<<16|bit16},
-   * accumulate into a fresh {@link Roaring64Bitmap}, then emit. Crosses to the next group when
-   * the composite key's prefix bytes change.</p>
+   * <p>
+   * Per group: deserialize each chunk's bitmap, expand bit16 → {@code chunkIdx<<16|bit16}, accumulate
+   * into a fresh {@link Roaring64Bitmap}, then emit. Crosses to the next group when the composite
+   * key's prefix bytes change.
+   * </p>
    */
   private final class ChunkAggregatingIterator implements Iterator<Map.Entry<K, NodeReferences>> {
     private final @Nullable HOTTrieReader trieReader;
     private final @Nullable HOTRangeCursor cursor;
     /**
-     * Lex-prefix lower bound. Groups whose prefix is lex-less than {@code fromPrefixFilter} are
-     * skipped during {@link #advance()}. Required because HOT sibling subtrees can have
-     * overlapping lex ranges, so a path-stack forward walk is not strictly lex-monotonic across
-     * the whole trie even after the BE partial-key encoding refactor.
+     * Lex-prefix lower bound. Groups whose prefix is lex-less than {@code fromPrefixFilter} are skipped
+     * during {@link #advance()}. Required because HOT sibling subtrees can have overlapping lex ranges,
+     * so a path-stack forward walk is not strictly lex-monotonic across the whole trie even after the
+     * BE partial-key encoding refactor.
      *
-     * <p>The overlap arises whenever a high-order key bit varies at the parent level <em>and</em>
-     * varies within some sibling subtree: HOT can only capture a bit as a parent disc bit when
-     * it is constant in every sibling's subtree (see {@code HOTTrieWriter#computeDiscBits},
-     * {@link HOTTrieWriter#bitConstantValueInSubtree}). Bits that fail that test must live at a
-     * deeper level, which means two sibling subtrees can share <em>some</em> lex prefixes while
-     * differing on lower bits. Forward sweep therefore can emit a leaf in subtree i whose key is
-     * lex-less than {@code fromKey} after the PEXT-routed seek already positioned us beyond it.
+     * <p>
+     * The overlap arises whenever a high-order key bit varies at the parent level <em>and</em> varies
+     * within some sibling subtree: HOT can only capture a bit as a parent disc bit when it is constant
+     * in every sibling's subtree (see {@code HOTTrieWriter#computeDiscBits},
+     * {@link HOTTrieWriter#bitConstantValueInSubtree}). Bits that fail that test must live at a deeper
+     * level, which means two sibling subtrees can share <em>some</em> lex prefixes while differing on
+     * lower bits. Forward sweep therefore can emit a leaf in subtree i whose key is lex-less than
+     * {@code fromKey} after the PEXT-routed seek already positioned us beyond it.
      *
-     * <p>The filter is a per-entry forward-only prefix compare — it never seeks backwards and
-     * never falls back to a full scan. The cursor still skips the bulk of the trie via the
-     * lower-bound seek; this only suppresses the small interleaving residue at the head of the
-     * sweep so {@code GREATER}/{@code GREATER_OR_EQUAL} CAS semantics are exact.
+     * <p>
+     * The filter is a per-entry forward-only prefix compare — it never seeks backwards and never falls
+     * back to a full scan. The cursor still skips the bulk of the trie via the lower-bound seek; this
+     * only suppresses the small interleaving residue at the head of the sweep so
+     * {@code GREATER}/{@code GREATER_OR_EQUAL} CAS semantics are exact.
      *
-     * <p>{@code null} disables filtering — used by full-trie iteration ({@link #iterator()}).</p>
+     * <p>
+     * {@code null} disables filtering — used by full-trie iteration ({@link #iterator()}).
+     * </p>
      */
     private final byte @Nullable [] fromPrefixFilter;
     private Map.@Nullable Entry<K, NodeReferences> nextEntry;
 
-    ChunkAggregatingIterator(byte[] fromComposite, byte @Nullable [] toComposite,
-        byte @Nullable [] fromPrefixFilter) {
+    ChunkAggregatingIterator(byte[] fromComposite, byte @Nullable [] toComposite, byte @Nullable [] fromPrefixFilter) {
       this.fromPrefixFilter = fromPrefixFilter;
       final PageReference rootRef = getRootReference();
       if (rootRef == null) {
@@ -396,8 +402,8 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
           }
           if (fromPrefixFilter != null) {
             final int candidatePrefixLen = composite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-            if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen,
-                fromPrefixFilter, 0, fromPrefixFilter.length) < 0) {
+            if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen, fromPrefixFilter, 0,
+                fromPrefixFilter.length) < 0) {
               cursor.advance();
               continue;
             }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -27,6 +27,7 @@
  */
 package io.sirix.index.hot;
 
+import io.sirix.access.trx.page.HOTRangeCursor;
 import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.index.IndexType;
@@ -178,96 +179,20 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
 
   /**
    * Phase 7v fallback: walk every leaf in the trie (left-to-right traversal order, NOT lex order —
-   * robust against I8 violations), filter each entry by exact prefix match. Used only when the
-   * primary PEXT-routed cursor returns 0 chunks for a key that is in fact stored. O(total trie
-   * entries) per call; only triggered on miss.
+   * robust against I8 violations) and merge every chunk whose composite carries the prefix. Used only
+   * when the primary PEXT-routed lookup returns 0 chunks for a key that IS stored. O(total trie
+   * entries) per call; only triggered on a miss, and only when explicitly enabled.
+   *
+   * <p>
+   * An unbounded cursor visits exactly the same slots in the same order, so this shares the one
+   * chunk-merge implementation rather than restating it — including its torn-read discipline, which a
+   * second copy would have to keep in lockstep by hand.
    */
   private @Nullable Roaring64Bitmap collectViaLeafWalk(PageReference rootRef, byte[] prefixBuf, int prefixLen) {
-    final int compositeLen = prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES;
-    Roaring64Bitmap merged = null;
-    try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader())) {
-      HOTLeafPage leaf = reader.navigateToLeftmostLeaf(rootRef);
-      int tornRounds = 0;
-      while (leaf != null) {
-        int idx = 0;
-        while (true) {
-          // One entry's read batch (or the end-of-leaf decision) against the UNPINNED leaf,
-          // validated before any effect: the chunk copy reaches the deserializer and the merge
-          // only after its bytes are proven stable, so `merged` never absorbs torn state and
-          // recovery is a same-position re-read on a refreshed copy.
-          boolean leafDone = false;
-          byte[] composite = null;
-          byte[] chunkBytes = null;
-          try {
-            if (idx >= leaf.getEntryCount()) {
-              leafDone = true;
-            } else {
-              final byte[] candidate = leaf.getKey(idx);
-              if (candidate != null && candidate.length == compositeLen
-                  && Arrays.compareUnsigned(candidate, 0, prefixLen, prefixBuf, 0, prefixLen) == 0) {
-                composite = candidate;
-                chunkBytes = leaf.getValue(idx);
-              }
-            }
-          } catch (RuntimeException e) {
-            if (reader.validateCurrentLeaf()) {
-              throw e; // stable bytes — genuine corruption, not a torn read
-            }
-            leaf = refreshTornLeaf(reader, ++tornRounds);
-            continue;
-          }
-          if (!reader.validateCurrentLeaf()) {
-            leaf = refreshTornLeaf(reader, ++tornRounds);
-            continue;
-          }
-          tornRounds = 0;
-          if (leafDone) {
-            break;
-          }
-          if (chunkBytes != null) {
-            merged = mergeChunk(merged, composite, chunkBytes);
-          }
-          idx++;
-        }
-        leaf = reader.advanceToNextLeaf();
-      }
+    try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader());
+        HOTRangeCursor cursor = reader.range(rootRef, null, null)) {
+      return NodeReferencesSerializer.mergeChunksInPrefixRange(cursor, prefixBuf, prefixLen);
     }
-    return merged;
-  }
-
-  /** Bounded torn-read recovery: reload the current leaf in place and re-adopt the fresh copy. */
-  private static HOTLeafPage refreshTornLeaf(final HOTTrieReader reader, final int round) {
-    if (round > 64) {
-      throw new IllegalStateException(
-          "HOT leaf walk failed stamp validation on 64 consecutive rounds — sustained allocator thrashing");
-    }
-    if (!reader.refreshCurrentLeaf()) {
-      throw new IllegalStateException("HOT leaf walk: evicted leaf could not be reloaded through its PageReference");
-    }
-    return reader.currentLeafPage();
-  }
-
-  /** Merge one VALIDATED chunk payload copy into the accumulator bitmap. */
-  private @Nullable Roaring64Bitmap mergeChunk(@Nullable Roaring64Bitmap merged, byte[] composite, byte[] chunkBytes) {
-    // Unsigned, as everywhere else the chunk trailer is expanded.
-    final long chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length) & 0xFFFFFFFFL;
-    if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-      return merged;
-    }
-    final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-    final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-    if (chunkBitmap.isEmpty()) {
-      return merged;
-    }
-    if (merged == null) {
-      merged = new Roaring64Bitmap();
-    }
-    final long high = chunkIdx << 16;
-    final LongIterator bIt = chunkBitmap.getLongIterator();
-    while (bIt.hasNext()) {
-      merged.add(high | (bIt.next() & 0xFFFFL));
-    }
-    return merged;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -129,12 +129,17 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    * </p>
    *
    * @param key the logical index key
-   * @param mode reserved (only {@code EQUAL} is meaningful for {@code get}); range modes go via
+   * @param mode must be {@link SearchMode#EQUAL}; range modes go via
    *        {@link #range(Comparable, Comparable)} / {@link #iteratorFrom(Comparable, boolean)}
    * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
+   * @throws IllegalArgumentException if {@code mode} is not {@link SearchMode#EQUAL}. This parameter
+   *         used to be documented as "reserved" and silently ignored, i.e. every mode got the
+   *         {@code EQUAL} answer; memoization makes that assumption load-bearing, because the cache
+   *         key does not carry the mode and a mode-sensitive answer would be served across modes.
    */
-  public @Nullable NodeReferences get(K key, SearchMode mode) {
+  public @Nullable NodeReferences get(final K key, final SearchMode mode) {
     requireNonNull(key);
+    requireEqualMode(mode);
 
     // Size the buffer BEFORE serializing: checking the returned length afterwards is too late,
     // the write past the end has already happened.
@@ -145,15 +150,25 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
       setKeyBuffer(keyBuf);
     }
     final int prefixLen = serializeKey(key, keyBuf, 0);
-    return reassembleChunksForPrefix(keyBuf, prefixLen);
+    // Through the cache: for a committed revision the walk below is deterministic, so a key already
+    // asked about under this revision is answered without re-walking. A writer-backed reader gets a
+    // null cache and always computes — see AbstractHOTIndexReader#lookupCache.
+    return pointLookup(keyBuf, prefixLen);
   }
 
   /**
-   * Internal helper: reassemble all chunk slots whose composite key starts with
-   * {@code prefixBuf[0..prefixLen)}. Shared by {@link #get} and the range iterators.
+   * Reassemble all chunk slots whose composite key starts with {@code keyBuf[0..keyLen)}, without
+   * consulting or populating the memoization cache.
+   *
+   * <p>
+   * This is the whole of what {@link #get} used to do inline. It carries the leftmost-fallback retry
+   * for tries written before the writer enforced I8/I12, which is why the override exists rather than
+   * leaving the base class's chunk-walk-only default.
+   * </p>
    */
-  private @Nullable NodeReferences reassembleChunksForPrefix(byte[] prefixBuf, int prefixLen) {
-    final NodeReferences collected = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
+  @Override
+  protected @Nullable NodeReferences computePointLookup(final byte[] keyBuf, final int keyLen) {
+    final NodeReferences collected = collectChunksViaLowerBoundWalk(keyBuf, keyLen);
     if (collected != null) {
       return collected;
     }
@@ -167,7 +182,7 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
     if (rootRef == null) {
       return null;
     }
-    final Roaring64Bitmap merged = collectViaLeafWalk(rootRef, prefixBuf, prefixLen);
+    final Roaring64Bitmap merged = collectViaLeafWalk(rootRef, keyBuf, keyLen);
     if (merged == null || merged.isEmpty()) {
       return null;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -141,9 +141,13 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    * {@code prefixBuf[0..prefixLen)}. Shared by {@link #get} and the range iterators.
    */
   private @Nullable NodeReferences reassembleChunksForPrefix(byte[] prefixBuf, int prefixLen) {
-    Roaring64Bitmap merged = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
+    final NodeReferences collected = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
+    if (collected != null) {
+      return collected;
+    }
 
-    if (merged == null || merged.isEmpty()) {
+    Roaring64Bitmap merged = null;
+    {
       if (Boolean.getBoolean("hot.cas.leftmostfallback.enable")) {
         // Historical Phase 7v retry, now OPT-IN: a full leaf-walk scan robust against
         // non-lex-order leaves, for tries written before the writer enforced I8/I12 (the
@@ -338,6 +342,9 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
      * </p>
      */
     private final byte @Nullable [] fromPrefixFilter;
+    /** Per-iterator chunk accumulator, reset per logical group. */
+    private final NodeReferencesSerializer.ChunkAccumulator accumulator =
+        new NodeReferencesSerializer.ChunkAccumulator();
     private Map.@Nullable Entry<K, NodeReferences> nextEntry;
 
     ChunkAggregatingIterator(byte[] fromComposite, byte @Nullable [] toComposite, byte @Nullable [] fromPrefixFilter) {
@@ -413,8 +420,6 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
         final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
         final int compositeLen = groupComposite.length;
 
-        Roaring64Bitmap merged = null;
-
         while (cursor.hasNext()) {
           final HOTLeafPage leaf = cursor.currentLeafPage();
           final int idx = cursor.currentEntryIndex();
@@ -422,12 +427,13 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
             break;
           }
           final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-          merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
+          accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
           cursor.advance();
         }
 
-        if (merged != null && !merged.isEmpty()) {
-          nextEntry = new LazyKeyEntry(groupComposite, prefixLen, NodeReferences.owning(merged));
+        final NodeReferences groupRefs = accumulator.toNodeReferencesAndReset();
+        if (groupRefs != null) {
+          nextEntry = new LazyKeyEntry(groupComposite, prefixLen, groupRefs);
           return;
         }
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -39,7 +39,6 @@ import org.jspecify.annotations.Nullable;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
-import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
@@ -406,8 +405,7 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
         }
 
         if (merged != null && !merged.isEmpty()) {
-          final K logicalKey = deserializeKey(groupComposite, 0, prefixLen);
-          nextEntry = new AbstractMap.SimpleImmutableEntry<>(logicalKey, NodeReferences.owning(merged));
+          nextEntry = new LazyKeyEntry(groupComposite, prefixLen, NodeReferences.owning(merged));
           return;
         }
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -278,6 +278,28 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
+   * Iterate every logical entry with key {@code <= toKey}: a from-the-start cursor bounded above by
+   * {@code toKey}'s composite ceiling. The LESS / LESS_OR_EQUAL CAS scans use this so the cursor
+   * STOPS at the bound instead of scanning the whole index and filtering every entry behind it.
+   */
+  public Iterator<Map.Entry<K, NodeReferences>> iteratorTo(K toKey) {
+    requireNonNull(toKey);
+
+    byte[] keyBuf = getKeyBuffer();
+    final int required = maxSerializedKeyLength(toKey);
+    if (required > keyBuf.length) {
+      keyBuf = new byte[required];
+      setKeyBuffer(keyBuf);
+    }
+    final int toLen = serializeKey(toKey, keyBuf, 0);
+    final byte[] toComposite = new byte[toLen + HOTKeySerializer.CHUNK_IDX_BYTES];
+    System.arraycopy(keyBuf, 0, toComposite, 0, toLen);
+    HOTKeySerializer.writeChunkIdxBE(toComposite, toLen, 0xFFFFFFFF);
+
+    return new ChunkAggregatingIterator(new byte[0], toComposite, null);
+  }
+
+  /**
    * Iterator that walks a chunked composite-key range and groups consecutive same-prefix slots into
    * logical {@link Map.Entry}{@code <K, NodeReferences>} records.
    *

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -124,13 +124,15 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   public @Nullable NodeReferences get(K key, SearchMode mode) {
     requireNonNull(key);
 
+    // Size the buffer BEFORE serializing: checking the returned length afterwards is too late,
+    // the write past the end has already happened.
     byte[] keyBuf = getKeyBuffer();
-    int prefixLen = serializeKey(key, keyBuf, 0);
-    if (prefixLen > keyBuf.length) {
-      keyBuf = new byte[prefixLen];
+    final int required = maxSerializedKeyLength(key);
+    if (required > keyBuf.length) {
+      keyBuf = new byte[required];
       setKeyBuffer(keyBuf);
-      prefixLen = serializeKey(key, keyBuf, 0);
     }
+    final int prefixLen = serializeKey(key, keyBuf, 0);
     return reassembleChunksForPrefix(keyBuf, prefixLen);
   }
 
@@ -451,6 +453,11 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
   @Override
   protected int serializeKey(K key, byte[] buffer, int offset) {
     return keySerializer.serialize(key, buffer, offset);
+  }
+
+  @Override
+  protected int maxSerializedKeyLength(K key) {
+    return keySerializer.maxSerializedLength(key);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -33,13 +33,10 @@ import io.sirix.api.StorageEngineReader;
 import io.sirix.index.IndexType;
 import io.sirix.index.SearchMode;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
-import io.sirix.page.HOTLeafPage;
 import io.sirix.page.PageReference;
 import org.jspecify.annotations.Nullable;
-import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexReader.java
@@ -142,54 +142,27 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
    * {@code prefixBuf[0..prefixLen)}. Shared by {@link #get} and the range iterators.
    */
   private @Nullable NodeReferences reassembleChunksForPrefix(byte[] prefixBuf, int prefixLen) {
-    final PageReference rootRef = getRootReference();
-    if (rootRef == null) {
-      return null;
-    }
+    Roaring64Bitmap merged = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
 
-    final byte[] fromBytes = new byte[prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(prefixBuf, 0, fromBytes, 0, prefixLen);
-    HOTKeySerializer.writeChunkIdxBE(fromBytes, prefixLen, 0);
-
-    final byte[] toBytes = new byte[prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(prefixBuf, 0, toBytes, 0, prefixLen);
-    HOTKeySerializer.writeChunkIdxBE(toBytes, prefixLen, 0xFFFFFFFF);
-
-    Roaring64Bitmap merged = collectViaCursor(rootRef, prefixBuf, prefixLen, fromBytes, toBytes);
-
-    if ((merged == null || merged.isEmpty()) && !Boolean.getBoolean("hot.cas.leftmostfallback.disable")) {
-      // Phase 7v retry: the PEXT-routed lowerBound may misroute under I6 violations
-      // (writer-side structural bugs from byte-10 encoder discontinuity). Retry with a
-      // full leaf-walk scan that's robust against non-lex-order leaves. Only fires when
-      // the fast path returned 0 chunks — zero overhead for queries that succeeded.
-      merged = collectViaLeafWalk(rootRef, prefixBuf, prefixLen);
+    if (merged == null || merged.isEmpty()) {
+      if (Boolean.getBoolean("hot.cas.leftmostfallback.enable")) {
+        // Historical Phase 7v retry, now OPT-IN: a full leaf-walk scan robust against
+        // non-lex-order leaves, for tries written before the writer enforced I8/I12 (the
+        // byte-10 encoder discontinuity era). It costs a whole-index walk on EVERY miss —
+        // measured at ~2.5 ms against ~1 µs for the primary path on a 33K-key index — so a
+        // lookup miss must not pay it by default now that the writer's invariants are
+        // guarded pre-commit and detector-verified.
+        final PageReference rootRef = getRootReference();
+        if (rootRef != null) {
+          merged = collectViaLeafWalk(rootRef, prefixBuf, prefixLen);
+        }
+      }
     }
 
     if (merged == null || merged.isEmpty()) {
       return null;
     }
     return NodeReferences.owning(merged);
-  }
-
-  private @Nullable Roaring64Bitmap collectViaCursor(PageReference rootRef, byte[] prefixBuf, int prefixLen,
-      byte[] fromBytes, byte[] toBytes) {
-    Roaring64Bitmap merged = null;
-    try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader());
-        HOTRangeCursor cursor = reader.range(rootRef, fromBytes, toBytes)) {
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        final byte[] composite = leaf.getKey(idx);
-        if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-            || Arrays.compareUnsigned(composite, 0, prefixLen, prefixBuf, 0, prefixLen) != 0) {
-          cursor.advance();
-          continue;
-        }
-        merged = mergeChunk(merged, leaf, idx, composite);
-        cursor.advance();
-      }
-    }
-    return merged;
   }
 
   /**
@@ -395,18 +368,16 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
       }
       while (true) {
         while (cursor.hasNext()) {
-          final byte[] composite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
-          if (composite.length < HOTKeySerializer.CHUNK_IDX_BYTES) {
+          final HOTLeafPage leaf = cursor.currentLeafPage();
+          final int idx = cursor.currentEntryIndex();
+          if (leaf.getKeyLength(idx) < HOTKeySerializer.CHUNK_IDX_BYTES) {
             cursor.advance();
             continue;
           }
-          if (fromPrefixFilter != null) {
-            final int candidatePrefixLen = composite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-            if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen, fromPrefixFilter, 0,
-                fromPrefixFilter.length) < 0) {
-              cursor.advance();
-              continue;
-            }
+          if (fromPrefixFilter != null && leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES,
+              fromPrefixFilter, fromPrefixFilter.length) < 0) {
+            cursor.advance();
+            continue;
           }
           break;
         }
@@ -415,35 +386,22 @@ public final class HOTIndexReader<K extends Comparable<? super K>> extends Abstr
           return;
         }
 
+        // Materialize the group's composite key ONCE — it doubles as the logical-key bytes for
+        // deserializeKey at emit. Per-slot filtering below stays zero-copy against it.
         final byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
         final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
+        final int compositeLen = groupComposite.length;
 
         Roaring64Bitmap merged = null;
 
         while (cursor.hasNext()) {
           final HOTLeafPage leaf = cursor.currentLeafPage();
           final int idx = cursor.currentEntryIndex();
-          final byte[] composite = leaf.getKey(idx);
-          if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-              || Arrays.compareUnsigned(composite, 0, prefixLen, groupComposite, 0, prefixLen) != 0) {
+          if (leaf.getKeyLength(idx) != compositeLen || leaf.compareKeyPrefix(idx, groupComposite, prefixLen) != 0) {
             break;
           }
-          final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-          final byte[] chunkBytes = leaf.getValue(idx);
-          if (!NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-            final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-            final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-            if (!chunkBitmap.isEmpty()) {
-              if (merged == null) {
-                merged = new Roaring64Bitmap();
-              }
-              final long high = ((long) chunkIdx) << 16;
-              final LongIterator bIt = chunkBitmap.getLongIterator();
-              while (bIt.hasNext()) {
-                merged.add(high | (bIt.next() & 0xFFFFL));
-              }
-            }
-          }
+          final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
+          merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
           cursor.advance();
         }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -65,12 +65,11 @@ import static java.util.Objects.requireNonNull;
 public final class HOTIndexWriter<K extends Comparable<? super K>> extends AbstractHOTIndexWriter<K> {
 
   /**
-   * Thread-local buffer for key serialization. Sized to fit the largest CAS prefix (10-byte
-   * header + {@code MAX_STRING_VALUE_BYTES = 246}) PLUS
-   * {@link HOTKeySerializer#CHUNK_IDX_BYTES} (= 4) chunkIdx trailer = 260 bytes minimum;
-   * rounded to 512 for headroom across future serializer changes. Previously 256, which
-   * overflowed by 4 bytes whenever the prefix maxed out (regression caught by
-   * {@code JsonIntegrationTest.testCreateAndScanCASIndex3} via long-string CAS values).
+   * Thread-local buffer for key serialization. Sized to fit the largest CAS prefix (10-byte header +
+   * {@code MAX_STRING_VALUE_BYTES = 246}) PLUS {@link HOTKeySerializer#CHUNK_IDX_BYTES} (= 4)
+   * chunkIdx trailer = 260 bytes minimum; rounded to 512 for headroom across future serializer
+   * changes. Previously 256, which overflowed by 4 bytes whenever the prefix maxed out (regression
+   * caught by {@code JsonIntegrationTest.testCreateAndScanCASIndex3} via long-string CAS values).
    */
   private static final ThreadLocal<byte[]> KEY_BUFFER = ThreadLocal.withInitial(() -> new byte[512]);
 
@@ -94,8 +93,8 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    * @param indexType the index type (PATH, CAS, NAME)
    * @param indexNumber the index number
    */
-  private HOTIndexWriter(StorageEngineWriter storageEngineWriter, HOTKeySerializer<K> keySerializer, IndexType indexType,
-      int indexNumber) {
+  private HOTIndexWriter(StorageEngineWriter storageEngineWriter, HOTKeySerializer<K> keySerializer,
+      IndexType indexType, int indexNumber) {
     super(storageEngineWriter, indexType, indexNumber);
     this.keySerializer = requireNonNull(keySerializer);
 
@@ -134,20 +133,26 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   /**
    * Index a key-value pair using chunked-bitmap storage.
    *
-   * <p>The logical {@link NodeReferences} is split across multiple HOT slots, one per
-   * <em>chunk</em>. A chunk holds the low-16 bits of all nodeKeys whose
-   * {@code (int)(nodeKey >>> 16)} equals its chunkIdx. The HOT key for a chunk is the composite
-   * {@code prefix(key) ‖ chunkIdx_be4}; see {@link HOTKeySerializer#serializeWithChunkIdx}.</p>
+   * <p>
+   * The logical {@link NodeReferences} is split across multiple HOT slots, one per <em>chunk</em>. A
+   * chunk holds the low-16 bits of all nodeKeys whose {@code (int)(nodeKey >>> 16)} equals its
+   * chunkIdx. The HOT key for a chunk is the composite {@code prefix(key) ‖ chunkIdx_be4}; see
+   * {@link HOTKeySerializer#serializeWithChunkIdx}.
+   * </p>
    *
    * <h3>Why chunk?</h3>
-   * <p>Per-revision write cost grows with the size of the slot value rewritten on update.
-   * Without chunking, every commit that touches a single nodeKey on a popular logical key
-   * rewrites the whole bitmap (potentially MBs). With chunking, only the one Roaring chunk
-   * of the modified nodeKey is rewritten — typical chunk size is a few hundred bytes.</p>
+   * <p>
+   * Per-revision write cost grows with the size of the slot value rewritten on update. Without
+   * chunking, every commit that touches a single nodeKey on a popular logical key rewrites the whole
+   * bitmap (potentially MBs). With chunking, only the one Roaring chunk of the modified nodeKey is
+   * rewritten — typical chunk size is a few hundred bytes.
+   * </p>
    *
-   * <p>If the chunk slot already exists, {@link HOTLeafPage#mergeWithNodeRefs} handles the
-   * OR-merge of the new bit into the existing chunk's bitmap; failure paths (page split /
-   * compact) are inherited unchanged from the per-slot write.</p>
+   * <p>
+   * If the chunk slot already exists, {@link HOTLeafPage#mergeWithNodeRefs} handles the OR-merge of
+   * the new bit into the existing chunk's bitmap; failure paths (page split / compact) are inherited
+   * unchanged from the per-slot write.
+   * </p>
    *
    * @param key the logical index key (e.g. a {@code QNm} for NAME, a {@code CASValue} for CAS)
    * @param value the node references
@@ -172,11 +177,13 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   /**
    * Add a single nodeKey to {@code key}'s chunked bitmap.
    *
-   * <p>Equivalent to {@link #index(Comparable, NodeReferences, RBTreeReader.MoveCursor)} with a
-   * one-element {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot
-   * write is an OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to
-   * ADD one reference never has to materialise — let alone read back — the references already
-   * stored under {@code key}.</p>
+   * <p>
+   * Equivalent to {@link #index(Comparable, NodeReferences, RBTreeReader.MoveCursor)} with a
+   * one-element {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot write
+   * is an OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to ADD one
+   * reference never has to materialise — let alone read back — the references already stored under
+   * {@code key}.
+   * </p>
    *
    * @param key the logical index key
    * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
@@ -191,10 +198,11 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    * {@link HOTBulkBuilder} pass — the right shape for building an index over an already-shredded
    * revision.
    *
-   * <p>Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
-   * <em>replaces</em> the root rather than merging into it. Callers that may run against a
-   * populated tree must check first and fall back to
-   * {@link #indexNodeKey(Comparable, long)}.</p>
+   * <p>
+   * Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
+   * <em>replaces</em> the root rather than merging into it. Callers that may run against a populated
+   * tree must check first and fall back to {@link #indexNodeKey(Comparable, long)}.
+   * </p>
    *
    * @return a fresh bulk loader bound to this writer
    */
@@ -205,11 +213,12 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   /**
    * Add one nodeKey to its chunk slot. Chunked-bitmap write hot path.
    *
-   * <p>Builds {@code prefix(key) ‖ chunkIdx_be4} where
-   * {@code chunkIdx = (int)(nodeKey >>> 16)}, encodes a single-bit
-   * {@link NodeReferences} containing {@code nodeKey & 0xFFFF}, and calls the inherited
+   * <p>
+   * Builds {@code prefix(key) ‖ chunkIdx_be4} where {@code chunkIdx = (int)(nodeKey >>> 16)}, encodes
+   * a single-bit {@link NodeReferences} containing {@code nodeKey & 0xFFFF}, and calls the inherited
    * {@link AbstractHOTIndexWriter#doIndex} which delegates to {@link HOTLeafPage#mergeWithNodeRefs}
-   * (OR-merge with any pre-existing chunk).</p>
+   * (OR-merge with any pre-existing chunk).
+   * </p>
    */
   private void addNodeKeyToChunk(K key, long nodeKey) {
     AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
@@ -233,15 +242,17 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   /**
    * Reassemble all chunks of a logical key into a single {@link NodeReferences}.
    *
-   * <p>Range-scans composite keys in {@code [(prefix, 0), (prefix, 0xFFFFFFFF)]} via
-   * {@link HOTTrieReader#lowerBound} (Phase 0b — Binna §4.2) so the seek is O(tree-height)
-   * even when the smallest existing chunkIdx for {@code key} is {@code > 0}. For every
-   * matching chunk slot the value bitmap is decoded and each bit16 is expanded to a full
-   * 64-bit nodeKey via {@code (chunkIdx << 16) | bit16}.</p>
+   * <p>
+   * Range-scans composite keys in {@code [(prefix, 0), (prefix, 0xFFFFFFFF)]} via
+   * {@link HOTTrieReader#lowerBound} (Phase 0b — Binna §4.2) so the seek is O(tree-height) even when
+   * the smallest existing chunkIdx for {@code key} is {@code > 0}. For every matching chunk slot the
+   * value bitmap is decoded and each bit16 is expanded to a full 64-bit nodeKey via
+   * {@code (chunkIdx << 16) | bit16}.
+   * </p>
    *
-   * @param key  the logical index key
-   * @param mode the search mode (only {@code EQUAL} is meaningful here; range modes go through
-   *             the reader's {@code range}/{@code iteratorFrom} APIs)
+   * @param key the logical index key
+   * @param mode the search mode (only {@code EQUAL} is meaningful here; range modes go through the
+   *        reader's {@code range}/{@code iteratorFrom} APIs)
    * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
    */
   public @Nullable NodeReferences get(K key, SearchMode mode) {
@@ -317,10 +328,12 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   /**
    * Remove a single nodeKey from the chunked bitmap of {@code key}.
    *
-   * <p>Locates the chunk slot {@code (prefix, (int)(nodeKey >>> 16))}, deserializes the chunk
-   * bitmap, removes {@code nodeKey & 0xFFFF}, re-serializes (or tombstones if the chunk is now
-   * empty). Other chunks of the same logical key are untouched — slot-granular CoW ensures the
-   * other chunks do not even appear in the new revision's TIL fragment.</p>
+   * <p>
+   * Locates the chunk slot {@code (prefix, (int)(nodeKey >>> 16))}, deserializes the chunk bitmap,
+   * removes {@code nodeKey & 0xFFFF}, re-serializes (or tombstones if the chunk is now empty). Other
+   * chunks of the same logical key are untouched — slot-granular CoW ensures the other chunks do not
+   * even appear in the new revision's TIL fragment.
+   * </p>
    *
    * @return true if a bit was actually cleared, false if absent
    */
@@ -334,7 +347,9 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
     final byte[] keyBuf = chunkedKeyBuffer(key);
     final int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
 
-    final byte[] keySlice = compLen == keyBuf.length ? keyBuf : Arrays.copyOf(keyBuf, compLen);
+    final byte[] keySlice = compLen == keyBuf.length
+        ? keyBuf
+        : Arrays.copyOf(keyBuf, compLen);
     final LeafNavigationResult navResult = prepareLeafOfTree(rootReference, keySlice, compLen);
     final HOTLeafPage leaf = navResult.leaf();
     if (leaf == null) {
@@ -371,14 +386,15 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * The thread-local key buffer, grown first if {@code key} could need more than it currently
-   * holds.
+   * The thread-local key buffer, grown first if {@code key} could need more than it currently holds.
    *
-   * <p>Sizing has to happen BEFORE the write. The previous shape serialized into the buffer and
-   * only then compared the returned length against {@code buffer.length} — by which point a key
-   * larger than the buffer had already been written past its end. Only NAME keys can reach that:
-   * a CAS key is bounded by a constant well under the buffer, but a local name is raw UTF-8 of
-   * whatever the document called the field.</p>
+   * <p>
+   * Sizing has to happen BEFORE the write. The previous shape serialized into the buffer and only
+   * then compared the returned length against {@code buffer.length} — by which point a key larger
+   * than the buffer had already been written past its end. Only NAME keys can reach that: a CAS key
+   * is bounded by a constant well under the buffer, but a local name is raw UTF-8 of whatever the
+   * document called the field.
+   * </p>
    *
    * @param key the key about to be serialized
    * @return a buffer with room for {@code key}'s prefix

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -177,6 +177,56 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
+   * Add a single nodeKey to {@code key}'s chunked bitmap.
+   *
+   * <p>Equivalent to {@link #index(Comparable, NodeReferences, RBTreeReader.MoveCursor)} with a
+   * one-element {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot
+   * write is an OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to
+   * ADD one reference never has to materialise — let alone read back — the references already
+   * stored under {@code key}.</p>
+   *
+   * @param key the logical index key
+   * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
+   */
+  public void indexNodeKey(K key, long nodeKey) {
+    requireNonNull(key);
+    addNodeKeyToChunk(key, nodeKey);
+  }
+
+  /**
+   * Reject a node key the chunked-bitmap encoding cannot represent.
+   *
+   * @param nodeKey the node key to validate
+   * @throws IllegalArgumentException if {@code nodeKey} is negative or exceeds
+   *         {@link #MAX_NODE_KEY}
+   */
+  static void checkNodeKeyRange(final long nodeKey) {
+    if (nodeKey < 0L) {
+      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
+    }
+    if (nodeKey > MAX_NODE_KEY) {
+      throw new IllegalArgumentException(
+          "nodeKey " + nodeKey + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
+    }
+  }
+
+  /**
+   * A loader that collects {@code (key, nodeKey)} pairs and materialises the whole index in one
+   * {@link HOTBulkBuilder} pass — the right shape for building an index over an already-shredded
+   * revision.
+   *
+   * <p>Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
+   * <em>replaces</em> the root rather than merging into it. Callers that may run against a
+   * populated tree must check first and fall back to
+   * {@link #indexNodeKey(Comparable, long)}.</p>
+   *
+   * @return a fresh bulk loader bound to this writer
+   */
+  public HOTBulkIndexLoader<K> createBulkLoader() {
+    return new HOTBulkIndexLoader<>(this, keySerializer);
+  }
+
+  /**
    * Add one nodeKey to its chunk slot. Chunked-bitmap write hot path.
    *
    * <p>Builds {@code prefix(key) ‖ chunkIdx_be4} where
@@ -186,13 +236,7 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    * (OR-merge with any pre-existing chunk).</p>
    */
   private void addNodeKeyToChunk(K key, long nodeKey) {
-    if (nodeKey < 0L) {
-      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
-    }
-    if (nodeKey > MAX_NODE_KEY) {
-      throw new IllegalArgumentException("nodeKey " + nodeKey
-          + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
-    }
+    checkNodeKeyRange(nodeKey);
 
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -251,12 +251,21 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    * </p>
    *
    * @param key the logical index key
-   * @param mode the search mode (only {@code EQUAL} is meaningful here; range modes go through the
-   *        reader's {@code range}/{@code iteratorFrom} APIs)
+   * @param mode must be {@link SearchMode#EQUAL}; range modes go through the reader's
+   *        {@code range}/{@code iteratorFrom} APIs
    * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
+   * @throws IllegalArgumentException if {@code mode} is not {@link SearchMode#EQUAL}. This parameter
+   *         used to be documented as advisory and silently ignored, i.e. every mode got the
+   *         {@code EQUAL} answer; the guard is shared with {@link HOTIndexReader#get} so a caller
+   *         cannot learn a different contract from whichever of the two twins it happened to pick.
    */
-  public @Nullable NodeReferences get(K key, SearchMode mode) {
+  public @Nullable NodeReferences get(final K key, final SearchMode mode) {
     requireNonNull(key);
+    // Same contract as the reader's get, enforced through the reader's helper so there is ONE copy of
+    // the rule. A writer-backed lookup is never memoized, so the cache-key argument does not apply
+    // here — but this method ignores `mode` exactly as the reader's did, and leaving the twin
+    // unguarded is how a caller learns the restriction from whichever of the two it happened to pick.
+    AbstractHOTIndexReader.requireEqualMode(mode);
 
     final byte[] keyBuf = prefixKeyBuffer(key);
     final int prefixLen = keySerializer.serialize(key, keyBuf, 0);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -284,40 +284,11 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
     if (chunkReader == null) {
       chunkReader = new HOTTrieReader(storageEngineWriter);
     }
-    Roaring64Bitmap merged = null;
+    // The sweep reads UNPINNED leaves under optimistic stamps — the shared helper validates each
+    // slot's copies against the cursor's leaf stamp before anything reaches the deserializer.
+    final Roaring64Bitmap merged;
     try (HOTRangeCursor cursor = chunkReader.range(rootRef, fromBytes, toBytes)) {
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        final byte[] composite = leaf.getKey(idx);
-        if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-            || Arrays.compareUnsigned(composite, 0, prefixLen, prefixBuf, 0, prefixLen) != 0) {
-          // Defensive — toKey already bounds the cursor to the prefix range.
-          cursor.advance();
-          continue;
-        }
-        final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-        final byte[] chunkBytes = leaf.getValue(idx);
-        if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-          cursor.advance();
-          continue;
-        }
-        final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-        final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-        if (chunkBitmap.isEmpty()) {
-          cursor.advance();
-          continue;
-        }
-        if (merged == null) {
-          merged = new Roaring64Bitmap();
-        }
-        final long high = ((long) chunkIdx) << 16;
-        final LongIterator bIt = chunkBitmap.getLongIterator();
-        while (bIt.hasNext()) {
-          merged.add(high | (bIt.next() & 0xFFFFL));
-        }
-        cursor.advance();
-      }
+      merged = NodeReferencesSerializer.mergeChunksInPrefixRange(cursor, prefixBuf, prefixLen);
     }
     if (merged == null || merged.isEmpty()) {
       return null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -81,13 +81,6 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    */
   private static final ThreadLocal<NodeReferences> SINGLE_BIT_REFS = ThreadLocal.withInitial(NodeReferences::new);
 
-  /**
-   * Cap on a permitted nodeKey for chunked-bitmap storage. The chunkIdx is stored as a 32-bit
-   * big-endian unsigned int trailer; with {@code chunkIdx = (int)(nodeKey >>> 16)} this gives a
-   * full 48-bit nodeKey range — well above any practical Sirix dataset.
-   */
-  private static final long MAX_NODE_KEY = (1L << 48) - 1L;
-
   private final HOTKeySerializer<K> keySerializer;
 
   /** Lazy reader for chunked-bitmap reassembly during {@link #get} / range scans. */
@@ -194,23 +187,6 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   }
 
   /**
-   * Reject a node key the chunked-bitmap encoding cannot represent.
-   *
-   * @param nodeKey the node key to validate
-   * @throws IllegalArgumentException if {@code nodeKey} is negative or exceeds
-   *         {@link #MAX_NODE_KEY}
-   */
-  static void checkNodeKeyRange(final long nodeKey) {
-    if (nodeKey < 0L) {
-      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
-    }
-    if (nodeKey > MAX_NODE_KEY) {
-      throw new IllegalArgumentException(
-          "nodeKey " + nodeKey + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
-    }
-  }
-
-  /**
    * A loader that collects {@code (key, nodeKey)} pairs and materialises the whole index in one
    * {@link HOTBulkBuilder} pass — the right shape for building an index over an already-shredded
    * revision.
@@ -236,7 +212,7 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    * (OR-merge with any pre-existing chunk).</p>
    */
   private void addNodeKeyToChunk(K key, long nodeKey) {
-    checkNodeKeyRange(nodeKey);
+    AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
 
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;
@@ -360,13 +336,7 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
    */
   public boolean remove(K key, long nodeKey) {
     requireNonNull(key);
-    if (nodeKey < 0L) {
-      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
-    }
-    if (nodeKey > MAX_NODE_KEY) {
-      throw new IllegalArgumentException("nodeKey " + nodeKey
-          + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
-    }
+    AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
 
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTIndexWriter.java
@@ -217,13 +217,8 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;
 
-    byte[] keyBuf = KEY_BUFFER.get();
-    int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
-    if (compLen > keyBuf.length) {
-      keyBuf = new byte[compLen];
-      KEY_BUFFER.set(keyBuf);
-      compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
-    }
+    final byte[] keyBuf = chunkedKeyBuffer(key);
+    final int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
 
     // Reusable single-bit payload — clear, set, serialize. Avoids per-call bitmap allocation.
     final NodeReferences singleBit = SINGLE_BIT_REFS.get();
@@ -252,13 +247,8 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
   public @Nullable NodeReferences get(K key, SearchMode mode) {
     requireNonNull(key);
 
-    byte[] keyBuf = KEY_BUFFER.get();
-    int prefixLen = keySerializer.serialize(key, keyBuf, 0);
-    if (prefixLen > keyBuf.length) {
-      keyBuf = new byte[prefixLen];
-      KEY_BUFFER.set(keyBuf);
-      prefixLen = keySerializer.serialize(key, keyBuf, 0);
-    }
+    final byte[] keyBuf = prefixKeyBuffer(key);
+    final int prefixLen = keySerializer.serialize(key, keyBuf, 0);
     return reassembleChunksForPrefix(keyBuf, prefixLen);
   }
 
@@ -341,13 +331,8 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;
 
-    byte[] keyBuf = KEY_BUFFER.get();
-    int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
-    if (compLen > keyBuf.length) {
-      keyBuf = new byte[compLen];
-      KEY_BUFFER.set(keyBuf);
-      compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
-    }
+    final byte[] keyBuf = chunkedKeyBuffer(key);
+    final int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
 
     final byte[] keySlice = compLen == keyBuf.length ? keyBuf : Arrays.copyOf(keyBuf, compLen);
     final LeafNavigationResult navResult = prepareLeafOfTree(rootReference, keySlice, compLen);
@@ -383,6 +368,37 @@ public final class HOTIndexWriter<K extends Comparable<? super K>> extends Abstr
     final int valueLen = NodeReferencesSerializer.serialize(chunkRefs, valueBuf, 0);
     leaf.updateValue(index, Arrays.copyOf(valueBuf, valueLen));
     return true;
+  }
+
+  /**
+   * The thread-local key buffer, grown first if {@code key} could need more than it currently
+   * holds.
+   *
+   * <p>Sizing has to happen BEFORE the write. The previous shape serialized into the buffer and
+   * only then compared the returned length against {@code buffer.length} — by which point a key
+   * larger than the buffer had already been written past its end. Only NAME keys can reach that:
+   * a CAS key is bounded by a constant well under the buffer, but a local name is raw UTF-8 of
+   * whatever the document called the field.</p>
+   *
+   * @param key the key about to be serialized
+   * @return a buffer with room for {@code key}'s prefix
+   */
+  private byte[] prefixKeyBuffer(final K key) {
+    return keyBufferOfAtLeast(keySerializer.maxSerializedLength(key));
+  }
+
+  /** As {@link #prefixKeyBuffer}, with room for the 4-byte chunkIdx trailer as well. */
+  private byte[] chunkedKeyBuffer(final K key) {
+    return keyBufferOfAtLeast(keySerializer.maxSerializedLength(key) + HOTKeySerializer.CHUNK_IDX_BYTES);
+  }
+
+  private static byte[] keyBufferOfAtLeast(final int required) {
+    byte[] keyBuf = KEY_BUFFER.get();
+    if (required > keyBuf.length) {
+      keyBuf = new byte[required];
+      KEY_BUFFER.set(keyBuf);
+    }
+    return keyBuf;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTKeySerializer.java
@@ -80,13 +80,17 @@ public interface HOTKeySerializer<K> {
   /**
    * Upper bound, in bytes, on what {@link #serialize} will write for {@code key}.
    *
-   * <p>Callers size their buffer from this <em>before</em> serializing. Checking the returned
-   * length against the buffer afterwards does not work: by then the write has already happened,
-   * and for a variable-length key it has happened past the end of the buffer.</p>
+   * <p>
+   * Callers size their buffer from this <em>before</em> serializing. Checking the returned length
+   * against the buffer afterwards does not work: by then the write has already happened, and for a
+   * variable-length key it has happened past the end of the buffer.
+   * </p>
    *
-   * <p>Deliberately not defaulted. A serializer that under-reports its own bound reintroduces
-   * exactly the overflow this method exists to prevent, so every implementation has to state one.
-   * An over-estimate is always safe.</p>
+   * <p>
+   * Deliberately not defaulted. A serializer that under-reports its own bound reintroduces exactly
+   * the overflow this method exists to prevent, so every implementation has to state one. An
+   * over-estimate is always safe.
+   * </p>
    *
    * @param key the key that is about to be serialized
    * @return a value {@code >= serialize(key, ...)} would return
@@ -148,29 +152,30 @@ public interface HOTKeySerializer<K> {
   }
 
   /**
-   * Number of bytes used to encode the chunk index trailer of a chunked composite key.
-   * Big-endian 32-bit unsigned, so {@code chunkIdx} can range over all positive ints.
-   * Sized to fit {@code nodeKey >>> 16} for any 64-bit nodeKey up to ~2^48 — comfortably above
-   * any practical Sirix dataset.
+   * Number of bytes used to encode the chunk index trailer of a chunked composite key. Big-endian
+   * 32-bit unsigned, so {@code chunkIdx} can range over all positive ints. Sized to fit
+   * {@code nodeKey >>> 16} for any 64-bit nodeKey up to ~2^48 — comfortably above any practical Sirix
+   * dataset.
    */
   int CHUNK_IDX_BYTES = 4;
 
   /**
-   * Append a 4-byte big-endian {@code chunkIdx} trailer to a serialised key. The {@code key} is
-   * first serialised at {@code offset}; the chunkIdx bytes follow immediately after. Callers
-   * MUST size {@code dest} to at least {@code prefixLen + CHUNK_IDX_BYTES} starting from
-   * {@code offset}.
+   * Append a 4-byte big-endian {@code chunkIdx} trailer to a serialised key. The {@code key} is first
+   * serialised at {@code offset}; the chunkIdx bytes follow immediately after. Callers MUST size
+   * {@code dest} to at least {@code prefixLen + CHUNK_IDX_BYTES} starting from {@code offset}.
    *
-   * <p>Big-endian byte order keeps adjacent chunkIdx values adjacent in lex order, so a
-   * {@code (prefix, chunkIdx)} composite preserves the sortedness needed by
-   * {@code HOTRangeCursor}'s navigate-then-walk-forward primitive when ranging over all chunks
-   * of one logical key (PROJECTION pattern).</p>
+   * <p>
+   * Big-endian byte order keeps adjacent chunkIdx values adjacent in lex order, so a
+   * {@code (prefix, chunkIdx)} composite preserves the sortedness needed by {@code HOTRangeCursor}'s
+   * navigate-then-walk-forward primitive when ranging over all chunks of one logical key (PROJECTION
+   * pattern).
+   * </p>
    *
-   * @param key       the logical key (e.g. a {@code QNm} for NAME, a {@code CASValue} for CAS)
-   * @param chunkIdx  the chunk index — typically {@code (int) (nodeKey >>> 16)} so each chunk
-   *                  covers one Roaring 16-bit container
-   * @param dest      destination buffer
-   * @param offset    offset in {@code dest}
+   * @param key the logical key (e.g. a {@code QNm} for NAME, a {@code CASValue} for CAS)
+   * @param chunkIdx the chunk index — typically {@code (int) (nodeKey >>> 16)} so each chunk covers
+   *        one Roaring 16-bit container
+   * @param dest destination buffer
+   * @param offset offset in {@code dest}
    * @return total number of bytes written ({@code prefixLen + CHUNK_IDX_BYTES})
    */
   default int serializeWithChunkIdx(K key, int chunkIdx, byte[] dest, int offset) {
@@ -180,9 +185,9 @@ public interface HOTKeySerializer<K> {
   }
 
   /**
-   * Same as {@link #serialize(Object, byte[], int)} but explicitly named to advertise
-   * "this is the prefix of a chunked composite key." The default delegates to {@code serialize}
-   * because the chunked composite is just {@code (prefix ‖ chunkIdx_be4)}.
+   * Same as {@link #serialize(Object, byte[], int)} but explicitly named to advertise "this is the
+   * prefix of a chunked composite key." The default delegates to {@code serialize} because the
+   * chunked composite is just {@code (prefix ‖ chunkIdx_be4)}.
    *
    * @return the prefix length (everything before the chunkIdx trailer)
    */
@@ -193,24 +198,22 @@ public interface HOTKeySerializer<K> {
   /**
    * Read the trailing 4-byte big-endian {@code chunkIdx} from a chunked composite key.
    *
-   * @param keyBytes  the full composite key bytes
+   * @param keyBytes the full composite key bytes
    * @param keyOffset offset in {@code keyBytes} where the composite key starts
-   * @param keyLen    full length of the composite key (prefix + {@link #CHUNK_IDX_BYTES})
+   * @param keyLen full length of the composite key (prefix + {@link #CHUNK_IDX_BYTES})
    * @return the chunkIdx
    */
   static int readChunkIdx(byte[] keyBytes, int keyOffset, int keyLen) {
     final int chunkIdxStart = keyOffset + keyLen - CHUNK_IDX_BYTES;
-    return ((keyBytes[chunkIdxStart] & 0xFF) << 24)
-        | ((keyBytes[chunkIdxStart + 1] & 0xFF) << 16)
-        | ((keyBytes[chunkIdxStart + 2] & 0xFF) << 8)
-        | (keyBytes[chunkIdxStart + 3] & 0xFF);
+    return ((keyBytes[chunkIdxStart] & 0xFF) << 24) | ((keyBytes[chunkIdxStart + 1] & 0xFF) << 16)
+        | ((keyBytes[chunkIdxStart + 2] & 0xFF) << 8) | (keyBytes[chunkIdxStart + 3] & 0xFF);
   }
 
   /**
    * Write a 4-byte big-endian {@code chunkIdx} into the destination buffer at the given offset.
    */
   static void writeChunkIdxBE(byte[] dest, int offset, int chunkIdx) {
-    dest[offset]     = (byte) (chunkIdx >>> 24);
+    dest[offset] = (byte) (chunkIdx >>> 24);
     dest[offset + 1] = (byte) (chunkIdx >>> 16);
     dest[offset + 2] = (byte) (chunkIdx >>> 8);
     dest[offset + 3] = (byte) chunkIdx;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTKeySerializer.java
@@ -78,6 +78,22 @@ public interface HOTKeySerializer<K> {
   int serialize(K key, byte[] dest, int offset);
 
   /**
+   * Upper bound, in bytes, on what {@link #serialize} will write for {@code key}.
+   *
+   * <p>Callers size their buffer from this <em>before</em> serializing. Checking the returned
+   * length against the buffer afterwards does not work: by then the write has already happened,
+   * and for a variable-length key it has happened past the end of the buffer.</p>
+   *
+   * <p>Deliberately not defaulted. A serializer that under-reports its own bound reintroduces
+   * exactly the overflow this method exists to prevent, so every implementation has to state one.
+   * An over-estimate is always safe.</p>
+   *
+   * @param key the key that is about to be serialized
+   * @return a value {@code >= serialize(key, ...)} would return
+   */
+  int maxSerializedLength(K key);
+
+  /**
    * Deserializes a key from bytes.
    *
    * <p>

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
@@ -6,17 +6,18 @@ package io.sirix.index.hot;
 import static java.util.Objects.requireNonNull;
 
 /**
- * {@link AbstractHOTBulkIndexLoader} for indexes with object keys — a {@code CASValue} for CAS, a
- * {@code QNm} for NAME.
+ * {@link AbstractHOTBulkIndexLoader} for the PATH index's primitive {@code long} keys.
  *
- * @param <K> the logical index key type
+ * <p>Separate from {@link HOTBulkIndexLoader} purely to keep the key primitive: a PATH build adds
+ * one entry per indexed node, so a {@code Long} key would be one box per node.</p>
+ *
  * @author Johannes Lichtenberger
  */
-public final class HOTBulkIndexLoader<K extends Comparable<? super K>> extends AbstractHOTBulkIndexLoader {
+public final class HOTLongBulkIndexLoader extends AbstractHOTBulkIndexLoader {
 
-  private final HOTKeySerializer<K> keySerializer;
+  private final HOTLongKeySerializer keySerializer;
 
-  HOTBulkIndexLoader(final HOTIndexWriter<K> writer, final HOTKeySerializer<K> keySerializer) {
+  HOTLongBulkIndexLoader(final HOTLongIndexWriter writer, final HOTLongKeySerializer keySerializer) {
     super(writer);
     this.keySerializer = requireNonNull(keySerializer, "keySerializer");
   }
@@ -24,11 +25,10 @@ public final class HOTBulkIndexLoader<K extends Comparable<? super K>> extends A
   /**
    * Record that {@code nodeKey} belongs to {@code key}'s posting list.
    *
-   * @param key the logical index key
+   * @param key the logical index key (a path-class record for the PATH index)
    * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
    */
-  public void add(final K key, final long nodeKey) {
-    requireNonNull(key, "key");
+  public void add(final long key, final long nodeKey) {
     final byte[] arena = reserveKeySpace(nodeKey);
     final int offset = arenaOffset();
     final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), arena, offset);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
@@ -29,7 +29,7 @@ public final class HOTLongBulkIndexLoader extends AbstractHOTBulkIndexLoader {
    * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
    */
   public void add(final long key, final long nodeKey) {
-    final byte[] block = reserveKeySpace(nodeKey);
+    final byte[] block = reserveKeySpace(nodeKey, HOTLongKeySerializer.CHUNKED_SERIALIZED_SIZE);
     final int offset = blockOffset();
     final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), block, offset);
     commitKey(length, nodeKey);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
@@ -29,9 +29,9 @@ public final class HOTLongBulkIndexLoader extends AbstractHOTBulkIndexLoader {
    * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
    */
   public void add(final long key, final long nodeKey) {
-    final byte[] arena = reserveKeySpace(nodeKey);
-    final int offset = arenaOffset();
-    final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), arena, offset);
+    final byte[] block = reserveKeySpace(nodeKey);
+    final int offset = blockOffset();
+    final int length = keySerializer.serializeWithChunkIdx(key, (int) (nodeKey >>> 16), block, offset);
     commitKey(length, nodeKey);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongBulkIndexLoader.java
@@ -8,8 +8,10 @@ import static java.util.Objects.requireNonNull;
 /**
  * {@link AbstractHOTBulkIndexLoader} for the PATH index's primitive {@code long} keys.
  *
- * <p>Separate from {@link HOTBulkIndexLoader} purely to keep the key primitive: a PATH build adds
- * one entry per indexed node, so a {@code Long} key would be one box per node.</p>
+ * <p>
+ * Separate from {@link HOTBulkIndexLoader} purely to keep the key primitive: a PATH build adds one
+ * entry per indexed node, so a {@code Long} key would be one box per node.
+ * </p>
  *
  * @author Johannes Lichtenberger
  */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -84,8 +84,8 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
    * @param indexType the index type (should be PATH)
    * @param indexNumber the index number
    */
-  private HOTLongIndexReader(StorageEngineReader storageEngineReader, HOTLongKeySerializer keySerializer, IndexType indexType,
-      int indexNumber) {
+  private HOTLongIndexReader(StorageEngineReader storageEngineReader, HOTLongKeySerializer keySerializer,
+      IndexType indexType, int indexNumber) {
     super(storageEngineReader, indexType, indexNumber);
     this.keySerializer = keySerializer;
   }
@@ -98,13 +98,14 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
    * @param indexNumber the index number
    * @return a new HOTLongIndexReader instance
    */
-  public static HOTLongIndexReader create(StorageEngineReader storageEngineReader, IndexType indexType, int indexNumber) {
+  public static HOTLongIndexReader create(StorageEngineReader storageEngineReader, IndexType indexType,
+      int indexNumber) {
     return new HOTLongIndexReader(storageEngineReader, PathKeySerializer.INSTANCE, indexType, indexNumber);
   }
 
   /**
-   * Reassemble all chunks of a primitive long key. See {@link HOTIndexReader#get} for the
-   * algorithm; this is the long-key mirror.
+   * Reassemble all chunks of a primitive long key. See {@link HOTIndexReader#get} for the algorithm;
+   * this is the long-key mirror.
    */
   public @Nullable NodeReferences get(long key, SearchMode mode) {
     final byte[] keyBuf = KEY_BUFFER.get();
@@ -168,17 +169,17 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   }
 
   /**
-   * Check if any chunk exists for {@code key}. Cheaper than {@link #get} because we only need
-   * to find the first non-tombstone chunk slot, not reassemble the full bitmap.
+   * Check if any chunk exists for {@code key}. Cheaper than {@link #get} because we only need to find
+   * the first non-tombstone chunk slot, not reassemble the full bitmap.
    */
   public boolean containsKey(long key) {
     return get(key, SearchMode.EQUAL) != null;
   }
 
   /**
-   * Range iterator from {@code fromKey} (inclusive) with no upper bound. Used for PATH
-   * sub-tree scans (e.g., "all paths under prefix X" when path-keys are encoded so that
-   * sub-trees have contiguous long ranges).
+   * Range iterator from {@code fromKey} (inclusive) with no upper bound. Used for PATH sub-tree scans
+   * (e.g., "all paths under prefix X" when path-keys are encoded so that sub-trees have contiguous
+   * long ranges).
    */
   public Iterator<Map.Entry<Long, NodeReferences>> iteratorFrom(long fromKey) {
     final byte[] keyBuf = KEY_BUFFER.get();
@@ -215,8 +216,8 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   }
 
   /**
-   * Iterator that walks chunked composite-key range and groups consecutive same-prefix slots
-   * into logical {@link Map.Entry}{@code <Long, NodeReferences>}. See
+   * Iterator that walks chunked composite-key range and groups consecutive same-prefix slots into
+   * logical {@link Map.Entry}{@code <Long, NodeReferences>}. See
    * {@code HOTIndexReader.ChunkAggregatingIterator} for the K=Object mirror.
    */
   private final class ChunkAggregatingLongIterator implements Iterator<Map.Entry<Long, NodeReferences>> {
@@ -283,8 +284,8 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
         }
         if (fromPrefixFilter != null) {
           final int candidatePrefixLen = composite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-          if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen,
-              fromPrefixFilter, 0, fromPrefixFilter.length) < 0) {
+          if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen, fromPrefixFilter, 0,
+              fromPrefixFilter.length) < 0) {
             cursor.advance();
             continue;
           }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -36,7 +36,6 @@ import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.page.PageReference;
 import org.jspecify.annotations.Nullable;
-import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 import java.util.AbstractMap;
@@ -114,54 +113,7 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   }
 
   private @Nullable NodeReferences reassembleChunksForLongPrefix(byte[] prefixBuf, int prefixLen) {
-    final PageReference rootRef = getRootReference();
-    if (rootRef == null) {
-      return null;
-    }
-
-    final byte[] fromBytes = new byte[prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(prefixBuf, 0, fromBytes, 0, prefixLen);
-    HOTKeySerializer.writeChunkIdxBE(fromBytes, prefixLen, 0);
-
-    final byte[] toBytes = new byte[prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(prefixBuf, 0, toBytes, 0, prefixLen);
-    HOTKeySerializer.writeChunkIdxBE(toBytes, prefixLen, 0xFFFFFFFF);
-
-    Roaring64Bitmap merged = null;
-    try (HOTTrieReader reader = new HOTTrieReader(getStorageEngineReader());
-        HOTRangeCursor cursor = reader.range(rootRef, fromBytes, toBytes)) {
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        final byte[] composite = leaf.getKey(idx);
-        if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-            || Arrays.compareUnsigned(composite, 0, prefixLen, prefixBuf, 0, prefixLen) != 0) {
-          cursor.advance();
-          continue;
-        }
-        final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-        final byte[] chunkBytes = leaf.getValue(idx);
-        if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-          cursor.advance();
-          continue;
-        }
-        final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-        final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-        if (chunkBitmap.isEmpty()) {
-          cursor.advance();
-          continue;
-        }
-        if (merged == null) {
-          merged = new Roaring64Bitmap();
-        }
-        final long high = ((long) chunkIdx) << 16;
-        final LongIterator bIt = chunkBitmap.getLongIterator();
-        while (bIt.hasNext()) {
-          merged.add(high | (bIt.next() & 0xFFFFL));
-        }
-        cursor.advance();
-      }
-    }
+    final Roaring64Bitmap merged = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
     if (merged == null || merged.isEmpty()) {
       return null;
     }
@@ -276,19 +228,18 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
       }
       // Skip lex-pre-fromPrefix groups (HOT path-stack walk isn't lex-monotonic; see
       // HOTIndexReader.ChunkAggregatingIterator.fromPrefixFilter for the full rationale).
+      // Zero-copy per slot: length + prefix filtering read straight off the leaf.
       while (cursor.hasNext()) {
-        final byte[] composite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
-        if (composite.length < HOTKeySerializer.CHUNK_IDX_BYTES) {
+        final HOTLeafPage leaf = cursor.currentLeafPage();
+        final int idx = cursor.currentEntryIndex();
+        if (leaf.getKeyLength(idx) < HOTKeySerializer.CHUNK_IDX_BYTES) {
           cursor.advance();
           continue;
         }
-        if (fromPrefixFilter != null) {
-          final int candidatePrefixLen = composite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-          if (Arrays.compareUnsigned(composite, 0, candidatePrefixLen, fromPrefixFilter, 0,
-              fromPrefixFilter.length) < 0) {
-            cursor.advance();
-            continue;
-          }
+        if (fromPrefixFilter != null && leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES,
+            fromPrefixFilter, fromPrefixFilter.length) < 0) {
+          cursor.advance();
+          continue;
         }
         break;
       }
@@ -296,38 +247,20 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
         nextEntry = null;
         return;
       }
-      byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
-      if (groupComposite.length < HOTKeySerializer.CHUNK_IDX_BYTES) {
-        cursor.advance();
-        advance();
-        return;
-      }
+      // Materialize the group's composite key ONCE — it doubles as the logical-key bytes for
+      // deserialization at emit. Per-slot filtering below stays zero-copy against it.
+      final byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
       final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
+      final int compositeLen = groupComposite.length;
       Roaring64Bitmap merged = null;
       while (cursor.hasNext()) {
         final HOTLeafPage leaf = cursor.currentLeafPage();
         final int idx = cursor.currentEntryIndex();
-        final byte[] composite = leaf.getKey(idx);
-        if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-            || Arrays.compareUnsigned(composite, 0, prefixLen, groupComposite, 0, prefixLen) != 0) {
+        if (leaf.getKeyLength(idx) != compositeLen || leaf.compareKeyPrefix(idx, groupComposite, prefixLen) != 0) {
           break;
         }
-        final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-        final byte[] chunkBytes = leaf.getValue(idx);
-        if (!NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-          final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-          final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-          if (!chunkBitmap.isEmpty()) {
-            if (merged == null) {
-              merged = new Roaring64Bitmap();
-            }
-            final long high = ((long) chunkIdx) << 16;
-            final LongIterator bIt = chunkBitmap.getLongIterator();
-            while (bIt.hasNext()) {
-              merged.add(high | (bIt.next() & 0xFFFFL));
-            }
-          }
-        }
+        final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
+        merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
         cursor.advance();
       }
       if (merged == null || merged.isEmpty()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -27,20 +27,14 @@
  */
 package io.sirix.index.hot;
 
-import io.sirix.access.trx.page.HOTRangeCursor;
-import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.index.IndexType;
 import io.sirix.index.SearchMode;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
-import io.sirix.page.HOTLeafPage;
-import io.sirix.page.PageReference;
 import org.jspecify.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 /**
  * Primitive-specialized HOT index reader for long keys (PATH index).
@@ -122,150 +116,10 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
     return get(key, SearchMode.EQUAL) != null;
   }
 
-  /**
-   * Range iterator from {@code fromKey} (inclusive) with no upper bound. Used for PATH sub-tree scans
-   * (e.g., "all paths under prefix X" when path-keys are encoded so that sub-trees have contiguous
-   * long ranges).
-   */
-  public Iterator<Map.Entry<Long, NodeReferences>> iteratorFrom(long fromKey) {
-    final byte[] keyBuf = KEY_BUFFER.get();
-    final int fromLen = keySerializer.serialize(fromKey, keyBuf, 0);
-    final byte[] fromPrefix = Arrays.copyOf(keyBuf, fromLen);
-    final byte[] fromComposite = new byte[fromLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(fromPrefix, 0, fromComposite, 0, fromLen);
-    HOTKeySerializer.writeChunkIdxBE(fromComposite, fromLen, 0);
-    return new ChunkAggregatingLongIterator(fromComposite, null, fromPrefix);
-  }
-
-  /**
-   * Range iterator over {@code [fromKey, toKey]} inclusive on the logical long-key axis.
-   */
-  public Iterator<Map.Entry<Long, NodeReferences>> range(long fromKey, long toKey) {
-    final byte[] keyBuf = KEY_BUFFER.get();
-    final int fromLen = keySerializer.serialize(fromKey, keyBuf, 0);
-    final byte[] fromPrefix = Arrays.copyOf(keyBuf, fromLen);
-    final byte[] fromComposite = new byte[fromLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(fromPrefix, 0, fromComposite, 0, fromLen);
-    HOTKeySerializer.writeChunkIdxBE(fromComposite, fromLen, 0);
-
-    final int toLen = keySerializer.serialize(toKey, keyBuf, 0);
-    final byte[] toComposite = new byte[toLen + HOTKeySerializer.CHUNK_IDX_BYTES];
-    System.arraycopy(keyBuf, 0, toComposite, 0, toLen);
-    HOTKeySerializer.writeChunkIdxBE(toComposite, toLen, 0xFFFFFFFF);
-
-    return new ChunkAggregatingLongIterator(fromComposite, toComposite, fromPrefix);
-  }
 
   @Override
   public Iterator<Map.Entry<Long, NodeReferences>> iterator() {
-    return new ChunkAggregatingLongIterator(new byte[0], null, null);
-  }
-
-  /**
-   * Iterator that walks chunked composite-key range and groups consecutive same-prefix slots into
-   * logical {@link Map.Entry}{@code <Long, NodeReferences>}. See
-   * {@code HOTIndexReader.ChunkAggregatingIterator} for the K=Object mirror.
-   */
-  private final class ChunkAggregatingLongIterator implements Iterator<Map.Entry<Long, NodeReferences>> {
-    private final @Nullable HOTTrieReader trieReader;
-    private final @Nullable HOTRangeCursor cursor;
-    /** See {@code HOTIndexReader.ChunkAggregatingIterator.fromPrefixFilter} for rationale. */
-    private final byte @Nullable [] fromPrefixFilter;
-    /** Per-iterator chunk accumulator, reset per logical group. */
-    private final NodeReferencesSerializer.ChunkAccumulator accumulator =
-        new NodeReferencesSerializer.ChunkAccumulator();
-    private Map.@Nullable Entry<Long, NodeReferences> nextEntry;
-
-    ChunkAggregatingLongIterator(byte[] fromComposite, byte @Nullable [] toComposite,
-        byte @Nullable [] fromPrefixFilter) {
-      this.fromPrefixFilter = fromPrefixFilter;
-      final PageReference rootRef = getRootReference();
-      if (rootRef == null) {
-        this.trieReader = null;
-        this.cursor = null;
-        this.nextEntry = null;
-        return;
-      }
-      this.trieReader = new HOTTrieReader(getStorageEngineReader());
-      this.cursor = trieReader.range(rootRef, fromComposite, toComposite);
-      advance();
-    }
-
-    @Override
-    public boolean hasNext() {
-      return nextEntry != null;
-    }
-
-    @Override
-    public Map.Entry<Long, NodeReferences> next() {
-      if (nextEntry == null) {
-        throw new NoSuchElementException();
-      }
-      final Map.Entry<Long, NodeReferences> result = nextEntry;
-      advance();
-      if (nextEntry == null) {
-        closeQuietly();
-      }
-      return result;
-    }
-
-    private void closeQuietly() {
-      if (cursor != null) {
-        cursor.close();
-      }
-      if (trieReader != null) {
-        trieReader.close();
-      }
-    }
-
-    private void advance() {
-      if (cursor == null) {
-        nextEntry = null;
-        return;
-      }
-      // Skip lex-pre-fromPrefix groups (HOT path-stack walk isn't lex-monotonic; see
-      // HOTIndexReader.ChunkAggregatingIterator.fromPrefixFilter for the full rationale).
-      // Zero-copy per slot: length + prefix filtering read straight off the leaf.
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        if (leaf.getKeyLength(idx) < HOTKeySerializer.CHUNK_IDX_BYTES) {
-          cursor.advance();
-          continue;
-        }
-        if (fromPrefixFilter != null && leaf.compareKeyPrefixPart(idx, HOTKeySerializer.CHUNK_IDX_BYTES,
-            fromPrefixFilter, fromPrefixFilter.length) < 0) {
-          cursor.advance();
-          continue;
-        }
-        break;
-      }
-      if (!cursor.hasNext()) {
-        nextEntry = null;
-        return;
-      }
-      // Materialize the group's composite key ONCE — it doubles as the logical-key bytes for
-      // deserialization at emit. Per-slot filtering below stays zero-copy against it.
-      final byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
-      final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
-      final int compositeLen = groupComposite.length;
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        if (leaf.getKeyLength(idx) != compositeLen || leaf.compareKeyPrefix(idx, groupComposite, prefixLen) != 0) {
-          break;
-        }
-        final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-        accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
-        cursor.advance();
-      }
-      final NodeReferences groupRefs = accumulator.toNodeReferencesAndReset();
-      if (groupRefs == null) {
-        advance();
-        return;
-      }
-      nextEntry = new LazyKeyEntry(groupComposite, prefixLen, groupRefs);
-    }
+    return new ChunkAggregatingIterator(null, true, null, true);
   }
 
   @Override
@@ -282,11 +136,6 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   @Override
   protected @Nullable Long deserializeKey(byte[] buffer, int offset, int length) {
     return keySerializer.deserialize(buffer, offset, length);
-  }
-
-  @Override
-  protected int compareKeys(byte[] key1, int offset1, int length1, byte[] key2, int offset2, int length2) {
-    return keySerializer.compare(key1, offset1, length1, key2, offset2, length2);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -343,6 +343,12 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
     return keySerializer.serialize(key, buffer, offset);
   }
 
+  /** A PATH key is a fixed-width sign-flipped long. */
+  @Override
+  protected int maxSerializedKeyLength(Long key) {
+    return HOTLongKeySerializer.SERIALIZED_SIZE;
+  }
+
   @Override
   protected @Nullable Long deserializeKey(byte[] buffer, int offset, int length) {
     return keySerializer.deserialize(buffer, offset, length);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -101,19 +101,7 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   public @Nullable NodeReferences get(long key, SearchMode mode) {
     final byte[] keyBuf = KEY_BUFFER.get();
     final int prefixLen = keySerializer.serialize(key, keyBuf, 0);
-    return reassembleChunksForLongPrefix(keyBuf, prefixLen);
-  }
-
-  private @Nullable NodeReferences reassembleChunksForLongPrefix(byte[] prefixBuf, int prefixLen) {
-    return collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
-  }
-
-  /**
-   * Check if any chunk exists for {@code key}. Cheaper than {@link #get} because we only need to find
-   * the first non-tombstone chunk slot, not reassemble the full bitmap.
-   */
-  public boolean containsKey(long key) {
-    return get(key, SearchMode.EQUAL) != null;
+    return collectChunksViaLowerBoundWalk(keyBuf, prefixLen);
   }
 
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -97,11 +97,21 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   /**
    * Reassemble all chunks of a primitive long key. See {@link HOTIndexReader#get} for the algorithm;
    * this is the long-key mirror.
+   *
+   * @param key the logical index key
+   * @param mode must be {@link SearchMode#EQUAL}; range modes go via the range cursors
+   * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
+   * @throws IllegalArgumentException if {@code mode} is not {@link SearchMode#EQUAL} — same guard,
+   *         same reason as {@link HOTIndexReader#get}, and shared with it so an unguarded twin cannot
+   *         reach the memoized path.
    */
-  public @Nullable NodeReferences get(long key, SearchMode mode) {
+  public @Nullable NodeReferences get(final long key, final SearchMode mode) {
+    requireEqualMode(mode);
     final byte[] keyBuf = KEY_BUFFER.get();
     final int prefixLen = keySerializer.serialize(key, keyBuf, 0);
-    return collectChunksViaLowerBoundWalk(keyBuf, prefixLen);
+    // Same memoization as HOTIndexReader#get: deterministic for a committed revision, bypassed for
+    // a writer-backed reader.
+    return pointLookup(keyBuf, prefixLen);
   }
 
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -38,7 +38,6 @@ import io.sirix.page.PageReference;
 import org.jspecify.annotations.Nullable;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
-import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
@@ -267,8 +266,7 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
         advance();
         return;
       }
-      final Long logicalKey = keySerializer.deserialize(groupComposite, 0, prefixLen);
-      nextEntry = new AbstractMap.SimpleImmutableEntry<>(logicalKey, NodeReferences.owning(merged));
+      nextEntry = new LazyKeyEntry(groupComposite, prefixLen, NodeReferences.owning(merged));
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexReader.java
@@ -36,7 +36,6 @@ import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.page.PageReference;
 import org.jspecify.annotations.Nullable;
-import org.roaringbitmap.longlong.Roaring64Bitmap;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -112,11 +111,7 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
   }
 
   private @Nullable NodeReferences reassembleChunksForLongPrefix(byte[] prefixBuf, int prefixLen) {
-    final Roaring64Bitmap merged = collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
-    if (merged == null || merged.isEmpty()) {
-      return null;
-    }
-    return NodeReferences.owning(merged);
+    return collectChunksViaLowerBoundWalk(prefixBuf, prefixLen);
   }
 
   /**
@@ -176,6 +171,9 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
     private final @Nullable HOTRangeCursor cursor;
     /** See {@code HOTIndexReader.ChunkAggregatingIterator.fromPrefixFilter} for rationale. */
     private final byte @Nullable [] fromPrefixFilter;
+    /** Per-iterator chunk accumulator, reset per logical group. */
+    private final NodeReferencesSerializer.ChunkAccumulator accumulator =
+        new NodeReferencesSerializer.ChunkAccumulator();
     private Map.@Nullable Entry<Long, NodeReferences> nextEntry;
 
     ChunkAggregatingLongIterator(byte[] fromComposite, byte @Nullable [] toComposite,
@@ -251,7 +249,6 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
       final byte[] groupComposite = cursor.currentLeafPage().getKey(cursor.currentEntryIndex());
       final int prefixLen = groupComposite.length - HOTKeySerializer.CHUNK_IDX_BYTES;
       final int compositeLen = groupComposite.length;
-      Roaring64Bitmap merged = null;
       while (cursor.hasNext()) {
         final HOTLeafPage leaf = cursor.currentLeafPage();
         final int idx = cursor.currentEntryIndex();
@@ -259,14 +256,15 @@ public final class HOTLongIndexReader extends AbstractHOTIndexReader<Long> {
           break;
         }
         final long chunkIdx = leaf.readKeyIntBE(idx, prefixLen) & 0xFFFFFFFFL;
-        merged = NodeReferencesSerializer.mergeChunkInto(leaf, leaf.valueRef(idx), chunkIdx << 16, merged);
+        accumulator.addChunk(leaf, leaf.valueRef(idx), chunkIdx << 16);
         cursor.advance();
       }
-      if (merged == null || merged.isEmpty()) {
+      final NodeReferences groupRefs = accumulator.toNodeReferencesAndReset();
+      if (groupRefs == null) {
         advance();
         return;
       }
-      nextEntry = new LazyKeyEntry(groupComposite, prefixLen, NodeReferences.owning(merged));
+      nextEntry = new LazyKeyEntry(groupComposite, prefixLen, groupRefs);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
@@ -90,8 +90,8 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
    * @param indexType the index type (should be PATH)
    * @param indexNumber the index number
    */
-  private HOTLongIndexWriter(StorageEngineWriter storageEngineWriter, HOTLongKeySerializer keySerializer, IndexType indexType,
-      int indexNumber) {
+  private HOTLongIndexWriter(StorageEngineWriter storageEngineWriter, HOTLongKeySerializer keySerializer,
+      IndexType indexType, int indexNumber) {
     super(storageEngineWriter, indexType, indexNumber);
     this.keySerializer = requireNonNull(keySerializer);
 
@@ -113,14 +113,15 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
    * @param indexNumber the index number
    * @return a new HOTLongIndexWriter instance
    */
-  public static HOTLongIndexWriter create(StorageEngineWriter storageEngineWriter, IndexType indexType, int indexNumber) {
+  public static HOTLongIndexWriter create(StorageEngineWriter storageEngineWriter, IndexType indexType,
+      int indexNumber) {
     return new HOTLongIndexWriter(storageEngineWriter, PathKeySerializer.INSTANCE, indexType, indexNumber);
   }
 
   /**
-   * Chunked-bitmap variant of {@link HOTIndexWriter#index} for primitive long keys (PATH).
-   * Splits the input bitmap by {@code chunkIdx = (int)(nodeKey >>> 16)} and ORs each bit16 into
-   * its {@code (longKeyBE ‖ chunkIdx_be4)} chunk slot.
+   * Chunked-bitmap variant of {@link HOTIndexWriter#index} for primitive long keys (PATH). Splits the
+   * input bitmap by {@code chunkIdx = (int)(nodeKey >>> 16)} and ORs each bit16 into its
+   * {@code (longKeyBE ‖ chunkIdx_be4)} chunk slot.
    */
   public NodeReferences index(long key, NodeReferences value, RBTreeReader.MoveCursor move) {
     requireNonNull(value);
@@ -138,11 +139,13 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
   /**
    * Add a single nodeKey to {@code key}'s chunked bitmap.
    *
-   * <p>Equivalent to {@link #index(long, NodeReferences, RBTreeReader.MoveCursor)} with a
-   * one-element {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot
-   * write is an OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to
-   * ADD one reference never has to materialise — let alone read back — the references already
-   * stored under {@code key}.</p>
+   * <p>
+   * Equivalent to {@link #index(long, NodeReferences, RBTreeReader.MoveCursor)} with a one-element
+   * {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot write is an
+   * OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to ADD one
+   * reference never has to materialise — let alone read back — the references already stored under
+   * {@code key}.
+   * </p>
    *
    * @param key the logical index key (a path-class record)
    * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
@@ -156,9 +159,11 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
    * {@link HOTBulkBuilder} pass — the right shape for building an index over an already-shredded
    * revision.
    *
-   * <p>Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
-   * <em>replaces</em> the root rather than merging into it. Callers that may run against a
-   * populated tree must check first and fall back to {@link #indexNodeKey(long, long)}.</p>
+   * <p>
+   * Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
+   * <em>replaces</em> the root rather than merging into it. Callers that may run against a populated
+   * tree must check first and fall back to {@link #indexNodeKey(long, long)}.
+   * </p>
    *
    * @return a fresh bulk loader bound to this writer
    */
@@ -258,7 +263,9 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
 
     final byte[] keyBuf = KEY_BUFFER.get();
     final int compLen = keySerializer.serializeWithChunkIdx(key, chunkIdx, keyBuf, 0);
-    final byte[] keySlice = compLen == keyBuf.length ? keyBuf : Arrays.copyOf(keyBuf, compLen);
+    final byte[] keySlice = compLen == keyBuf.length
+        ? keyBuf
+        : Arrays.copyOf(keyBuf, compLen);
 
     final LeafNavigationResult navResult = prepareLeafOfTree(rootReference, keySlice, compLen);
     final HOTLeafPage leaf = navResult.leaf();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
@@ -77,9 +77,6 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
    */
   private static final ThreadLocal<NodeReferences> SINGLE_BIT_REFS = ThreadLocal.withInitial(NodeReferences::new);
 
-  /** Same chunked-bitmap nodeKey range cap as {@link HOTIndexWriter#MAX_NODE_KEY}. */
-  private static final long MAX_NODE_KEY = (1L << 48) - 1L;
-
   private final HOTLongKeySerializer keySerializer;
 
   /** Lazy reader for chunked reassembly. */
@@ -138,14 +135,39 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
     return value;
   }
 
+  /**
+   * Add a single nodeKey to {@code key}'s chunked bitmap.
+   *
+   * <p>Equivalent to {@link #index(long, NodeReferences, RBTreeReader.MoveCursor)} with a
+   * one-element {@link NodeReferences}, minus the {@code Roaring64Bitmap} allocation: the slot
+   * write is an OR-merge ({@link HOTLeafPage#mergeWithNodeRefs}), so a caller that only wants to
+   * ADD one reference never has to materialise — let alone read back — the references already
+   * stored under {@code key}.</p>
+   *
+   * @param key the logical index key (a path-class record)
+   * @param nodeKey the node key to add; must be in {@code [0, 2^48)}
+   */
+  public void indexNodeKey(long key, long nodeKey) {
+    addNodeKeyToChunk(key, nodeKey);
+  }
+
+  /**
+   * A loader that collects {@code (key, nodeKey)} pairs and materialises the whole index in one
+   * {@link HOTBulkBuilder} pass — the right shape for building an index over an already-shredded
+   * revision.
+   *
+   * <p>Only valid while the index tree is still empty ({@link #isEmptyTree()}): the loader
+   * <em>replaces</em> the root rather than merging into it. Callers that may run against a
+   * populated tree must check first and fall back to {@link #indexNodeKey(long, long)}.</p>
+   *
+   * @return a fresh bulk loader bound to this writer
+   */
+  public HOTLongBulkIndexLoader createBulkLoader() {
+    return new HOTLongBulkIndexLoader(this, keySerializer);
+  }
+
   private void addNodeKeyToChunk(long key, long nodeKey) {
-    if (nodeKey < 0L) {
-      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
-    }
-    if (nodeKey > MAX_NODE_KEY) {
-      throw new IllegalArgumentException("nodeKey " + nodeKey
-          + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
-    }
+    AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;
 
@@ -230,13 +252,7 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
    * {@link HOTIndexWriter#remove}.
    */
   public boolean remove(long key, long nodeKey) {
-    if (nodeKey < 0L) {
-      throw new IllegalArgumentException("nodeKey must be non-negative: " + nodeKey);
-    }
-    if (nodeKey > MAX_NODE_KEY) {
-      throw new IllegalArgumentException("nodeKey " + nodeKey
-          + " exceeds chunked-bitmap range (max " + MAX_NODE_KEY + ")");
-    }
+    AbstractHOTIndexWriter.checkNodeKeyRange(nodeKey);
     final int chunkIdx = (int) (nodeKey >>> 16);
     final long bit16 = nodeKey & 0xFFFFL;
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
@@ -191,8 +191,18 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
   /**
    * Reassemble all chunks of {@code key} into a single {@link NodeReferences}. See
    * {@link HOTIndexReader#get} for the algorithm; this is the primitive-long mirror.
+   *
+   * @param key the logical index key
+   * @param mode must be {@link SearchMode#EQUAL}; range modes go via the range cursors
+   * @return reassembled NodeReferences, or {@code null} if no chunks exist for {@code key}
+   * @throws IllegalArgumentException if {@code mode} is not {@link SearchMode#EQUAL} — same guard,
+   *         same reason as {@link HOTIndexReader#get}, which previously documented the mode as
+   *         advisory and silently ignored it
    */
-  public @Nullable NodeReferences get(long key, SearchMode mode) {
+  public @Nullable NodeReferences get(final long key, final SearchMode mode) {
+    // See HOTIndexWriter#get — one shared rule, enforced on every twin rather than on whichever one
+    // was edited last.
+    AbstractHOTIndexReader.requireEqualMode(mode);
     final byte[] keyBuf = KEY_BUFFER.get();
     final int prefixLen = keySerializer.serialize(key, keyBuf, 0);
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTLongIndexWriter.java
@@ -212,39 +212,11 @@ public final class HOTLongIndexWriter extends AbstractHOTIndexWriter<Long> {
     if (chunkReader == null) {
       chunkReader = new HOTTrieReader(storageEngineWriter);
     }
-    Roaring64Bitmap merged = null;
+    // The sweep reads UNPINNED leaves under optimistic stamps — the shared helper validates each
+    // slot's copies against the cursor's leaf stamp before anything reaches the deserializer.
+    final Roaring64Bitmap merged;
     try (HOTRangeCursor cursor = chunkReader.range(rootRef, fromBytes, toBytes)) {
-      while (cursor.hasNext()) {
-        final HOTLeafPage leaf = cursor.currentLeafPage();
-        final int idx = cursor.currentEntryIndex();
-        final byte[] composite = leaf.getKey(idx);
-        if (composite.length != prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES
-            || Arrays.compareUnsigned(composite, 0, prefixLen, keyBuf, 0, prefixLen) != 0) {
-          cursor.advance();
-          continue;
-        }
-        final int chunkIdx = HOTKeySerializer.readChunkIdx(composite, 0, composite.length);
-        final byte[] chunkBytes = leaf.getValue(idx);
-        if (NodeReferencesSerializer.isTombstone(chunkBytes, 0, chunkBytes.length)) {
-          cursor.advance();
-          continue;
-        }
-        final NodeReferences chunkRefs = NodeReferencesSerializer.deserialize(chunkBytes);
-        final Roaring64Bitmap chunkBitmap = chunkRefs.getNodeKeys();
-        if (chunkBitmap.isEmpty()) {
-          cursor.advance();
-          continue;
-        }
-        if (merged == null) {
-          merged = new Roaring64Bitmap();
-        }
-        final long high = ((long) chunkIdx) << 16;
-        final LongIterator bIt = chunkBitmap.getLongIterator();
-        while (bIt.hasNext()) {
-          merged.add(high | (bIt.next() & 0xFFFFL));
-        }
-        cursor.advance();
-      }
+      merged = NodeReferencesSerializer.mergeChunksInPrefixRange(cursor, keyBuf, prefixLen);
     }
     if (merged == null || merged.isEmpty()) {
       return null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTMalformedSubtreeDetector.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTMalformedSubtreeDetector.java
@@ -22,39 +22,45 @@ import java.util.Set;
  * docs/HOT_FORMAL_FOUNDATION.md} §8). Walks a HOT secondary-index trie top-down and returns the
  * <em>highest</em> malformed indirect pages — the roots of the maximal drifted subtrees.
  *
- * <p><b>What "malformed" means.</b> An indirect is malformed when it violates a structural
- * invariant in its own block. The predicates mirror {@code HOTInvariantValidator} (the executable
- * specification of the foundation document's §2 invariants); a production detector cannot depend
- * on that test-only class, so the per-indirect predicate logic is reproduced here:
+ * <p>
+ * <b>What "malformed" means.</b> An indirect is malformed when it violates a structural invariant
+ * in its own block. The predicates mirror {@code HOTInvariantValidator} (the executable
+ * specification of the foundation document's §2 invariants); a production detector cannot depend on
+ * that test-only class, so the per-indirect predicate logic is reproduced here:
  * <ul>
- *   <li><b>I3</b> — partial-key uniqueness: no two children share a stored partial.</li>
- *   <li><b>I4</b> — first-partial-zero: the smallest stored partial is {@code 0} (Binna's "first
- *       mask always zero" rule under sparse-path encoding).</li>
- *   <li><b>I5</b> — leaf-constancy: for every child {@code i} with a non-zero stored partial
- *       {@code p_i}, every key {@code K} in {@code subtree(child_i)} satisfies
- *       {@code (p_i & ~densePK(K, mask)) == 0}. I5 is the routing-soundness linchpin
- *       (foundation Theorem 2).</li>
- *   <li><b>I7</b> — partial keys strictly ascending (unsigned) across child slots.</li>
- *   <li><b>I8</b> — children ordered by ascending first-key of their subtree (range-scan
- *       correctness — {@code HOTRangeCursor} advances by child index).</li>
- *   <li><b>I11</b> — trie condition: each indirect child's most-significant discriminative bit is
- *       strictly less significant than this node's. I11 is cross-level; a violation on edge
- *       {@code (P, C)} is attributed to the <em>parent</em> {@code P}, because rebuilding
- *       {@code P}'s subtree (which contains both {@code P} and {@code C}) is what fixes it.</li>
+ * <li><b>I3</b> — partial-key uniqueness: no two children share a stored partial.</li>
+ * <li><b>I4</b> — first-partial-zero: the smallest stored partial is {@code 0} (Binna's "first mask
+ * always zero" rule under sparse-path encoding).</li>
+ * <li><b>I5</b> — leaf-constancy: for every child {@code i} with a non-zero stored partial
+ * {@code p_i}, every key {@code K} in {@code subtree(child_i)} satisfies
+ * {@code (p_i & ~densePK(K, mask)) == 0}. I5 is the routing-soundness linchpin (foundation Theorem
+ * 2).</li>
+ * <li><b>I7</b> — partial keys strictly ascending (unsigned) across child slots.</li>
+ * <li><b>I8</b> — children ordered by ascending first-key of their subtree (range-scan correctness
+ * — {@code HOTRangeCursor} advances by child index).</li>
+ * <li><b>I12</b> — subtree ranges disjoint: consecutive children's key ranges must not interleave
+ * (checked at their shared boundary; sound at detectAndHeal's fixed point).</li>
+ * <li><b>I11</b> — trie condition: each indirect child's most-significant discriminative bit is
+ * strictly less significant than this node's. I11 is cross-level; a violation on edge
+ * {@code (P, C)} is attributed to the <em>parent</em> {@code P}, because rebuilding {@code P}'s
+ * subtree (which contains both {@code P} and {@code C}) is what fixes it.</li>
  * </ul>
  *
- * <p><b>Highest-malformed semantics.</b> The walk is a pre-order DFS. When an indirect is found
+ * <p>
+ * <b>Highest-malformed semantics.</b> The walk is a pre-order DFS. When an indirect is found
  * malformed, its page is recorded and the walk does <em>not</em> descend into it: rebuilding the
  * highest malformed indirect with {@link HOTBulkBuilder} produces a canonical subtree (foundation
  * Theorem 1) and therefore subsumes every malformed descendant (Binna Lemma 3 — a subtree's
  * canonical form depends only on its own keys). The returned subtrees are pairwise non-nested.
  *
- * <p><b>Purity.</b> The detector reads only; it never mutates a page or performs I/O. Pages are
- * obtained through a caller-supplied {@link PageResolver} so the same detector serves a
- * commit-path writer (TIL-aware resolution) and a unit test (swizzled-page resolution).
+ * <p>
+ * <b>Purity.</b> The detector reads only; it never mutates a page or performs I/O. Pages are
+ * obtained through a caller-supplied {@link PageResolver} so the same detector serves a commit-path
+ * writer (TIL-aware resolution) and a unit test (swizzled-page resolution).
  *
- * <p><b>Cost.</b> One DFS per index. The I5 check walks each indirect's subtree keys; summed over
- * a root-to-leaf path a key is visited once per ancestor, and HOT's height is a small constant
+ * <p>
+ * <b>Cost.</b> One DFS per index. The I5 check walks each indirect's subtree keys; summed over a
+ * root-to-leaf path a key is visited once per ancestor, and HOT's height is a small constant
  * (height-optimized — {@code log_k |S|}), so the pass is {@code O(|S|)} per index.
  *
  * @author Johannes Lichtenberger
@@ -67,29 +73,31 @@ public final class HOTMalformedSubtreeDetector {
   private static final int MAX_DEPTH = 64;
 
   /**
-   * Resolves a {@link PageReference} to its in-memory {@link Page}. Returning {@code null} marks
-   * the reference as unresolvable; the detector then skips that branch rather than failing.
+   * Resolves a {@link PageReference} to its in-memory {@link Page}. Returning {@code null} marks the
+   * reference as unresolvable; the detector then skips that branch rather than failing.
    */
   @FunctionalInterface
   public interface PageResolver {
-    @Nullable Page resolve(PageReference reference);
+    @Nullable
+    Page resolve(PageReference reference);
   }
 
   /**
-   * A maximal malformed subtree: the indirect page that is the highest violating node of a
-   * drifted region. Rebuilding the subtree rooted here with {@link HOTBulkBuilder} repairs it.
+   * A maximal malformed subtree: the indirect page that is the highest violating node of a drifted
+   * region. Rebuilding the subtree rooted here with {@link HOTBulkBuilder} repairs it.
    *
-   * @param reference        the in-trie reference whose page is the malformed indirect (the
-   *                         copy-on-write splice point for a rebuild)
-   * @param indirectPageKey  the malformed indirect's page key
-   * @param invariant        the first violated invariant tag (diagnostic)
-   * @param detail           a human-readable description of the violation (diagnostic)
+   * @param reference the in-trie reference whose page is the malformed indirect (the copy-on-write
+   *        splice point for a rebuild)
+   * @param indirectPageKey the malformed indirect's page key
+   * @param invariant the first violated invariant tag (diagnostic)
+   * @param detail a human-readable description of the violation (diagnostic)
    */
-  public record MalformedSubtree(PageReference reference, long indirectPageKey, String invariant,
-                                 String detail) {}
+  public record MalformedSubtree(PageReference reference, long indirectPageKey, String invariant, String detail) {
+  }
 
   /** First violated invariant of an indirect's own block — {@code null} encodes "clean". */
-  private record Defect(String invariant, String detail) {}
+  private record Defect(String invariant, String detail) {
+  }
 
   private final PageResolver resolver;
   private final List<MalformedSubtree> malformed = new ArrayList<>();
@@ -102,11 +110,10 @@ public final class HOTMalformedSubtreeDetector {
   /**
    * Walk the HOT trie rooted at {@code rootReference} and return its highest malformed indirects.
    *
-   * @param rootReference the trie root; {@code null} (an unmaterialized index) yields an empty
-   *                      result
-   * @param resolver      resolves page references to in-memory pages
-   * @return the maximal malformed subtrees in pre-order; empty when the trie is canonical or has
-   *         no indirect pages (a single-leaf index cannot have a malformed <em>indirect</em>)
+   * @param rootReference the trie root; {@code null} (an unmaterialized index) yields an empty result
+   * @param resolver resolves page references to in-memory pages
+   * @return the maximal malformed subtrees in pre-order; empty when the trie is canonical or has no
+   *         indirect pages (a single-leaf index cannot have a malformed <em>indirect</em>)
    * @throws NullPointerException if {@code resolver} is {@code null}
    */
   public static List<MalformedSubtree> detect(final @Nullable PageReference rootReference,
@@ -127,8 +134,7 @@ public final class HOTMalformedSubtreeDetector {
   // Pre-order DFS — record a malformed indirect and stop; descend into clean ones.
   // ======================================================================
 
-  private void walk(final PageReference reference, final HOTIndirectPage indirect,
-      final int depth) {
+  private void walk(final PageReference reference, final HOTIndirectPage indirect, final int depth) {
     if (depth > MAX_DEPTH) {
       return;
     }
@@ -171,8 +177,7 @@ public final class HOTMalformedSubtreeDetector {
         for (int j = i + 1; j < n; j++) {
           if (partials[i] == partials[j]) {
             return new Defect("I3-partial-key-uniqueness",
-                "duplicate partial 0x" + Integer.toHexString(partials[i]) + " at children "
-                    + i + " and " + j);
+                "duplicate partial 0x" + Integer.toHexString(partials[i]) + " at children " + i + " and " + j);
           }
         }
       }
@@ -196,10 +201,8 @@ public final class HOTMalformedSubtreeDetector {
     if (partialsUsable) {
       for (int i = 1; i < n; i++) {
         if (Integer.compareUnsigned(partials[i], partials[i - 1]) <= 0) {
-          return new Defect("I7-partial-keys-sorted",
-              "partials not ascending at " + (i - 1) + "->" + i + ": 0x"
-                  + Integer.toHexString(partials[i - 1]) + " vs 0x"
-                  + Integer.toHexString(partials[i]));
+          return new Defect("I7-partial-keys-sorted", "partials not ascending at " + (i - 1) + "->" + i + ": 0x"
+              + Integer.toHexString(partials[i - 1]) + " vs 0x" + Integer.toHexString(partials[i]));
         }
       }
     }
@@ -216,16 +219,25 @@ public final class HOTMalformedSubtreeDetector {
         if (resolve(childReference) instanceof HOTIndirectPage childIndirect) {
           final int childMSB = childIndirect.getMostSignificantBitIndex();
           if (childMSB >= 0 && childMSB <= parentMSB) {
-            return new Defect("I11-trie-condition",
-                "child[" + i + "]=" + childIndirect.getPageKey() + " MSB=" + childMSB
-                    + " must be > parent MSB=" + parentMSB);
+            return new Defect("I11-trie-condition", "child[" + i + "]=" + childIndirect.getPageKey() + " MSB="
+                + childMSB + " must be > parent MSB=" + parentMSB);
           }
         }
       }
     }
 
-    // I8 — children ordered by ascending first-key of their subtree.
+    // I8 — children ordered by ascending first-key of their subtree — and I12, its strict form:
+    // consecutive children's key RANGES must not interleave. I8 alone compares first keys, so a
+    // child whose subtree also holds keys sorting after its successor's first key passes it; point
+    // lookups still route, but a range scan silently emits keys out of order. The check is local on
+    // purpose: a child's extremes are read off its leftmost/rightmost edge descents, which report
+    // the true extremes exactly when the child's own subtree is clean — and detectAndHeal re-runs
+    // this detector after every discharge until nothing is found, so a spurious pass against a
+    // still-malformed child cannot survive to that fixed point. At the fixed point the local
+    // condition implies full range-disjointness by induction over the height, at O(children x
+    // height) per node instead of the O(subtree) key walk the direct range computation would cost.
     byte[] previousFirstKey = null;
+    byte[] previousLastKey = null;
     for (int i = 0; i < n; i++) {
       final PageReference childReference = indirect.getChildReference(i);
       if (childReference == null) {
@@ -235,13 +247,19 @@ public final class HOTMalformedSubtreeDetector {
       if (firstKey == null) {
         continue;
       }
-      if (previousFirstKey != null
-          && Arrays.compareUnsigned(previousFirstKey, firstKey) >= 0) {
+      if (previousFirstKey != null && Arrays.compareUnsigned(previousFirstKey, firstKey) >= 0) {
         return new Defect("I8-children-sorted-by-firstkey",
-            "child[" + i + "] firstKey " + hex(firstKey) + " <= a preceding child's firstKey "
-                + hex(previousFirstKey));
+            "child[" + i + "] firstKey " + hex(firstKey) + " <= a preceding child's firstKey " + hex(previousFirstKey));
+      }
+      if (previousLastKey != null && Arrays.compareUnsigned(previousLastKey, firstKey) >= 0) {
+        return new Defect("I12-subtree-ranges-disjoint", "child[" + i + "] starts at " + hex(firstKey)
+            + " but a preceding child's subtree spans up to " + hex(previousLastKey) + " — the subtrees interleave");
       }
       previousFirstKey = firstKey;
+      final byte[] lastKey = lastKeyOfSubtree(childReference);
+      if (lastKey != null) {
+        previousLastKey = lastKey;
+      }
     }
 
     // I5 — leaf-constancy. The expensive check (a subtree-wide key walk) runs last so a cheaper
@@ -258,13 +276,12 @@ public final class HOTMalformedSubtreeDetector {
         if (childReference == null) {
           continue;
         }
-        final byte[] failingKey =
-            findI5FailingKey(childReference, indirect, sparsePartial, 0, failingDensePK);
+        final byte[] failingKey = findI5FailingKey(childReference, indirect, sparsePartial, 0, failingDensePK);
         if (failingKey != null) {
           return new Defect("I5-leaf-constancy",
               "child[" + i + "] stored partial 0x" + Integer.toHexString(sparsePartial)
-                  + " is not a subset of dense PEXT 0x" + Integer.toHexString(failingDensePK[0])
-                  + " of subtree key " + hex(failingKey));
+                  + " is not a subset of dense PEXT 0x" + Integer.toHexString(failingDensePK[0]) + " of subtree key "
+                  + hex(failingKey));
         }
       }
     }
@@ -278,13 +295,12 @@ public final class HOTMalformedSubtreeDetector {
 
   /**
    * Find the first key in the subtree at {@code reference} whose dense partial key under
-   * {@code maskNode}'s mask fails the sparse-path subset condition for {@code sparsePartial}
-   * (i.e. {@code (sparsePartial & ~densePK) != 0}). Returns {@code null} when every key passes;
+   * {@code maskNode}'s mask fails the sparse-path subset condition for {@code sparsePartial} (i.e.
+   * {@code (sparsePartial & ~densePK) != 0}). Returns {@code null} when every key passes;
    * {@code failingDensePK[0]} receives the offending key's dense partial key.
    */
-  private byte @Nullable [] findI5FailingKey(final PageReference reference,
-      final HOTIndirectPage maskNode, final int sparsePartial, final int depth,
-      final int[] failingDensePK) {
+  private byte @Nullable [] findI5FailingKey(final PageReference reference, final HOTIndirectPage maskNode,
+      final int sparsePartial, final int depth, final int[] failingDensePK) {
     if (depth > MAX_DEPTH) {
       return null;
     }
@@ -312,8 +328,7 @@ public final class HOTMalformedSubtreeDetector {
         if (childReference == null) {
           continue;
         }
-        final byte[] failing =
-            findI5FailingKey(childReference, maskNode, sparsePartial, depth + 1, failingDensePK);
+        final byte[] failing = findI5FailingKey(childReference, maskNode, sparsePartial, depth + 1, failingDensePK);
         if (failing != null) {
           return failing;
         }
@@ -331,7 +346,9 @@ public final class HOTMalformedSubtreeDetector {
     for (int depth = 0; depth <= MAX_DEPTH; depth++) {
       final Page page = resolve(current);
       if (page instanceof HOTLeafPage leaf) {
-        return leaf.getEntryCount() == 0 ? null : leaf.getFirstKey();
+        return leaf.getEntryCount() == 0
+            ? null
+            : leaf.getFirstKey();
       }
       if (!(page instanceof HOTIndirectPage indirect) || indirect.getNumChildren() == 0) {
         return null;
@@ -344,15 +361,45 @@ public final class HOTMalformedSubtreeDetector {
     return null;
   }
 
+  /**
+   * The last (lex-greatest) key of the subtree at {@code reference}, found by rightmost descent — the
+   * true maximum once the subtree is internally clean, which is all the I12 boundary check needs (see
+   * the comment there). Returns {@code null} for an empty or unresolvable subtree.
+   */
+  private byte @Nullable [] lastKeyOfSubtree(final PageReference reference) {
+    PageReference current = reference;
+    for (int depth = 0; depth <= MAX_DEPTH; depth++) {
+      final Page page = resolve(current);
+      if (page instanceof HOTLeafPage leaf) {
+        final int entryCount = leaf.getEntryCount();
+        return entryCount == 0
+            ? null
+            : leaf.getKey(entryCount - 1);
+      }
+      if (!(page instanceof HOTIndirectPage indirect) || indirect.getNumChildren() == 0) {
+        return null;
+      }
+      current = indirect.getChildReference(indirect.getNumChildren() - 1);
+      if (current == null) {
+        return null;
+      }
+    }
+    return null;
+  }
+
   private @Nullable Page resolve(final @Nullable PageReference reference) {
     if (reference == null) {
       return null;
     }
     final Page page = resolver.resolve(reference);
-    return page != null && !page.isClosed() ? page : null;
+    return page != null && !page.isClosed()
+        ? page
+        : null;
   }
 
   private static String hex(final byte @Nullable [] bytes) {
-    return bytes == null ? "null" : HexFormat.of().formatHex(bytes);
+    return bytes == null
+        ? "null"
+        : HexFormat.of().formatHex(bytes);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
@@ -142,9 +142,9 @@ public final class NameKeySerializer implements HOTKeySerializer<QNm> {
   }
 
   /**
-   * A local name and a prefix are written as raw UTF-8, so the bound is three bytes a char — the
-   * most any single {@code char} encodes to, a surrogate pair being two chars for four bytes — plus
-   * the sentinel and length byte the prefixed format prepends.
+   * A local name and a prefix are written as raw UTF-8, so the bound is three bytes a char — the most
+   * any single {@code char} encodes to, a surrogate pair being two chars for four bytes — plus the
+   * sentinel and length byte the prefixed format prepends.
    *
    * @throws IllegalArgumentException if the name is so long that its own bound overflows an
    *         {@code int}; such a name could never be serialized into any buffer anyway
@@ -154,7 +154,9 @@ public final class NameKeySerializer implements HOTKeySerializer<QNm> {
     requireNonNull(key, "Key cannot be null");
     final String localName = key.getLocalName();
     final String prefix = key.getPrefix();
-    long bound = localName == null ? 0L : 3L * localName.length();
+    long bound = localName == null
+        ? 0L
+        : 3L * localName.length();
     if (prefix != null && !prefix.isEmpty()) {
       bound += 2L + 3L * prefix.length();
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
@@ -141,6 +141,29 @@ public final class NameKeySerializer implements HOTKeySerializer<QNm> {
     return pos - offset;
   }
 
+  /**
+   * A local name and a prefix are written as raw UTF-8, so the bound is three bytes a char — the
+   * most any single {@code char} encodes to, a surrogate pair being two chars for four bytes — plus
+   * the sentinel and length byte the prefixed format prepends.
+   *
+   * @throws IllegalArgumentException if the name is so long that its own bound overflows an
+   *         {@code int}; such a name could never be serialized into any buffer anyway
+   */
+  @Override
+  public int maxSerializedLength(final QNm key) {
+    requireNonNull(key, "Key cannot be null");
+    final String localName = key.getLocalName();
+    final String prefix = key.getPrefix();
+    long bound = localName == null ? 0L : 3L * localName.length();
+    if (prefix != null && !prefix.isEmpty()) {
+      bound += 2L + 3L * prefix.length();
+    }
+    if (bound > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("QNm too long to serialize: " + bound + " bytes");
+    }
+    return (int) bound;
+  }
+
   @Override
   public QNm deserialize(final byte[] bytes, final int offset, final int length) {
     if (length == 0) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NameKeySerializer.java
@@ -108,20 +108,35 @@ public final class NameKeySerializer implements HOTKeySerializer<QNm> {
 
     if (hasPrefix) {
       // Prefixed format: [0xFF][prefixLen:1][prefix:N][localName:M]
-      final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
-      if (prefixBytes.length > 255) {
-        throw new IllegalArgumentException("Namespace prefix too long: " + prefixBytes.length + " bytes (max 255)");
+      if (AsciiKeyBytes.isAsciiPrefix(prefix, prefix.length())) {
+        if (prefix.length() > 255) {
+          throw new IllegalArgumentException("Namespace prefix too long: " + prefix.length() + " bytes (max 255)");
+        }
+        dest[pos++] = PREFIX_SENTINEL;
+        dest[pos++] = (byte) prefix.length();
+        pos += AsciiKeyBytes.writeAsciiPrefix(prefix, prefix.length(), dest, pos);
+      } else {
+        final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+        if (prefixBytes.length > 255) {
+          throw new IllegalArgumentException("Namespace prefix too long: " + prefixBytes.length + " bytes (max 255)");
+        }
+        dest[pos++] = PREFIX_SENTINEL;
+        dest[pos++] = (byte) prefixBytes.length;
+        System.arraycopy(prefixBytes, 0, dest, pos, prefixBytes.length);
+        pos += prefixBytes.length;
       }
-      dest[pos++] = PREFIX_SENTINEL;
-      dest[pos++] = (byte) prefixBytes.length;
-      System.arraycopy(prefixBytes, 0, dest, pos, prefixBytes.length);
-      pos += prefixBytes.length;
     }
 
-    // Local name: raw UTF-8 bytes
-    final byte[] localBytes = localName.getBytes(StandardCharsets.UTF_8);
-    System.arraycopy(localBytes, 0, dest, pos, localBytes.length);
-    pos += localBytes.length;
+    // Local name: raw UTF-8 bytes. A name is serialized once per indexed node, so the ASCII case —
+    // which is very nearly all of them — writes straight into dest instead of through a throwaway
+    // byte[] (see AsciiKeyBytes).
+    if (AsciiKeyBytes.isAsciiPrefix(localName, localName.length())) {
+      pos += AsciiKeyBytes.writeAsciiPrefix(localName, localName.length(), dest, pos);
+    } else {
+      final byte[] localBytes = localName.getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(localBytes, 0, dest, pos, localBytes.length);
+      pos += localBytes.length;
+    }
 
     return pos - offset;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -79,9 +79,11 @@ public final class NodeReferencesSerializer {
   /**
    * Threshold for switching from packed to Roaring format.
    *
-   * <p>Packed format stores each node key as 8 raw bytes: total = 2 + count*8.
-   * At 64 entries, packed = 514 bytes while Roaring typically compresses to 200-400 bytes.
-   * Below this threshold packed is more compact; above it Roaring wins.</p>
+   * <p>
+   * Packed format stores each node key as 8 raw bytes: total = 2 + count*8. At 64 entries, packed =
+   * 514 bytes while Roaring typically compresses to 200-400 bytes. Below this threshold packed is
+   * more compact; above it Roaring wins.
+   * </p>
    */
   private static final int PACKED_THRESHOLD = 64;
 
@@ -117,17 +119,19 @@ public final class NodeReferencesSerializer {
    * Serializes an already-sorted, duplicate-free run of node keys, without materialising a
    * {@link NodeReferences} or (below {@link #PACKED_THRESHOLD}) a {@link Roaring64Bitmap}.
    *
-   * <p>For the bulk index build this is the difference between a handful of objects per indexed
-   * value and none: the builder already has the run sorted ascending in a reusable array, which is
-   * exactly what the packed format wants, so the bitmap round-trip
-   * {@code add-all → iterate → write} buys nothing. The output is byte-identical to
-   * {@link #serialize(NodeReferences)} over a bitmap holding the same keys.</p>
+   * <p>
+   * For the bulk index build this is the difference between a handful of objects per indexed value
+   * and none: the builder already has the run sorted ascending in a reusable array, which is exactly
+   * what the packed format wants, so the bitmap round-trip {@code add-all → iterate → write} buys
+   * nothing. The output is byte-identical to {@link #serialize(NodeReferences)} over a bitmap holding
+   * the same keys.
+   * </p>
    *
    * @param nodeKeys the backing array
    * @param from index of the first key, inclusive
    * @param to index one past the last key, exclusive
-   * @param scratch a bitmap the method may clear and reuse for runs above the packed threshold;
-   *        never retained
+   * @param scratch a bitmap the method may clear and reuse for runs above the packed threshold; never
+   *        retained
    * @return the serialized payload
    * @throws IllegalArgumentException if the run is empty
    */
@@ -242,8 +246,8 @@ public final class NodeReferencesSerializer {
   }
 
   /**
-   * Computes the exact number of bytes needed to serialize the given NodeReferences,
-   * without actually writing any data.
+   * Computes the exact number of bytes needed to serialize the given NodeReferences, without actually
+   * writing any data.
    *
    * @param refs the node references
    * @return number of bytes needed
@@ -276,10 +280,12 @@ public final class NodeReferencesSerializer {
   /**
    * {@link #isTombstone(byte[], int, int)} over a slot value still in off-heap memory.
    *
-   * <p>Allocation-free: the predicate reads one byte, so callers that only need to classify a value
-   * must not copy the whole payload out first. The sliding-snapshot carry-forward runs this per
-   * entry of an aging fragment on the default commit path, where values are serialized bitmaps or
-   * projection descriptors — copying each one to test a single byte is pure garbage.</p>
+   * <p>
+   * Allocation-free: the predicate reads one byte, so callers that only need to classify a value must
+   * not copy the whole payload out first. The sliding-snapshot carry-forward runs this per entry of
+   * an aging fragment on the default commit path, where values are serialized bitmaps or projection
+   * descriptors — copying each one to test a single byte is pure garbage.
+   * </p>
    *
    * @param value the slot value slice ({@code byteSize() == 0} for an absent value)
    * @return {@code true} if the slice is the single-byte tombstone marker
@@ -291,9 +297,11 @@ public final class NodeReferencesSerializer {
   /**
    * Merges two NodeReferences (OR operation on bitmaps).
    *
-   * <p><b>WARNING: This method mutates {@code a} in-place.</b> The bitmap of {@code a} is
-   * modified by OR-ing in the entries from {@code b}. If you need both originals unchanged,
-   * clone {@code a} before calling this method.</p>
+   * <p>
+   * <b>WARNING: This method mutates {@code a} in-place.</b> The bitmap of {@code a} is modified by
+   * OR-ing in the entries from {@code b}. If you need both originals unchanged, clone {@code a}
+   * before calling this method.
+   * </p>
    *
    * @param a the references to merge INTO (modified in-place)
    * @param b the references to merge from (not modified)
@@ -305,36 +313,37 @@ public final class NodeReferencesSerializer {
   }
 
   /**
-   * Allocation-free fast path for merging a single-key value into an existing value when both are
-   * in {@link #PACKED_FORMAT}. This is the dominant secondary-index churn path:
+   * Allocation-free fast path for merging a single-key value into an existing value when both are in
+   * {@link #PACKED_FORMAT}. This is the dominant secondary-index churn path:
    * {@code HOTIndexWriter.addNodeKeyToChunk} always serializes the inserted value as a one-entry
    * packed payload, and most live buckets are packed (below {@link #PACKED_THRESHOLD}).
    *
-   * <p>Avoids the two {@link Roaring64Bitmap} + two {@link NodeReferences} allocations a
-   * deserialize / {@link #merge} / {@link #serialize} round-trip incurs. Returns:
+   * <p>
+   * Avoids the two {@link Roaring64Bitmap} + two {@link NodeReferences} allocations a deserialize /
+   * {@link #merge} / {@link #serialize} round-trip incurs. Returns:
    * <ul>
-   *   <li>{@code existing} (the same reference) when the new key is already present — the merged
-   *       set is unchanged, so the caller can skip rewriting the slot entirely;</li>
-   *   <li>a freshly allocated packed {@code byte[]} of {@code count + 1} keys (sorted ascending,
-   *       byte-identical to the slow path's output) when the key was absent;</li>
-   *   <li>{@code null} when the fast path does not apply: the existing value is not packed, the
-   *       new value is not a single packed key, or adding a key would cross
-   *       {@link #PACKED_THRESHOLD} into the Roaring representation. The caller must then fall
-   *       back to the deserialize path.</li>
+   * <li>{@code existing} (the same reference) when the new key is already present — the merged set is
+   * unchanged, so the caller can skip rewriting the slot entirely;</li>
+   * <li>a freshly allocated packed {@code byte[]} of {@code count + 1} keys (sorted ascending,
+   * byte-identical to the slow path's output) when the key was absent;</li>
+   * <li>{@code null} when the fast path does not apply: the existing value is not packed, the new
+   * value is not a single packed key, or adding a key would cross {@link #PACKED_THRESHOLD} into the
+   * Roaring representation. The caller must then fall back to the deserialize path.</li>
    * </ul>
    *
-   * <p>Relies on the packed format being sorted ascending by unsigned key, which holds for every
-   * value this class emits ({@link #serializePacked} iterates {@link Roaring64Bitmap} in ascending
-   * order). The binary search for presence depends on that ordering.
+   * <p>
+   * Relies on the packed format being sorted ascending by unsigned key, which holds for every value
+   * this class emits ({@link #serializePacked} iterates {@link Roaring64Bitmap} in ascending order).
+   * The binary search for presence depends on that ordering.
    *
-   * @param existing  the existing serialized value (exact length, not a tombstone)
-   * @param newValue  buffer holding the inserted serialized value
+   * @param existing the existing serialized value (exact length, not a tombstone)
+   * @param newValue buffer holding the inserted serialized value
    * @param newOffset offset of the inserted value within {@code newValue}
-   * @param newLen    length of the inserted value
+   * @param newLen length of the inserted value
    * @return see above
    */
-  public static byte @Nullable [] mergePackedSingleBit(
-      final byte[] existing, final byte[] newValue, final int newOffset, final int newLen) {
+  public static byte @Nullable [] mergePackedSingleBit(final byte[] existing, final byte[] newValue,
+      final int newOffset, final int newLen) {
     // New value must be a single-entry packed payload: [PACKED][count=1][key:8] == 10 bytes.
     if (newLen != 2 + 8 || newValue[newOffset] != PACKED_FORMAT || newValue[newOffset + 1] != 1) {
       return null;
@@ -378,9 +387,8 @@ public final class NodeReferencesSerializer {
   }
 
   private static long readKeyBE(final byte[] b, final int p) {
-    return ((long) (b[p] & 0xFF) << 56) | ((long) (b[p + 1] & 0xFF) << 48)
-        | ((long) (b[p + 2] & 0xFF) << 40) | ((long) (b[p + 3] & 0xFF) << 32)
-        | ((long) (b[p + 4] & 0xFF) << 24) | ((long) (b[p + 5] & 0xFF) << 16)
+    return ((long) (b[p] & 0xFF) << 56) | ((long) (b[p + 1] & 0xFF) << 48) | ((long) (b[p + 2] & 0xFF) << 40)
+        | ((long) (b[p + 3] & 0xFF) << 32) | ((long) (b[p + 4] & 0xFF) << 24) | ((long) (b[p + 5] & 0xFF) << 16)
         | ((long) (b[p + 6] & 0xFF) << 8) | ((long) (b[p + 7] & 0xFF));
   }
 
@@ -460,8 +468,7 @@ public final class NodeReferencesSerializer {
     final int requiredBytes = 1 + count * 8;
     if (requiredBytes > length) {
       throw new IllegalArgumentException(
-          "Packed count " + count + " requires " + requiredBytes
-              + " bytes but only " + length + " available");
+          "Packed count " + count + " requires " + requiredBytes + " bytes but only " + length + " available");
     }
 
     final Roaring64Bitmap bitmap = new Roaring64Bitmap();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import static java.util.Objects.requireNonNull;
 
@@ -277,6 +278,127 @@ public final class NodeReferencesSerializer {
    */
   public static boolean isTombstone(byte[] bytes, int offset, int length) {
     return length == 1 && bytes[offset] == TOMBSTONE_FORMAT;
+  }
+
+  /**
+   * Accumulates a lookup's chunk payloads into the cheapest sufficient representation: a sorted
+   * {@code long[]} while the result stays small (the average CAS posting list holds one or two node
+   * keys), spilling to a {@link Roaring64Bitmap} past {@link #COMPACT_LIMIT} or when a Roaring-format
+   * chunk appears. The emitted {@link NodeReferences#ofSortedArray} result costs one right-sized
+   * array + one wrapper instead of a bitmap container tree per lookup — the single largest allocation
+   * the read path had left.
+   *
+   * <p>
+   * Sortedness precondition: chunks must be appended in ascending composite-key order (the chunk
+   * walk's natural order — chunkIdx-major, bit16-minor, duplicate-free), which makes every append
+   * strictly ascending. Not thread-safe; pool per reader or per iterator.
+   */
+  public static final class ChunkAccumulator {
+
+    private static final int COMPACT_LIMIT = 512;
+
+    private long[] keys = new long[8];
+    private int count;
+    private @Nullable Roaring64Bitmap bitmap;
+
+    /** Drop all accumulated state (also called implicitly by {@link #toNodeReferencesAndReset}). */
+    public void reset() {
+      count = 0;
+      bitmap = null;
+    }
+
+    private void add(final long key) {
+      Roaring64Bitmap spilled = bitmap;
+      if (spilled != null) {
+        spilled.add(key);
+        return;
+      }
+      if (count == keys.length) {
+        if (count >= COMPACT_LIMIT) {
+          spilled = new Roaring64Bitmap();
+          for (int i = 0; i < count; i++) {
+            spilled.add(keys[i]);
+          }
+          bitmap = spilled;
+          count = 0;
+          spilled.add(key);
+          return;
+        }
+        keys = Arrays.copyOf(keys, count * 2);
+      }
+      keys[count++] = key;
+    }
+
+    /**
+     * Append one chunk payload, expanding each stored bit16 to {@code high | bit16}. Same format
+     * handling as {@link #mergeChunkInto}: packed reads straight off slot memory, tombstones and empty
+     * payloads are skipped, the (rare) Roaring format round-trips through a heap array.
+     *
+     * @param leaf the leaf page holding the chunk slot
+     * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
+     * @param high the pre-shifted chunk base ({@code chunkIdx << 16}, chunkIdx treated unsigned)
+     */
+    public void addChunk(final HOTLeafPage leaf, final long ref, final long high) {
+      final int length = HOTLeafPage.refLength(ref);
+      if (length <= 0) {
+        return;
+      }
+      final byte format = leaf.refByteAt(ref, 0);
+      if (format == TOMBSTONE_FORMAT) {
+        return;
+      }
+      if (format == PACKED_FORMAT) {
+        if (length < 2) {
+          return;
+        }
+        final int chunkCount = leaf.refByteAt(ref, 1) & 0xFF;
+        if (chunkCount == 0 || 2 + chunkCount * 8 > length) {
+          return;
+        }
+        for (int i = 0; i < chunkCount; i++) {
+          // Stored big-endian; refLongAt reads little-endian off the segment.
+          final long bit16 = Long.reverseBytes(leaf.refLongAt(ref, 2 + i * 8)) & 0xFFFFL;
+          add(high | bit16);
+        }
+        return;
+      }
+      if (format == ROARING_FORMAT) {
+        final byte[] bytes = new byte[length - 1];
+        leaf.copyRefInto(ref, 1, bytes, 0, length - 1);
+        final Roaring64Bitmap chunkBitmap = new Roaring64Bitmap();
+        try {
+          chunkBitmap.deserialize(ByteBuffer.wrap(bytes));
+        } catch (IOException e) {
+          throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap deserialization", e);
+        }
+        final LongIterator it = chunkBitmap.getLongIterator();
+        while (it.hasNext()) {
+          add(high | (it.next() & 0xFFFFL));
+        }
+        return;
+      }
+      throw new IllegalArgumentException("Unknown NodeReferences format: " + format);
+    }
+
+    /**
+     * Emit the accumulated result — compact when it stayed small, bitmap-backed when it spilled — and
+     * reset for reuse. {@code null} when nothing live was accumulated.
+     */
+    public @Nullable NodeReferences toNodeReferencesAndReset() {
+      final Roaring64Bitmap spilled = bitmap;
+      if (spilled != null) {
+        reset();
+        return spilled.isEmpty()
+            ? null
+            : NodeReferences.owning(spilled);
+      }
+      final int resultCount = count;
+      if (resultCount == 0) {
+        return null;
+      }
+      count = 0;
+      return NodeReferences.ofSortedArray(Arrays.copyOf(keys, resultCount), resultCount);
+    }
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -27,6 +27,8 @@
  */
 package io.sirix.index.hot;
 
+import io.sirix.access.trx.page.HOTRangeCursor;
+import io.sirix.access.trx.page.HOTTrieReader;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.HOTLeafPage;
 import org.jspecify.annotations.Nullable;
@@ -153,15 +155,7 @@ public final class NodeReferencesSerializer {
       buf[1] = (byte) count;
       int pos = 2;
       for (int i = from; i < to; i++) {
-        final long key = nodeKeys[i];
-        buf[pos] = (byte) (key >>> 56);
-        buf[pos + 1] = (byte) (key >>> 48);
-        buf[pos + 2] = (byte) (key >>> 40);
-        buf[pos + 3] = (byte) (key >>> 32);
-        buf[pos + 4] = (byte) (key >>> 24);
-        buf[pos + 5] = (byte) (key >>> 16);
-        buf[pos + 6] = (byte) (key >>> 8);
-        buf[pos + 7] = (byte) key;
+        writeKeyBE(buf, pos, nodeKeys[i]);
         pos += 8;
       }
       return buf;
@@ -281,6 +275,84 @@ public final class NodeReferencesSerializer {
   }
 
   /**
+   * Drain a composite-bounded cursor sweep, merging every chunk slot whose composite key starts with
+   * {@code prefixBuf[0..prefixLen)} into one bitmap of {@code (chunkIdx << 16) | bit16} node keys.
+   * Shared by the CAS/NAME and primitive-long index writers' same-transaction {@code get} — the two
+   * walks were hand-mirrored copies, and both read UNPINNED leaves under optimistic stamps, so the
+   * torn-read discipline lives once, here: each slot's (composite, payload) copies are validated
+   * against the cursor's leaf stamp BEFORE the payload reaches {@link #deserialize} or the merge, and
+   * a torn read re-evaluates the SAME slot on a refreshed leaf copy.
+   *
+   * @param cursor a cursor positioned by the caller over the composite range of {@code prefixBuf}
+   * @param prefixBuf buffer holding the serialized logical key
+   * @param prefixLen serialized length of the logical key
+   * @return the merged node keys, or {@code null} when no chunk holds a live reference
+   */
+  public static @Nullable Roaring64Bitmap mergeChunksInPrefixRange(final HOTRangeCursor cursor, final byte[] prefixBuf,
+      final int prefixLen) {
+    requireNonNull(cursor, "cursor cannot be null");
+    requireNonNull(prefixBuf, "prefixBuf cannot be null");
+    final int compositeLen = prefixLen + HOTKeySerializer.CHUNK_IDX_BYTES;
+    Roaring64Bitmap merged = null;
+    int tornRounds = 0;
+    while (cursor.hasNext()) {
+      final HOTLeafPage leaf = cursor.currentLeafPage();
+      final int idx = cursor.currentEntryIndex();
+      byte[] composite = null;
+      byte[] chunkBytes = null;
+      try {
+        final byte[] candidate = leaf.getKey(idx);
+        if (candidate != null && candidate.length == compositeLen
+            && Arrays.compareUnsigned(candidate, 0, prefixLen, prefixBuf, 0, prefixLen) == 0) {
+          composite = candidate;
+          chunkBytes = leaf.getValue(idx);
+        }
+      } catch (RuntimeException e) {
+        if (cursor.validateLeaf()) {
+          throw e; // stable bytes — genuine corruption, not a torn read
+        }
+        recoverTornCursorSlot(cursor, ++tornRounds);
+        continue;
+      }
+      if (!cursor.validateLeaf()) {
+        recoverTornCursorSlot(cursor, ++tornRounds);
+        continue;
+      }
+      tornRounds = 0;
+      if (chunkBytes != null && !isTombstone(chunkBytes, 0, chunkBytes.length)) {
+        // The copies are validated heap bytes now — safe to hand to the deserializer.
+        final Roaring64Bitmap chunkBitmap = deserialize(chunkBytes).getNodeKeys();
+        if (!chunkBitmap.isEmpty()) {
+          if (merged == null) {
+            merged = new Roaring64Bitmap();
+          }
+          // chunkIdx is UNSIGNED (see ChunkAccumulator#addChunk): mask before widening, exactly as the
+          // reader-side call sites do. Sign-extending here would make the writer's same-transaction
+          // view reconstruct a different node key than the reader for the very same stored chunk.
+          final long high = (HOTKeySerializer.readChunkIdx(composite, 0, composite.length) & 0xFFFFFFFFL) << 16;
+          final LongIterator bIt = chunkBitmap.getLongIterator();
+          while (bIt.hasNext()) {
+            merged.add(high | (bIt.next() & 0xFFFFL));
+          }
+        }
+      }
+      cursor.advance();
+    }
+    return merged;
+  }
+
+  /** Bound on consecutive torn-read recovery rounds per slot for the cursor merge above. */
+  private static final int MAX_TORN_SLOT_ROUNDS = 64;
+
+  private static void recoverTornCursorSlot(final HOTRangeCursor cursor, final int round) {
+    if (round > MAX_TORN_SLOT_ROUNDS) {
+      throw new IllegalStateException("HOT: chunk merge failed stamp validation on " + MAX_TORN_SLOT_ROUNDS
+          + " consecutive rounds — sustained allocator thrashing");
+    }
+    cursor.refreshLeaf();
+  }
+
+  /**
    * Accumulates a lookup's chunk payloads into the cheapest sufficient representation: a sorted
    * {@code long[]} while the result stays small (the average CAS posting list holds one or two node
    * keys), spilling to a {@link Roaring64Bitmap} past {@link #COMPACT_LIMIT} or when a Roaring-format
@@ -299,6 +371,8 @@ public final class NodeReferencesSerializer {
 
     private long[] keys = new long[8];
     private int count;
+    /** Last appended key, kept as a scalar so the ordering guard needs no bounds-checked array read. */
+    private long lastKey;
     private @Nullable Roaring64Bitmap bitmap;
 
     /** Drop all accumulated state (also called implicitly by {@link #toNodeReferencesAndReset}). */
@@ -313,58 +387,139 @@ public final class NodeReferencesSerializer {
         spilled.add(key);
         return;
       }
+      // The compact result is binary-searched by NodeReferences.contains, so the array MUST come
+      // out strictly ascending. It does for a well-formed trie (chunkIdx-major slot order, ascending
+      // bit16 within a payload), but that rests on the walk being lex-monotonic — the property the
+      // detector/heal machinery exists because we do not assume everywhere. One compare per key buys
+      // the guarantee unconditionally: a non-ascending append spills to a bitmap, which is
+      // order-insensitive and de-duplicates.
+      if (count > 0 && Long.compareUnsigned(key, lastKey) <= 0) {
+        spillToBitmap().add(key);
+        return;
+      }
       if (count == keys.length) {
         if (count >= COMPACT_LIMIT) {
-          spilled = new Roaring64Bitmap();
-          for (int i = 0; i < count; i++) {
-            spilled.add(keys[i]);
-          }
-          bitmap = spilled;
-          count = 0;
-          spilled.add(key);
+          spillToBitmap().add(key);
           return;
         }
         keys = Arrays.copyOf(keys, count * 2);
       }
       keys[count++] = key;
+      lastKey = key;
+    }
+
+    /** Move everything accumulated so far into a bitmap and switch to it. */
+    private Roaring64Bitmap spillToBitmap() {
+      final Roaring64Bitmap spilled = new Roaring64Bitmap();
+      for (int i = 0; i < count; i++) {
+        spilled.add(keys[i]);
+      }
+      bitmap = spilled;
+      count = 0;
+      return spilled;
     }
 
     /**
      * Append one chunk payload, expanding each stored bit16 to {@code high | bit16}. Same format
-     * handling as {@link #mergeChunkInto}: packed reads straight off slot memory, tombstones and empty
-     * payloads are skipped, the (rare) Roaring format round-trips through a heap array.
+     * handling as {@link #mergePackedSingleBitFromSlot}: packed reads straight off slot memory,
+     * tombstones and empty payloads are skipped, the (rare) Roaring format round-trips through a heap
+     * array.
      *
      * @param leaf the leaf page holding the chunk slot
      * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
      * @param high the pre-shifted chunk base ({@code chunkIdx << 16}, chunkIdx treated unsigned)
      */
     public void addChunk(final HOTLeafPage leaf, final long ref, final long high) {
+      // Kept for tests that build a leaf directly and have no reader. Deliberately NOT for
+      // production use: with no trie to validate against, a torn slot read cannot be distinguished
+      // from real corruption, so it is either merged or rethrown — never retried. Every production
+      // caller passes the reader.
+      addChunk(leaf, ref, high, null);
+    }
+
+    /**
+     * Torn-read-aware variant of {@link #addChunk(HOTLeafPage, long, long)} for callers reading an
+     * UNPINNED leaf under optimistic stamps. The slot's declared payload length is clamped against the
+     * leaf's slot capacity before any allocation, a thrown read is distinguished from real corruption
+     * by validating {@code trie}'s current-leaf stamp, and a Roaring payload is copied out and
+     * validated BEFORE it reaches the deserializer — garbage bytes there risk absurd allocations, not
+     * just wrong answers.
+     *
+     * <p>
+     * A {@code false} return means the merge read torn bytes and this accumulator's state can no longer
+     * be trusted: the caller must {@link #reset()} and re-walk its aggregate from a validated position.
+     * {@code true} means the merge completed — subject to the caller's own batch validation, since the
+     * packed fast path merges straight off slot memory.
+     *
+     * @param leaf the leaf page holding the chunk slot
+     * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
+     * @param high the pre-shifted chunk base ({@code chunkIdx << 16}, chunkIdx treated unsigned)
+     * @param trie the trie reader whose current leaf is {@code leaf}, or {@code null} when the caller
+     *        pins pages and torn reads are impossible
+     * @return {@code false} iff a torn read was detected and the accumulator must be reset
+     */
+    public boolean addChunk(final HOTLeafPage leaf, final long ref, final long high,
+        final @Nullable HOTTrieReader trie) {
+      try {
+        return addChunkFromSlot(leaf, ref, high, trie);
+      } catch (RuntimeException e) {
+        if (trie == null || trie.validateCurrentLeaf()) {
+          throw e; // stable bytes — genuine corruption, not a torn read
+        }
+        return false;
+      }
+    }
+
+    private boolean addChunkFromSlot(final HOTLeafPage leaf, final long ref, final long high,
+        final @Nullable HOTTrieReader trie) {
       final int length = HOTLeafPage.refLength(ref);
       if (length <= 0) {
-        return;
+        return true;
+      }
+      if (length > leaf.slotCapacity()) {
+        // A payload no slot can hold: on a torn read the wrapper's validation fails and the caller
+        // retries; on stable bytes this escapes as the storage corruption it is.
+        throw new IllegalStateException(
+            "Chunk payload of " + length + " bytes exceeds the slot capacity of " + leaf.slotCapacity() + " bytes");
       }
       final byte format = leaf.refByteAt(ref, 0);
       if (format == TOMBSTONE_FORMAT) {
-        return;
+        return true;
       }
       if (format == PACKED_FORMAT) {
         if (length < 2) {
-          return;
+          return true;
         }
         final int chunkCount = leaf.refByteAt(ref, 1) & 0xFF;
-        if (chunkCount == 0 || 2 + chunkCount * 8 > length) {
-          return;
+        if (chunkCount == 0) {
+          return true; // an empty packed payload carries nothing; not corruption
+        }
+        if (2 + chunkCount * 8 > length) {
+          // Same loud failure the deserializePacked path this replaced raised: a declared count the
+          // slot cannot hold is storage corruption, and degrading it to silently-missing postings
+          // would let a torn write masquerade as an absent key.
+          throw new IllegalArgumentException("Packed count " + chunkCount + " requires " + (2 + chunkCount * 8)
+              + " bytes but only " + length + " available");
         }
         for (int i = 0; i < chunkCount; i++) {
-          // Stored big-endian; refLongAt reads little-endian off the segment.
-          final long bit16 = Long.reverseBytes(leaf.refLongAt(ref, 2 + i * 8)) & 0xFFFFL;
+          final long bit16 = leaf.refLongBEAt(ref, 2 + i * 8) & 0xFFFFL;
           add(high | bit16);
         }
-        return;
+        return true;
       }
       if (format == ROARING_FORMAT) {
+        if (length < 2) {
+          // Same treatment as a packed payload whose declared count overruns the slot: a Roaring
+          // marker with no bitmap behind it is storage corruption, not an empty posting list.
+          throw new IllegalArgumentException("Roaring payload of " + length + " byte(s) carries no bitmap");
+        }
         final byte[] bytes = new byte[length - 1];
         leaf.copyRefInto(ref, 1, bytes, 0, length - 1);
+        if (trie != null && !trie.validateCurrentLeaf()) {
+          // Torn copy — never hand it to the Roaring deserializer, whose failure modes on garbage
+          // include huge container allocations, not just exceptions.
+          return false;
+        }
         final Roaring64Bitmap chunkBitmap = new Roaring64Bitmap();
         try {
           chunkBitmap.deserialize(ByteBuffer.wrap(bytes));
@@ -375,7 +530,7 @@ public final class NodeReferencesSerializer {
         while (it.hasNext()) {
           add(high | (it.next() & 0xFFFFL));
         }
-        return;
+        return true;
       }
       throw new IllegalArgumentException("Unknown NodeReferences format: " + format);
     }
@@ -397,24 +552,24 @@ public final class NodeReferencesSerializer {
         return null;
       }
       count = 0;
-      return NodeReferences.ofSortedArray(Arrays.copyOf(keys, resultCount), resultCount);
+      return NodeReferences.ofSortedArray(Arrays.copyOf(keys, resultCount));
     }
   }
 
   /**
    * Identity sentinel returned by {@link #mergePackedSingleBitFromSlot} when the new bit is already
-   * present in the slot's packed set — the caller skips the slot rewrite entirely. (The array-based
-   * {@link #mergePackedSingleBit} signals the same case by returning its {@code existing} argument;
-   * with the payload still in slot memory there is no such array to return.)
+   * present in the slot's packed set — the caller skips the slot rewrite entirely. A distinct
+   * sentinel is needed because the payload is still in slot memory: there is no existing array to
+   * hand back by identity the way a copying merge would.
    */
   public static final byte[] MERGE_UNCHANGED = new byte[0];
 
   /**
-   * {@link #mergePackedSingleBit} against a payload still resident in its leaf slot: binary-search
-   * and splice directly off slot memory via the leaf's value-ref accessors. This is the insert-time
-   * hot path — every listener-driven index insert merges a single-bit payload into its chunk bucket,
-   * and the copying variant first materialized the whole existing bucket (up to {@code 2 + 64*8}
-   * bytes) just to read it.
+   * Single-bit packed merge against a payload still resident in its leaf slot: binary-search and
+   * splice directly off slot memory via the leaf's value-ref accessors. This is the insert-time hot
+   * path — every listener-driven index insert merges a single-bit payload into its chunk bucket, and
+   * the copying variant first materialized the whole existing bucket (up to {@code 2 + 64*8} bytes)
+   * just to read it.
    *
    * @param leaf the leaf holding the existing payload
    * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
@@ -443,12 +598,12 @@ public final class NodeReferencesSerializer {
 
     final long newKey = readKeyBE(newValue, newOffset + 2);
 
-    // Binary search the sorted-ascending packed keys for newKey (stored BE; refLongAt reads LE).
+    // Binary search the sorted-ascending packed keys for newKey (stored big-endian).
     int lo = 0;
     int hi = count; // exclusive
     while (lo < hi) {
       final int mid = (lo + hi) >>> 1;
-      final int cmp = Long.compareUnsigned(Long.reverseBytes(leaf.refLongAt(ref, 2 + mid * 8)), newKey);
+      final int cmp = Long.compareUnsigned(leaf.refLongBEAt(ref, 2 + mid * 8), newKey);
       if (cmp < 0) {
         lo = mid + 1;
       } else if (cmp > 0) {
@@ -484,73 +639,6 @@ public final class NodeReferencesSerializer {
     return HOTLeafPage.refLength(ref) == 1 && leaf.refByteAt(ref, 0) == TOMBSTONE_FORMAT;
   }
 
-  /**
-   * Merge one serialized chunk bitmap — still resident in its leaf's off-heap slot memory — into
-   * {@code target}, expanding each stored bit16 to {@code high | bit16}. The read path's chunk
-   * reassembly ran {@code getValue → deserialize → NodeReferences → Roaring64Bitmap → iterate} per
-   * chunk before this: two heap copies and two container allocations to move at most 64 longs. This
-   * reads the packed format directly off the slot via the leaf's zero-alloc value-ref accessors; only
-   * the (rare, > {@link #PACKED_THRESHOLD}-cardinality) Roaring format still round-trips through a
-   * heap array.
-   *
-   * @param leaf the leaf page holding the chunk slot
-   * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
-   * @param high the pre-shifted chunk base ({@code chunkIdx << 16}, chunkIdx treated unsigned)
-   * @param target the accumulator, or {@code null} if none exists yet
-   * @return the accumulator — {@code target} if given, freshly created on the first merged bit, or
-   *         unchanged/{@code null} for a tombstone or empty chunk
-   */
-  public static @Nullable Roaring64Bitmap mergeChunkInto(final HOTLeafPage leaf, final long ref, final long high,
-      @Nullable Roaring64Bitmap target) {
-    final int length = HOTLeafPage.refLength(ref);
-    if (length <= 0) {
-      return target;
-    }
-    final byte format = leaf.refByteAt(ref, 0);
-    if (format == TOMBSTONE_FORMAT) {
-      return target;
-    }
-    if (format == PACKED_FORMAT) {
-      if (length < 2) {
-        return target;
-      }
-      final int count = leaf.refByteAt(ref, 1) & 0xFF;
-      if (count == 0 || 2 + count * 8 > length) {
-        return target;
-      }
-      if (target == null) {
-        target = new Roaring64Bitmap();
-      }
-      for (int i = 0; i < count; i++) {
-        // Stored big-endian; refLongAt reads little-endian off the segment.
-        final long bit16 = Long.reverseBytes(leaf.refLongAt(ref, 2 + i * 8)) & 0xFFFFL;
-        target.add(high | bit16);
-      }
-      return target;
-    }
-    if (format == ROARING_FORMAT) {
-      final byte[] bytes = new byte[length - 1];
-      leaf.copyRefInto(ref, 1, bytes, 0, length - 1);
-      final Roaring64Bitmap chunkBitmap = new Roaring64Bitmap();
-      try {
-        chunkBitmap.deserialize(ByteBuffer.wrap(bytes));
-      } catch (IOException e) {
-        throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap deserialization", e);
-      }
-      if (chunkBitmap.isEmpty()) {
-        return target;
-      }
-      if (target == null) {
-        target = new Roaring64Bitmap();
-      }
-      final LongIterator it = chunkBitmap.getLongIterator();
-      while (it.hasNext()) {
-        target.add(high | (it.next() & 0xFFFFL));
-      }
-      return target;
-    }
-    throw new IllegalArgumentException("Unknown NodeReferences format: " + format);
-  }
 
   /**
    * {@link #isTombstone(byte[], int, int)} over a slot value still in off-heap memory.
@@ -587,79 +675,6 @@ public final class NodeReferencesSerializer {
     return a;
   }
 
-  /**
-   * Allocation-free fast path for merging a single-key value into an existing value when both are in
-   * {@link #PACKED_FORMAT}. This is the dominant secondary-index churn path:
-   * {@code HOTIndexWriter.addNodeKeyToChunk} always serializes the inserted value as a one-entry
-   * packed payload, and most live buckets are packed (below {@link #PACKED_THRESHOLD}).
-   *
-   * <p>
-   * Avoids the two {@link Roaring64Bitmap} + two {@link NodeReferences} allocations a deserialize /
-   * {@link #merge} / {@link #serialize} round-trip incurs. Returns:
-   * <ul>
-   * <li>{@code existing} (the same reference) when the new key is already present — the merged set is
-   * unchanged, so the caller can skip rewriting the slot entirely;</li>
-   * <li>a freshly allocated packed {@code byte[]} of {@code count + 1} keys (sorted ascending,
-   * byte-identical to the slow path's output) when the key was absent;</li>
-   * <li>{@code null} when the fast path does not apply: the existing value is not packed, the new
-   * value is not a single packed key, or adding a key would cross {@link #PACKED_THRESHOLD} into the
-   * Roaring representation. The caller must then fall back to the deserialize path.</li>
-   * </ul>
-   *
-   * <p>
-   * Relies on the packed format being sorted ascending by unsigned key, which holds for every value
-   * this class emits ({@link #serializePacked} iterates {@link Roaring64Bitmap} in ascending order).
-   * The binary search for presence depends on that ordering.
-   *
-   * @param existing the existing serialized value (exact length, not a tombstone)
-   * @param newValue buffer holding the inserted serialized value
-   * @param newOffset offset of the inserted value within {@code newValue}
-   * @param newLen length of the inserted value
-   * @return see above
-   */
-  public static byte @Nullable [] mergePackedSingleBit(final byte[] existing, final byte[] newValue,
-      final int newOffset, final int newLen) {
-    // New value must be a single-entry packed payload: [PACKED][count=1][key:8] == 10 bytes.
-    if (newLen != 2 + 8 || newValue[newOffset] != PACKED_FORMAT || newValue[newOffset + 1] != 1) {
-      return null;
-    }
-    // Existing must be packed and well-formed.
-    if (existing.length < 2 || existing[0] != PACKED_FORMAT) {
-      return null;
-    }
-    final int count = existing[1] & 0xFF;
-    // A full-or-overflowing bucket would switch representation; leave that to the slow path.
-    if (count >= PACKED_THRESHOLD || existing.length != 2 + count * 8) {
-      return null;
-    }
-
-    final long newKey = readKeyBE(newValue, newOffset + 2);
-
-    // Binary search the sorted-ascending packed keys for newKey.
-    int lo = 0;
-    int hi = count; // exclusive
-    while (lo < hi) {
-      final int mid = (lo + hi) >>> 1;
-      final int cmp = Long.compareUnsigned(readKeyBE(existing, 2 + mid * 8), newKey);
-      if (cmp < 0) {
-        lo = mid + 1;
-      } else if (cmp > 0) {
-        hi = mid;
-      } else {
-        return existing; // already present — merged set unchanged
-      }
-    }
-
-    // Insert newKey at position lo, preserving ascending order.
-    final byte[] merged = new byte[2 + (count + 1) * 8];
-    merged[0] = PACKED_FORMAT;
-    merged[1] = (byte) (count + 1);
-    final int insAt = 2 + lo * 8;
-    System.arraycopy(existing, 2, merged, 2, lo * 8);
-    writeKeyBE(merged, insAt, newKey);
-    System.arraycopy(existing, insAt, merged, insAt + 8, (count - lo) * 8);
-    return merged;
-  }
 
   private static long readKeyBE(final byte[] b, final int p) {
     return ((long) (b[p] & 0xFF) << 56) | ((long) (b[p + 1] & 0xFF) << 48) | ((long) (b[p + 2] & 0xFF) << 40)

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -28,10 +28,12 @@
 package io.sirix.index.hot;
 
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.page.HOTLeafPage;
 import org.jspecify.annotations.Nullable;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
+import java.io.IOException;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
@@ -278,6 +280,74 @@ public final class NodeReferencesSerializer {
   }
 
   /**
+   * Merge one serialized chunk bitmap — still resident in its leaf's off-heap slot memory — into
+   * {@code target}, expanding each stored bit16 to {@code high | bit16}. The read path's chunk
+   * reassembly ran {@code getValue → deserialize → NodeReferences → Roaring64Bitmap → iterate} per
+   * chunk before this: two heap copies and two container allocations to move at most 64 longs. This
+   * reads the packed format directly off the slot via the leaf's zero-alloc value-ref accessors; only
+   * the (rare, > {@link #PACKED_THRESHOLD}-cardinality) Roaring format still round-trips through a
+   * heap array.
+   *
+   * @param leaf the leaf page holding the chunk slot
+   * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
+   * @param high the pre-shifted chunk base ({@code chunkIdx << 16}, chunkIdx treated unsigned)
+   * @param target the accumulator, or {@code null} if none exists yet
+   * @return the accumulator — {@code target} if given, freshly created on the first merged bit, or
+   *         unchanged/{@code null} for a tombstone or empty chunk
+   */
+  public static @Nullable Roaring64Bitmap mergeChunkInto(final HOTLeafPage leaf, final long ref, final long high,
+      @Nullable Roaring64Bitmap target) {
+    final int length = HOTLeafPage.refLength(ref);
+    if (length <= 0) {
+      return target;
+    }
+    final byte format = leaf.refByteAt(ref, 0);
+    if (format == TOMBSTONE_FORMAT) {
+      return target;
+    }
+    if (format == PACKED_FORMAT) {
+      if (length < 2) {
+        return target;
+      }
+      final int count = leaf.refByteAt(ref, 1) & 0xFF;
+      if (count == 0 || 2 + count * 8 > length) {
+        return target;
+      }
+      if (target == null) {
+        target = new Roaring64Bitmap();
+      }
+      for (int i = 0; i < count; i++) {
+        // Stored big-endian; refLongAt reads little-endian off the segment.
+        final long bit16 = Long.reverseBytes(leaf.refLongAt(ref, 2 + i * 8)) & 0xFFFFL;
+        target.add(high | bit16);
+      }
+      return target;
+    }
+    if (format == ROARING_FORMAT) {
+      final byte[] bytes = new byte[length - 1];
+      leaf.copyRefInto(ref, 1, bytes, 0, length - 1);
+      final Roaring64Bitmap chunkBitmap = new Roaring64Bitmap();
+      try {
+        chunkBitmap.deserialize(ByteBuffer.wrap(bytes));
+      } catch (IOException e) {
+        throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap deserialization", e);
+      }
+      if (chunkBitmap.isEmpty()) {
+        return target;
+      }
+      if (target == null) {
+        target = new Roaring64Bitmap();
+      }
+      final LongIterator it = chunkBitmap.getLongIterator();
+      while (it.hasNext()) {
+        target.add(high | (it.next() & 0xFFFFL));
+      }
+      return target;
+    }
+    throw new IllegalArgumentException("Unknown NodeReferences format: " + format);
+  }
+
+  /**
    * {@link #isTombstone(byte[], int, int)} over a slot value still in off-heap memory.
    *
    * <p>
@@ -440,7 +510,7 @@ public final class NodeReferencesSerializer {
     buf[0] = ROARING_FORMAT;
     try {
       bitmap.serialize(ByteBuffer.wrap(buf, 1, size));
-    } catch (java.io.IOException e) {
+    } catch (IOException e) {
       throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap serialization", e);
     }
     return buf;
@@ -451,7 +521,7 @@ public final class NodeReferencesSerializer {
     final int size = (int) bitmap.serializedSizeInBytes();
     try {
       bitmap.serialize(ByteBuffer.wrap(dest, offset + 1, size));
-    } catch (java.io.IOException e) {
+    } catch (IOException e) {
       throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap serialization", e);
     }
     return 1 + size;
@@ -490,7 +560,7 @@ public final class NodeReferencesSerializer {
     final Roaring64Bitmap bitmap = new Roaring64Bitmap();
     try {
       bitmap.deserialize(ByteBuffer.wrap(bytes, offset, length));
-    } catch (java.io.IOException e) {
+    } catch (IOException e) {
       throw new IllegalStateException("Unexpected I/O error during in-memory Roaring64Bitmap deserialization", e);
     }
     return NodeReferences.owning(bitmap);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -280,6 +280,89 @@ public final class NodeReferencesSerializer {
   }
 
   /**
+   * Identity sentinel returned by {@link #mergePackedSingleBitFromSlot} when the new bit is already
+   * present in the slot's packed set — the caller skips the slot rewrite entirely. (The array-based
+   * {@link #mergePackedSingleBit} signals the same case by returning its {@code existing} argument;
+   * with the payload still in slot memory there is no such array to return.)
+   */
+  public static final byte[] MERGE_UNCHANGED = new byte[0];
+
+  /**
+   * {@link #mergePackedSingleBit} against a payload still resident in its leaf slot: binary-search
+   * and splice directly off slot memory via the leaf's value-ref accessors. This is the insert-time
+   * hot path — every listener-driven index insert merges a single-bit payload into its chunk bucket,
+   * and the copying variant first materialized the whole existing bucket (up to {@code 2 + 64*8}
+   * bytes) just to read it.
+   *
+   * @param leaf the leaf holding the existing payload
+   * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
+   * @param newValue buffer holding the new single-entry packed payload
+   * @param newOffset offset of the payload in {@code newValue}
+   * @param newLen length of the payload
+   * @return {@link #MERGE_UNCHANGED} when the bit is already present; a freshly built merged payload
+   *         otherwise; {@code null} when the shapes don't qualify (caller falls back to the copying
+   *         slow path)
+   */
+  public static byte @Nullable [] mergePackedSingleBitFromSlot(final HOTLeafPage leaf, final long ref,
+      final byte[] newValue, final int newOffset, final int newLen) {
+    // New value must be a single-entry packed payload: [PACKED][count=1][key:8] == 10 bytes.
+    if (newLen != 2 + 8 || newValue[newOffset] != PACKED_FORMAT || newValue[newOffset + 1] != 1) {
+      return null;
+    }
+    final int existingLen = HOTLeafPage.refLength(ref);
+    if (existingLen < 2 || leaf.refByteAt(ref, 0) != PACKED_FORMAT) {
+      return null;
+    }
+    final int count = leaf.refByteAt(ref, 1) & 0xFF;
+    // A full-or-overflowing bucket would switch representation; leave that to the slow path.
+    if (count >= PACKED_THRESHOLD || existingLen != 2 + count * 8) {
+      return null;
+    }
+
+    final long newKey = readKeyBE(newValue, newOffset + 2);
+
+    // Binary search the sorted-ascending packed keys for newKey (stored BE; refLongAt reads LE).
+    int lo = 0;
+    int hi = count; // exclusive
+    while (lo < hi) {
+      final int mid = (lo + hi) >>> 1;
+      final int cmp = Long.compareUnsigned(Long.reverseBytes(leaf.refLongAt(ref, 2 + mid * 8)), newKey);
+      if (cmp < 0) {
+        lo = mid + 1;
+      } else if (cmp > 0) {
+        hi = mid;
+      } else {
+        return MERGE_UNCHANGED; // already present — merged set unchanged
+      }
+    }
+
+    // Insert newKey at position lo, preserving ascending order — one allocation, two slot copies.
+    final byte[] merged = new byte[2 + (count + 1) * 8];
+    merged[0] = PACKED_FORMAT;
+    merged[1] = (byte) (count + 1);
+    final int insAt = 2 + lo * 8;
+    if (lo > 0) {
+      leaf.copyRefInto(ref, 2, merged, 2, lo * 8);
+    }
+    writeKeyBE(merged, insAt, newKey);
+    if (lo < count) {
+      leaf.copyRefInto(ref, insAt, merged, insAt + 8, (count - lo) * 8);
+    }
+    return merged;
+  }
+
+  /**
+   * {@link #isTombstone(byte[], int, int)} against a payload still resident in its leaf slot.
+   *
+   * @param leaf the leaf holding the payload
+   * @param ref the slot's packed value handle from {@link HOTLeafPage#valueRef(int)}
+   * @return {@code true} iff the payload is the single-byte tombstone marker
+   */
+  public static boolean isTombstone(final HOTLeafPage leaf, final long ref) {
+    return HOTLeafPage.refLength(ref) == 1 && leaf.refByteAt(ref, 0) == TOMBSTONE_FORMAT;
+  }
+
+  /**
    * Merge one serialized chunk bitmap — still resident in its leaf's off-heap slot memory — into
    * {@code target}, expanding each stored bit16 to {@code high | bit16}. The read path's chunk
    * reassembly ran {@code getValue → deserialize → NodeReferences → Roaring64Bitmap → iterate} per

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -311,11 +311,11 @@ public final class NodeReferencesSerializer {
         if (cursor.validateLeaf()) {
           throw e; // stable bytes — genuine corruption, not a torn read
         }
-        recoverTornCursorSlot(cursor, ++tornRounds);
+        cursor.recoverTorn(++tornRounds);
         continue;
       }
       if (!cursor.validateLeaf()) {
-        recoverTornCursorSlot(cursor, ++tornRounds);
+        cursor.recoverTorn(++tornRounds);
         continue;
       }
       tornRounds = 0;
@@ -339,17 +339,6 @@ public final class NodeReferencesSerializer {
       cursor.advance();
     }
     return merged;
-  }
-
-  /** Bound on consecutive torn-read recovery rounds per slot for the cursor merge above. */
-  private static final int MAX_TORN_SLOT_ROUNDS = 64;
-
-  private static void recoverTornCursorSlot(final HOTRangeCursor cursor, final int round) {
-    if (round > MAX_TORN_SLOT_ROUNDS) {
-      throw new IllegalStateException("HOT: chunk merge failed stamp validation on " + MAX_TORN_SLOT_ROUNDS
-          + " consecutive rounds — sustained allocator thrashing");
-    }
-    cursor.refreshLeaf();
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/NodeReferencesSerializer.java
@@ -114,6 +114,60 @@ public final class NodeReferencesSerializer {
   }
 
   /**
+   * Serializes an already-sorted, duplicate-free run of node keys, without materialising a
+   * {@link NodeReferences} or (below {@link #PACKED_THRESHOLD}) a {@link Roaring64Bitmap}.
+   *
+   * <p>For the bulk index build this is the difference between a handful of objects per indexed
+   * value and none: the builder already has the run sorted ascending in a reusable array, which is
+   * exactly what the packed format wants, so the bitmap round-trip
+   * {@code add-all → iterate → write} buys nothing. The output is byte-identical to
+   * {@link #serialize(NodeReferences)} over a bitmap holding the same keys.</p>
+   *
+   * @param nodeKeys the backing array
+   * @param from index of the first key, inclusive
+   * @param to index one past the last key, exclusive
+   * @param scratch a bitmap the method may clear and reuse for runs above the packed threshold;
+   *        never retained
+   * @return the serialized payload
+   * @throws IllegalArgumentException if the run is empty
+   */
+  public static byte[] serializeAscendingRun(final long[] nodeKeys, final int from, final int to,
+      final Roaring64Bitmap scratch) {
+    requireNonNull(nodeKeys, "nodeKeys cannot be null");
+    requireNonNull(scratch, "scratch cannot be null");
+    final int count = to - from;
+    if (count <= 0) {
+      throw new IllegalArgumentException("run must be non-empty: from=" + from + ", to=" + to);
+    }
+
+    if (count <= PACKED_THRESHOLD) {
+      final byte[] buf = new byte[2 + count * 8];
+      buf[0] = PACKED_FORMAT;
+      buf[1] = (byte) count;
+      int pos = 2;
+      for (int i = from; i < to; i++) {
+        final long key = nodeKeys[i];
+        buf[pos] = (byte) (key >>> 56);
+        buf[pos + 1] = (byte) (key >>> 48);
+        buf[pos + 2] = (byte) (key >>> 40);
+        buf[pos + 3] = (byte) (key >>> 32);
+        buf[pos + 4] = (byte) (key >>> 24);
+        buf[pos + 5] = (byte) (key >>> 16);
+        buf[pos + 6] = (byte) (key >>> 8);
+        buf[pos + 7] = (byte) key;
+        pos += 8;
+      }
+      return buf;
+    }
+
+    scratch.clear();
+    for (int i = from; i < to; i++) {
+      scratch.add(nodeKeys[i]);
+    }
+    return serializeRoaring(scratch);
+  }
+
+  /**
    * Serializes to a caller-provided buffer, returning bytes written.
    *
    * @param refs the node references to serialize

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/SparsePartialKeys.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/SparsePartialKeys.java
@@ -32,6 +32,7 @@ import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.ShortVector;
 import jdk.incubator.vector.IntVector;
 import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
 /**
@@ -139,8 +140,8 @@ public final class SparsePartialKeys<T extends Number> {
     this.partialKeyType = partialKeyType;
     this.numEntries = numEntries;
 
-    // Allocate storage with padding for SIMD alignment
-    int alignedSize = alignToNext8(numEntries);
+    // Storage is always the full MAX_ENTRIES so a whole SIMD block can be loaded past the live
+    // entries without an out-of-bounds read; searchInts/searchShorts skip the blocks that hold none.
     if (partialKeyType == Byte.class) {
       this.byteEntries = new byte[MAX_ENTRIES]; // Always 32 for AVX2 alignment
     } else if (partialKeyType == Short.class) {
@@ -193,7 +194,7 @@ public final class SparsePartialKeys<T extends Number> {
 
       // Compute: (search & haystack) == haystack
       ByteVector andResult = searchReg.and(haystack);
-      VectorMask<Byte> matches = andResult.compare(jdk.incubator.vector.VectorOperators.EQ, haystack);
+      VectorMask<Byte> matches = andResult.compare(VectorOperators.EQ, haystack);
 
       // Use long shift to avoid overflow when numEntries=32
       long mask = numEntries == 32
@@ -221,6 +222,11 @@ public final class SparsePartialKeys<T extends Number> {
 
   /**
    * SIMD search for 16-bit partial keys.
+   *
+   * <p>
+   * HFT: the second 16-lane block is compared only when the node actually has entries in it. The
+   * trailing lanes are masked out of the result either way, so skipping the block is exactly
+   * equivalent — see {@link #searchInts} for why that matters on the descent hot path.
    */
   private int searchShorts(short densePartialKey) {
     if (SHORT_SPECIES.length() >= 16) {
@@ -229,13 +235,15 @@ public final class SparsePartialKeys<T extends Number> {
 
       // First 16 entries
       ShortVector haystack1 = ShortVector.fromArray(SHORT_SPECIES, shortEntries, 0);
-      VectorMask<Short> matches1 = searchReg.and(haystack1).compare(jdk.incubator.vector.VectorOperators.EQ, haystack1);
+      VectorMask<Short> matches1 = searchReg.and(haystack1).compare(VectorOperators.EQ, haystack1);
 
-      // Second 16 entries
-      ShortVector haystack2 = ShortVector.fromArray(SHORT_SPECIES, shortEntries, 16);
-      VectorMask<Short> matches2 = searchReg.and(haystack2).compare(jdk.incubator.vector.VectorOperators.EQ, haystack2);
-
-      int result = (int) matches1.toLong() | ((int) matches2.toLong() << 16);
+      int result = (int) matches1.toLong();
+      if (numEntries > 16) {
+        // Second 16 entries
+        ShortVector haystack2 = ShortVector.fromArray(SHORT_SPECIES, shortEntries, 16);
+        VectorMask<Short> matches2 = searchReg.and(haystack2).compare(VectorOperators.EQ, haystack2);
+        result |= (int) matches2.toLong() << 16;
+      }
       long mask = numEntries == 32 ? 0xFFFFFFFFL : ((1L << numEntries) - 1);
       return (int) (result & mask);
     } else {
@@ -255,17 +263,26 @@ public final class SparsePartialKeys<T extends Number> {
 
   /**
    * SIMD search for 32-bit partial keys.
+   *
+   * <p>
+   * HFT: this is the innermost operation of the trie descent — one call per level, per lookup — and
+   * it used to run all four 8-lane blocks unconditionally, i.e. cover 32 entries whatever the node's
+   * actual fan-out. A node with eight or fewer children therefore paid four vector loads, four
+   * subset compares and four mask extractions to produce 24 bits that the trailing {@code mask}
+   * immediately discarded. Bounding the loop by the live entry count is exactly equivalent — every
+   * bit a skipped block could set sits at position {@code >= numEntries} and is masked off — and on
+   * the profiled CAS index the mask extraction alone was 10% of a point lookup.
    */
   private int searchInts(int densePartialKey) {
     if (INT_SPECIES.length() >= 8) {
       IntVector searchReg = IntVector.broadcast(INT_SPECIES, densePartialKey);
       int result = 0;
 
-      // Process 8 entries at a time
-      for (int i = 0; i < 4; i++) {
+      // Process 8 entries at a time, over the blocks that hold live entries only.
+      final int blocks = (numEntries + 7) >>> 3;
+      for (int i = 0; i < blocks; i++) {
         IntVector haystack = IntVector.fromArray(INT_SPECIES, intEntries, i * 8);
-        VectorMask<Integer> matches =
-            searchReg.and(haystack).compare(jdk.incubator.vector.VectorOperators.EQ, haystack);
+        VectorMask<Integer> matches = searchReg.and(haystack).compare(VectorOperators.EQ, haystack);
         result |= ((int) matches.toLong() << (i * 8));
       }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/SparsePartialKeys.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/SparsePartialKeys.java
@@ -244,7 +244,9 @@ public final class SparsePartialKeys<T extends Number> {
         VectorMask<Short> matches2 = searchReg.and(haystack2).compare(VectorOperators.EQ, haystack2);
         result |= (int) matches2.toLong() << 16;
       }
-      long mask = numEntries == 32 ? 0xFFFFFFFFL : ((1L << numEntries) - 1);
+      final long mask = numEntries == 32
+          ? 0xFFFFFFFFL
+          : ((1L << numEntries) - 1);
       return (int) (result & mask);
     } else {
       return searchShortsScalar(densePartialKey);
@@ -267,11 +269,11 @@ public final class SparsePartialKeys<T extends Number> {
    * <p>
    * HFT: this is the innermost operation of the trie descent — one call per level, per lookup — and
    * it used to run all four 8-lane blocks unconditionally, i.e. cover 32 entries whatever the node's
-   * actual fan-out. A node with eight or fewer children therefore paid four vector loads, four
-   * subset compares and four mask extractions to produce 24 bits that the trailing {@code mask}
-   * immediately discarded. Bounding the loop by the live entry count is exactly equivalent — every
-   * bit a skipped block could set sits at position {@code >= numEntries} and is masked off — and on
-   * the profiled CAS index the mask extraction alone was 10% of a point lookup.
+   * actual fan-out. A node with eight or fewer children therefore paid four vector loads, four subset
+   * compares and four mask extractions to produce 24 bits that the trailing {@code mask} immediately
+   * discarded. Bounding the loop by the live entry count is exactly equivalent — every bit a skipped
+   * block could set sits at position {@code >= numEntries} and is masked off — and on the profiled
+   * CAS index the mask extraction alone was 10% of a point lookup.
    */
   private int searchInts(int densePartialKey) {
     if (INT_SPECIES.length() >= 8) {
@@ -286,7 +288,9 @@ public final class SparsePartialKeys<T extends Number> {
         result |= ((int) matches.toLong() << (i * 8));
       }
 
-      long mask = numEntries == 32 ? 0xFFFFFFFFL : ((1L << numEntries) - 1);
+      final long mask = numEntries == 32
+          ? 0xFFFFFFFFL
+          : ((1L << numEntries) - 1);
       return (int) (result & mask);
     } else {
       return searchIntsScalar(densePartialKey);
@@ -321,8 +325,8 @@ public final class SparsePartialKeys<T extends Number> {
   }
 
   /**
-   * Set entry at index (boxed API, allocates).
-   * Prefer {@link #setByteEntry(int, byte)} for byte-type sparse keys.
+   * Set entry at index (boxed API, allocates). Prefer {@link #setByteEntry(int, byte)} for byte-type
+   * sparse keys.
    *
    * @param index the entry index
    * @param value the partial key value
@@ -340,8 +344,10 @@ public final class SparsePartialKeys<T extends Number> {
   /**
    * Set byte-type entry at index without boxing.
    *
-   * <p>This is the preferred hot-path setter for {@code forBytes()} instances — avoids autoboxing
-   * {@code byte} to {@code Byte} that {@link #setEntry(int, Number)} would incur.</p>
+   * <p>
+   * This is the preferred hot-path setter for {@code forBytes()} instances — avoids autoboxing
+   * {@code byte} to {@code Byte} that {@link #setEntry(int, Number)} would incur.
+   * </p>
    *
    * @param index the entry index
    * @param value the partial key value

--- a/bundles/sirix-core/src/main/java/io/sirix/index/interval/ValidTimeKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/interval/ValidTimeKeySerializer.java
@@ -12,18 +12,22 @@ import static java.util.Objects.requireNonNull;
 /**
  * Order-preserving serializer for {@link ValidTimeKey}s.
  *
- * <p>The 17-byte encoding is {@code [store:1][signFlippedBE(forkNode):8][signFlippedBE(endpoint):8]}.
+ * <p>
+ * The 17-byte encoding is {@code [store:1][signFlippedBE(forkNode):8][signFlippedBE(endpoint):8]}.
  * The {@code store} discriminator leads so the two RI-tree stores (lower / upper) occupy disjoint,
  * contiguous key ranges in the single HOT sub-tree; the fork node leads the endpoint so a fixed
  * {@code (store, forkNode)} endpoint sub-range is one contiguous range scan. Both longs are
- * sign-flipped big-endian (XOR with the sign bit) so unsigned byte comparison matches signed numeric
- * order — the exact technique {@code CASKeySerializer} uses for the path-node-key prefix.</p>
+ * sign-flipped big-endian (XOR with the sign bit) so unsigned byte comparison matches signed
+ * numeric order — the exact technique {@code CASKeySerializer} uses for the path-node-key prefix.
+ * </p>
  *
- * <p>Stateless and thread-safe; all methods write into caller-provided buffers (zero allocation on
- * the hot path). The HOT chunked-bitmap layer appends a 4-byte {@code chunkIdx} trailer after this
+ * <p>
+ * Stateless and thread-safe; all methods write into caller-provided buffers (zero allocation on the
+ * hot path). The HOT chunked-bitmap layer appends a 4-byte {@code chunkIdx} trailer after this
  * prefix (see {@link HOTKeySerializer#serializeWithChunkIdx}); the trailing chunkIdx keeps all
  * chunks of one {@code (store, fork, endpoint)} key lex-clustered, so the endpoint range scan still
- * captures every chunk of every endpoint in range.</p>
+ * captures every chunk of every endpoint in range.
+ * </p>
  *
  * @author Johannes Lichtenberger
  */
@@ -38,8 +42,7 @@ public final class ValidTimeKeySerializer implements HOTKeySerializer<ValidTimeK
   /** Singleton instance (stateless, thread-safe). */
   public static final ValidTimeKeySerializer INSTANCE = new ValidTimeKeySerializer();
 
-  private ValidTimeKeySerializer() {
-  }
+  private ValidTimeKeySerializer() {}
 
   @Override
   public int serialize(final ValidTimeKey key, final byte[] dest, final int offset) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/interval/ValidTimeKeySerializer.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/interval/ValidTimeKeySerializer.java
@@ -51,6 +51,12 @@ public final class ValidTimeKeySerializer implements HOTKeySerializer<ValidTimeK
     return o - offset;
   }
 
+  /** Fixed width: a store byte plus two sign-flipped longs. */
+  @Override
+  public int maxSerializedLength(final ValidTimeKey key) {
+    return KEY_BYTES;
+  }
+
   @Override
   public ValidTimeKey deserialize(final byte[] bytes, final int offset, final int length) {
     final byte store = bytes[offset];

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
@@ -69,7 +69,9 @@ public final class NameIndexBuilder {
     this.useHOT = true;
     // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into it,
     // so an index that already holds entries keeps the incremental path.
-    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
+    this.bulkLoader = hotWriter.isEmptyTree()
+        ? hotWriter.createBulkLoader()
+        : null;
   }
 
   public VisitResultType build(QNm name, ImmutableNode node) {
@@ -103,10 +105,12 @@ public final class NameIndexBuilder {
   /**
    * Add {@code node} to {@code name}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
+   * <p>
+   * A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
    * reference needs neither a read-back of the stored references nor a re-insert of them. Doing so
-   * made building an index quadratic in how many nodes share a name — which, for a name index, is
-   * the point of the index.</p>
+   * made building an index quadratic in how many nodes share a name — which, for a name index, is the
+   * point of the index.
+   * </p>
    */
   private void buildHOT(QNm name, ImmutableNode node) {
     assert hotWriter != null;
@@ -118,9 +122,8 @@ public final class NameIndexBuilder {
   }
 
   /**
-   * Materialise everything the traversal collected. Must be called exactly once, after the
-   * document traversal that feeds {@link #build} has finished; a no-op unless this builder is
-   * bulk-loading.
+   * Materialise everything the traversal collected. Must be called exactly once, after the document
+   * traversal that feeds {@link #build} has finished; a no-op unless this builder is bulk-loading.
    */
   public void finish() {
     if (bulkLoader != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
@@ -4,6 +4,7 @@ import io.sirix.api.StorageEngineReader;
 import io.sirix.api.visitor.VisitResultType;
 import io.sirix.index.SearchMode;
 import io.sirix.exception.SirixIOException;
+import io.sirix.index.hot.HOTBulkIndexLoader;
 import io.sirix.index.hot.HOTIndexWriter;
 import io.sirix.index.redblacktree.RBTreeReader;
 import io.sirix.index.redblacktree.RBTreeWriter;
@@ -35,6 +36,13 @@ public final class NameIndexBuilder {
   private final boolean useHOT;
 
   /**
+   * Bulk loader for the HOT backend, non-{@code null} exactly when this builder starts against an
+   * empty index tree — the normal "create an index over an already-shredded revision" case. Every
+   * entry is collected and the trie is materialised once in {@link #finish()}.
+   */
+  private final @Nullable HOTBulkIndexLoader<QNm> bulkLoader;
+
+  /**
    * Constructor with RBTree writer (legacy path).
    */
   public NameIndexBuilder(final Set<QNm> includes, final Set<QNm> excludes,
@@ -45,6 +53,7 @@ public final class NameIndexBuilder {
     this.hotWriter = null;
     this.storageEngineReader = storageEngineReader;
     this.useHOT = false;
+    this.bulkLoader = null;
   }
 
   /**
@@ -58,6 +67,9 @@ public final class NameIndexBuilder {
     this.hotWriter = hotWriter;
     this.storageEngineReader = storageEngineReader;
     this.useHOT = true;
+    // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into it,
+    // so an index that already holds entries keeps the incremental path.
+    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
   }
 
   public VisitResultType build(QNm name, ImmutableNode node) {
@@ -88,23 +100,36 @@ public final class NameIndexBuilder {
         () -> setNodeReferencesRBTree(node, new NodeReferences(), name));
   }
 
+  /**
+   * Add {@code node} to {@code name}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
+   * reference needs neither a read-back of the stored references nor a re-insert of them. Doing so
+   * made building an index quadratic in how many nodes share a name — which, for a name index, is
+   * the point of the index.</p>
+   */
   private void buildHOT(QNm name, ImmutableNode node) {
     assert hotWriter != null;
-    NodeReferences existingRefs = hotWriter.get(name, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(node, existingRefs, name);
+    if (bulkLoader != null) {
+      bulkLoader.add(name, node.getNodeKey());
     } else {
-      setNodeReferencesHOT(node, new NodeReferences(), name);
+      hotWriter.indexNodeKey(name, node.getNodeKey());
+    }
+  }
+
+  /**
+   * Materialise everything the traversal collected. Must be called exactly once, after the
+   * document traversal that feeds {@link #build} has finished; a no-op unless this builder is
+   * bulk-loading.
+   */
+  public void finish() {
+    if (bulkLoader != null) {
+      bulkLoader.flush();
     }
   }
 
   private void setNodeReferencesRBTree(final ImmutableNode node, final NodeReferences references, final QNm name) {
     assert rbTreeWriter != null;
     rbTreeWriter.index(name, references.addNodeKey(node.getNodeKey()), RBTreeReader.MoveCursor.NO_MOVE);
-  }
-
-  private void setNodeReferencesHOT(final ImmutableNode node, final NodeReferences references, final QNm name) {
-    assert hotWriter != null;
-    hotWriter.index(name, references.addNodeKey(node.getNodeKey()), RBTreeReader.MoveCursor.NO_MOVE);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexListener.java
@@ -106,11 +106,13 @@ public final class NameIndexListener {
   /**
    * Add {@code nodeKey} to {@code name}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
-   * already recorded for {@code name} need neither be read back nor re-inserted — doing so cost
-   * one range scan plus one full trie descent per already-stored node key, making a bulk insert
-   * of k nodes sharing a name quadratic in k. (It also handed the live record straight to
-   * {@code addNodeKey}, the in-place mutation the RBTree path above clones to avoid.)</p>
+   * <p>
+   * A HOT slot write OR-merges the incoming bitmap into the stored one, so the references already
+   * recorded for {@code name} need neither be read back nor re-inserted — doing so cost one range
+   * scan plus one full trie descent per already-stored node key, making a bulk insert of k nodes
+   * sharing a name quadratic in k. (It also handed the live record straight to {@code addNodeKey},
+   * the in-place mutation the RBTree path above clones to avoid.)
+   * </p>
    */
   private void handleInsertHOT(long nodeKey, QNm name) {
     assert hotWriter != null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexListener.java
@@ -103,23 +103,22 @@ public final class NameIndexListener {
     }
   }
 
+  /**
+   * Add {@code nodeKey} to {@code name}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
+   * already recorded for {@code name} need neither be read back nor re-inserted — doing so cost
+   * one range scan plus one full trie descent per already-stored node key, making a bulk insert
+   * of k nodes sharing a name quadratic in k. (It also handed the live record straight to
+   * {@code addNodeKey}, the in-place mutation the RBTree path above clones to avoid.)</p>
+   */
   private void handleInsertHOT(long nodeKey, QNm name) {
     assert hotWriter != null;
-    NodeReferences existingRefs = hotWriter.get(name, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(nodeKey, existingRefs, name);
-    } else {
-      setNodeReferencesHOT(nodeKey, new NodeReferences(), name);
-    }
+    hotWriter.indexNodeKey(name, nodeKey);
   }
 
   private void setNodeReferencesRBTree(final long nodeKey, final NodeReferences references, final QNm name) {
     assert rbTreeWriter != null;
     rbTreeWriter.index(name, references.addNodeKey(nodeKey), RBTreeReader.MoveCursor.NO_MOVE);
-  }
-
-  private void setNodeReferencesHOT(final long nodeKey, final NodeReferences references, final QNm name) {
-    assert hotWriter != null;
-    hotWriter.index(name, references.addNodeKey(nodeKey), RBTreeReader.MoveCursor.NO_MOVE);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/json/JsonNameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/json/JsonNameIndexBuilder.java
@@ -3,6 +3,7 @@ package io.sirix.index.name.json;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.trx.node.json.AbstractJsonNodeVisitor;
 import io.sirix.api.visitor.VisitResult;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.name.NameIndexBuilder;
 import io.sirix.node.NodeKind;
 import io.sirix.node.json.ObjectNamedArrayNode;
@@ -12,7 +13,7 @@ import io.sirix.node.json.ObjectNamedNumberNode;
 import io.sirix.node.json.ObjectNamedObjectNode;
 import io.sirix.node.json.ObjectNamedStringNode;
 
-final class JsonNameIndexBuilder extends AbstractJsonNodeVisitor {
+final class JsonNameIndexBuilder extends AbstractJsonNodeVisitor implements IndexBuildFinalizer {
   private final NameIndexBuilder builder;
 
   public JsonNameIndexBuilder(final NameIndexBuilder builder) {
@@ -57,5 +58,10 @@ final class JsonNameIndexBuilder extends AbstractJsonNodeVisitor {
     if (cachedName != null) return cachedName;
     final String localName = builder.storageEngineReader.getName(nameKey, NodeKind.OBJECT_NAMED_OBJECT);
     return localName == null ? null : new QNm(localName);
+  }
+
+  @Override
+  public void finishIndexBuild() {
+    builder.finish();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/json/JsonNameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/json/JsonNameIndexBuilder.java
@@ -55,9 +55,12 @@ final class JsonNameIndexBuilder extends AbstractJsonNodeVisitor implements Inde
   }
 
   private QNm resolveName(final QNm cachedName, final int nameKey) {
-    if (cachedName != null) return cachedName;
+    if (cachedName != null)
+      return cachedName;
     final String localName = builder.storageEngineReader.getName(nameKey, NodeKind.OBJECT_NAMED_OBJECT);
-    return localName == null ? null : new QNm(localName);
+    return localName == null
+        ? null
+        : new QNm(localName);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/xml/XmlNameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/xml/XmlNameIndexBuilder.java
@@ -4,9 +4,10 @@ import io.sirix.api.visitor.VisitResult;
 import io.sirix.node.immutable.xml.ImmutableElement;
 import io.brackit.query.atomic.QNm;
 import io.sirix.access.trx.node.xml.AbstractXmlNodeVisitor;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.name.NameIndexBuilder;
 
-final class XmlNameIndexBuilder extends AbstractXmlNodeVisitor {
+final class XmlNameIndexBuilder extends AbstractXmlNodeVisitor implements IndexBuildFinalizer {
   private final NameIndexBuilder builder;
 
   XmlNameIndexBuilder(final NameIndexBuilder builder) {
@@ -18,5 +19,10 @@ final class XmlNameIndexBuilder extends AbstractXmlNodeVisitor {
     final QNm name = node.getName();
 
     return builder.build(name, node);
+  }
+
+  @Override
+  public void finishIndexBuild() {
+    builder.finish();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
@@ -78,7 +78,9 @@ public final class PathIndexBuilder {
     this.useHOT = true;
     // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into it,
     // so an index that already holds entries keeps the incremental path.
-    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
+    this.bulkLoader = hotWriter.isEmptyTree()
+        ? hotWriter.createBulkLoader()
+        : null;
   }
 
   public VisitResult process(final ImmutableNode node, final long pathNodeKey) {
@@ -98,9 +100,9 @@ public final class PathIndexBuilder {
   }
 
   /**
-   * Returns the {@link PathSummaryReader} backing this builder. Used by JSON-specific dispatch
-   * (e.g. fused {@code OBJECT_NAMED_ARRAY} which must index its host record at both the
-   * OBJECT_KEY layer and the {@code __array__/ARRAY} layer) to navigate path-summary parents.
+   * Returns the {@link PathSummaryReader} backing this builder. Used by JSON-specific dispatch (e.g.
+   * fused {@code OBJECT_NAMED_ARRAY} which must index its host record at both the OBJECT_KEY layer
+   * and the {@code __array__/ARRAY} layer) to navigate path-summary parents.
    */
   public PathSummaryReader getPathSummaryReader() {
     return pathSummaryReader;
@@ -120,10 +122,12 @@ public final class PathIndexBuilder {
    * Whether {@code pathNodeKey} is one of the path-class records this index covers. An empty path
    * configuration means "index every path".
    *
-   * <p>The resolved PCR set is computed once and reused: the builder runs a single traversal of an
+   * <p>
+   * The resolved PCR set is computed once and reused: the builder runs a single traversal of an
    * already-shredded revision, so the path summary cannot gain nodes underneath it, and
    * {@link PathSummaryReader#getPCRsForPaths(java.util.Collection)} allocates and fills a fresh
-   * {@code LongOpenHashSet} on every call — once per visited node, on the build hot path.</p>
+   * {@code LongOpenHashSet} on every call — once per visited node, on the build hot path.
+   * </p>
    */
   private boolean matchesIndexedPath(final long pathNodeKey) {
     if (paths.isEmpty()) {
@@ -140,10 +144,12 @@ public final class PathIndexBuilder {
   /**
    * Add {@code node} to {@code PCR}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
+   * <p>
+   * A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
    * reference needs neither a read-back of the stored references nor a re-insert of them. Doing so
    * made building an index quadratic in the number of nodes sharing a key — and for a PATH index
-   * every node under the indexed path shares one key, so that was the whole index.</p>
+   * every node under the indexed path shares one key, so that was the whole index.
+   * </p>
    */
   private void processHOT(final ImmutableNode node, final long PCR) throws SirixIOException {
     assert hotWriter != null;
@@ -155,9 +161,8 @@ public final class PathIndexBuilder {
   }
 
   /**
-   * Materialise everything the traversal collected. Must be called exactly once, after the
-   * document traversal that feeds {@link #process} has finished; a no-op unless this builder is
-   * bulk-loading.
+   * Materialise everything the traversal collected. Must be called exactly once, after the document
+   * traversal that feeds {@link #process} has finished; a no-op unless this builder is bulk-loading.
    */
   public void finish() {
     if (bulkLoader != null) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
@@ -7,6 +7,7 @@ import io.brackit.query.atomic.QNm;
 import io.brackit.query.util.path.Path;
 import io.brackit.query.util.path.PathException;
 import io.sirix.exception.SirixIOException;
+import io.sirix.index.hot.HOTLongBulkIndexLoader;
 import io.sirix.index.hot.HOTLongIndexWriter;
 import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.index.redblacktree.RBTreeReader.MoveCursor;
@@ -14,6 +15,7 @@ import io.sirix.index.redblacktree.RBTreeWriter;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.node.interfaces.immutable.ImmutableNode;
 import io.sirix.utils.LogWrapper;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,16 @@ public final class PathIndexBuilder {
 
   private final boolean useHOT;
 
+  /** Path-class records covered by {@link #paths}, resolved lazily on the first indexed node. */
+  private @Nullable LongSet resolvedPCRs;
+
+  /**
+   * Bulk loader for the HOT backend, non-{@code null} exactly when this builder starts against an
+   * empty index tree — the normal "create an index over an already-shredded revision" case. Every
+   * entry is collected and the trie is materialised once in {@link #finish()}.
+   */
+  private final @Nullable HOTLongBulkIndexLoader bulkLoader;
+
   /**
    * Constructor with RBTree writer (legacy path).
    */
@@ -51,6 +63,7 @@ public final class PathIndexBuilder {
     this.rbTreeWriter = indexWriter;
     this.hotWriter = null;
     this.useHOT = false;
+    this.bulkLoader = null;
   }
 
   /**
@@ -63,12 +76,15 @@ public final class PathIndexBuilder {
     this.rbTreeWriter = null;
     this.hotWriter = hotWriter;
     this.useHOT = true;
+    // Bulk-load only into a virgin tree: the loader replaces the root instead of merging into it,
+    // so an index that already holds entries keeps the incremental path.
+    this.bulkLoader = hotWriter.isEmptyTree() ? hotWriter.createBulkLoader() : null;
   }
 
   public VisitResult process(final ImmutableNode node, final long pathNodeKey) {
     try {
       final long PCR = pathNodeKey;
-      if (pathSummaryReader.getPCRsForPaths(paths).contains(PCR) || paths.isEmpty()) {
+      if (matchesIndexedPath(PCR)) {
         if (useHOT) {
           processHOT(node, PCR);
         } else {
@@ -100,13 +116,52 @@ public final class PathIndexBuilder {
     }
   }
 
+  /**
+   * Whether {@code pathNodeKey} is one of the path-class records this index covers. An empty path
+   * configuration means "index every path".
+   *
+   * <p>The resolved PCR set is computed once and reused: the builder runs a single traversal of an
+   * already-shredded revision, so the path summary cannot gain nodes underneath it, and
+   * {@link PathSummaryReader#getPCRsForPaths(java.util.Collection)} allocates and fills a fresh
+   * {@code LongOpenHashSet} on every call — once per visited node, on the build hot path.</p>
+   */
+  private boolean matchesIndexedPath(final long pathNodeKey) {
+    if (paths.isEmpty()) {
+      return true;
+    }
+    LongSet pcrs = resolvedPCRs;
+    if (pcrs == null) {
+      pcrs = pathSummaryReader.getPCRsForPaths(paths);
+      resolvedPCRs = pcrs;
+    }
+    return pcrs.contains(pathNodeKey);
+  }
+
+  /**
+   * Add {@code node} to {@code PCR}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write is an OR-merge of the incoming bitmap into the stored one, so adding one
+   * reference needs neither a read-back of the stored references nor a re-insert of them. Doing so
+   * made building an index quadratic in the number of nodes sharing a key — and for a PATH index
+   * every node under the indexed path shares one key, so that was the whole index.</p>
+   */
   private void processHOT(final ImmutableNode node, final long PCR) throws SirixIOException {
     assert hotWriter != null;
-    NodeReferences existingRefs = hotWriter.get(PCR, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(node, existingRefs, PCR);
+    if (bulkLoader != null) {
+      bulkLoader.add(PCR, node.getNodeKey());
     } else {
-      setNodeReferencesHOT(node, new NodeReferences(), PCR);
+      hotWriter.indexNodeKey(PCR, node.getNodeKey());
+    }
+  }
+
+  /**
+   * Materialise everything the traversal collected. Must be called exactly once, after the
+   * document traversal that feeds {@link #process} has finished; a no-op unless this builder is
+   * bulk-loading.
+   */
+  public void finish() {
+    if (bulkLoader != null) {
+      bulkLoader.flush();
     }
   }
 
@@ -116,9 +171,4 @@ public final class PathIndexBuilder {
     rbTreeWriter.index(pathNodeKey, references.addNodeKey(node.getNodeKey()), MoveCursor.NO_MOVE);
   }
 
-  private void setNodeReferencesHOT(final ImmutableNode node, final NodeReferences references, final long pathNodeKey)
-      throws SirixIOException {
-    assert hotWriter != null;
-    hotWriter.index(pathNodeKey, references.addNodeKey(node.getNodeKey()), MoveCursor.NO_MOVE);
-  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexListener.java
@@ -57,9 +57,9 @@ public final class PathIndexListener {
   }
 
   /**
-   * Returns the {@link PathSummaryReader} backing this listener. Used by JSON-specific dispatch
-   * (e.g. fused {@code OBJECT_NAMED_ARRAY} which must mirror its index entry at both the
-   * OBJECT_KEY layer and the {@code __array__/ARRAY} layer) to navigate path-summary parents.
+   * Returns the {@link PathSummaryReader} backing this listener. Used by JSON-specific dispatch (e.g.
+   * fused {@code OBJECT_NAMED_ARRAY} which must mirror its index entry at both the OBJECT_KEY layer
+   * and the {@code __array__/ARRAY} layer) to navigate path-summary parents.
    */
   public PathSummaryReader getPathSummaryReader() {
     return pathSummaryReader;
@@ -117,10 +117,12 @@ public final class PathIndexListener {
   /**
    * Add {@code nodeKey} to {@code pathNodeKey}'s posting list in the HOT backend.
    *
-   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
-   * already recorded for {@code pathNodeKey} need neither be read back nor re-inserted — doing so
-   * cost one range scan plus one full trie descent per already-stored node key, and every node
-   * under an indexed path shares a single PATH key, so that grew with the whole index.</p>
+   * <p>
+   * A HOT slot write OR-merges the incoming bitmap into the stored one, so the references already
+   * recorded for {@code pathNodeKey} need neither be read back nor re-inserted — doing so cost one
+   * range scan plus one full trie descent per already-stored node key, and every node under an
+   * indexed path shares a single PATH key, so that grew with the whole index.
+   * </p>
    */
   private void handleInsertHOT(final long nodeKey, final long pathNodeKey) {
     assert hotWriter != null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexListener.java
@@ -114,15 +114,18 @@ public final class PathIndexListener {
     }
   }
 
+  /**
+   * Add {@code nodeKey} to {@code pathNodeKey}'s posting list in the HOT backend.
+   *
+   * <p>A HOT slot write OR-merges the incoming bitmap into the stored one, so the references
+   * already recorded for {@code pathNodeKey} need neither be read back nor re-inserted — doing so
+   * cost one range scan plus one full trie descent per already-stored node key, and every node
+   * under an indexed path shares a single PATH key, so that grew with the whole index.</p>
+   */
   private void handleInsertHOT(final long nodeKey, final long pathNodeKey) {
     assert hotWriter != null;
     // HOT writer uses primitive long - no boxing!
-    NodeReferences existingRefs = hotWriter.get(pathNodeKey, SearchMode.EQUAL);
-    if (existingRefs != null) {
-      setNodeReferencesHOT(nodeKey, existingRefs, pathNodeKey);
-    } else {
-      setNodeReferencesHOT(nodeKey, new NodeReferences(), pathNodeKey);
-    }
+    hotWriter.indexNodeKey(pathNodeKey, nodeKey);
   }
 
   private void setNodeReferencesRBTree(final long nodeKey, final NodeReferences references, final long pathNodeKey) {
@@ -130,9 +133,4 @@ public final class PathIndexListener {
     rbTreeWriter.index(pathNodeKey, references.addNodeKey(nodeKey), MoveCursor.NO_MOVE);
   }
 
-  private void setNodeReferencesHOT(final long nodeKey, final NodeReferences references, final long pathNodeKey) {
-    assert hotWriter != null;
-    // HOT writer uses primitive long - no boxing!
-    hotWriter.index(pathNodeKey, references.addNodeKey(nodeKey), MoveCursor.NO_MOVE);
-  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/json/JsonPathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/json/JsonPathIndexBuilder.java
@@ -3,6 +3,7 @@ package io.sirix.index.path.json;
 import io.sirix.access.trx.node.json.AbstractJsonNodeVisitor;
 import io.sirix.api.visitor.VisitResult;
 import io.sirix.api.visitor.VisitResultType;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.path.PathIndexBuilder;
 import io.sirix.node.immutable.json.ImmutableArrayNode;
 import io.sirix.node.json.ObjectNamedArrayNode;
@@ -12,7 +13,7 @@ import io.sirix.node.json.ObjectNamedNumberNode;
 import io.sirix.node.json.ObjectNamedObjectNode;
 import io.sirix.node.json.ObjectNamedStringNode;
 
-public final class JsonPathIndexBuilder extends AbstractJsonNodeVisitor {
+public final class JsonPathIndexBuilder extends AbstractJsonNodeVisitor implements IndexBuildFinalizer {
 
   private final PathIndexBuilder pathIndexBuilder;
 
@@ -72,5 +73,10 @@ public final class JsonPathIndexBuilder extends AbstractJsonNodeVisitor {
       }
     }
     return VisitResultType.CONTINUE;
+  }
+
+  @Override
+  public void finishIndexBuild() {
+    pathIndexBuilder.finish();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/json/JsonPathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/json/JsonPathIndexBuilder.java
@@ -64,8 +64,7 @@ public final class JsonPathIndexBuilder extends AbstractJsonNodeVisitor implemen
     // to be populated. We index the fused record under BOTH layers so either path resolves.
     final long arrayLayerPathNodeKey = node.getPathNodeKey();
     pathIndexBuilder.process(node, arrayLayerPathNodeKey);
-    final var arrayPathNode =
-        pathIndexBuilder.getPathSummaryReader().getPathNodeForPathNodeKey(arrayLayerPathNodeKey);
+    final var arrayPathNode = pathIndexBuilder.getPathSummaryReader().getPathNodeForPathNodeKey(arrayLayerPathNodeKey);
     if (arrayPathNode != null) {
       final long objectKeyLayerPathNodeKey = arrayPathNode.getParentKey();
       if (objectKeyLayerPathNodeKey >= 0) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/xml/XmlPathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/xml/XmlPathIndexBuilder.java
@@ -2,11 +2,12 @@ package io.sirix.index.path.xml;
 
 import io.sirix.access.trx.node.xml.AbstractXmlNodeVisitor;
 import io.sirix.api.visitor.VisitResult;
+import io.sirix.index.IndexBuildFinalizer;
 import io.sirix.index.path.PathIndexBuilder;
 import io.sirix.node.immutable.xml.ImmutableAttributeNode;
 import io.sirix.node.immutable.xml.ImmutableElement;
 
-public final class XmlPathIndexBuilder extends AbstractXmlNodeVisitor {
+public final class XmlPathIndexBuilder extends AbstractXmlNodeVisitor implements IndexBuildFinalizer {
 
   private final PathIndexBuilder mPathIndexBuilder;
 
@@ -24,4 +25,9 @@ public final class XmlPathIndexBuilder extends AbstractXmlNodeVisitor {
     return mPathIndexBuilder.process(node, node.getPathNodeKey());
   }
 
+
+  @Override
+  public void finishIndexBuild() {
+    mPathIndexBuilder.finish();
+  }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -591,47 +591,24 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       return null;
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
-      final byte[] keyBuf = KEY_BUFFER.get();
-      // Same optimistic-stamp discipline as readBlob: validate the found/absent decision and the
-      // value copy before the discriminator dispatch runs on them.
-      for (int attempt = 0; attempt <= MAX_TORN_SLOT_ROUNDS; attempt++) {
-        final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
-        if (leaf == null) {
-          return null;
-        }
-        final byte[] value;
-        try {
-          final int idx = leaf.findEntry(keyBuf);
-          value = idx < 0
-              ? null
-              : leaf.getValue(idx);
-        } catch (RuntimeException e) {
-          if (trieReader.validateCurrentLeaf()) {
-            throw e; // stable bytes — genuine corruption, not a torn read
-          }
-          continue;
-        }
-        if (!trieReader.validateCurrentLeaf()) {
-          continue;
-        }
-        if (value == null || value.length == 0) {
-          return null;
-        }
-        final byte[] inline = inlineColumnSegmentPayload(value, slotKey);
-        if (inline != null) {
-          return inline;
-        }
-        final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
-        if (ref == null) {
-          return null;
-        }
-        final OverflowPage page = reader.readSideOverflowPage(ref);
-        return page == null
-            ? null
-            : page.getDataBytes();
+      final HOTLeafPage[] leafOut = new HOTLeafPage[1];
+      final byte[] value =
+          readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), leafOut, "readColumnSegmentSlot");
+      if (value == null) {
+        return null;
       }
-      throw new IllegalStateException("readColumnSegmentSlot(slot " + slotKey + ") failed stamp validation on "
-          + MAX_TORN_SLOT_ROUNDS + " consecutive attempts — sustained allocator thrashing");
+      final byte[] inline = inlineColumnSegmentPayload(value, slotKey);
+      if (inline != null) {
+        return inline;
+      }
+      final PageReference ref = leafOut[0].getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+      if (ref == null) {
+        return null;
+      }
+      final OverflowPage page = reader.readSideOverflowPage(ref);
+      return page == null
+          ? null
+          : page.getDataBytes();
     }
   }
 
@@ -854,11 +831,11 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
           if (cursor.validateLeaf()) {
             throw e; // stable bytes — genuine corruption, not a torn read
           }
-          recoverTornSlot(cursor, ++tornRounds);
+          cursor.recoverTorn(++tornRounds);
           continue;
         }
         if (!cursor.validateLeaf()) {
-          recoverTornSlot(cursor, ++tornRounds);
+          cursor.recoverTorn(++tornRounds);
           continue;
         }
         tornRounds = 0;
@@ -1641,11 +1618,11 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
           if (cursor.validateLeaf()) {
             throw e; // stable bytes — genuine corruption, not a torn read
           }
-          recoverTornSlot(cursor, ++tornRounds);
+          cursor.recoverTorn(++tornRounds);
           continue;
         }
         if (!cursor.validateLeaf()) {
-          recoverTornSlot(cursor, ++tornRounds);
+          cursor.recoverTorn(++tornRounds);
           continue;
         }
         tornRounds = 0;
@@ -1907,48 +1884,22 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       return null;
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
-      final byte[] keyBuf = KEY_BUFFER.get();
-      // The leaf is UNPINNED: the found/absent decision and the value copy must validate against
-      // the leaf's stamp before anything is derived from them — a torn read could otherwise
-      // surface as a silent "absent" or as a spurious hash-verification failure. Retries
-      // re-descend on freshly reloaded copies of the same immutable content.
-      for (int attempt = 0; attempt <= MAX_TORN_SLOT_ROUNDS; attempt++) {
-        final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
-        if (leaf == null) {
-          return null;
-        }
-        final byte[] value;
-        try {
-          final int idx = leaf.findEntry(keyBuf);
-          value = idx < 0
-              ? null
-              : leaf.getValue(idx);
-        } catch (RuntimeException e) {
-          if (trieReader.validateCurrentLeaf()) {
-            throw e; // stable bytes — genuine corruption, not a torn read
-          }
-          continue;
-        }
-        if (!trieReader.validateCurrentLeaf()) {
-          continue;
-        }
-        if (value == null || value.length == 0) {
-          return null;
-        }
-        if (isInlineBlob(value)) {
-          return verifyInlineBlob(value, slotKey);
-        }
-        final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
-        if (ref == null) {
-          return verifyBlob(value, null, slotKey);
-        }
-        final OverflowPage page = reader.readSideOverflowPage(ref);
-        return verifyBlob(value, page == null
-            ? null
-            : page.getDataBytes(), slotKey);
+      final HOTLeafPage[] leafOut = new HOTLeafPage[1];
+      final byte[] value = readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), leafOut, "readBlob");
+      if (value == null) {
+        return null;
       }
-      throw new IllegalStateException("readBlob(slot " + slotKey + ") failed stamp validation on "
-          + MAX_TORN_SLOT_ROUNDS + " consecutive attempts — sustained allocator thrashing");
+      if (isInlineBlob(value)) {
+        return verifyInlineBlob(value, slotKey);
+      }
+      final PageReference ref = leafOut[0].getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+      if (ref == null) {
+        return verifyBlob(value, null, slotKey);
+      }
+      final OverflowPage page = reader.readSideOverflowPage(ref);
+      return verifyBlob(value, page == null
+          ? null
+          : page.getDataBytes(), slotKey);
     }
   }
 
@@ -2023,6 +1974,46 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
    * such leaf. The caller owns the {@code trieReader} lifetime (segment resolution reads through the
    * returned leaf's side map while the reader is open).
    */
+  /**
+   * Navigate to {@code slotKey}'s leaf and read its raw value under the optimistic-stamp protocol:
+   * the found/absent decision and the value copy are both validated before anything is derived from
+   * them, and a torn batch re-descends on freshly reloaded copies. Shared by the two reader-side slot
+   * reads, which differ only in how they interpret the bytes — restating this scaffolding per caller
+   * meant a fix to the validation discipline had to be applied twice, 1300 lines apart.
+   *
+   * @param out receives the leaf the value came from, so the caller can resolve its side-map refs
+   * @return the validated value bytes, or {@code null} when the slot is absent or tombstoned
+   */
+  private static byte @Nullable [] readValidatedSlotValue(final HOTTrieReader trieReader, final PageReference rootRef,
+      final long slotKey, final byte[] keyBuf, final HOTLeafPage[] out, final String operation) {
+    for (int attempt = 0; attempt <= HOTTrieReader.MAX_STAMP_RETRIES; attempt++) {
+      final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
+      if (leaf == null) {
+        return null;
+      }
+      final byte[] value;
+      try {
+        final int idx = leaf.findEntry(keyBuf);
+        value = idx < 0
+            ? null
+            : leaf.getValue(idx);
+      } catch (RuntimeException e) {
+        if (trieReader.validateCurrentLeaf()) {
+          throw e; // stable bytes — genuine corruption, not a torn read
+        }
+        continue;
+      }
+      if (!trieReader.validateCurrentLeaf()) {
+        continue;
+      }
+      out[0] = leaf;
+      return value == null || value.length == 0
+          ? null
+          : value;
+    }
+    throw HOTTrieReader.stampRetriesExhausted(operation + "(slot " + slotKey + ")");
+  }
+
   private static @Nullable HOTLeafPage navigateToSlotLeaf(final HOTTrieReader trieReader, final PageReference rootRef,
       final long slotKey, final byte[] keyBuf) {
     PathKeySerializer.INSTANCE.serialize(slotKey, keyBuf, 0);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -14,6 +14,7 @@ import io.sirix.index.hot.AbstractHOTIndexWriter;
 import io.sirix.index.hot.PathKeySerializer;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.io.filechannel.FileChannelReader;
+import io.sirix.node.LE;
 import io.sirix.page.PageReference;
 import io.sirix.page.ProjectionIndexPage;
 import io.sirix.page.OverflowPage;
@@ -591,30 +592,46 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
       final byte[] keyBuf = KEY_BUFFER.get();
-      final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
-      if (leaf == null) {
-        return null;
+      // Same optimistic-stamp discipline as readBlob: validate the found/absent decision and the
+      // value copy before the discriminator dispatch runs on them.
+      for (int attempt = 0; attempt <= MAX_TORN_SLOT_ROUNDS; attempt++) {
+        final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
+        if (leaf == null) {
+          return null;
+        }
+        final byte[] value;
+        try {
+          final int idx = leaf.findEntry(keyBuf);
+          value = idx < 0
+              ? null
+              : leaf.getValue(idx);
+        } catch (RuntimeException e) {
+          if (trieReader.validateCurrentLeaf()) {
+            throw e; // stable bytes — genuine corruption, not a torn read
+          }
+          continue;
+        }
+        if (!trieReader.validateCurrentLeaf()) {
+          continue;
+        }
+        if (value == null || value.length == 0) {
+          return null;
+        }
+        final byte[] inline = inlineColumnSegmentPayload(value, slotKey);
+        if (inline != null) {
+          return inline;
+        }
+        final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+        if (ref == null) {
+          return null;
+        }
+        final OverflowPage page = reader.readSideOverflowPage(ref);
+        return page == null
+            ? null
+            : page.getDataBytes();
       }
-      final int idx = leaf.findEntry(keyBuf);
-      if (idx < 0) {
-        return null;
-      }
-      final byte[] value = leaf.getValue(idx);
-      if (value == null || value.length == 0) {
-        return null;
-      }
-      final byte[] inline = inlineColumnSegmentPayload(value, slotKey);
-      if (inline != null) {
-        return inline;
-      }
-      final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
-      if (ref == null) {
-        return null;
-      }
-      final OverflowPage page = reader.readSideOverflowPage(ref);
-      return page == null
-          ? null
-          : page.getDataBytes();
+      throw new IllegalStateException("readColumnSegmentSlot(slot " + slotKey + ") failed stamp validation on "
+          + MAX_TORN_SLOT_ROUNDS + " consecutive attempts — sustained allocator thrashing");
     }
   }
 
@@ -796,34 +813,62 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     final Long2ObjectRBTreeMap<RawBlobSlot> descriptors = new Long2ObjectRBTreeMap<>();
     try (HOTTrieReader trieReader = new HOTTrieReader(reader);
         HOTRangeCursor cursor = trieReader.range(rootRef, null, null)) {
+      // The walk reads UNPINNED leaves under optimistic stamps: each slot's read batch — key
+      // decode, value slice, capture copy — is validated before its outcome is committed to the
+      // collections; a torn batch re-evaluates the SAME slot on a refreshed leaf copy.
+      int tornRounds = 0;
       while (cursor.hasNext()) {
         final HOTLeafPage leaf = cursor.currentLeafPage();
         final int entryIdx = cursor.currentEntryIndex();
-        final long slotKey = leaf.decodeKey8BE(entryIdx) ^ 0x8000_0000_0000_0000L;
-        final long rowGroupId = slotKey >>> 16;
-        final MemorySegment valueSlice = cursor.currentValueSlice();
-        final int valueSize = valueSlice == null
-            ? 0
-            : (int) valueSlice.byteSize();
-        // The leaf slots must be told apart from the two other blob families by KEY: the metadata
-        // (PIXM) blob at slot 0, and the fence chunk blobs at slotKey >= CHUNK_SLOT_BASE (2^42, far
-        // above any rowGroupId<<16). Both are skipped; tombstones are zero-length. The DESCRIPTOR slot
-        // (slotKind 0) is a hashed blob; SEGMENT slots (slotKind >= 1) are BARE (discriminator byte).
-        if (valueSize == 0 || rowGroupId == 0 || slotKey >= ProjectionIndexFences.CHUNK_SLOT_BASE) {
-          cursor.advance();
+        long rowGroupId = 0;
+        RawBlobSlot descriptorSlot = null;
+        RawBlobSlot segmentSlot = null;
+        try {
+          final long slotKey = leaf.decodeKey8BE(entryIdx) ^ 0x8000_0000_0000_0000L;
+          rowGroupId = slotKey >>> 16;
+          final MemorySegment valueSlice = cursor.currentValueSlice();
+          final int valueSize = valueSlice == null
+              ? 0
+              : (int) valueSlice.byteSize();
+          if (valueSize > leaf.slotCapacity()) {
+            // A length no slot can hold must not drive the capture copies below: torn (validation
+            // fails — retried) or genuine corruption (it holds — the throw escapes).
+            throw new IllegalStateException("segment-slot value of " + valueSize + " bytes exceeds the slot capacity");
+          }
+          // The leaf slots must be told apart from the two other blob families by KEY: the metadata
+          // (PIXM) blob at slot 0, and the fence chunk blobs at slotKey >= CHUNK_SLOT_BASE (2^42, far
+          // above any rowGroupId<<16). Both are skipped; tombstones are zero-length. The DESCRIPTOR
+          // slot (slotKind 0) is a hashed blob; SEGMENT slots (slotKind >= 1) are BARE (discriminator
+          // byte).
+          if (valueSize != 0 && rowGroupId != 0 && slotKey < ProjectionIndexFences.CHUNK_SLOT_BASE) {
+            final int slotKind = (int) (slotKey & 0xFFFF);
+            if (slotKind == 0) {
+              descriptorSlot =
+                  captureDescriptorSlot(reader, leaf, valueSlice, valueSize, rowGroupId, slotKey, indexNumber);
+            } else if (segmentSlotsOut != null) {
+              segmentSlot = captureColumnSegmentSlot(reader, leaf, valueSlice, valueSize, rowGroupId, slotKind, slotKey,
+                  indexNumber);
+            }
+          }
+        } catch (RuntimeException e) {
+          if (cursor.validateLeaf()) {
+            throw e; // stable bytes — genuine corruption, not a torn read
+          }
+          recoverTornSlot(cursor, ++tornRounds);
           continue;
         }
-        final int slotKind = (int) (slotKey & 0xFFFF);
-        if (slotKind == 0) {
-          final RawBlobSlot desc =
-              captureDescriptorSlot(reader, leaf, valueSlice, valueSize, rowGroupId, slotKey, indexNumber);
-          if (descriptors.put(rowGroupId, desc) != null) {
+        if (!cursor.validateLeaf()) {
+          recoverTornSlot(cursor, ++tornRounds);
+          continue;
+        }
+        tornRounds = 0;
+        if (descriptorSlot != null) {
+          if (descriptors.put(rowGroupId, descriptorSlot) != null) {
             throw new IllegalStateException(
                 "segment-slot leaf " + rowGroupId + " has two descriptor slots (indexNumber=" + indexNumber + ")");
           }
-        } else if (segmentSlotsOut != null) {
-          segmentSlotsOut.add(captureColumnSegmentSlot(reader, leaf, valueSlice, valueSize, rowGroupId, slotKind,
-              slotKey, indexNumber));
+        } else if (segmentSlot != null) {
+          segmentSlotsOut.add(segmentSlot);
         }
         cursor.advance();
       }
@@ -942,11 +987,11 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   private static RawBlobSlot captureDescriptorSlot(final StorageEngineReader reader, final HOTLeafPage leaf,
       final MemorySegment valueSlice, final int valueSize, final long rowGroupId, final long slotKey,
       final int indexNumber) {
-    if (valueSize < BLOB_MARKER_BYTES || valueSlice.get(ValueLayout.JAVA_INT_UNALIGNED, 0) != BLOB_MAGIC) {
+    if (valueSize < BLOB_MARKER_BYTES || valueSlice.get(LE.INT, 0) != BLOB_MAGIC) {
       throw new IllegalStateException("segment-slot descriptor slot " + slotKey + " is not a blob" + " marker ("
           + valueSize + " bytes) — mixed storage layouts in one sub-tree (indexNumber=" + indexNumber + ")");
     }
-    final boolean inline = (valueSlice.get(ValueLayout.JAVA_INT_UNALIGNED, 5) & BLOB_INLINE_FLAG) != 0;
+    final boolean inline = (valueSlice.get(LE.INT, 5) & BLOB_INLINE_FLAG) != 0;
     if (inline) {
       final byte[] value = new byte[valueSize];
       MemorySegment.copy(valueSlice, ValueLayout.JAVA_BYTE, 0, value, 0, valueSize);
@@ -1539,40 +1584,106 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     // better outcome for a store that must contain only 8-byte slot keys.
     try (HOTTrieReader trieReader = new HOTTrieReader(reader);
         HOTRangeCursor cursor = trieReader.range(rootRef, null, null)) {
+      // Optimistic-stamp discipline: all reads and capture copies for a slot happen first, the
+      // stamp is validated, and only then do the results reach the DirectoryWalk callbacks (whose
+      // effects cannot be retracted) or the unresolved-page early return. A torn batch
+      // re-evaluates the SAME slot on a refreshed leaf copy.
+      int tornRounds = 0;
       while (cursor.hasNext()) {
         final HOTLeafPage leaf = cursor.currentLeafPage();
         final int entryIndex = cursor.currentEntryIndex();
-        final long slotKey = leaf.decodeKey8BE(entryIndex) ^ 0x8000_0000_0000_0000L;
-        final long rowGroupId = slotKey >>> 16;
-        // The value's LOCATION, resolved once, not a slice of it: nine of every ten slots here
-        // need only their size plus a discriminator byte, and materializing a MemorySegment per
-        // slot made the walk's largest allocation a set of objects it immediately threw away.
-        // Every read below reuses this one handle. A malformed slot reports length -1, which the
-        // tombstone branch already covers.
-        final long valueRef = leaf.valueRef(entryIndex);
-        final int valueSize = Math.max(HOTLeafPage.refLength(valueRef), 0);
-        // Skip tombstones, the slot-0 metadata and the fence chunks — see the key families
-        // documented on readAllRowGroupsFromColumnSegmentSlots.
-        if (valueSize == 0 || rowGroupId == 0 || slotKey >= ProjectionIndexFences.CHUNK_SLOT_BASE) {
-          cursor.advance();
+        long rowGroupId = 0;
+        int slotKind = 0;
+        boolean skip = false;
+        boolean unresolved = false;
+        byte[] descriptor = null;
+        byte[] inlinePayload = null;
+        long segmentOffset = Constants.NULL_ID_LONG;
+        try {
+          final long slotKey = leaf.decodeKey8BE(entryIndex) ^ 0x8000_0000_0000_0000L;
+          rowGroupId = slotKey >>> 16;
+          // The value's LOCATION, resolved once, not a slice of it: nine of every ten slots here
+          // need only their size plus a discriminator byte, and materializing a MemorySegment per
+          // slot made the walk's largest allocation a set of objects it immediately threw away.
+          // Every read below reuses this one handle. A malformed slot reports length -1, which the
+          // tombstone branch already covers.
+          final long valueRef = leaf.valueRef(entryIndex);
+          final int valueSize = Math.max(HOTLeafPage.refLength(valueRef), 0);
+          if (valueSize > leaf.slotCapacity()) {
+            // Never let a length no slot can hold size an allocation: torn (validation fails —
+            // retried) or genuine corruption (it holds — the throw escapes).
+            throw new IllegalStateException("segment-slot value of " + valueSize + " bytes exceeds the slot capacity");
+          }
+          // Skip tombstones, the slot-0 metadata and the fence chunks — see the key families
+          // documented on readAllRowGroupsFromColumnSegmentSlots.
+          if (valueSize == 0 || rowGroupId == 0 || slotKey >= ProjectionIndexFences.CHUNK_SLOT_BASE) {
+            skip = true;
+          } else {
+            slotKind = (int) (slotKey & 0xFFFF);
+            if (slotKind == 0) {
+              descriptor = resolveDirectoryDescriptorSlot(reader, leaf, valueRef, valueSize, slotKey);
+              unresolved = descriptor == null;
+            } else {
+              final byte kind = leaf.refByteAt(valueRef, 0);
+              if (kind == SEG_KIND_INLINE) {
+                inlinePayload = new byte[valueSize - 1];
+                leaf.copyRefInto(valueRef, 1, inlinePayload, 0, valueSize - 1);
+              } else if (kind != SEG_KIND_REF) {
+                throw new IllegalStateException("segment-slot segment slot " + slotKey + " has an unknown"
+                    + " discriminator " + kind + " (indexNumber=" + indexNumber + ")");
+              } else {
+                segmentOffset = resolvedSegmentPageOffset(leaf, slotKey);
+                unresolved = segmentOffset == Constants.NULL_ID_LONG;
+              }
+            }
+          }
+        } catch (RuntimeException e) {
+          if (cursor.validateLeaf()) {
+            throw e; // stable bytes — genuine corruption, not a torn read
+          }
+          recoverTornSlot(cursor, ++tornRounds);
           continue;
         }
-        final int slotKind = (int) (slotKey & 0xFFFF);
-        if (slotKind == 0) {
-          final byte[] descriptor = resolveDirectoryDescriptorSlot(reader, leaf, valueRef, valueSize, slotKey);
-          if (descriptor == null) {
+        if (!cursor.validateLeaf()) {
+          recoverTornSlot(cursor, ++tornRounds);
+          continue;
+        }
+        tornRounds = 0;
+        if (!skip) {
+          if (unresolved) {
             return false;
           }
-          walk.beginRowGroup(rowGroupId, descriptor);
-        } else if (!captureDirectoryColumnSegmentSlot(leaf, valueRef, valueSize, slotKey, rowGroupId, slotKind - 1,
-            indexNumber, walk)) {
-          return false;
+          if (slotKind == 0) {
+            walk.beginRowGroup(rowGroupId, descriptor);
+          } else if (inlinePayload != null) {
+            walk.putInline(rowGroupId, slotKind - 1, inlinePayload);
+          } else {
+            walk.putOffset(rowGroupId, slotKind - 1, segmentOffset);
+          }
         }
         cursor.advance();
       }
     }
     return true;
   }
+
+  /**
+   * Bounded torn-read recovery shared by the projection walks: refresh the cursor's leaf and let the
+   * caller re-evaluate the same slot on the fresh copy.
+   */
+  private static void recoverTornSlot(final HOTRangeCursor cursor, final int round) {
+    if (round > MAX_TORN_SLOT_ROUNDS) {
+      throw new IllegalStateException("segment-slot walk failed stamp validation on " + MAX_TORN_SLOT_ROUNDS
+          + " consecutive rounds — sustained allocator thrashing");
+    }
+    cursor.refreshLeaf();
+  }
+
+  /**
+   * Bound on consecutive torn-read recovery rounds per slot; each round races eviction independently
+   * on a freshly reloaded copy of the same immutable content.
+   */
+  private static final int MAX_TORN_SLOT_ROUNDS = 64;
 
   /**
    * A descriptor slot's bytes during the directory walk. Unlike a segment, the descriptor IS read
@@ -1587,8 +1698,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     // descriptor is well under BLOB_INLINE_MAX — copies EXACTLY ONCE, straight from the slot into
     // the array that is handed back. Reading the marker straight off the leaf avoids both the
     // slice object and materializing the marker+payload bytes only to copy the payload back out.
-    if (valueSize >= BLOB_MARKER_BYTES && leaf.refIntAt(valueRef, 0) == BLOB_MAGIC
-        && (leaf.refIntAt(valueRef, 5) & BLOB_INLINE_FLAG) != 0) {
+    if (valueSize >= BLOB_MARKER_BYTES && leaf.refIntLEAt(valueRef, 0) == BLOB_MAGIC
+        && (leaf.refIntLEAt(valueRef, 5) & BLOB_INLINE_FLAG) != 0) {
       return verifyInlineBlobFromSlot(leaf, valueRef, valueSize, slotKey);
     }
     final byte[] value = new byte[valueSize];
@@ -1613,46 +1724,22 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     if (leaf.refByteAt(valueRef, 4) != BLOB_VERSION) {
       throw new IllegalStateException("Slot " + slotKey + " does not hold a blob marker");
     }
-    final int len = leaf.refIntAt(valueRef, 5) & ~BLOB_INLINE_FLAG;
+    final int len = leaf.refIntLEAt(valueRef, 5) & ~BLOB_INLINE_FLAG;
     if (len < 0 || valueSize != BLOB_MARKER_BYTES + len) {
       throw new IllegalStateException("Inline blob at slot " + slotKey + " has inconsistent length (" + valueSize
           + " bytes, expected " + (BLOB_MARKER_BYTES + len) + ")");
     }
     final byte[] payload = new byte[len];
     leaf.copyRefInto(valueRef, BLOB_MARKER_BYTES, payload, 0, len);
-    if (ProjectionIndexColumnSegmentCodec.contentHash(payload) != leaf.refLongAt(valueRef, 9)) {
+    if (ProjectionIndexColumnSegmentCodec.contentHash(payload) != leaf.refLongLEAt(valueRef, 9)) {
       throw new IllegalStateException("Inline blob at slot " + slotKey + " failed hash verification");
     }
     return payload;
   }
 
-  /**
-   * One segment slot during the directory walk: an inline slot contributes its bytes, a referenced
-   * one only its durable offset (no page read — that is the point of the offset-lazy handle).
-   *
-   * @return {@code false} when a referenced slot's page is unresolved
-   */
-  private static boolean captureDirectoryColumnSegmentSlot(final HOTLeafPage leaf, final long valueRef,
-      final int valueSize, final long slotKey, final long rowGroupId, final int columnSegmentId, final int indexNumber,
-      final DirectoryWalk walk) {
-    final byte kind = leaf.refByteAt(valueRef, 0);
-    if (kind == SEG_KIND_INLINE) {
-      final byte[] payload = new byte[valueSize - 1];
-      leaf.copyRefInto(valueRef, 1, payload, 0, valueSize - 1);
-      walk.putInline(rowGroupId, columnSegmentId, payload);
-      return true;
-    }
-    if (kind != SEG_KIND_REF) {
-      throw new IllegalStateException("segment-slot segment slot " + slotKey + " has an unknown" + " discriminator "
-          + kind + " (indexNumber=" + indexNumber + ")");
-    }
-    final long offset = resolvedSegmentPageOffset(leaf, slotKey);
-    if (offset == Constants.NULL_ID_LONG) {
-      return false;
-    }
-    walk.putOffset(rowGroupId, columnSegmentId, offset);
-    return true;
-  }
+  // captureDirectoryColumnSegmentSlot was folded into collectRowGroupDirectorySlots: under
+  // optimistic stamps its DirectoryWalk side effects must not fire until the slot's read batch
+  // has validated, so the reads and the callbacks had to be split around the validation point.
 
   /** Durable offset of the page backing {@code slotKey}, or {@link Constants#NULL_ID_LONG}. */
   private static long resolvedSegmentPageOffset(final HOTLeafPage leaf, final long slotKey) {
@@ -1821,29 +1908,47 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
       final byte[] keyBuf = KEY_BUFFER.get();
-      final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
-      if (leaf == null) {
-        return null;
+      // The leaf is UNPINNED: the found/absent decision and the value copy must validate against
+      // the leaf's stamp before anything is derived from them — a torn read could otherwise
+      // surface as a silent "absent" or as a spurious hash-verification failure. Retries
+      // re-descend on freshly reloaded copies of the same immutable content.
+      for (int attempt = 0; attempt <= MAX_TORN_SLOT_ROUNDS; attempt++) {
+        final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
+        if (leaf == null) {
+          return null;
+        }
+        final byte[] value;
+        try {
+          final int idx = leaf.findEntry(keyBuf);
+          value = idx < 0
+              ? null
+              : leaf.getValue(idx);
+        } catch (RuntimeException e) {
+          if (trieReader.validateCurrentLeaf()) {
+            throw e; // stable bytes — genuine corruption, not a torn read
+          }
+          continue;
+        }
+        if (!trieReader.validateCurrentLeaf()) {
+          continue;
+        }
+        if (value == null || value.length == 0) {
+          return null;
+        }
+        if (isInlineBlob(value)) {
+          return verifyInlineBlob(value, slotKey);
+        }
+        final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+        if (ref == null) {
+          return verifyBlob(value, null, slotKey);
+        }
+        final OverflowPage page = reader.readSideOverflowPage(ref);
+        return verifyBlob(value, page == null
+            ? null
+            : page.getDataBytes(), slotKey);
       }
-      final int idx = leaf.findEntry(keyBuf);
-      if (idx < 0) {
-        return null;
-      }
-      final byte[] value = leaf.getValue(idx);
-      if (value == null || value.length == 0) {
-        return null;
-      }
-      if (isInlineBlob(value)) {
-        return verifyInlineBlob(value, slotKey);
-      }
-      final PageReference ref = leaf.getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
-      if (ref == null) {
-        return verifyBlob(value, null, slotKey);
-      }
-      final OverflowPage page = reader.readSideOverflowPage(ref);
-      return verifyBlob(value, page == null
-          ? null
-          : page.getDataBytes(), slotKey);
+      throw new IllegalStateException("readBlob(slot " + slotKey + ") failed stamp validation on "
+          + MAX_TORN_SLOT_ROUNDS + " consecutive attempts — sustained allocator thrashing");
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -591,9 +591,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       return null;
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
-      final HOTLeafPage[] leafOut = new HOTLeafPage[1];
       final byte[] value =
-          readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), leafOut, "readColumnSegmentSlot");
+          readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), "readColumnSegmentSlot");
       if (value == null) {
         return null;
       }
@@ -601,7 +600,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       if (inline != null) {
         return inline;
       }
-      final PageReference ref = leafOut[0].getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+      final PageReference ref =
+          trieReader.currentLeafPage().getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
       if (ref == null) {
         return null;
       }
@@ -1644,23 +1644,7 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     return true;
   }
 
-  /**
-   * Bounded torn-read recovery shared by the projection walks: refresh the cursor's leaf and let the
-   * caller re-evaluate the same slot on the fresh copy.
-   */
-  private static void recoverTornSlot(final HOTRangeCursor cursor, final int round) {
-    if (round > MAX_TORN_SLOT_ROUNDS) {
-      throw new IllegalStateException("segment-slot walk failed stamp validation on " + MAX_TORN_SLOT_ROUNDS
-          + " consecutive rounds — sustained allocator thrashing");
-    }
-    cursor.refreshLeaf();
-  }
 
-  /**
-   * Bound on consecutive torn-read recovery rounds per slot; each round races eviction independently
-   * on a freshly reloaded copy of the same immutable content.
-   */
-  private static final int MAX_TORN_SLOT_ROUNDS = 64;
 
   /**
    * A descriptor slot's bytes during the directory walk. Unlike a segment, the descriptor IS read
@@ -1884,15 +1868,15 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       return null;
     }
     try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
-      final HOTLeafPage[] leafOut = new HOTLeafPage[1];
-      final byte[] value = readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), leafOut, "readBlob");
+      final byte[] value = readValidatedSlotValue(trieReader, rootRef, slotKey, KEY_BUFFER.get(), "readBlob");
       if (value == null) {
         return null;
       }
       if (isInlineBlob(value)) {
         return verifyInlineBlob(value, slotKey);
       }
-      final PageReference ref = leafOut[0].getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
+      final PageReference ref =
+          trieReader.currentLeafPage().getPageReference(HOTLeafPage.overflowPageRefKey(slotKey, BLOB_SEGMENT_ID));
       if (ref == null) {
         return verifyBlob(value, null, slotKey);
       }
@@ -1969,23 +1953,21 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   // ==================== descriptor-layout internals ====================
 
   /**
-   * Shared navigation preamble of the reader-side descriptor-layout statics: serialize the slot key
-   * into {@code keyBuf} and navigate to the HOT leaf covering it. {@code null} when the trie has no
-   * such leaf. The caller owns the {@code trieReader} lifetime (segment resolution reads through the
-   * returned leaf's side map while the reader is open).
-   */
-  /**
    * Navigate to {@code slotKey}'s leaf and read its raw value under the optimistic-stamp protocol:
    * the found/absent decision and the value copy are both validated before anything is derived from
    * them, and a torn batch re-descends on freshly reloaded copies. Shared by the two reader-side slot
    * reads, which differ only in how they interpret the bytes — restating this scaffolding per caller
    * meant a fix to the validation discipline had to be applied twice, 1300 lines apart.
    *
-   * @param out receives the leaf the value came from, so the caller can resolve its side-map refs
+   * <p>
+   * The leaf the value came from is NOT returned: {@code loadPage} installs every leaf it resolves as
+   * the reader's current leaf, so the caller reads it back with {@code trieReader.currentLeafPage()}
+   * and no per-read holder has to be allocated.
+   *
    * @return the validated value bytes, or {@code null} when the slot is absent or tombstoned
    */
   private static byte @Nullable [] readValidatedSlotValue(final HOTTrieReader trieReader, final PageReference rootRef,
-      final long slotKey, final byte[] keyBuf, final HOTLeafPage[] out, final String operation) {
+      final long slotKey, final byte[] keyBuf, final String operation) {
     for (int attempt = 0; attempt <= HOTTrieReader.MAX_STAMP_RETRIES; attempt++) {
       final HOTLeafPage leaf = navigateToSlotLeaf(trieReader, rootRef, slotKey, keyBuf);
       if (leaf == null) {
@@ -2006,7 +1988,6 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       if (!trieReader.validateCurrentLeaf()) {
         continue;
       }
-      out[0] = leaf;
       return value == null || value.length == 0
           ? null
           : value;
@@ -2014,6 +1995,12 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     throw HOTTrieReader.stampRetriesExhausted(operation + "(slot " + slotKey + ")");
   }
 
+  /**
+   * Shared navigation preamble of the reader-side descriptor-layout statics: serialize the slot key
+   * into {@code keyBuf} and navigate to the HOT leaf covering it. {@code null} when the trie has no
+   * such leaf. The caller owns the {@code trieReader} lifetime (segment resolution reads through the
+   * returned leaf's side map while the reader is open).
+   */
   private static @Nullable HOTLeafPage navigateToSlotLeaf(final HOTTrieReader trieReader, final PageReference rootRef,
       final long slotKey, final byte[] keyBuf) {
     PathKeySerializer.INSTANCE.serialize(slotKey, keyBuf, 0);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/CASValue.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/CASValue.java
@@ -83,10 +83,32 @@ public final class CASValue implements Comparable<CASValue> {
       return 1;
     }
 
-    Atomic thisAtomic = value.asType(type);
-    Atomic otherAtomic = other.value.asType(other.type);
+    final Atomic thisAtomic = asDeclaredType(value, type);
+    final Atomic otherAtomic = asDeclaredType(other.value, other.type);
 
     return ComparisonChain.start().compare(pathNodeKey, other.pathNodeKey).compare(thisAtomic, otherAtomic).result();
+  }
+
+  /**
+   * {@code value} as {@code type}, skipping the conversion when it already IS that type.
+   *
+   * <p>
+   * Not merely an optimization. brackit's instant atomics throw {@code BIDY0005} from
+   * {@link Atomic#asType} when the target is their OWN type, so converting an already-typed
+   * {@code xs:dateTime} is an error rather than a no-op. That went unnoticed while the index stored
+   * every value as a {@link io.brackit.query.atomic.Str} and this method was the only thing that ever
+   * typed it; once the builder began storing the converted value — so that the stored and probed
+   * sides share one shape — the unconditional cast started failing on the instant family.
+   * </p>
+   *
+   * @param value the value to view as {@code type}
+   * @param type the declared content type
+   * @return the typed value
+   */
+  private static Atomic asDeclaredType(final Atomic value, final Type type) {
+    return value.type() == type
+        ? value
+        : value.asType(type);
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
@@ -1,15 +1,16 @@
 package io.sirix.index.redblacktree.keyvalue;
 
-import io.sirix.utils.ToStringHelper;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.function.LongConsumer;
 import io.sirix.index.redblacktree.interfaces.References;
+import io.sirix.utils.ToStringHelper;
 import org.jspecify.annotations.Nullable;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64Bitmap;
 
-import java.util.Set;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.LongConsumer;
 
 /**
  * Text node-ID references.
@@ -33,23 +34,34 @@ import java.util.Set;
  * @author Johannes Lichtenberger
  */
 public final class NodeReferences implements References {
-  /** Node keys as a bitmap; {@code null} while the compact representation is authoritative. */
-  private @Nullable Roaring64Bitmap nodeKeys;
+  /**
+   * The one authoritative representation: a {@link Roaring64Bitmap} or an exactly-sized
+   * {@code long[]} sorted strictly ascending. A SINGLE field, and {@code volatile}, so the two
+   * representations can never be observed half-swapped: materializing the bitmap publishes it with a
+   * release, and every accessor reads the field once into a local. (Two fields plus a plain write
+   * would let another thread see the compact array already cleared while the bitmap write is still
+   * invisible.) Reads stay a plain load on x86/ARM; materialization is once per instance at most.
+   */
+  private volatile Object refs;
 
   /**
-   * Compact representation: {@code compactKeys[0..compactCount)} sorted strictly ascending.
-   * {@code null} when {@link #nodeKeys} is authoritative. Never exposed; adopted from
-   * {@link #ofSortedArray(long[], int)} callers who hand over ownership.
+   * Handle on {@link #refs}, for the lock-free compact-to-bitmap promotion in {@link #getNodeKeys()}.
    */
-  private long @Nullable [] compactKeys;
+  private static final VarHandle REFS;
 
-  private int compactCount;
+  static {
+    try {
+      REFS = MethodHandles.lookup().findVarHandle(NodeReferences.class, "refs", Object.class);
+    } catch (ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
 
   /**
    * Default constructor.
    */
   public NodeReferences() {
-    nodeKeys = new Roaring64Bitmap();
+    refs = new Roaring64Bitmap();
   }
 
   /**
@@ -98,27 +110,39 @@ public final class NodeReferences implements References {
    * bitmap view is created lazily only if some consumer insists on {@link #getNodeKeys()} or mutates
    * the set.
    *
-   * @param keys the backing array, adopted; sorted strictly ascending in {@code [0, count)}
-   * @param count number of live keys
+   * <p>
+   * The array must be EXACTLY sized: its length is the cardinality, so there is no separate count to
+   * publish and no branch that silently copies instead of adopting — the contract is unconditional,
+   * which is what a caller handing over a buffer needs it to be.
+   *
+   * @param keys the backing array, adopted; sorted strictly ascending over its whole length
    * @return references over the run
    */
-  public static NodeReferences ofSortedArray(final long[] keys, final int count) {
+  public static NodeReferences ofSortedArray(final long[] keys) {
     Objects.requireNonNull(keys, "keys");
-    Objects.checkFromIndexSize(0, count, keys.length);
-    final NodeReferences refs = new NodeReferences((Roaring64Bitmap) null, false);
-    refs.compactKeys = keys;
-    refs.compactCount = count;
-    return refs;
+    // The precondition is what containsSorted's binary search rests on, and this factory is public
+    // and ADOPTS the caller's array — so violating it yields a posting list that silently reports
+    // present keys as absent, with no exception anywhere. Note the order is UNSIGNED: a caller who
+    // sorted with Arrays.sort (signed) and holds any high-bit-set key would otherwise be accepted
+    // and then misbehave only for those keys.
+    for (int i = 1; i < keys.length; i++) {
+      if (Long.compareUnsigned(keys[i - 1], keys[i]) >= 0) {
+        throw new IllegalArgumentException("keys must be sorted strictly ascending by unsigned order; index " + (i - 1)
+            + " (" + Long.toUnsignedString(keys[i - 1]) + ") is not below index " + i + " ("
+            + Long.toUnsignedString(keys[i]) + ")");
+      }
+    }
+    return new NodeReferences(keys);
   }
 
-  private NodeReferences(final @Nullable Roaring64Bitmap nodeKeys, final boolean copy) {
-    if (nodeKeys == null) {
-      this.nodeKeys = null; // compact caller fills the array fields
-    } else {
-      this.nodeKeys = copy
-          ? nodeKeys.clone()
-          : nodeKeys;
-    }
+  private NodeReferences(final long[] compactKeys) {
+    this.refs = compactKeys;
+  }
+
+  private NodeReferences(final Roaring64Bitmap nodeKeys, final boolean copy) {
+    this.refs = copy
+        ? nodeKeys.clone()
+        : nodeKeys;
   }
 
   /**
@@ -128,18 +152,23 @@ public final class NodeReferences implements References {
    */
   @Override
   public Roaring64Bitmap getNodeKeys() {
-    Roaring64Bitmap bitmap = nodeKeys;
-    if (bitmap == null) {
-      bitmap = new Roaring64Bitmap();
-      final long[] keys = compactKeys;
-      for (int i = 0; i < compactCount; i++) {
-        bitmap.add(keys[i]);
-      }
-      nodeKeys = bitmap;
-      compactKeys = null;
-      compactCount = 0;
+    final Object current = refs;
+    if (current instanceof Roaring64Bitmap bitmap) {
+      return bitmap;
     }
-    return bitmap;
+    final Roaring64Bitmap materialized = new Roaring64Bitmap();
+    for (final long key : (long[]) current) {
+      materialized.add(key);
+    }
+    // Publish lock-free rather than under a monitor: the promotion happens at most once per
+    // instance, so a monitor here is pure inflation risk on a read path. The loser of a race
+    // discards its own copy and returns the winner's, which is what actually matters — every
+    // caller must end up mutating THE bitmap, never an orphan. The only transition this field
+    // ever makes is long[] -> Roaring64Bitmap, so a non-matching witness is always the bitmap.
+    final Object witness = REFS.compareAndExchange(this, current, (Object) materialized);
+    return witness == current
+        ? materialized
+        : (Roaring64Bitmap) witness;
   }
 
   @Override
@@ -163,11 +192,10 @@ public final class NodeReferences implements References {
 
   /** Number of referenced node keys, without materializing a bitmap. */
   public long cardinality() {
-    final long[] keys = compactKeys;
-    if (keys != null) {
-      return compactCount;
-    }
-    return nodeKeys.getLongCardinality();
+    final Object current = refs;
+    return current instanceof long[] keys
+        ? keys.length
+        : ((Roaring64Bitmap) current).getLongCardinality();
   }
 
   /**
@@ -175,11 +203,11 @@ public final class NodeReferences implements References {
    * instances. The representation-independent twin of {@code getNodeKeys().getLongIterator()}.
    */
   public LongIterator nodeKeyIterator() {
-    final long[] keys = compactKeys;
-    if (keys == null) {
-      return nodeKeys.getLongIterator();
+    final Object current = refs;
+    if (!(current instanceof long[] keys)) {
+      return ((Roaring64Bitmap) current).getLongIterator();
     }
-    final int count = compactCount;
+    final int count = keys.length;
     return new LongIterator() {
       private int position;
 
@@ -206,15 +234,14 @@ public final class NodeReferences implements References {
 
   /** Visit every referenced node key in ascending order, without materializing a bitmap. */
   public void forEachNodeKey(final LongConsumer consumer) {
-    final long[] keys = compactKeys;
-    if (keys != null) {
-      final int count = compactCount;
-      for (int i = 0; i < count; i++) {
-        consumer.accept(keys[i]);
+    final Object current = refs;
+    if (current instanceof long[] keys) {
+      for (final long key : keys) {
+        consumer.accept(key);
       }
       return;
     }
-    final LongIterator iterator = nodeKeys.getLongIterator();
+    final LongIterator iterator = ((Roaring64Bitmap) current).getLongIterator();
     while (iterator.hasNext()) {
       consumer.accept(iterator.next());
     }
@@ -234,15 +261,17 @@ public final class NodeReferences implements References {
 
   @Override
   public boolean equals(final @Nullable Object obj) {
-    if (!(obj instanceof final NodeReferences refs)) {
+    // Named `other`, not `refs`: a pattern variable called `refs` would shadow the instance field of
+    // that name, so a later edit meaning "my own representation" would silently read the argument's.
+    if (!(obj instanceof final NodeReferences other)) {
       return false;
     }
-    if (cardinality() != refs.cardinality()) {
+    if (cardinality() != other.cardinality()) {
       return false;
     }
     // Both iterate ascending, so paired iteration decides set equality without materializing.
     final LongIterator a = nodeKeyIterator();
-    final LongIterator b = refs.nodeKeyIterator();
+    final LongIterator b = other.nodeKeyIterator();
     while (a.hasNext()) {
       if (a.next() != b.next()) {
         return false;
@@ -264,19 +293,42 @@ public final class NodeReferences implements References {
 
   @Override
   public boolean hasNodeKeys() {
-    final long[] keys = compactKeys;
-    if (keys != null) {
-      return compactCount > 0;
-    }
-    return !nodeKeys.isEmpty();
+    final Object current = refs;
+    return current instanceof long[] keys
+        ? keys.length > 0
+        : !((Roaring64Bitmap) current).isEmpty();
   }
 
   @Override
   public boolean contains(long nodeKey) {
-    final long[] keys = compactKeys;
-    if (keys != null) {
-      return Arrays.binarySearch(keys, 0, compactCount, nodeKey) >= 0;
+    final Object current = refs;
+    return current instanceof long[] keys
+        ? containsSorted(keys, nodeKey)
+        : ((Roaring64Bitmap) current).contains(nodeKey);
+  }
+
+  /**
+   * Binary search over the compact run, UNSIGNED. The array is strictly ascending by construction —
+   * {@code ChunkAccumulator} spills to a bitmap the moment an append would break that — but its
+   * ordering guard is {@link Long#compareUnsigned}, so the search has to agree with it. Matching
+   * {@link Arrays#binarySearch}'s signed order instead would silently mislocate any key with the high
+   * bit set; today's chunk expansion tops out at 48 bits, but that is the caller's arithmetic, not an
+   * invariant this class can hold, and {@link #ofSortedArray} is public.
+   */
+  private static boolean containsSorted(final long[] keys, final long nodeKey) {
+    int low = 0;
+    int high = keys.length - 1;
+    while (low <= high) {
+      final int mid = (low + high) >>> 1;
+      final int cmp = Long.compareUnsigned(keys[mid], nodeKey);
+      if (cmp < 0) {
+        low = mid + 1;
+      } else if (cmp > 0) {
+        high = mid - 1;
+      } else {
+        return true;
+      }
     }
-    return nodeKeys.contains(nodeKey);
+    return false;
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
@@ -1,7 +1,9 @@
 package io.sirix.index.redblacktree.keyvalue;
 
 import io.sirix.utils.ToStringHelper;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.LongConsumer;
 import io.sirix.index.redblacktree.interfaces.References;
 import org.jspecify.annotations.Nullable;
 import org.roaringbitmap.longlong.LongIterator;
@@ -12,12 +14,36 @@ import java.util.Set;
 /**
  * Text node-ID references.
  *
- * @author Johannes Lichtenberger
+ * <p>
+ * Two internal representations, invisible through the API:
+ * </p>
+ * <ul>
+ * <li><b>Bitmap-backed</b> — a {@link Roaring64Bitmap}, the historical form. Mutable, merge-
+ * friendly; what the write path and the RB-tree backend build and serialize.</li>
+ * <li><b>Compact</b> — a sorted-ascending {@code long[]} slice, produced by the HOT read path. The
+ * average CAS posting list holds one or two node keys, and materializing a Roaring bitmap
+ * (container tree + wrapper) per lookup result was the single largest remaining allocation on the
+ * read path. A compact instance materializes its bitmap LAZILY on the first {@link #getNodeKeys()}
+ * or mutation, so every existing consumer keeps working unchanged, while consumers using the
+ * representation-independent accessors ({@link #nodeKeyIterator()},
+ * {@link #forEachNodeKey(LongConsumer)}, {@link #cardinality()}, {@link #contains(long)}) never pay
+ * for the bitmap at all.</li>
+ * </ul>
  *
+ * @author Johannes Lichtenberger
  */
 public final class NodeReferences implements References {
-  /** A {@link Set} of node-keys. */
-  private final Roaring64Bitmap nodeKeys;
+  /** Node keys as a bitmap; {@code null} while the compact representation is authoritative. */
+  private @Nullable Roaring64Bitmap nodeKeys;
+
+  /**
+   * Compact representation: {@code compactKeys[0..compactCount)} sorted strictly ascending.
+   * {@code null} when {@link #nodeKeys} is authoritative. Never exposed; adopted from
+   * {@link #ofSortedArray(long[], int)} callers who hand over ownership.
+   */
+  private long @Nullable [] compactKeys;
+
+  private int compactCount;
 
   /**
    * Default constructor.
@@ -29,81 +55,206 @@ public final class NodeReferences implements References {
   /**
    * Constructor taking a defensive copy of {@code nodeKeys}.
    *
-   * <p>Use this when the bitmap belongs to someone else — notably another {@code NodeReferences}
-   * reached through {@link #getNodeKeys()}, which hands out the live set. Since
-   * {@link #addNodeKey} and {@link #removeNodeKey} mutate in place, sharing the instance would
-   * let one reference set silently rewrite another's.
+   * <p>
+   * Use this when the bitmap belongs to someone else — notably another {@code NodeReferences} reached
+   * through {@link #getNodeKeys()}, which hands out the live set. Since {@link #addNodeKey} and
+   * {@link #removeNodeKey} mutate in place, sharing the instance would let one reference set silently
+   * rewrite another's.
    *
-   * <p>When the caller built the bitmap itself and nothing else can see it, the copy is pure
-   * waste on a hot path — the index writer merges a reference set per indexed node, so an O(n)
-   * copy and a whole duplicate bitmap allocation per merge is money burned. Use
-   * {@link #owning(Roaring64Bitmap)} there instead.
+   * <p>
+   * When the caller built the bitmap itself and nothing else can see it, the copy is pure waste on a
+   * hot path — the index writer merges a reference set per indexed node, so an O(n) copy and a whole
+   * duplicate bitmap allocation per merge is money burned. Use {@link #owning(Roaring64Bitmap)} there
+   * instead.
    *
    * @param nodeKeys node keys, copied
    */
   public NodeReferences(final Roaring64Bitmap nodeKeys) {
-    this(nodeKeys, true);
+    this(Objects.requireNonNull(nodeKeys, "nodeKeys"), true);
   }
 
   /**
    * Wrap a bitmap the caller is handing over, without copying it.
    *
-   * <p>The returned instance takes ownership: the caller must not retain the reference or mutate
-   * the bitmap afterwards. Intended for freshly-built bitmaps that have not escaped — a
-   * deserialize result, or a set merged together locally.
+   * <p>
+   * The returned instance takes ownership: the caller must not retain the reference or mutate the
+   * bitmap afterwards. Intended for freshly-built bitmaps that have not escaped — a deserialize
+   * result, or a set merged together locally.
    *
    * @param nodeKeys node keys, adopted rather than copied
    * @return references over {@code nodeKeys}
    */
   public static NodeReferences owning(final Roaring64Bitmap nodeKeys) {
-    return new NodeReferences(nodeKeys, false);
+    return new NodeReferences(Objects.requireNonNull(nodeKeys, "nodeKeys"), false);
   }
 
-  private NodeReferences(final Roaring64Bitmap nodeKeys, final boolean copy) {
-    Objects.requireNonNull(nodeKeys, "nodeKeys");
-    this.nodeKeys = copy ? nodeKeys.clone() : nodeKeys;
+  /**
+   * Wrap a sorted run of node keys the caller is handing over, without building a bitmap.
+   *
+   * <p>
+   * The returned instance takes ownership of {@code keys}: the caller must not retain or mutate the
+   * array afterwards. {@code keys[0..count)} must be sorted strictly ascending — exactly what the HOT
+   * chunk reassembly produces (chunkIdx-major, bit16-minor, duplicate-free by construction). The
+   * bitmap view is created lazily only if some consumer insists on {@link #getNodeKeys()} or mutates
+   * the set.
+   *
+   * @param keys the backing array, adopted; sorted strictly ascending in {@code [0, count)}
+   * @param count number of live keys
+   * @return references over the run
+   */
+  public static NodeReferences ofSortedArray(final long[] keys, final int count) {
+    Objects.requireNonNull(keys, "keys");
+    Objects.checkFromIndexSize(0, count, keys.length);
+    final NodeReferences refs = new NodeReferences((Roaring64Bitmap) null, false);
+    refs.compactKeys = keys;
+    refs.compactCount = count;
+    return refs;
+  }
+
+  private NodeReferences(final @Nullable Roaring64Bitmap nodeKeys, final boolean copy) {
+    if (nodeKeys == null) {
+      this.nodeKeys = null; // compact caller fills the array fields
+    } else {
+      this.nodeKeys = copy
+          ? nodeKeys.clone()
+          : nodeKeys;
+    }
+  }
+
+  /**
+   * The bitmap view, materializing (and caching) it from the compact representation on first call.
+   * After materialization the bitmap is the single authoritative, MUTABLE set — the compact array is
+   * dropped so the two can never diverge.
+   */
+  @Override
+  public Roaring64Bitmap getNodeKeys() {
+    Roaring64Bitmap bitmap = nodeKeys;
+    if (bitmap == null) {
+      bitmap = new Roaring64Bitmap();
+      final long[] keys = compactKeys;
+      for (int i = 0; i < compactCount; i++) {
+        bitmap.add(keys[i]);
+      }
+      nodeKeys = bitmap;
+      compactKeys = null;
+      compactCount = 0;
+    }
+    return bitmap;
   }
 
   @Override
   public boolean isPresent(final long nodeKey) {
-    return nodeKeys.contains(nodeKey);
-  }
-
-  @Override
-  public Roaring64Bitmap getNodeKeys() {
-    return nodeKeys;
+    return contains(nodeKey);
   }
 
   @Override
   public NodeReferences addNodeKey(final long nodeKey) {
-    nodeKeys.add(nodeKey);
+    getNodeKeys().add(nodeKey);
     return this;
   }
 
   @Override
   public boolean removeNodeKey(long nodeKey) {
-    boolean containsNodeKey = nodeKeys.contains(nodeKey);
-    nodeKeys.removeLong(nodeKey);
+    final Roaring64Bitmap bitmap = getNodeKeys();
+    boolean containsNodeKey = bitmap.contains(nodeKey);
+    bitmap.removeLong(nodeKey);
     return containsNodeKey;
+  }
+
+  /** Number of referenced node keys, without materializing a bitmap. */
+  public long cardinality() {
+    final long[] keys = compactKeys;
+    if (keys != null) {
+      return compactCount;
+    }
+    return nodeKeys.getLongCardinality();
+  }
+
+  /**
+   * Iterate the referenced node keys in ascending order, without materializing a bitmap for compact
+   * instances. The representation-independent twin of {@code getNodeKeys().getLongIterator()}.
+   */
+  public LongIterator nodeKeyIterator() {
+    final long[] keys = compactKeys;
+    if (keys == null) {
+      return nodeKeys.getLongIterator();
+    }
+    final int count = compactCount;
+    return new LongIterator() {
+      private int position;
+
+      @Override
+      public boolean hasNext() {
+        return position < count;
+      }
+
+      @Override
+      public long next() {
+        return keys[position++];
+      }
+
+      @Override
+      public LongIterator clone() {
+        try {
+          return (LongIterator) super.clone();
+        } catch (CloneNotSupportedException e) {
+          throw new IllegalStateException(e);
+        }
+      }
+    };
+  }
+
+  /** Visit every referenced node key in ascending order, without materializing a bitmap. */
+  public void forEachNodeKey(final LongConsumer consumer) {
+    final long[] keys = compactKeys;
+    if (keys != null) {
+      final int count = compactCount;
+      for (int i = 0; i < count; i++) {
+        consumer.accept(keys[i]);
+      }
+      return;
+    }
+    final LongIterator iterator = nodeKeys.getLongIterator();
+    while (iterator.hasNext()) {
+      consumer.accept(iterator.next());
+    }
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(nodeKeys);
+    // Representation-independent: derived from the ascending key sequence, never from the
+    // internal container structure, so a compact instance and its bitmap twin agree.
+    long h = 1;
+    final LongIterator iterator = nodeKeyIterator();
+    while (iterator.hasNext()) {
+      h = 31 * h + Long.hashCode(iterator.next());
+    }
+    return Long.hashCode(h);
   }
 
   @Override
   public boolean equals(final @Nullable Object obj) {
-    if (obj instanceof final NodeReferences refs) {
-      return nodeKeys.equals(refs.nodeKeys);
+    if (!(obj instanceof final NodeReferences refs)) {
+      return false;
     }
-    return false;
+    if (cardinality() != refs.cardinality()) {
+      return false;
+    }
+    // Both iterate ascending, so paired iteration decides set equality without materializing.
+    final LongIterator a = nodeKeyIterator();
+    final LongIterator b = refs.nodeKeyIterator();
+    while (a.hasNext()) {
+      if (a.next() != b.next()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override
   public String toString() {
     final ToStringHelper helper = ToStringHelper.of(this);
-    final LongIterator iterator = nodeKeys.getLongIterator();
+    final LongIterator iterator = nodeKeyIterator();
     while (iterator.hasNext()) {
       final var nodeKey = iterator.next();
       helper.add("referenced node key", nodeKey);
@@ -113,11 +264,19 @@ public final class NodeReferences implements References {
 
   @Override
   public boolean hasNodeKeys() {
+    final long[] keys = compactKeys;
+    if (keys != null) {
+      return compactCount > 0;
+    }
     return !nodeKeys.isEmpty();
   }
 
   @Override
   public boolean contains(long nodeKey) {
+    final long[] keys = compactKeys;
+    if (keys != null) {
+      return Arrays.binarySearch(keys, 0, compactCount, nodeKey) >= 0;
+    }
     return nodeKeys.contains(nodeKey);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
@@ -125,14 +125,101 @@ public final class NodeReferences implements References {
     // present keys as absent, with no exception anywhere. Note the order is UNSIGNED: a caller who
     // sorted with Arrays.sort (signed) and holds any high-bit-set key would otherwise be accepted
     // and then misbehave only for those keys.
-    for (int i = 1; i < keys.length; i++) {
+    requireAscending(keys);
+    return new NodeReferences(keys);
+  }
+
+  /**
+   * {@link #ofSortedArray} for a run the caller must KEEP: copies rather than adopts, so the caller's
+   * array stays its own.
+   *
+   * <p>
+   * The one caller that needs this is the HOT lookup cache's hit path, which holds a SHARED stored
+   * posting list and has to copy before handing it to a mutable {@code NodeReferences} anyway.
+   * </p>
+   *
+   * <p>
+   * The ordering is NOT re-checked here, and that is the difference from {@link #ofSortedArray}. The
+   * check is O(n) in a serial {@code Long.compareUnsigned} chain, and this method sits on a memoized
+   * READ path: re-deriving a property of an immutable, already-validated array on hit number one
+   * million produces the same answer it produced on hit number one, at up to
+   * {@code MAX_CACHED_NODE_KEYS} comparisons a time in front of a vectorizable {@code clone()}. The
+   * check moved to the ADMISSION side, where it runs once per array ever cached — see
+   * {@link #isSortedAscending} and its caller in {@code AbstractHOTIndexReader.memoize}.
+   * {@link #ofSortedArray}, which ADOPTS an arbitrary caller's array, keeps its own check.
+   * </p>
+   *
+   * <p>
+   * The name carries the {@code Unchecked} suffix because that is the only thing standing between a
+   * future caller and silent wrong answers: this is {@code public}, it validates nothing beyond null,
+   * and an out-of-order run makes {@link #contains}'s unsigned binary search report PRESENT node keys
+   * as absent, with no exception anywhere. A caller that cannot point at the
+   * {@link #isSortedAscending} check that already covered its array wants {@link #ofSortedArray}.
+   * </p>
+   *
+   * @param keys a run this class itself produced (via {@link #toSortedArray()}) and validated on the
+   *        way in; must be sorted strictly ascending in UNSIGNED order
+   * @return references over a private copy of the run
+   */
+  public static NodeReferences copyOfSortedUnchecked(final long[] keys) {
+    Objects.requireNonNull(keys, "keys");
+    return new NodeReferences(keys.clone());
+  }
+
+  /**
+   * The ordering contract of {@link #ofSortedArray}, ANSWERED rather than thrown, so a producer whose
+   * admission is optional can decline instead of failing — {@code AbstractHOTIndexReader.memoize}
+   * refuses to cache a run it cannot vouch for rather than failing a query that already has its
+   * answer. Exposed so that check is paid ONCE, on the write side, for a run then handed to
+   * {@link #copyOfSortedUnchecked} many times.
+   *
+   * <p>
+   * An {@code assert} was not enough: assertions are off in production, so a caller that sorted with
+   * {@code Arrays.sort} (SIGNED) and holds a high-bit-set key would be accepted, and
+   * {@link #contains}'s unsigned binary search would then report present node keys as ABSENT with no
+   * exception anywhere.
+   * </p>
+   *
+   * @param keys the run to test
+   * @return {@code true} iff {@code keys} is strictly ascending in unsigned order
+   */
+  public static boolean isSortedAscending(final long[] keys) {
+    Objects.requireNonNull(keys, "keys");
+    for (int i = 1, n = keys.length; i < n; i++) {
       if (Long.compareUnsigned(keys[i - 1], keys[i]) >= 0) {
-        throw new IllegalArgumentException("keys must be sorted strictly ascending by unsigned order; index " + (i - 1)
-            + " (" + Long.toUnsignedString(keys[i - 1]) + ") is not below index " + i + " ("
-            + Long.toUnsignedString(keys[i]) + ")");
+        return false;
       }
     }
-    return new NodeReferences(keys);
+    return true;
+  }
+
+  /**
+   * ONE scan behind every entry point's rejection, so no two of them can come to enforce different
+   * contracts.
+   *
+   * @param keys the array to check
+   * @throws IllegalArgumentException if {@code keys} is not strictly ascending unsigned
+   */
+  private static void requireAscending(final long[] keys) {
+    final int offender = firstNonAscendingIndex(keys);
+    if (offender >= 0) {
+      throw new IllegalArgumentException("keys must be sorted strictly ascending by unsigned order; index " + offender
+          + " (" + Long.toUnsignedString(keys[offender]) + ") is not below index " + (offender + 1) + " ("
+          + Long.toUnsignedString(keys[offender + 1]) + ")");
+    }
+  }
+
+  /**
+   * @param keys the array to scan
+   * @return the index whose successor does not exceed it, or {@code -1} when strictly ascending
+   */
+  private static int firstNonAscendingIndex(final long[] keys) {
+    for (int i = 1; i < keys.length; i++) {
+      if (Long.compareUnsigned(keys[i - 1], keys[i]) >= 0) {
+        return i - 1;
+      }
+    }
+    return -1;
   }
 
   private NodeReferences(final long[] compactKeys) {
@@ -230,6 +317,28 @@ public final class NodeReferences implements References {
         }
       }
     };
+  }
+
+  /**
+   * The referenced node keys as a fresh, exactly-sized {@code long[]} in ascending unsigned order —
+   * the array form {@link #ofSortedArray} accepts back.
+   *
+   * <p>
+   * ONE read of {@link #refs} decides both the size and the contents, which is the whole point:
+   * draining from outside the class costs a {@link #cardinality()} read plus a
+   * {@link #forEachNodeKey} read, and those two can disagree if the instance is mutated in between —
+   * leaving the caller to size an array from one answer and fill it from another. The compact case,
+   * which is what the HOT read path produces, is a single {@code clone()}; the bitmap case defers to
+   * Roaring's own bulk export instead of a per-key callback.
+   * </p>
+   *
+   * @return a fresh array the caller owns, ascending unsigned; empty when there are no references
+   */
+  public long[] toSortedArray() {
+    final Object current = refs;
+    return current instanceof long[] keys
+        ? keys.clone()
+        : ((Roaring64Bitmap) current).toArray();
   }
 
   /** Visit every referenced node key in ascending order, without materializing a bitmap. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/redblacktree/keyvalue/NodeReferences.java
@@ -185,12 +185,12 @@ public final class NodeReferences implements References {
    */
   public static boolean isSortedAscending(final long[] keys) {
     Objects.requireNonNull(keys, "keys");
-    for (int i = 1, n = keys.length; i < n; i++) {
-      if (Long.compareUnsigned(keys[i - 1], keys[i]) >= 0) {
-        return false;
-      }
-    }
-    return true;
+    // Delegates rather than repeating the loop, so the throwing and answering entry points cannot
+    // come to enforce different contracts — which is what firstNonAscendingIndex's own javadoc
+    // promises and what a second copy of the scan would quietly break. A divergence here is silent:
+    // a run this accepted and requireAscending rejected would be memoized by the lookup cache and
+    // then make contains()'s unsigned binary search report present node keys as absent.
+    return firstNonAscendingIndex(keys) < 0;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
@@ -38,6 +38,9 @@ import org.jspecify.annotations.Nullable;
 
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.settings.Constants;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -241,6 +244,15 @@ public final class HOTIndirectPage implements Page {
   // ===== SIMD gather for MultiMask (vpshufb optimization) =====
   private static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_256;
   private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_256;
+
+  /**
+   * Reads eight key bytes as one big-endian {@code long}, for {@link #getKeyWordAt}. Big-endian is
+   * the layout the PEXT routing needs: after {@code Long.compress} the partial key's MSB holds the
+   * most significant discriminative bit, which is what makes sibling partial keys compare in lex
+   * order. Compiles to a single unaligned load plus a byte swap.
+   */
+  private static final VarHandle BYTE_ARRAY_LONG_BE =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
 
   /**
    * Per-thread scratch byte[] sized to {@link #BYTE_SPECIES}.length() for the SIMD partial-key load
@@ -569,7 +581,14 @@ public final class HOTIndirectPage implements Page {
       if (matchMask == 0)
         return NOT_FOUND;
       final int subsetPick = 31 - Integer.numberOfLeadingZeros(matchMask);
-      for (int i = 0; i < numChildren; i++) {
+      // HFT: the exact-match probe walks the SET BITS of matchMask, not all numChildren slots.
+      // Equality implies subset — a child whose partial key EQUALS densePartialKey trivially
+      // satisfies (densePartialKey & partial) == partial — so every candidate the old linear scan
+      // could return is already a match bit, and clearing the lowest set bit each round visits them
+      // in ascending index order, returning the same child the scan did. On a full node that is a
+      // handful of candidates instead of 32 branches, once per descent level per lookup.
+      for (int remaining = matchMask; remaining != 0; remaining &= remaining - 1) {
+        final int i = Integer.numberOfTrailingZeros(remaining);
         if (partialKeys[i] == densePartialKey)
           return i;
       }
@@ -818,6 +837,12 @@ public final class HOTIndirectPage implements Page {
    * </p>
    */
   private static long getKeyWordAt(byte[] key, int pos) {
+    // HFT: the whole-window case — every descent level of a key long enough to reach it — is one
+    // unaligned load plus a byte swap. The per-byte assembly below is only for the tail, where the
+    // window runs past the end of the key and the missing bytes must read as 0x00.
+    if (pos >= 0 && pos + Long.BYTES <= key.length) {
+      return (long) BYTE_ARRAY_LONG_BE.get(key, pos);
+    }
     long result = 0;
     int end = Math.min(pos + 8, key.length);
     for (int i = pos; i < end; i++) {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
@@ -39,6 +39,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * HOT (Height Optimized Trie) indirect page for cache-friendly secondary indexes.
@@ -103,9 +104,9 @@ public final class HOTIndirectPage implements Page {
   public static final int MAX_NODE_ENTRIES = 32;
 
   /**
-   * Node type enumeration. Each constant carries an explicit stable id byte that is written to
-   * disk — never persist {@link #ordinal()}, so constants can be reordered or inserted without
-   * changing the on-disk meaning.
+   * Node type enumeration. Each constant carries an explicit stable id byte that is written to disk —
+   * never persist {@link #ordinal()}, so constants can be reordered or inserted without changing the
+   * on-disk meaning.
    */
   public enum NodeType {
     /** 2-16 children, SIMD-searchable partial keys. */
@@ -140,8 +141,8 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Layout type for discriminative bit storage. Each constant carries an explicit stable id byte
-   * that is written to disk — never persist {@link #ordinal()}.
+   * Layout type for discriminative bit storage. Each constant carries an explicit stable id byte that
+   * is written to disk — never persist {@link #ordinal()}.
    */
   public enum LayoutType {
     /** Single 64-bit mask with initial byte position. */
@@ -180,10 +181,12 @@ public final class HOTIndirectPage implements Page {
    * {@code initialBytePos}. The MSB is the bit closest to the start of the key (smallest absolute
    * MSB-first bit position).
    *
-   * <p><b>BE word layout</b> (byte 0 of the 8-byte window in long bits 56-63, byte 7 in bits 0-7):
-   * for an absolute bit at byte {@code i} of the window, MSB-first bit-in-byte {@code b}, the long
-   * bit position is {@code (7-i)*8 + (7-b) = 63 - (i*8 + b) = 63 - absoluteBitInWindow}. The bit in
-   * the {@code bitMask} with the HIGHEST long bit position is the most significant disc bit.</p>
+   * <p>
+   * <b>BE word layout</b> (byte 0 of the 8-byte window in long bits 56-63, byte 7 in bits 0-7): for
+   * an absolute bit at byte {@code i} of the window, MSB-first bit-in-byte {@code b}, the long bit
+   * position is {@code (7-i)*8 + (7-b) = 63 - (i*8 + b) = 63 - absoluteBitInWindow}. The bit in the
+   * {@code bitMask} with the HIGHEST long bit position is the most significant disc bit.
+   * </p>
    */
   public static short computeMostSignificantBitIndex(int initialBytePos, long bitMask) {
     if (bitMask == 0) {
@@ -237,12 +240,11 @@ public final class HOTIndirectPage implements Page {
   private static final VectorSpecies<Long> LONG_SPECIES = LongVector.SPECIES_256;
 
   /**
-   * Per-thread scratch byte[] sized to {@link #BYTE_SPECIES}.length() for the SIMD partial-key
-   * load fallback when the search key is shorter than the load window. Lazily populated on
-   * first access per thread (one {@code new byte[32]} per worker thread for the lifetime of the
-   * JVM); steady-state zero-alloc on the fallback branch. Cleared via {@code Arrays.fill} before
-   * each use because the buffer is reused across calls with potentially different
-   * {@code available} lengths.
+   * Per-thread scratch byte[] sized to {@link #BYTE_SPECIES}.length() for the SIMD partial-key load
+   * fallback when the search key is shorter than the load window. Lazily populated on first access
+   * per thread (one {@code new byte[32]} per worker thread for the lifetime of the JVM); steady-state
+   * zero-alloc on the fallback branch. Cleared via {@code Arrays.fill} before each use because the
+   * buffer is reused across calls with potentially different {@code available} lengths.
    */
   private static final ThreadLocal<byte[]> SIMD_PADDED_SCRATCH =
       ThreadLocal.withInitial(() -> new byte[BYTE_SPECIES.length()]);
@@ -250,7 +252,7 @@ public final class HOTIndirectPage implements Page {
   // Transient SIMD state — lazily initialized from extractionPositions after deserialization.
   // VectorShuffle maps each extraction byte to its offset within the contiguous key load window.
   private transient VectorShuffle<Byte> gatherShuffle;
-  private transient int gatherLoadOffset;   // min extraction position (start of load window)
+  private transient int gatherLoadOffset; // min extraction position (start of load window)
   private transient boolean gatherFitsInVector; // true if span ≤ 32 bytes
   private transient boolean gatherInitialized;
 
@@ -258,8 +260,8 @@ public final class HOTIndirectPage implements Page {
   private byte[] childIndex; // Maps byte value -> child slot
 
   /**
-   * Determine the partial key width (in bytes) from the number of discriminative bits.
-   * Matches C++ reference: uint8_t for ≤8 bits, uint16_t for ≤16, uint32_t for ≤32.
+   * Determine the partial key width (in bytes) from the number of discriminative bits. Matches C++
+   * reference: uint8_t for ≤8 bits, uint16_t for ≤16, uint32_t for ≤32.
    *
    * @param bitMask the discriminative bit mask
    * @return 1 for byte, 2 for short, 4 for int
@@ -269,8 +271,8 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Determine partial key width from the total number of discriminative bits.
-   * Matches C++ reference: uint8_t for ≤8, uint16_t for ≤16, uint32_t for ≤32.
+   * Determine partial key width from the total number of discriminative bits. Matches C++ reference:
+   * uint8_t for ≤8, uint16_t for ≤16, uint32_t for ≤32.
    *
    * @param numDiscBits total number of discriminative bits
    * @return 1 for byte, 2 for short, 4 for int
@@ -342,10 +344,12 @@ public final class HOTIndirectPage implements Page {
   /**
    * Create a 2-child compound node (SpanNode) from a discriminative bit position.
    *
-   * <p>In the C++ reference, BiNodes are ephemeral return values from split() that are
-   * immediately integrated into the tree as proper compound nodes. This method follows
-   * that pattern: it creates a SPAN_NODE with 2 children, complete with SparsePartialKeys
-   * for PEXT-based routing. No special BiNode routing path is needed.</p>
+   * <p>
+   * In the C++ reference, BiNodes are ephemeral return values from split() that are immediately
+   * integrated into the tree as proper compound nodes. This method follows that pattern: it creates a
+   * SPAN_NODE with 2 children, complete with SparsePartialKeys for PEXT-based routing. No special
+   * BiNode routing path is needed.
+   * </p>
    *
    * @param pageKey the page key
    * @param revision the revision
@@ -409,8 +413,8 @@ public final class HOTIndirectPage implements Page {
   public static HOTIndirectPage createMultiNode(long pageKey, int revision, int discriminativeByte, byte[] childIndex,
       PageReference[] children) {
     if (children.length < 1 || children.length > MAX_NODE_ENTRIES) {
-      throw new IllegalArgumentException("MultiNode must have 1-" + MAX_NODE_ENTRIES + " children, got: "
-          + children.length);
+      throw new IllegalArgumentException(
+          "MultiNode must have 1-" + MAX_NODE_ENTRIES + " children, got: " + children.length);
     }
     HOTIndirectPage page = new HOTIndirectPage(pageKey, revision, 0, NodeType.MULTI_NODE, children.length);
     page.layoutType = LayoutType.SINGLE_MASK;
@@ -459,8 +463,8 @@ public final class HOTIndirectPage implements Page {
     this.numExtractionBytes = other.numExtractionBytes;
     if (other.partialKeys != null) {
       this.partialKeys = other.partialKeys.clone();
-      this.sparsePartialKeys = createSparsePartialKeys(
-          other.partialKeys, other.numChildren, other.getPartialKeyWidth());
+      this.sparsePartialKeys =
+          createSparsePartialKeys(other.partialKeys, other.numChildren, other.getPartialKeyWidth());
     }
     if (other.childIndex != null) {
       this.childIndex = other.childIndex.clone();
@@ -503,14 +507,15 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Compute the dense partial key of {@code key} under this node's discriminative-bit mask — the
-   * PEXT extraction of the disc bits, packed MSB-first by absolute key-bit significance. This is
-   * <em>exactly</em> the value {@link #findChildIndex} routes on, so it is the canonical input for
-   * a sparse-path subset check {@code (storedPartial & ~densePartialKey) == 0} (invariant I5).
+   * Compute the dense partial key of {@code key} under this node's discriminative-bit mask — the PEXT
+   * extraction of the disc bits, packed MSB-first by absolute key-bit significance. This is
+   * <em>exactly</em> the value {@link #findChildIndex} routes on, so it is the canonical input for a
+   * sparse-path subset check {@code (storedPartial & ~densePartialKey) == 0} (invariant I5).
    *
-   * <p>For a {@code SINGLE_MASK} node it is {@code Long.compress(keyWord, bitMask)} (the PEXT
-   * intrinsic on the 8-byte big-endian window at {@code initialBytePos}); for {@code MULTI_MASK}
-   * it is the chunked gather + compress. Out-of-range key bytes are treated as {@code 0x00}.
+   * <p>
+   * For a {@code SINGLE_MASK} node it is {@code Long.compress(keyWord, bitMask)} (the PEXT intrinsic
+   * on the 8-byte big-endian window at {@code initialBytePos}); for {@code MULTI_MASK} it is the
+   * chunked gather + compress. Out-of-range key bytes are treated as {@code 0x00}.
    *
    * @param key the key to extract the discriminative bits from
    * @return the dense partial key (the disc bits of {@code key} packed into an int)
@@ -535,9 +540,9 @@ public final class HOTIndirectPage implements Page {
    * </p>
    * 
    * <p>
-   * This finds ALL entries that could match the search key based on the discriminative bits.
-   * The HIGHEST (most-specific) match is selected — the entry with the most bits set in its
-   * sparse partial key is the most specific match for this key's bit pattern.
+   * This finds ALL entries that could match the search key based on the discriminative bits. The
+   * HIGHEST (most-specific) match is selected — the entry with the most bits set in its sparse
+   * partial key is the most specific match for this key's bit pattern.
    * </p>
    */
   private int findChildSpanNode(byte[] key) {
@@ -558,10 +563,12 @@ public final class HOTIndirectPage implements Page {
     // returns "not found" cleanly).
     if (sparsePartialKeys != null) {
       int matchMask = sparsePartialKeys.search(densePartialKey);
-      if (matchMask == 0) return NOT_FOUND;
+      if (matchMask == 0)
+        return NOT_FOUND;
       final int subsetPick = 31 - Integer.numberOfLeadingZeros(matchMask);
       for (int i = 0; i < numChildren; i++) {
-        if (partialKeys[i] == densePartialKey) return i;
+        if (partialKeys[i] == densePartialKey)
+          return i;
       }
       return subsetPick;
     }
@@ -569,20 +576,31 @@ public final class HOTIndirectPage implements Page {
     int best = NOT_FOUND;
     for (int i = 0; i < numChildren; i++) {
       int sparseKey = partialKeys[i];
-      if (sparseKey == densePartialKey) { exact = i; break; }
-      if ((densePartialKey & sparseKey) == sparseKey) best = i;
+      if (sparseKey == densePartialKey) {
+        exact = i;
+        break;
+      }
+      if ((densePartialKey & sparseKey) == sparseKey)
+        best = i;
     }
-    return exact >= 0 ? exact : best;
+    return exact >= 0
+        ? exact
+        : best;
   }
 
   /**
    * Compute partial key using MultiMask layout.
    *
-   * <p>Dispatches to SIMD path (vpshufb gather) when extraction positions span ≤32 key bytes,
-   * otherwise falls back to scalar. The SIMD path uses {@code ByteVector.rearrange()} which
-   * compiles to vpshufb on x86 AVX2 — a single-cycle byte shuffle instruction.</p>
+   * <p>
+   * Dispatches to SIMD path (vpshufb gather) when extraction positions span ≤32 key bytes, otherwise
+   * falls back to scalar. The SIMD path uses {@code ByteVector.rearrange()} which compiles to vpshufb
+   * on x86 AVX2 — a single-cycle byte shuffle instruction.
+   * </p>
    *
-   * <p>Matches C++ reference: MultiMaskPartialKeyMapping::extractMask() = mapInput() + extractMaskForMappedInput().</p>
+   * <p>
+   * Matches C++ reference: MultiMaskPartialKeyMapping::extractMask() = mapInput() +
+   * extractMaskForMappedInput().
+   * </p>
    */
   private int computeMultiMaskPartialKey(byte[] key) {
     if (!gatherInitialized) {
@@ -597,9 +615,11 @@ public final class HOTIndirectPage implements Page {
   /**
    * Initialize the SIMD gather shuffle from extraction positions.
    *
-   * <p>Pre-computes a {@link VectorShuffle} that maps each extraction byte lane to the
-   * offset of its source key byte within a contiguous load window. Lanes beyond
-   * {@code numExtractionBytes} are zeroed via wrap-around to lane 0 (don't-care).</p>
+   * <p>
+   * Pre-computes a {@link VectorShuffle} that maps each extraction byte lane to the offset of its
+   * source key byte within a contiguous load window. Lanes beyond {@code numExtractionBytes} are
+   * zeroed via wrap-around to lane 0 (don't-care).
+   * </p>
    */
   private void initGatherShuffle() {
     gatherInitialized = true;
@@ -613,8 +633,10 @@ public final class HOTIndirectPage implements Page {
     int maxPos = Integer.MIN_VALUE;
     for (int i = 0; i < numExtractionBytes; i++) {
       final int pos = extractionPositions[i] & 0xFF;
-      if (pos < minPos) minPos = pos;
-      if (pos > maxPos) maxPos = pos;
+      if (pos < minPos)
+        minPos = pos;
+      if (pos > maxPos)
+        maxPos = pos;
     }
 
     final int span = maxPos - minPos + 1;
@@ -645,13 +667,15 @@ public final class HOTIndirectPage implements Page {
   /**
    * SIMD-accelerated MultiMask partial key extraction using vpshufb gather.
    *
-   * <p>Algorithm:
+   * <p>
+   * Algorithm:
    * <ol>
-   *   <li>Load key bytes from [gatherLoadOffset .. gatherLoadOffset+31] into a ByteVector</li>
-   *   <li>Rearrange using pre-computed gatherShuffle (vpshufb) — gathered bytes now in lanes 0..N-1</li>
-   *   <li>Reinterpret as LongVector (4 longs for AVX2) — each long holds 8 gathered bytes</li>
-   *   <li>Extract each long lane and apply Long.compress() (PEXT) with the extraction mask</li>
-   *   <li>Concatenate PEXT results by bit-shifting</li>
+   * <li>Load key bytes from [gatherLoadOffset .. gatherLoadOffset+31] into a ByteVector</li>
+   * <li>Rearrange using pre-computed gatherShuffle (vpshufb) — gathered bytes now in lanes
+   * 0..N-1</li>
+   * <li>Reinterpret as LongVector (4 longs for AVX2) — each long holds 8 gathered bytes</li>
+   * <li>Extract each long lane and apply Long.compress() (PEXT) with the extraction mask</li>
+   * <li>Concatenate PEXT results by bit-shifting</li>
    * </ol>
    * </p>
    */
@@ -706,14 +730,16 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Scalar fallback for MultiMask partial key extraction. BE within each chunk and
-   * BE concatenation across chunks: extraction byte 0 lands at the MSB of the result.
+   * Scalar fallback for MultiMask partial key extraction. BE within each chunk and BE concatenation
+   * across chunks: extraction byte 0 lands at the MSB of the result.
    *
-   * <p>Zero-allocation: builds each 8-byte chunk word as a local {@code long}, applies the
-   * per-chunk PEXT, and folds the result inline — no intermediate {@code long[]} scratch array.
-   * Equivalent to the previous two-pass implementation (gather all chunk words into a heap array,
-   * then PEXT-compress each); since {@code chunkIdx = i/8} is monotonic across the gather loop,
-   * the rebuild can stream chunk-by-chunk without losing intermediate state.</p>
+   * <p>
+   * Zero-allocation: builds each 8-byte chunk word as a local {@code long}, applies the per-chunk
+   * PEXT, and folds the result inline — no intermediate {@code long[]} scratch array. Equivalent to
+   * the previous two-pass implementation (gather all chunk words into a heap array, then
+   * PEXT-compress each); since {@code chunkIdx = i/8} is monotonic across the gather loop, the
+   * rebuild can stream chunk-by-chunk without losing intermediate state.
+   * </p>
    */
   private int computeMultiMaskPartialKeyScalar(byte[] key) {
     final int numChunks = extractionMasks.length;
@@ -733,7 +759,9 @@ public final class HOTIndirectPage implements Page {
       long chunkWord = 0L;
       for (int i = chunkStart; i < chunkEnd; i++) {
         final int keyBytePos = extractionPositions[i] & 0xFF;
-        final int keyByte = keyBytePos < keyLen ? (key[keyBytePos] & 0xFF) : 0;
+        final int keyByte = keyBytePos < keyLen
+            ? (key[keyBytePos] & 0xFF)
+            : 0;
         final int byteOffsetInChunk = i - chunkStart;
         chunkWord |= ((long) keyByte) << ((7 - byteOffsetInChunk) * 8);
       }
@@ -770,17 +798,21 @@ public final class HOTIndirectPage implements Page {
 
   /**
    * Extract up to 8 bytes from {@code key} starting at {@code pos} into a 64-bit big-endian word.
-   * Byte at {@code pos} maps to bits 56-63 (the long's MSB byte), {@code pos+1} → bits 48-55,
-   * ..., {@code pos+7} → bits 0-7.
+   * Byte at {@code pos} maps to bits 56-63 (the long's MSB byte), {@code pos+1} → bits 48-55, ...,
+   * {@code pos+7} → bits 0-7.
    *
-   * <p>Within each byte, the byte's MSB lands on its slot's bit-7 (highest of slot) and the byte's
-   * LSB on its slot's bit-0. Combined: an absolute MSB-first bit position {@code B = i*8 + b}
-   * (within the 8-byte window) maps to long bit {@code 63 - B}.</p>
+   * <p>
+   * Within each byte, the byte's MSB lands on its slot's bit-7 (highest of slot) and the byte's LSB
+   * on its slot's bit-0. Combined: an absolute MSB-first bit position {@code B = i*8 + b} (within the
+   * 8-byte window) maps to long bit {@code 63 - B}.
+   * </p>
    *
-   * <p><b>Why BE:</b> after {@code Long.compress(keyWord_BE, bitMask_BE)} the partial-key's MSB
-   * holds the value of the most-significant disc bit in the key — so integer-comparing partial-keys
-   * yields lex order on the disc-bit subset. This is what makes path-stack forward walks
-   * lex-monotonic across siblings (Binna §4.2).</p>
+   * <p>
+   * <b>Why BE:</b> after {@code Long.compress(keyWord_BE, bitMask_BE)} the partial-key's MSB holds
+   * the value of the most-significant disc bit in the key — so integer-comparing partial-keys yields
+   * lex order on the disc-bit subset. This is what makes path-stack forward walks lex-monotonic
+   * across siblings (Binna §4.2).
+   * </p>
    */
   private static long getKeyWordAt(byte[] key, int pos) {
     long result = 0;
@@ -811,18 +843,57 @@ public final class HOTIndirectPage implements Page {
   public void setChildReference(int index, PageReference ref) {
     Objects.checkIndex(index, numChildren);
     childReferences[index] = ref;
+    childFirstKeyCache = null; // subtree behind the slot changed — drop memoized first keys
   }
 
   /**
-   * Sort children and their partial keys together so that firstKeys are
-   * monotonically non-decreasing.  PEXT routing matches by partial VALUE,
-   * not position, so reordering children+partials is safe as long as the
-   * two arrays stay paired.
+   * Lazily memoized subtree first-key per child, for the lex-descent probes of read-only sessions.
+   * PURELY an in-memory memo of derivable data — never serialized, never consulted by writers (a
+   * write transaction can re-point a child {@link PageReference}'s page without touching this node,
+   * which no parent-local invalidation can observe; the trie reader therefore only reads/fills this
+   * when its storage engine is a read-only snapshot, where everything below a committed reference is
+   * immutable — swizzling and eviction reload the same revision's content). {@code volatile} +
+   * {@link AtomicReferenceArray} so concurrent readers sharing this committed page object publish
+   * cached keys safely; racing initializers are idempotent. The in-place mutators
+   * ({@link #setChildReference}, {@link #sortChildrenByFirstKey}) clear it defensively.
+   */
+  private volatile @Nullable AtomicReferenceArray<byte[]> childFirstKeyCache;
+
+  /**
+   * The memoized first key of child {@code index}'s subtree, or {@code null} when not cached. Only
+   * meaningful for read-only usage — see {@link #childFirstKeyCache}.
+   */
+  public byte @Nullable [] cachedChildFirstKey(final int index) {
+    final AtomicReferenceArray<byte[]> cache = childFirstKeyCache;
+    return cache == null
+        ? null
+        : cache.get(index);
+  }
+
+  /**
+   * Memoize child {@code index}'s subtree first key. Only read-only sessions may call this — see
+   * {@link #childFirstKeyCache}.
+   */
+  public void cacheChildFirstKey(final int index, final byte[] firstKey) {
+    AtomicReferenceArray<byte[]> cache = childFirstKeyCache;
+    if (cache == null) {
+      cache = new AtomicReferenceArray<>(MAX_NODE_ENTRIES);
+      childFirstKeyCache = cache;
+    }
+    cache.set(index, firstKey);
+  }
+
+  /**
+   * Sort children and their partial keys together so that firstKeys are monotonically non-decreasing.
+   * PEXT routing matches by partial VALUE, not position, so reordering children+partials is safe as
+   * long as the two arrays stay paired.
    *
    * @param firstKeys the firstKey bytes for each child (same length as numChildren)
    */
   public void sortChildrenByFirstKey(final byte[][] firstKeys) {
-    if (partialKeys == null || numChildren < 2) return;
+    if (partialKeys == null || numChildren < 2)
+      return;
+    childFirstKeyCache = null; // slot order changes — drop memoized first keys
     for (int i = 1; i < numChildren; i++) {
       final byte[] keyI = firstKeys[i];
       final int partI = partialKeys[i];
@@ -838,18 +909,21 @@ public final class HOTIndirectPage implements Page {
       partialKeys[j + 1] = partI;
       childReferences[j + 1] = refI;
     }
-    sparsePartialKeys = createSparsePartialKeys(
-        partialKeys, numChildren, getPartialKeyWidth());
+    sparsePartialKeys = createSparsePartialKeys(partialKeys, numChildren, getPartialKeyWidth());
   }
 
   private static int compareUnsigned(final byte[] a, final byte[] b) {
-    if (a == null && b == null) return 0;
-    if (a == null) return -1;
-    if (b == null) return 1;
+    if (a == null && b == null)
+      return 0;
+    if (a == null)
+      return -1;
+    if (b == null)
+      return 1;
     final int len = Math.min(a.length, b.length);
     for (int i = 0; i < len; i++) {
       final int diff = (a[i] & 0xFF) - (b[i] & 0xFF);
-      if (diff != 0) return diff;
+      if (diff != 0)
+        return diff;
     }
     return a.length - b.length;
   }
@@ -927,8 +1001,8 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Get the most significant discriminative bit index (absolute, MSB-first convention).
-   * Matches C++ reference: PartialKeyMappingBase::mMostSignificantDiscriminativeBitIndex.
+   * Get the most significant discriminative bit index (absolute, MSB-first convention). Matches C++
+   * reference: PartialKeyMappingBase::mMostSignificantDiscriminativeBitIndex.
    *
    * @return the most significant bit index
    */
@@ -938,9 +1012,9 @@ public final class HOTIndirectPage implements Page {
 
   /**
    * Test whether {@code beta} (an absolute, MSB-first key-bit position) is one of this node's
-   * discriminative bits, without materializing the disc-bit array. Zero-allocation: reads the
-   * mask layout directly. For SINGLE_MASK, a constant-time bit test on the 64-bit window; for
-   * MULTI_MASK, a scan of the extraction bytes (small, bounded by the node's disc-bit count).
+   * discriminative bits, without materializing the disc-bit array. Zero-allocation: reads the mask
+   * layout directly. For SINGLE_MASK, a constant-time bit test on the 64-bit window; for MULTI_MASK,
+   * a scan of the extraction bytes (small, bounded by the node's disc-bit count).
    *
    * @param beta absolute bit position (MSB-first)
    * @return {@code true} iff {@code beta} is a discriminative bit of this node
@@ -996,8 +1070,8 @@ public final class HOTIndirectPage implements Page {
   }
 
   /**
-   * Internal read-only view of the partial-key array — no defensive copy. Hot-path callers that
-   * only read the partials (e.g. the incremental-insert branch logic) use this to avoid the per-call
+   * Internal read-only view of the partial-key array — no defensive copy. Hot-path callers that only
+   * read the partials (e.g. the incremental-insert branch logic) use this to avoid the per-call
    * {@code clone()} of {@link #getPartialKeys()}. Callers MUST NOT mutate the returned array. May be
    * {@code null} for a not-yet-populated node (the routing nodes that use this always have it set).
    *
@@ -1005,7 +1079,9 @@ public final class HOTIndirectPage implements Page {
    *         {@code numChildren} when not yet populated (matching {@link #getPartialKeys()})
    */
   public int[] getPartialKeysRef() {
-    return partialKeys != null ? partialKeys : new int[numChildren];
+    return partialKeys != null
+        ? partialKeys
+        : new int[numChildren];
   }
 
   /**
@@ -1070,7 +1146,9 @@ public final class HOTIndirectPage implements Page {
    * @return copy of extraction positions, or null if not MultiMask
    */
   public byte @Nullable [] getExtractionPositions() {
-    return extractionPositions != null ? extractionPositions.clone() : null;
+    return extractionPositions != null
+        ? extractionPositions.clone()
+        : null;
   }
 
   /**
@@ -1079,7 +1157,9 @@ public final class HOTIndirectPage implements Page {
    * @return copy of extraction masks, or null if not MultiMask
    */
   public long @Nullable [] getExtractionMasks() {
-    return extractionMasks != null ? extractionMasks.clone() : null;
+    return extractionMasks != null
+        ? extractionMasks.clone()
+        : null;
   }
 
   /**
@@ -1130,8 +1210,7 @@ public final class HOTIndirectPage implements Page {
     copy.numExtractionBytes = this.numExtractionBytes;
     if (this.partialKeys != null) {
       copy.partialKeys = this.partialKeys.clone();
-      copy.sparsePartialKeys = createSparsePartialKeys(
-          this.partialKeys, this.numChildren, this.getPartialKeyWidth());
+      copy.sparsePartialKeys = createSparsePartialKeys(this.partialKeys, this.numChildren, this.getPartialKeyWidth());
     }
     if (this.childIndex != null) {
       copy.childIndex = this.childIndex.clone();
@@ -1243,9 +1322,9 @@ public final class HOTIndirectPage implements Page {
    * @param mostSignificantBitIndex the MSB index (smallest absolute disc bit position)
    * @return new SpanNode with MultiMask layout
    */
-  public static HOTIndirectPage createSpanNodeMultiMask(long pageKey, int revision,
-      byte[] extractionPositions, long[] extractionMasks, int numExtractionBytes,
-      int[] partialKeys, PageReference[] children, int height, short mostSignificantBitIndex) {
+  public static HOTIndirectPage createSpanNodeMultiMask(long pageKey, int revision, byte[] extractionPositions,
+      long[] extractionMasks, int numExtractionBytes, int[] partialKeys, PageReference[] children, int height,
+      short mostSignificantBitIndex) {
     if (children.length < 2 || children.length > 16) {
       throw new IllegalArgumentException("SpanNode must have 2-16 children");
     }
@@ -1260,8 +1339,8 @@ public final class HOTIndirectPage implements Page {
     for (final long mask : extractionMasks) {
       totalDiscBits += Long.bitCount(mask);
     }
-    page.sparsePartialKeys = createSparsePartialKeys(partialKeys, children.length,
-        determinePartialKeyWidthFromBitCount(totalDiscBits));
+    page.sparsePartialKeys =
+        createSparsePartialKeys(partialKeys, children.length, determinePartialKeyWidthFromBitCount(totalDiscBits));
     System.arraycopy(children, 0, page.childReferences, 0, children.length);
     return page;
   }
@@ -1280,9 +1359,9 @@ public final class HOTIndirectPage implements Page {
    * @param mostSignificantBitIndex the MSB index
    * @return new MultiNode with MultiMask layout
    */
-  public static HOTIndirectPage createMultiNodeMultiMask(long pageKey, int revision,
-      byte[] extractionPositions, long[] extractionMasks, int numExtractionBytes,
-      int[] partialKeys, PageReference[] children, int height, short mostSignificantBitIndex) {
+  public static HOTIndirectPage createMultiNodeMultiMask(long pageKey, int revision, byte[] extractionPositions,
+      long[] extractionMasks, int numExtractionBytes, int[] partialKeys, PageReference[] children, int height,
+      short mostSignificantBitIndex) {
     if (children.length < 1 || children.length > 32) {
       throw new IllegalArgumentException("MultiNode must have 1-32 children, got: " + children.length);
     }
@@ -1297,8 +1376,8 @@ public final class HOTIndirectPage implements Page {
     for (final long mask : extractionMasks) {
       totalDiscBits += Long.bitCount(mask);
     }
-    page.sparsePartialKeys = createSparsePartialKeys(partialKeys, children.length,
-        determinePartialKeyWidthFromBitCount(totalDiscBits));
+    page.sparsePartialKeys =
+        createSparsePartialKeys(partialKeys, children.length, determinePartialKeyWidthFromBitCount(totalDiscBits));
     System.arraycopy(children, 0, page.childReferences, 0, children.length);
     return page;
   }
@@ -1363,8 +1442,8 @@ public final class HOTIndirectPage implements Page {
   @Override
   public String toString() {
     return "HOTIndirectPage{" + "pageKey=" + pageKey + ", revision=" + revision + ", height=" + height + ", nodeType="
-        + nodeType + ", layoutType=" + layoutType + ", numChildren=" + numChildren
-        + ", msbIndex=" + mostSignificantBitIndex + '}';
+        + nodeType + ", layoutType=" + layoutType + ", numChildren=" + numChildren + ", msbIndex="
+        + mostSignificantBitIndex + '}';
   }
 }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
@@ -587,6 +587,10 @@ public final class HOTIndirectPage implements Page {
       // could return is already a match bit, and clearing the lowest set bit each round visits them
       // in ascending index order, returning the same child the scan did. On a full node that is a
       // handful of candidates instead of 32 branches, once per descent level per lookup.
+      //
+      // Measured NEUTRAL on the profiled CAS index: an interleaved A/B against the linear scan put
+      // descendToLeaf at 72.6 -> 70.9 ns, inside the per-fork spread. Kept because it is equivalent
+      // and strictly less work, not because it was measured to help here.
       for (int remaining = matchMask; remaining != 0; remaining &= remaining - 1) {
         final int i = Integer.numberOfTrailingZeros(remaining);
         if (partialKeys[i] == densePartialKey)
@@ -839,7 +843,9 @@ public final class HOTIndirectPage implements Page {
   private static long getKeyWordAt(byte[] key, int pos) {
     // HFT: the whole-window case — every descent level of a key long enough to reach it — is one
     // unaligned load plus a byte swap. The per-byte assembly below is only for the tail, where the
-    // window runs past the end of the key and the missing bytes must read as 0x00.
+    // window runs past the end of the key and the missing bytes must read as 0x00. Measured
+    // neutral on the profiled CAS index, same as the match-mask probe in findChildSpanNode: the
+    // descent's cost is not in assembling this word.
     if (pos >= 0 && pos + Long.BYTES <= key.length) {
       return (long) BYTE_ARRAY_LONG_BE.get(key, pos);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTIndirectPage.java
@@ -36,7 +36,10 @@ import jdk.incubator.vector.VectorShuffle;
 import jdk.incubator.vector.VectorSpecies;
 import org.jspecify.annotations.Nullable;
 
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.settings.Constants;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -699,7 +702,7 @@ public final class HOTIndirectPage implements Page {
         System.arraycopy(key, gatherLoadOffset, padded, 0, available);
       }
       if (available < vectorLen) {
-        java.util.Arrays.fill(padded, available, vectorLen, (byte) 0);
+        Arrays.fill(padded, available, vectorLen, (byte) 0);
       }
       keyVec = ByteVector.fromArray(BYTE_SPECIES, padded, 0);
     }
@@ -843,7 +846,14 @@ public final class HOTIndirectPage implements Page {
   public void setChildReference(int index, PageReference ref) {
     Objects.checkIndex(index, numChildren);
     childReferences[index] = ref;
-    childFirstKeyCache = null; // subtree behind the slot changed — drop memoized first keys
+    // UNCONDITIONAL volatile store, deliberately not guarded by a `!= null` pre-check. The guard
+    // would be a check-then-act on a field a concurrent reader publishes: a reader inside
+    // cacheChildFirstKey can observe null, this writer can then observe null and skip the clear,
+    // and the reader's subsequent store installs a memo holding the PRE-rewrite first key that
+    // nothing will ever invalidate — after which the lex descent routes on it and can skip a
+    // subtree that holds in-range keys. The store also supplies the release edge that publishes
+    // the plain childReferences[] write above.
+    childFirstKeyCache = null;
   }
 
   /**
@@ -1416,6 +1426,7 @@ public final class HOTIndirectPage implements Page {
     }
     if (childReferences[offset] == null) {
       childReferences[offset] = new PageReference();
+      childFirstKeyCache = null; // a slot gained a subtree — drop memoized first keys
     }
     return childReferences[offset];
   }
@@ -1426,14 +1437,22 @@ public final class HOTIndirectPage implements Page {
       return true; // Page full
     }
     childReferences[offset] = pageReference;
+    // UNCONDITIONAL volatile store, deliberately not guarded by a `!= null` pre-check. The guard
+    // would be a check-then-act on a field a concurrent reader publishes: a reader inside
+    // cacheChildFirstKey can observe null, this writer can then observe null and skip the clear,
+    // and the reader's subsequent store installs a memo holding the PRE-rewrite first key that
+    // nothing will ever invalidate — after which the lex descent routes on it and can skip a
+    // subtree that holds in-range keys. The store also supplies the release edge that publishes
+    // the plain childReferences[] write above.
+    childFirstKeyCache = null;
     return false;
   }
 
   @Override
-  public void commit(io.sirix.api.StorageEngineWriter storageEngineWriter) {
+  public void commit(StorageEngineWriter storageEngineWriter) {
     for (int i = 0; i < numChildren; i++) {
       PageReference ref = childReferences[i];
-      if (ref != null && ref.getLogKey() != io.sirix.settings.Constants.NULL_ID_INT) {
+      if (ref != null && ref.getLogKey() != Constants.NULL_ID_INT) {
         storageEngineWriter.commit(ref);
       }
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -107,9 +107,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   public static final int DEFAULT_SIZE = 64 * 1024;
 
   /**
-   * Page-envelope flag bit: this leaf serializes a trailing overflow-page-reference section (the
-   * side map of {@link OverflowPage} references keyed by {@link #overflowPageRefKey(long, int)} —
-   * a generic leaf-page facility; the projection index is its current user, see
+   * Page-envelope flag bit: this leaf serializes a trailing overflow-page-reference section (the side
+   * map of {@link OverflowPage} references keyed by {@link #overflowPageRefKey(long, int)} — a
+   * generic leaf-page facility; the projection index is its current user, see
    * docs/PROJECTION_INDEX_STORAGE_REDESIGN.md §2.3).
    */
   public static final byte FLAG_OVERFLOW_PAGE_REFS = 0x01;
@@ -118,22 +118,23 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   public static final int MAX_OVERFLOW_PAGE_REF_SUB_ID = 0xFFFF;
 
   /**
-   * THE side-map key convention, in one place so the writer and the
-   * decoder ({@link #moveOverflowPageRefsAfterSplit}) cannot drift: a side-map entry's key is
+   * THE side-map key convention, in one place so the writer and the decoder
+   * ({@link #moveOverflowPageRefsAfterSplit}) cannot drift: a side-map entry's key is
    * {@code (ownerSlotKey << 16) | subId}, where {@code ownerSlotKey} is the long whose
-   * {@code PathKeySerializer} encoding is the owning slot's stored key bytes. Validates both
-   * halves — a truncated owner key would collide two distinct owners and mis-route refs after
-   * splits (sign-extended {@code >> 16} recovery), so it fails loudly here instead.
+   * {@code PathKeySerializer} encoding is the owning slot's stored key bytes. Validates both halves —
+   * a truncated owner key would collide two distinct owners and mis-route refs after splits
+   * (sign-extended {@code >> 16} recovery), so it fails loudly here instead.
    *
-   * <p>The sub-id occupies 16 bits (was 8): the projection index encodes a column's segment id
-   * here, and 8 bits capped it at 84 columns ({@code (255-2)/3}). 16 bits lifts that to ~21,844
-   * (see {@code RowGroupDescriptor.MAX_COLUMNS}). The trade is owner-slot headroom — |ownerSlotKey|
-   * must now be {@code < 2^47} instead of {@code 2^55} — still ~1.4e14 slot keys, far beyond any
-   * row-group count.</p>
+   * <p>
+   * The sub-id occupies 16 bits (was 8): the projection index encodes a column's segment id here, and
+   * 8 bits capped it at 84 columns ({@code (255-2)/3}). 16 bits lifts that to ~21,844 (see
+   * {@code RowGroupDescriptor.MAX_COLUMNS}). The trade is owner-slot headroom — |ownerSlotKey| must
+   * now be {@code < 2^47} instead of {@code 2^55} — still ~1.4e14 slot keys, far beyond any row-group
+   * count.
+   * </p>
    *
-   * @throws IllegalArgumentException when {@code subId} is outside [0, 65535] or
-   *         {@code ownerSlotKey} does not survive the {@code << 16 >> 16} round-trip
-   *         (|ownerSlotKey| ≥ 2^47)
+   * @throws IllegalArgumentException when {@code subId} is outside [0, 65535] or {@code ownerSlotKey}
+   *         does not survive the {@code << 16 >> 16} round-trip (|ownerSlotKey| ≥ 2^47)
    */
   public static long overflowPageRefKey(final long ownerSlotKey, final int subId) {
     if (subId < 0 || subId > MAX_OVERFLOW_PAGE_REF_SUB_ID) {
@@ -170,18 +171,18 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   private static final ValueLayout.OfShort JAVA_SHORT_UNALIGNED = LE.SHORT;
 
   /**
-   * Unaligned big-endian long layout for zero-allocation lexicographic key comparison.
-   * Big-endian ensures that Long.compareUnsigned correctly orders byte sequences lexicographically.
+   * Unaligned big-endian long layout for zero-allocation lexicographic key comparison. Big-endian
+   * ensures that Long.compareUnsigned correctly orders byte sequences lexicographically.
    */
   private static final ValueLayout.OfLong JAVA_LONG_BE_UNALIGNED =
       ValueLayout.JAVA_LONG.withByteAlignment(1).withOrder(ByteOrder.BIG_ENDIAN);
 
   /**
-   * Narrower big-endian companions to {@link #JAVA_LONG_BE_UNALIGNED}, for assembling a key from
-   * a suffix shorter than eight bytes without falling back to per-byte reads. Explicitly
-   * big-endian rather than {@code reverseBytes} over a native-order load, so the assembly is
-   * correct on a big-endian host too; on a little-endian one the JIT folds the order change into
-   * the load's byte swap.
+   * Narrower big-endian companions to {@link #JAVA_LONG_BE_UNALIGNED}, for assembling a key from a
+   * suffix shorter than eight bytes without falling back to per-byte reads. Explicitly big-endian
+   * rather than {@code reverseBytes} over a native-order load, so the assembly is correct on a
+   * big-endian host too; on a little-endian one the JIT folds the order change into the load's byte
+   * swap.
    */
   private static final ValueLayout.OfInt JAVA_INT_BE_UNALIGNED =
       ValueLayout.JAVA_INT.withByteAlignment(1).withOrder(ByteOrder.BIG_ENDIAN);
@@ -191,14 +192,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   /**
    * {@link #valueRef} sentinel for a slot that does not address a readable value. Chosen as
-   * {@code -1L} so that {@link #refLength}, which is just the handle's low word, already reports
-   * the {@code -1} length a caller would otherwise have to special-case.
+   * {@code -1L} so that {@link #refLength}, which is just the handle's low word, already reports the
+   * {@code -1} length a caller would otherwise have to special-case.
    */
   public static final long NO_VALUE_REF = -1L;
 
   /**
-   * Thread-local scratch buffer for compact() to avoid 2*n byte[] allocations.
-   * Sized to DEFAULT_SIZE (64KB) to handle worst-case full page.
+   * Thread-local scratch buffer for compact() to avoid 2*n byte[] allocations. Sized to DEFAULT_SIZE
+   * (64KB) to handle worst-case full page.
    */
   private static final ThreadLocal<byte[]> COMPACT_SCRATCH = ThreadLocal.withInitial(() -> new byte[DEFAULT_SIZE]);
 
@@ -232,13 +233,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   // Discriminative bits over suffixes using single-mask layout (LE word, matches HOTIndirectPage).
   // Dense partial key = Long.compress(loadSuffixWordLE(suffix, discBytePos), discBitMask).
   // SIMD equality search finds entries with matching partial key; verify with full suffix comparison.
-  private int discBytePos;            // Starting byte position in suffix for disc bits
-  private long discBitMask;           // 64-bit PEXT mask over suffix bytes (LE word layout)
-  private int discBitCount;           // Number of discriminative bits (= Long.bitCount(discBitMask))
-  private byte[] densePKBytes;        // Dense partial keys per entry (for ≤8 disc bits)
-  private short[] densePKShorts;      // Dense partial keys per entry (for 9-16 disc bits)
-  private int[] densePKInts;          // Dense partial keys per entry (for 17-32 disc bits)
-  private boolean pextValid;          // True if PEXT index is current
+  private int discBytePos; // Starting byte position in suffix for disc bits
+  private long discBitMask; // 64-bit PEXT mask over suffix bytes (LE word layout)
+  private int discBitCount; // Number of discriminative bits (= Long.bitCount(discBitMask))
+  private byte[] densePKBytes; // Dense partial keys per entry (for ≤8 disc bits)
+  private short[] densePKShorts; // Dense partial keys per entry (for 9-16 disc bits)
+  private int[] densePKInts; // Dense partial keys per entry (for 17-32 disc bits)
+  private boolean pextValid; // True if PEXT index is current
 
   // ===== Guard-based lifetime management (LeanStore/Umbra pattern) =====
   // Note: For production, consider using @Contended annotation to avoid false sharing
@@ -340,8 +341,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @param commonPrefixLen the length of the common prefix
    */
   public HOTLeafPage(long recordPageKey, int revision, IndexType indexType, MemorySegment slotMemory,
-      @Nullable Runnable releaser, int[] slotOffsets, int entryCount, int usedSlotMemorySize,
-      byte[] commonPrefix, int commonPrefixLen) {
+      @Nullable Runnable releaser, int[] slotOffsets, int entryCount, int usedSlotMemorySize, byte[] commonPrefix,
+      int commonPrefixLen) {
     this.recordPageKey = recordPageKey;
     this.revision = revision;
     this.indexType = Objects.requireNonNull(indexType);
@@ -350,7 +351,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     this.slotOffsets = slotOffsets;
     this.entryCount = entryCount;
     this.usedSlotMemorySize = usedSlotMemorySize;
-    this.commonPrefix = commonPrefix != null ? commonPrefix : EMPTY_PREFIX;
+    this.commonPrefix = commonPrefix != null
+        ? commonPrefix
+        : EMPTY_PREFIX;
     this.commonPrefixLen = commonPrefixLen;
     this.pageReferences = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>();
     // Eagerly build PEXT index so read-only lookups after deserialization
@@ -370,8 +373,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   // ===== Suffix access (zero-copy from slotMemory) =====
 
   /**
-   * Get suffix slice from off-heap segment (zero-copy). Suffixes are stored as the entry key
-   * in slotMemory: {@code [u16 suffixLen][suffix bytes][u16 valueLen][value bytes]}.
+   * Get suffix slice from off-heap segment (zero-copy). Suffixes are stored as the entry key in
+   * slotMemory: {@code [u16 suffixLen][suffix bytes][u16 valueLen][value bytes]}.
    *
    * @param index the entry index
    * @return the suffix as a MemorySegment slice
@@ -399,13 +402,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   /**
    * Build the PEXT routing index over entry suffixes. Only built when
-   * {@code 2 <= entryCount <= PEXT_MAX_ENTRIES}. Uses single-mask layout
-   * (LE word at {@link #discBytePos} + 64-bit {@link #discBitMask}).
+   * {@code 2 <= entryCount <= PEXT_MAX_ENTRIES}. Uses single-mask layout (LE word at
+   * {@link #discBytePos} + 64-bit {@link #discBitMask}).
    *
-   * <p>For each adjacent pair of sorted suffixes, computes the first differing
-   * bit position. All these bit positions are combined into a single PEXT mask.
-   * Then for each entry, the dense partial key is extracted and stored in a
-   * type-appropriate array for SIMD equality search.</p>
+   * <p>
+   * For each adjacent pair of sorted suffixes, computes the first differing bit position. All these
+   * bit positions are combined into a single PEXT mask. Then for each entry, the dense partial key is
+   * extracted and stored in a type-appropriate array for SIMD equality search.
+   * </p>
    */
   private void buildPextIndex() {
     if (entryCount < 2 || entryCount > PEXT_MAX_ENTRIES) {
@@ -432,8 +436,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       final int len1 = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, off1));
       final int off2 = slotOffsets[i + 1];
       final int len2 = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, off2));
-      final int diffBit = DiscriminativeBitComputer.computeDifferingBit(
-          slotMemory, off1 + 2L, len1, off2 + 2L, len2);
+      final int diffBit = DiscriminativeBitComputer.computeDifferingBit(slotMemory, off1 + 2L, len1, off2 + 2L, len2);
       diffBits[i] = diffBit;
       if (diffBit >= 0) {
         hasDiffBits = true;
@@ -512,10 +515,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Compute the PEXT partial key for the suffix at the given entry index.
    *
-   * <p>Zero-allocation: reads {@code slotMemory} directly via {@code (offset, length)} instead of
+   * <p>
+   * Zero-allocation: reads {@code slotMemory} directly via {@code (offset, length)} instead of
    * materializing a {@code MemorySegment.asSlice} view per call. Called once per entry during
-   * {@link #buildPextIndex}, so removing the slice eliminates {@code entryCount} view allocations
-   * per deserialized leaf page.</p>
+   * {@link #buildPextIndex}, so removing the slice eliminates {@code entryCount} view allocations per
+   * deserialized leaf page.
+   * </p>
    */
   private int computeSuffixPartialKey(int index) {
     final int offset = slotOffsets[index];
@@ -526,11 +531,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Compute PEXT partial key from a byte-range within a MemorySegment.
    *
-   * <p>Zero-allocation counterpart to {@link #computePartialKeyFromSegment} that avoids the
-   * intermediate {@code asSlice} wrapper.</p>
+   * <p>
+   * Zero-allocation counterpart to {@link #computePartialKeyFromSegment} that avoids the intermediate
+   * {@code asSlice} wrapper.
+   * </p>
    */
-  private static int computePartialKeyFromSegmentRegion(
-      MemorySegment seg, long suffixStart, int suffixLen, int bytePos, long bitMask) {
+  private static int computePartialKeyFromSegmentRegion(MemorySegment seg, long suffixStart, int suffixLen, int bytePos,
+      long bitMask) {
     final long suffixWord = loadWordBE(seg, suffixStart, suffixLen, bytePos);
     return (int) Long.compress(suffixWord, bitMask);
   }
@@ -552,8 +559,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Load up to 8 bytes from a MemorySegment in BE word layout: byte at {@code pos} → long bits
-   * 56-63, {@code pos+1} → 48-55, ..., {@code pos+7} → 0-7. Matches
+   * Load up to 8 bytes from a MemorySegment in BE word layout: byte at {@code pos} → long bits 56-63,
+   * {@code pos+1} → 48-55, ..., {@code pos+7} → 0-7. Matches
    * {@link io.sirix.page.HOTIndirectPage#getKeyWordAt} for PEXT consistency.
    */
   private static long loadWordBE(MemorySegment segment, int pos) {
@@ -569,15 +576,17 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Load up to 8 bytes from a logical byte-range within {@code segment} in BE word layout.
    *
-   * <p>The {@code (regionStart, regionLen)} pair carries the implicit slice the legacy
+   * <p>
+   * The {@code (regionStart, regionLen)} pair carries the implicit slice the legacy
    * {@link #loadWordBE(MemorySegment, int)} reads via {@link MemorySegment#byteSize()}. Equivalent
-   * semantics but allocation-free at call sites that own the start/length explicitly
-   * (e.g. {@link #computeSuffixPartialKey}).</p>
+   * semantics but allocation-free at call sites that own the start/length explicitly (e.g.
+   * {@link #computeSuffixPartialKey}).
+   * </p>
    *
-   * @param segment    underlying memory
+   * @param segment underlying memory
    * @param regionStart absolute byte offset of the logical key region within {@code segment}
-   * @param regionLen   length of the logical key region in bytes
-   * @param pos         byte offset within the region (0-based) to start reading from
+   * @param regionLen length of the logical key region in bytes
+   * @param pos byte offset within the region (0-based) to start reading from
    * @return the up-to-8-byte word in BE layout, zero-padded if the region is shorter than 8 bytes
    *         from {@code pos}
    */
@@ -607,11 +616,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Find entry index for key using PEXT-accelerated search with prefix compression.
    *
-   * <p><b>Algorithm:</b></p>
+   * <p>
+   * <b>Algorithm:</b>
+   * </p>
    * <ol>
-   *   <li>Check that key starts with commonPrefix (short-circuit if not)</li>
-   *   <li>For ≤32 entries with valid PEXT: SIMD equality search on partial keys → verify suffix</li>
-   *   <li>Otherwise: binary search comparing suffixes (shorter keys = faster comparison)</li>
+   * <li>Check that key starts with commonPrefix (short-circuit if not)</li>
+   * <li>For ≤32 entries with valid PEXT: SIMD equality search on partial keys → verify suffix</li>
+   * <li>Otherwise: binary search comparing suffixes (shorter keys = faster comparison)</li>
    * </ol>
    *
    * @param key the search key (full key including prefix)
@@ -635,7 +646,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         if (key[i] != commonPrefix[i]) {
           // Key doesn't match prefix. Determine if key < prefix or key > prefix
           final int cmp = (key[i] & 0xFF) - (commonPrefix[i] & 0xFF);
-          return cmp < 0 ? -1 : -(entryCount + 1);
+          return cmp < 0
+              ? -1
+              : -(entryCount + 1);
         }
       }
     }
@@ -654,24 +667,26 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Compute the insertion point when key doesn't match the common prefix.
-   * If key &lt; prefix, insertion point is before all entries (return -1).
-   * If key &gt; prefix, insertion point is after all entries (return -(entryCount+1)).
+   * Compute the insertion point when key doesn't match the common prefix. If key &lt; prefix,
+   * insertion point is before all entries (return -1). If key &gt; prefix, insertion point is after
+   * all entries (return -(entryCount+1)).
    */
   private int computeInsertionPointFromPrefix(byte[] key) {
     final int minLen = Math.min(key.length, commonPrefixLen);
     for (int i = 0; i < minLen; i++) {
       final int cmp = (key[i] & 0xFF) - (commonPrefix[i] & 0xFF);
-      if (cmp < 0) return -1;
-      if (cmp > 0) return -(entryCount + 1);
+      if (cmp < 0)
+        return -1;
+      if (cmp > 0)
+        return -(entryCount + 1);
     }
     // key is a prefix of commonPrefix → key < all entries (prefix is shorter)
     return -1;
   }
 
   /**
-   * PEXT-accelerated search: compute partial key from suffix, SIMD equality search,
-   * verify candidates with full suffix comparison.
+   * PEXT-accelerated search: compute partial key from suffix, SIMD equality search, verify candidates
+   * with full suffix comparison.
    */
   private int pextSearch(byte[] key) {
     final int searchPK = computePartialKeyFromArray(key, commonPrefixLen, discBytePos, discBitMask);
@@ -707,7 +722,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       final ByteVector searchVec = ByteVector.broadcast(BYTE_SPECIES, searchPK);
       final ByteVector entriesVec = ByteVector.fromArray(BYTE_SPECIES, densePKBytes, 0);
       final VectorMask<Byte> matches = searchVec.compare(VectorOperators.EQ, entriesVec);
-      final long mask = entryCount == 32 ? 0xFFFFFFFFL : ((1L << entryCount) - 1);
+      final long mask = entryCount == 32
+          ? 0xFFFFFFFFL
+          : ((1L << entryCount) - 1);
       return (int) (matches.toLong() & mask);
     }
     // Scalar fallback
@@ -728,7 +745,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       final ShortVector searchVec = ShortVector.broadcast(SHORT_SPECIES, searchPK);
       final ShortVector entriesVec = ShortVector.fromArray(SHORT_SPECIES, densePKShorts, 0);
       final VectorMask<Short> matches = searchVec.compare(VectorOperators.EQ, entriesVec);
-      final long mask = entryCount == 16 ? 0xFFFFL : ((1L << Math.min(entryCount, 16)) - 1);
+      final long mask = entryCount == 16
+          ? 0xFFFFL
+          : ((1L << Math.min(entryCount, 16)) - 1);
       int result = (int) (matches.toLong() & mask);
       if (entryCount > 16) {
         final ShortVector entriesVec2 = ShortVector.fromArray(SHORT_SPECIES, densePKShorts, 16);
@@ -740,7 +759,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     }
     int result = 0;
     for (int i = 0; i < entryCount; i++) {
-      if (densePKShorts[i] == searchPK) result |= (1 << i);
+      if (densePKShorts[i] == searchPK)
+        result |= (1 << i);
     }
     return result;
   }
@@ -757,12 +777,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         final VectorMask<Integer> matches = searchVec.compare(VectorOperators.EQ, entriesVec);
         result |= ((int) matches.toLong()) << (chunk * 8);
       }
-      final long mask = entryCount == 32 ? 0xFFFFFFFFL : ((1L << entryCount) - 1);
+      final long mask = entryCount == 32
+          ? 0xFFFFFFFFL
+          : ((1L << entryCount) - 1);
       return (int) (result & mask);
     }
     int result = 0;
     for (int i = 0; i < entryCount; i++) {
-      if (densePKInts[i] == searchPK) result |= (1 << i);
+      if (densePKInts[i] == searchPK)
+        result |= (1 << i);
     }
     return result;
   }
@@ -792,8 +815,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Binary search on suffixes. Compares the search key's suffix portion with stored suffixes.
-   * Uses branchless comparison for better branch prediction.
+   * Binary search on suffixes. Compares the search key's suffix portion with stored suffixes. Uses
+   * branchless comparison for better branch prediction.
    *
    * @param key the full search key
    * @return index if found, or -(insertionPoint + 1) if not found
@@ -805,8 +828,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     while (low < high) {
       final int mid = (low + high) >>> 1;
       final int cmp = compareSuffixWithKey(mid, key);
-      low = cmp < 0 ? mid + 1 : low;
-      high = cmp > 0 ? mid : high;
+      low = cmp < 0
+          ? mid + 1
+          : low;
+      high = cmp > 0
+          ? mid
+          : high;
       if (cmp == 0) {
         return mid;
       }
@@ -815,8 +842,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Compare the suffix at entry index with the suffix portion of the search key.
-   * Zero-allocation: reads directly from slotMemory and key array.
+   * Compare the suffix at entry index with the suffix portion of the search key. Zero-allocation:
+   * reads directly from slotMemory and key array.
    *
    * @param index the entry index
    * @param key the full search key
@@ -834,14 +861,11 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     int i = 0;
     for (; i + 8 <= minLen; i += 8) {
       final long aWord = slotMemory.get(JAVA_LONG_BE_UNALIGNED, suffixStart + i);
-      final long bWord = ((long) (key[keySuffixStart + i]     & 0xFF) << 56)
-                       | ((long) (key[keySuffixStart + i + 1] & 0xFF) << 48)
-                       | ((long) (key[keySuffixStart + i + 2] & 0xFF) << 40)
-                       | ((long) (key[keySuffixStart + i + 3] & 0xFF) << 32)
-                       | ((long) (key[keySuffixStart + i + 4] & 0xFF) << 24)
-                       | ((long) (key[keySuffixStart + i + 5] & 0xFF) << 16)
-                       | ((long) (key[keySuffixStart + i + 6] & 0xFF) << 8)
-                       |  (long) (key[keySuffixStart + i + 7] & 0xFF);
+      final long bWord = ((long) (key[keySuffixStart + i] & 0xFF) << 56)
+          | ((long) (key[keySuffixStart + i + 1] & 0xFF) << 48) | ((long) (key[keySuffixStart + i + 2] & 0xFF) << 40)
+          | ((long) (key[keySuffixStart + i + 3] & 0xFF) << 32) | ((long) (key[keySuffixStart + i + 4] & 0xFF) << 24)
+          | ((long) (key[keySuffixStart + i + 5] & 0xFF) << 16) | ((long) (key[keySuffixStart + i + 6] & 0xFF) << 8)
+          | (long) (key[keySuffixStart + i + 7] & 0xFF);
       if (aWord != bWord) {
         return Long.compareUnsigned(aWord, bWord);
       }
@@ -862,11 +886,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   // ===== Key/Value access (prefix + suffix reconstruction) =====
 
   /**
-   * Get key slice as MemorySegment. Reconstructs the full key by concatenating
-   * commonPrefix + suffix. Allocates a byte array (not zero-copy) because
-   * prefix and suffix are not contiguous in memory.
+   * Get key slice as MemorySegment. Reconstructs the full key by concatenating commonPrefix + suffix.
+   * Allocates a byte array (not zero-copy) because prefix and suffix are not contiguous in memory.
    *
-   * <p>For zero-copy suffix access (internal use), use {@link #getSuffixSlice(int)}.</p>
+   * <p>
+   * For zero-copy suffix access (internal use), use {@link #getSuffixSlice(int)}.
+   * </p>
    *
    * @param index the entry index
    * @return the full key as a MemorySegment (backed by on-heap byte[])
@@ -877,21 +902,22 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Resolve entry {@code index}'s value ONCE into a packed {@code (startOffset, length)} handle,
-   * or {@link #NO_VALUE_REF} when the slot table does not address a readable value —
+   * Resolve entry {@code index}'s value ONCE into a packed {@code (startOffset, length)} handle, or
+   * {@link #NO_VALUE_REF} when the slot table does not address a readable value —
    * {@link #getValueSlice} without materializing a slice.
    *
-   * <p><b>Why a packed long and not a slice.</b> A scan that reads a value's size plus a header
-   * byte or two — a discriminator, a blob marker — gets no use out of a {@link MemorySegment}
-   * view but pays for one per slot. The projection directory walk visits roughly ten slots per
-   * row group and keeps the full bytes of one, so slices there were almost entirely garbage.
+   * <p>
+   * <b>Why a packed long and not a slice.</b> A scan that reads a value's size plus a header byte or
+   * two — a discriminator, a blob marker — gets no use out of a {@link MemorySegment} view but pays
+   * for one per slot. The projection directory walk visits roughly ten slots per row group and keeps
+   * the full bytes of one, so slices there were almost entirely garbage.
    *
-   * <p><b>Why the handle is resolved once.</b> Locating a value means reading the slot's suffix
-   * length and then its value length — two segment accesses, each with a session-liveness and a
-   * bounds check — before a single byte of payload is touched. Index-keyed accessors would repeat
-   * that walk on every call; the descriptor path alone reads a marker, a version byte, a length,
-   * a hash and the payload, so resolving once and passing the handle turns five re-derivations
-   * into one.
+   * <p>
+   * <b>Why the handle is resolved once.</b> Locating a value means reading the slot's suffix length
+   * and then its value length — two segment accesses, each with a session-liveness and a bounds check
+   * — before a single byte of payload is touched. Index-keyed accessors would repeat that walk on
+   * every call; the descriptor path alone reads a marker, a version byte, a length, a hash and the
+   * payload, so resolving once and passing the handle turns five re-derivations into one.
    *
    * @param index the entry index
    * @return {@code (startOffset << 32) | length}, always non-negative for a readable value
@@ -917,8 +943,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Byte length of the value {@code ref} resolves, or {@code -1} for {@link #NO_VALUE_REF} —
-   * which is why the sentinel is {@code -1L}: its low word is already the {@code -1} length.
+   * Byte length of the value {@code ref} resolves, or {@code -1} for {@link #NO_VALUE_REF} — which is
+   * why the sentinel is {@code -1L}: its low word is already the {@code -1} length.
    */
   public static int refLength(long ref) {
     return (int) ref;
@@ -945,15 +971,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /** Bulk-copy {@code len} bytes of the value {@code ref} resolves into {@code dst}. */
   public void copyRefInto(long ref, int offsetInValue, byte[] dst, int dstOff, int len) {
     checkRefRange(ref, offsetInValue, len);
-    MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, (ref >>> 32) + offsetInValue, dst, dstOff,
-        len);
+    MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, (ref >>> 32) + offsetInValue, dst, dstOff, len);
   }
 
   private static void checkRefRange(long ref, int offsetInValue, int width) {
     final int valueLen = refLength(ref);
     if (offsetInValue < 0 || width < 0 || offsetInValue > valueLen - width) {
-      throw new IndexOutOfBoundsException("range [" + offsetInValue + ", " + (offsetInValue + width)
-          + ") outside value of length " + valueLen);
+      throw new IndexOutOfBoundsException(
+          "range [" + offsetInValue + ", " + (offsetInValue + width) + ") outside value of length " + valueLen);
     }
   }
 
@@ -1003,19 +1028,19 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Zero-alloc lexicographic comparison of the key at {@code index} against
-   * {@code bound} (treated as an unsigned byte sequence). Returns the usual
-   * tri-value: {@code <0} if key&lt;bound, {@code 0} if equal, {@code >0} if
-   * key&gt;bound. Avoids the {@code byte[]} allocation that {@link #getKey}
-   * and the subsequent {@code MemorySegment.ofArray} wrap incur.
+   * Zero-alloc lexicographic comparison of the key at {@code index} against {@code bound} (treated as
+   * an unsigned byte sequence). Returns the usual tri-value: {@code <0} if key&lt;bound, {@code 0} if
+   * equal, {@code >0} if key&gt;bound. Avoids the {@code byte[]} allocation that {@link #getKey} and
+   * the subsequent {@code MemorySegment.ofArray} wrap incur.
    *
-   * <p>Reads the {@code commonPrefix} on-heap bytes first, then the
-   * per-entry suffix bytes from off-heap {@code slotMemory}. Lengths use
-   * the same {@code suffixLen}-prefix encoding as {@link #getKey}.
+   * <p>
+   * Reads the {@code commonPrefix} on-heap bytes first, then the per-entry suffix bytes from off-heap
+   * {@code slotMemory}. Lengths use the same {@code suffixLen}-prefix encoding as {@link #getKey}.
    *
-   * <p>HFT: used by {@link io.sirix.access.trx.page.HOTRangeCursor} during
-   * its per-entry range check to stay allocation-free. The caller holds
-   * the leaf guard; the off-heap slot memory is guaranteed live.
+   * <p>
+   * HFT: used by {@link io.sirix.access.trx.page.HOTRangeCursor} during its per-entry range check to
+   * stay allocation-free. The caller holds the leaf guard; the off-heap slot memory is guaranteed
+   * live.
    *
    * @param index the entry index (checked)
    * @param bound the upper-bound key (not null)
@@ -1035,12 +1060,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     while (p < commonMin) {
       final int a = commonPrefix[p] & 0xFF;
       final int b = bound[p] & 0xFF;
-      if (a != b) return a - b;
+      if (a != b)
+        return a - b;
       p++;
     }
     // If bound ended within the commonPrefix, the key (which extends via
     // its suffix) is strictly longer → key > bound.
-    if (bound.length == commonPrefixLen && suffixLen > 0) return 1;
+    if (bound.length == commonPrefixLen && suffixLen > 0)
+      return 1;
     if (p == keyLen) {
       // key fully consumed; equal up to keyLen → key < bound if bound longer
       return keyLen - bound.length;
@@ -1051,11 +1078,137 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     while (p < minLen) {
       final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
       final int b = bound[p] & 0xFF;
-      if (a != b) return a - b;
+      if (a != b)
+        return a - b;
       p++;
     }
     // Length tie-breaker: longer wins (unsigned lex).
     return keyLen - bound.length;
+  }
+
+  /**
+   * Total key length (commonPrefix + suffix) of the entry at {@code index}, without materializing the
+   * key. The read-path composite-key filters are pure length checks once a prefix compare has
+   * matched, so this replaces a {@link #getKey} copy per visited slot.
+   *
+   * @param index the entry index (checked)
+   * @return the full key length in bytes
+   */
+  public int getKeyLength(final int index) {
+    Objects.checkIndex(index, entryCount);
+    return commonPrefixLen + Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, slotOffsets[index]));
+  }
+
+  /**
+   * Zero-alloc unsigned-lex compare of the FIRST {@code prefixLen} bytes of the key at {@code index}
+   * against {@code prefix[0..prefixLen)}. Returns {@code 0} iff the key starts with {@code prefix}
+   * (or equals it); a key shorter than {@code prefixLen} compares by its available bytes and, on a
+   * tie, is less (returns negative). The chunked-posting-list read path uses this as its slot filter
+   * — a composite key belongs to a logical key iff this returns {@code 0} AND {@link #getKeyLength}
+   * equals {@code prefixLen + CHUNK_IDX_BYTES} — replacing a full {@link #getKey} materialization per
+   * visited slot.
+   *
+   * @param index the entry index (checked)
+   * @param prefix the probe prefix bytes
+   * @param prefixLen number of prefix bytes to compare
+   * @return negative / zero / positive per unsigned-lex order of {@code key[0..prefixLen)} vs
+   *         {@code prefix[0..prefixLen)}
+   */
+  public int compareKeyPrefix(final int index, final byte[] prefix, final int prefixLen) {
+    Objects.checkIndex(index, entryCount);
+    final int offset = slotOffsets[index];
+    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
+    final int keyLen = commonPrefixLen + suffixLen;
+    final int cmpLen = Math.min(keyLen, prefixLen);
+    int p = 0;
+    final int commonMin = Math.min(commonPrefixLen, cmpLen);
+    while (p < commonMin) {
+      final int a = commonPrefix[p] & 0xFF;
+      final int b = prefix[p] & 0xFF;
+      if (a != b) {
+        return a - b;
+      }
+      p++;
+    }
+    final long suffixStart = offset + 2;
+    while (p < cmpLen) {
+      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
+      final int b = prefix[p] & 0xFF;
+      if (a != b) {
+        return a - b;
+      }
+      p++;
+    }
+    return keyLen < prefixLen
+        ? -1
+        : 0;
+  }
+
+  /**
+   * Zero-alloc unsigned-lex compare of the key at {@code index} MINUS its {@code trailerBytes}-byte
+   * tail against {@code other[0..otherLen)}, with the usual shorter-is-less length tie-break. The
+   * chunk-aggregating iterators compare a composite key's LOGICAL prefix (composite minus the 4-byte
+   * chunkIdx trailer) against a probe prefix this way without materializing the key.
+   *
+   * @param index the entry index (checked)
+   * @param trailerBytes bytes to exclude from the key's tail (clamped to the key length)
+   * @param other the probe bytes
+   * @param otherLen number of probe bytes to compare
+   * @return negative / zero / positive per unsigned-lex order of the trimmed key vs the probe
+   */
+  public int compareKeyPrefixPart(final int index, final int trailerBytes, final byte[] other, final int otherLen) {
+    Objects.checkIndex(index, entryCount);
+    final int offset = slotOffsets[index];
+    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
+    final int partLen = Math.max(0, commonPrefixLen + suffixLen - Math.max(0, trailerBytes));
+    final int cmpLen = Math.min(partLen, otherLen);
+    int p = 0;
+    final int commonMin = Math.min(commonPrefixLen, cmpLen);
+    while (p < commonMin) {
+      final int a = commonPrefix[p] & 0xFF;
+      final int b = other[p] & 0xFF;
+      if (a != b) {
+        return a - b;
+      }
+      p++;
+    }
+    final long suffixStart = offset + 2;
+    while (p < cmpLen) {
+      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
+      final int b = other[p] & 0xFF;
+      if (a != b) {
+        return a - b;
+      }
+      p++;
+    }
+    return partLen - otherLen;
+  }
+
+  /**
+   * Read a 4-byte big-endian int from the key at {@code index}, starting at key byte {@code pos} —
+   * spanning the on-heap commonPrefix and off-heap suffix regions as needed, without materializing
+   * the key. The chunked read path uses it to extract a composite key's chunkIdx trailer:
+   * {@code readKeyIntBE(idx, getKeyLength(idx) - CHUNK_IDX_BYTES)}.
+   *
+   * @param index the entry index (checked)
+   * @param pos byte offset within the key of the int's first (most significant) byte
+   * @return the big-endian int at {@code key[pos..pos+4)}
+   */
+  public int readKeyIntBE(final int index, final int pos) {
+    Objects.checkIndex(index, entryCount);
+    final int offset = slotOffsets[index];
+    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
+    final int keyLen = commonPrefixLen + suffixLen;
+    Objects.checkFromIndexSize(pos, Integer.BYTES, keyLen);
+    final long suffixStart = offset + 2;
+    int v = 0;
+    for (int i = pos; i < pos + Integer.BYTES; i++) {
+      final int b = i < commonPrefixLen
+          ? commonPrefix[i] & 0xFF
+          : slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (i - commonPrefixLen)) & 0xFF;
+      v = (v << 8) | b;
+    }
+    return v;
   }
 
   /**
@@ -1085,7 +1238,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
           : (i < keyLen
               ? (slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (i - commonPrefixLen)) & 0xFF)
               : 0);
-      final int otherByte = i < other.length ? (other[i] & 0xFF) : 0;
+      final int otherByte = i < other.length
+          ? (other[i] & 0xFF)
+          : 0;
       final int x = leafByte ^ otherByte;
       if (x != 0) {
         return i * 8 + (Integer.numberOfLeadingZeros(x) - 24);
@@ -1095,18 +1250,16 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Zero-alloc little-endian eight-byte decode of the key at {@code index}.
-   * Reconstructs the 8-byte composite key from {@code commonPrefix} +
-   * {@code slotMemory} suffix bytes in big-endian form, then returns it as
-   * a single {@code long}. The projection HOT index uses 8-byte composite
-   * keys encoded via {@link io.sirix.index.hot.PathKeySerializer} (sign-flip
-   * big-endian), so this method lets callers decode the logical composite
-   * without allocating a {@code MemorySegment} wrapper.
+   * Zero-alloc little-endian eight-byte decode of the key at {@code index}. Reconstructs the 8-byte
+   * composite key from {@code commonPrefix} + {@code slotMemory} suffix bytes in big-endian form,
+   * then returns it as a single {@code long}. The projection HOT index uses 8-byte composite keys
+   * encoded via {@link io.sirix.index.hot.PathKeySerializer} (sign-flip big-endian), so this method
+   * lets callers decode the logical composite without allocating a {@code MemorySegment} wrapper.
    *
-   * <p>Caller MUST ensure the key is exactly 8 bytes long (i.e.
-   * {@code commonPrefixLen + suffixLen == 8}) before calling — the helper
-   * is designed for the projection index's invariant key length and does
-   * not defend against shorter/longer keys.
+   * <p>
+   * Caller MUST ensure the key is exactly 8 bytes long (i.e.
+   * {@code commonPrefixLen + suffixLen == 8}) before calling — the helper is designed for the
+   * projection index's invariant key length and does not defend against shorter/longer keys.
    *
    * @param index the entry index (checked)
    * @return the 8-byte key as an unsigned big-endian long
@@ -1117,9 +1270,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
     final int keyLen = commonPrefixLen + suffixLen;
     if (keyLen != 8) {
-      throw new IllegalStateException(
-          "decodeKey8BE requires 8-byte keys, got " + keyLen + " (commonPrefixLen="
-              + commonPrefixLen + ", suffixLen=" + suffixLen + ") at index=" + index);
+      throw new IllegalStateException("decodeKey8BE requires 8-byte keys, got " + keyLen + " (commonPrefixLen="
+          + commonPrefixLen + ", suffixLen=" + suffixLen + ") at index=" + index);
     }
     // Assemble high-bytes from commonPrefix, low-bytes from slotMemory suffix.
     //
@@ -1140,8 +1292,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         read += 4;
       }
       if (suffixLen - read >= 2) {
-        suffix = (suffix << 16)
-            | Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_BE_UNALIGNED, suffixStart + read));
+        suffix = (suffix << 16) | Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_BE_UNALIGNED, suffixStart + read));
         read += 2;
       }
       if (suffixLen - read >= 1) {
@@ -1161,14 +1312,16 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Get value as byte array (copies data).
    *
-   * <p>Zero-intermediate-alloc: reads the value's {@code (offset, length)} directly from
-   * {@code slotMemory} and copies into a freshly-allocated {@code byte[]} without going through
-   * the {@link #getValueSlice} {@code asSlice} wrapper — the latter would heap-allocate a
-   * transient {@code NativeMemorySegmentImpl} view that the copy immediately discards.</p>
+   * <p>
+   * Zero-intermediate-alloc: reads the value's {@code (offset, length)} directly from
+   * {@code slotMemory} and copies into a freshly-allocated {@code byte[]} without going through the
+   * {@link #getValueSlice} {@code asSlice} wrapper — the latter would heap-allocate a transient
+   * {@code NativeMemorySegmentImpl} view that the copy immediately discards.
+   * </p>
    *
    * @param index the entry index
-   * @return the value as byte array, or {@code null} when the slot table doesn't address a
-   *         readable value (matches the {@link #getValueSlice} {@code NULL} sentinel contract)
+   * @return the value as byte array, or {@code null} when the slot table doesn't address a readable
+   *         value (matches the {@link #getValueSlice} {@code NULL} sentinel contract)
    */
   public byte[] getValue(int index) {
     Objects.checkIndex(index, entryCount);
@@ -1224,26 +1377,23 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Zero-allocation variant of {@link #put(byte[], byte[])}: writes the
-   * value range {@code [valueOff, valueOff+valueLen)} from {@code valueBuf}
-   * directly into the slot heap without requiring the caller to slice its
-   * payload into a standalone {@code byte[]} first.
+   * Zero-allocation variant of {@link #put(byte[], byte[])}: writes the value range
+   * {@code [valueOff, valueOff+valueLen)} from {@code valueBuf} directly into the slot heap without
+   * requiring the caller to slice its payload into a standalone {@code byte[]} first.
    *
-   * <p>HFT write path: the projection builder stores 20 KB leaves as 5×4 KB
-   * chunks — the per-leaf arraycopy on this path alone was ~100 MB/s churn
-   * at 100M scale. Letting {@link HOTLeafPage} consume the range directly
-   * eliminates the intermediate allocation, dropping the per-chunk cost to
+   * <p>
+   * HFT write path: the projection builder stores 20 KB leaves as 5×4 KB chunks — the per-leaf
+   * arraycopy on this path alone was ~100 MB/s churn at 100M scale. Letting {@link HOTLeafPage}
+   * consume the range directly eliminates the intermediate allocation, dropping the per-chunk cost to
    * a single {@code MemorySegment.copy} against the pre-allocated heap.
    *
-   * @param key the full key (routing bytes — the trie caller already
-   *            navigated here, so this is used only for suffix extraction
-   *            and binary-search ordering).
+   * @param key the full key (routing bytes — the trie caller already navigated here, so this is used
+   *        only for suffix extraction and binary-search ordering).
    * @param valueBuf buffer holding the value range
    * @param valueOff offset in {@code valueBuf} where the value starts
    * @param valueLen length of the value range
-   * @return {@code true} on successful insert; {@code false} if the key
-   *         already exists (caller should fall through to {@link #updateValue})
-   *         or the page is full (caller should split).
+   * @return {@code true} on successful insert; {@code false} if the key already exists (caller should
+   *         fall through to {@link #updateValue}) or the page is full (caller should split).
    */
   public boolean putRange(byte[] key, byte[] valueBuf, int valueOff, int valueLen) {
     Objects.requireNonNull(key);
@@ -1266,12 +1416,11 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Insert entry at {@code pos} using a value slice from {@code valueBuf}.
-   * Identical to {@link #insertAtSuffix} apart from consuming a range
-   * rather than a stand-alone array.
+   * Insert entry at {@code pos} using a value slice from {@code valueBuf}. Identical to
+   * {@link #insertAtSuffix} apart from consuming a range rather than a stand-alone array.
    */
-  private boolean insertAtSuffixRange(int pos, byte[] keyBuf, int suffixOffset, int suffixLen,
-      byte[] valueBuf, int valueOff, int valueLen) {
+  private boolean insertAtSuffixRange(int pos, byte[] keyBuf, int suffixOffset, int suffixLen, byte[] valueBuf,
+      int valueOff, int valueLen) {
     if (suffixLen > MAX_KEY_VALUE_LENGTH) {
       throw new IllegalArgumentException("Suffix length " + suffixLen + " exceeds maximum " + MAX_KEY_VALUE_LENGTH);
     }
@@ -1322,17 +1471,16 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * MemorySegment-native variant of {@link #putRange(byte[], byte[], int, int)}:
-   * consumes the value directly from an off-heap {@code MemorySegment}
-   * — no intermediate byte[]. Matches the pattern
-   * {@link io.sirix.page.KeyValueLeafPage} uses for writing slot payloads
-   * straight from off-heap buffers.
+   * MemorySegment-native variant of {@link #putRange(byte[], byte[], int, int)}: consumes the value
+   * directly from an off-heap {@code MemorySegment} — no intermediate byte[]. Matches the pattern
+   * {@link io.sirix.page.KeyValueLeafPage} uses for writing slot payloads straight from off-heap
+   * buffers.
    *
-   * <p>HFT use case: the projection builder serialises into a reusable
-   * off-heap scratch segment, then slices 4 KB ranges from that segment
-   * directly into the HOT leaf's {@code slotMemory} via
-   * {@link MemorySegment#copy(MemorySegment, long, MemorySegment, long, long)}.
-   * Zero heap allocation per chunk, zero GC pressure at commit time.
+   * <p>
+   * HFT use case: the projection builder serialises into a reusable off-heap scratch segment, then
+   * slices 4 KB ranges from that segment directly into the HOT leaf's {@code slotMemory} via
+   * {@link MemorySegment#copy(MemorySegment, long, MemorySegment, long, long)}. Zero heap allocation
+   * per chunk, zero GC pressure at commit time.
    */
   public boolean putRange(byte[] key, MemorySegment valueSrc, long valueOff, int valueLen) {
     Objects.requireNonNull(key);
@@ -1408,10 +1556,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * MemorySegment-native variant of {@link #updateValueRange(int, byte[], int, int)}:
-   * in-place update from an off-heap segment range. Returns {@code true}
-   * iff the new value length matches the existing slot (in-place). Size
-   * change falls back to the caller's copying path.
+   * MemorySegment-native variant of {@link #updateValueRange(int, byte[], int, int)}: in-place update
+   * from an off-heap segment range. Returns {@code true} iff the new value length matches the
+   * existing slot (in-place). Size change falls back to the caller's copying path.
    */
   public boolean updateValueRange(int index, MemorySegment valueSrc, long valueOff, int valueLen) {
     if (index < 0 || index >= entryCount) {
@@ -1439,9 +1586,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   /**
    * Zero-allocation variant of {@link #updateValue(int, byte[])}: writes
-   * {@code [valueOff, valueOff+valueLen)} from {@code valueBuf} as the new
-   * value for the entry at {@code index}. Falls back to the copying path
-   * if the new value doesn't fit the existing slot, returning {@code false}.
+   * {@code [valueOff, valueOff+valueLen)} from {@code valueBuf} as the new value for the entry at
+   * {@code index}. Falls back to the copying path if the new value doesn't fit the existing slot,
+   * returning {@code false}.
    */
   public boolean updateValueRange(int index, byte[] valueBuf, int valueOff, int valueLen) {
     if (index < 0 || index >= entryCount) {
@@ -1477,9 +1624,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Establish or update the common prefix when inserting a new key.
    *
-   * <p>On first insert: commonPrefix = key (suffix = empty).
-   * On subsequent inserts: if LCP(key, commonPrefix) &lt; commonPrefixLen,
-   * shrink prefix and extend all existing suffixes.</p>
+   * <p>
+   * On first insert: commonPrefix = key (suffix = empty). On subsequent inserts: if LCP(key,
+   * commonPrefix) &lt; commonPrefixLen, shrink prefix and extend all existing suffixes.
+   * </p>
    */
   private void handlePrefixForInsert(byte[] key) {
     if (entryCount == 0) {
@@ -1512,13 +1660,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Rebuild the page with a shorter common prefix. All existing suffixes are extended
-   * by prepending the bytes that were removed from the prefix.
+   * Rebuild the page with a shorter common prefix. All existing suffixes are extended by prepending
+   * the bytes that were removed from the prefix.
    *
-   * <p>This is expensive (rewrites all entries) but rare — it only happens when a key
-   * arrives that shares fewer bytes with the common prefix than all existing entries.
-   * After a trie split, this becomes impossible because the discriminative bit will
-   * separate such keys.</p>
+   * <p>
+   * This is expensive (rewrites all entries) but rare — it only happens when a key arrives that
+   * shares fewer bytes with the common prefix than all existing entries. After a trie split, this
+   * becomes impossible because the discriminative bit will separate such keys.
+   * </p>
    *
    * @param newPrefixLen the new (shorter) prefix length
    */
@@ -1720,10 +1869,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Ensure the slot memory is full-size ({@link #DEFAULT_SIZE}) for mutation.
-   * Zero-copy deserialized pages have a slotMemory sized to exactly {@code usedSlotMemorySize},
-   * which prevents any new inserts. This method lazily re-allocates to DEFAULT_SIZE,
-   * copying existing data, so the page becomes mutable.
+   * Ensure the slot memory is full-size ({@link #DEFAULT_SIZE}) for mutation. Zero-copy deserialized
+   * pages have a slotMemory sized to exactly {@code usedSlotMemorySize}, which prevents any new
+   * inserts. This method lazily re-allocates to DEFAULT_SIZE, copying existing data, so the page
+   * becomes mutable.
    */
   private void ensureMutableSlotMemory() {
     if (slotMemory.byteSize() >= DEFAULT_SIZE) {
@@ -1752,8 +1901,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * fragmented. This method rebuilds the page with all entries packed contiguously, freeing up space.
    * </p>
    *
-   * <p>Uses a thread-local scratch buffer to avoid the 2×n byte[] allocations of the naive approach
-   * (which would allocate 1024+ arrays for a full 512-entry page).</p>
+   * <p>
+   * Uses a thread-local scratch buffer to avoid the 2×n byte[] allocations of the naive approach
+   * (which would allocate 1024+ arrays for a full 512-entry page).
+   * </p>
    *
    * @return the amount of space reclaimed
    */
@@ -1777,7 +1928,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     for (int i = 0; i < entryCount; i++) {
       final int oldOffset = slotOffsets[i];
       final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, oldOffset));
-      final int valueLen  = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, oldOffset + 2 + suffixLen));
+      final int valueLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, oldOffset + 2 + suffixLen));
       final int entrySize = Math.addExact(Math.addExact(2 + suffixLen, 2), valueLen);
 
       // Bulk-copy the raw entry bytes [u16 suffixLen][suffix][u16 valueLen][value]
@@ -1798,9 +1949,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Physically remove tombstoned entries. After compaction, only active (non-tombstoned)
-   * entries remain. The page is marked as a complete dump so fragment combining does not
-   * resurrect removed entries from the base revision.
+   * Physically remove tombstoned entries. After compaction, only active (non-tombstoned) entries
+   * remain. The page is marked as a complete dump so fragment combining does not resurrect removed
+   * entries from the base revision.
    *
    * @return the number of entries removed
    */
@@ -1808,7 +1959,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     int activeCount = 0;
     for (int i = 0; i < entryCount; i++) {
       final byte[] value = getValue(i);
-      if (value == null) continue;
+      if (value == null)
+        continue;
       if (!NodeReferencesSerializer.isTombstone(value, 0, value.length)) {
         activeCount++;
       }
@@ -1821,7 +1973,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     int idx = 0;
     for (int i = 0; i < entryCount; i++) {
       final byte[] value = getValue(i);
-      if (value == null) continue;
+      if (value == null)
+        continue;
       if (!NodeReferencesSerializer.isTombstone(value, 0, value.length)) {
         activeKeys[idx] = getKey(i);
         activeValues[idx] = value;
@@ -1854,52 +2007,59 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Phase 6a — Check whether bit at MSB-first absolute position {@code absBit} is constant
-   * across all keys in this leaf. Returns:
+   * Phase 6a — Check whether bit at MSB-first absolute position {@code absBit} is constant across all
+   * keys in this leaf. Returns:
    * <ul>
-   *   <li>0 — all keys have bit {@code absBit} = 0</li>
-   *   <li>1 — all keys have bit {@code absBit} = 1</li>
-   *   <li>-1 — leaf is β-mixed at this bit (= some keys have 0, some have 1) OR leaf is empty</li>
+   * <li>0 — all keys have bit {@code absBit} = 0</li>
+   * <li>1 — all keys have bit {@code absBit} = 1</li>
+   * <li>-1 — leaf is β-mixed at this bit (= some keys have 0, some have 1) OR leaf is empty</li>
    * </ul>
    *
-   * <p>O(N) scan over leaf entries. Keys past their length contribute 0 to the bit lookup
-   * (= bit position beyond key length is treated as 0).
+   * <p>
+   * O(N) scan over leaf entries. Keys past their length contribute 0 to the bit lookup (= bit
+   * position beyond key length is treated as 0).
    *
-   * <p>Used by Phase 5 / Phase 6 helpers in HOTTrieWriter to determine whether extending
-   * an ancestor's mask with bit {@code absBit} would preserve β-constancy at this leaf
-   * without splitting.
+   * <p>
+   * Used by Phase 5 / Phase 6 helpers in HOTTrieWriter to determine whether extending an ancestor's
+   * mask with bit {@code absBit} would preserve β-constancy at this leaf without splitting.
    */
   public int isBitConstantAtAbsBit(int absBit) {
-    if (absBit < 0 || entryCount == 0) return -1;
+    if (absBit < 0 || entryCount == 0)
+      return -1;
     boolean seen0 = false;
     boolean seen1 = false;
     for (int i = 0; i < entryCount; i++) {
       final byte[] key = getKey(i);
-      if (key == null) continue;
+      if (key == null)
+        continue;
       final int bytePos = absBit / 8;
       final int bitInByte = absBit % 8;
-      final boolean bitSet = (bytePos < key.length)
-          && ((key[bytePos] & (1 << (7 - bitInByte))) != 0);
-      if (bitSet) seen1 = true;
-      else seen0 = true;
-      if (seen0 && seen1) return -1;
+      final boolean bitSet = (bytePos < key.length) && ((key[bytePos] & (1 << (7 - bitInByte))) != 0);
+      if (bitSet)
+        seen1 = true;
+      else
+        seen0 = true;
+      if (seen0 && seen1)
+        return -1;
     }
-    if (seen1 && !seen0) return 1;
-    if (seen0 && !seen1) return 0;
+    if (seen1 && !seen0)
+      return 1;
+    if (seen0 && !seen1)
+      return 0;
     return -1;
   }
 
   // ===== Phase 7a — owned-bits metadata API =====
 
   /**
-   * Set the leaf's ancestor-owned bits (= absolute MSB-first bit positions captured by any
-   * ancestor mask on the path to this leaf). Each owned bit must be β-constant across all
-   * keys in the leaf; {@code ownedValues[i]} provides the constant value 0/1 for owned bit
-   * {@code ownedBits[i]}.
+   * Set the leaf's ancestor-owned bits (= absolute MSB-first bit positions captured by any ancestor
+   * mask on the path to this leaf). Each owned bit must be β-constant across all keys in the leaf;
+   * {@code ownedValues[i]} provides the constant value 0/1 for owned bit {@code ownedBits[i]}.
    *
-   * <p>Arrays must be the same length; {@code ownedBits} must be sorted ascending. Caller
-   * is responsible for verifying that the constraint actually holds; this method just
-   * records the metadata. Empty arrays = no constraint (= legacy multi-entry leaf).
+   * <p>
+   * Arrays must be the same length; {@code ownedBits} must be sorted ascending. Caller is responsible
+   * for verifying that the constraint actually holds; this method just records the metadata. Empty
+   * arrays = no constraint (= legacy multi-entry leaf).
    */
   public void setAncestorOwnedBits(int[] ownedBits, byte[] ownedValues) {
     if (ownedBits == null || ownedBits.length == 0) {
@@ -1914,8 +2074,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     for (int i = 1; i < ownedBits.length; i++) {
       if (ownedBits[i] <= ownedBits[i - 1]) {
         throw new IllegalArgumentException(
-            "ownedBits must be sorted strictly ascending; got " + ownedBits[i - 1]
-                + " followed by " + ownedBits[i]);
+            "ownedBits must be sorted strictly ascending; got " + ownedBits[i - 1] + " followed by " + ownedBits[i]);
       }
     }
     this.ancestorOwnedBits = ownedBits.clone();
@@ -1924,35 +2083,41 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   /** Returns a defensive copy of the leaf's ancestor-owned bit positions. */
   public int[] getAncestorOwnedBits() {
-    return ancestorOwnedBits.length == 0 ? EMPTY_BITS : ancestorOwnedBits.clone();
+    return ancestorOwnedBits.length == 0
+        ? EMPTY_BITS
+        : ancestorOwnedBits.clone();
   }
 
   /** Returns a defensive copy of the leaf's ancestor-owned bit values. */
   public byte[] getAncestorOwnedValues() {
-    return ancestorOwnedValues.length == 0 ? EMPTY_VALUES : ancestorOwnedValues.clone();
+    return ancestorOwnedValues.length == 0
+        ? EMPTY_VALUES
+        : ancestorOwnedValues.clone();
   }
 
   /**
    * Check whether inserting {@code key} would violate the leaf's owned-bits constancy. Returns:
    * <ul>
-   *   <li>-1 — key matches all owned bits (= safe to merge);
-   *   <li>≥0 — the FIRST offending absolute bit position where key's value disagrees with the
-   *       owned constant.
+   * <li>-1 — key matches all owned bits (= safe to merge);
+   * <li>≥0 — the FIRST offending absolute bit position where key's value disagrees with the owned
+   * constant.
    * </ul>
    *
-   * <p>HFT-grade: O(ownedBits.length), no allocation. Used by callers BEFORE merge to
-   * detect β-break and trigger constancy-aware split.
+   * <p>
+   * HFT-grade: O(ownedBits.length), no allocation. Used by callers BEFORE merge to detect β-break and
+   * trigger constancy-aware split.
    */
   public int checkOwnedBitsAgainstKey(byte[] key) {
-    if (key == null || ancestorOwnedBits.length == 0) return -1;
+    if (key == null || ancestorOwnedBits.length == 0)
+      return -1;
     for (int i = 0; i < ancestorOwnedBits.length; i++) {
       final int absBit = ancestorOwnedBits[i];
       final int bytePos = absBit / 8;
       final int bitInByte = absBit % 8;
-      final boolean keyBit = (bytePos < key.length)
-          && ((key[bytePos] & (1 << (7 - bitInByte))) != 0);
+      final boolean keyBit = (bytePos < key.length) && ((key[bytePos] & (1 << (7 - bitInByte))) != 0);
       final boolean ownedBit = ancestorOwnedValues[i] != 0;
-      if (keyBit != ownedBit) return absBit;
+      if (keyBit != ownedBit)
+        return absBit;
     }
     return -1;
   }
@@ -1962,22 +2127,24 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Tombstone value: single byte 0xFE indicating a logically deleted entry.
    *
-   * <p>Tombstones are required for correctness with INCREMENTAL and DIFFERENTIAL
-   * versioning: if an entry were physically removed, older fragments would still
-   * contain the key and {@code combineHOTLeafPages} would resurrect it. By keeping
-   * the key with a tombstone value, the newer fragment "shadows" the older entry
-   * and versioning reconstruction correctly skips it.</p>
+   * <p>
+   * Tombstones are required for correctness with INCREMENTAL and DIFFERENTIAL versioning: if an entry
+   * were physically removed, older fragments would still contain the key and
+   * {@code combineHOTLeafPages} would resurrect it. By keeping the key with a tombstone value, the
+   * newer fragment "shadows" the older entry and versioning reconstruction correctly skips it.
+   * </p>
    */
   private static final byte[] TOMBSTONE_VALUE = {(byte) 0xFE};
 
   /**
    * Delete an entry by key (tombstone-based).
    *
-   * <p>Replaces the value with a tombstone marker ({@code 0xFE}) rather than
-   * physically removing the entry. This is essential for versioning correctness:
-   * INCREMENTAL and DIFFERENTIAL modes reconstruct pages by merging fragments
-   * from newest to oldest. If an entry were physically removed, the older
-   * fragment's copy would be resurrected during reconstruction.</p>
+   * <p>
+   * Replaces the value with a tombstone marker ({@code 0xFE}) rather than physically removing the
+   * entry. This is essential for versioning correctness: INCREMENTAL and DIFFERENTIAL modes
+   * reconstruct pages by merging fragments from newest to oldest. If an entry were physically
+   * removed, the older fragment's copy would be resurrected during reconstruction.
+   * </p>
    *
    * @param key the key to delete
    * @return true if entry was found and tombstoned, false if not found or already tombstoned
@@ -1994,8 +2161,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Delete entry at the given index (tombstone-based).
    *
-   * <p>Replaces the value with a tombstone marker rather than physically removing
-   * the entry. See {@link #delete(byte[])} for the rationale.</p>
+   * <p>
+   * Replaces the value with a tombstone marker rather than physically removing the entry. See
+   * {@link #delete(byte[])} for the rationale.
+   * </p>
    *
    * @param index the entry index to delete
    * @return true if the entry was tombstoned, false if index is invalid or already a tombstone
@@ -2034,7 +2203,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     Objects.checkIndex(index, entryCount);
     Objects.requireNonNull(newValue);
     if (newValue.length > MAX_KEY_VALUE_LENGTH) {
-      throw new IllegalArgumentException("Value length " + newValue.length + " exceeds maximum " + MAX_KEY_VALUE_LENGTH);
+      throw new IllegalArgumentException(
+          "Value length " + newValue.length + " exceeds maximum " + MAX_KEY_VALUE_LENGTH);
     }
 
     // Get old entry info (suffix-based: [u16 suffixLen][suffix][u16 valueLen][value])
@@ -2072,8 +2242,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
           newOffset + 2, suffixLen);
     }
     slotMemory.set(JAVA_SHORT_UNALIGNED, newOffset + 2 + suffixLen, (short) newValue.length);
-    MemorySegment.copy(newValue, 0, slotMemory, ValueLayout.JAVA_BYTE, newOffset + 2 + suffixLen + 2,
-        newValue.length);
+    MemorySegment.copy(newValue, 0, slotMemory, ValueLayout.JAVA_BYTE, newOffset + 2 + suffixLen + 2, newValue.length);
 
     slotOffsets[index] = newOffset;
     usedSlotMemorySize += newEntrySize;
@@ -2111,48 +2280,52 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Phase 7b — Strict variant of {@link #mergeWithNodeRefs} that checks
-   * ancestor-owned bits before merging. If the key would violate a β-constancy
-   * constraint (= owned bit value disagrees with key's value), returns the
-   * offending absolute bit position as a NEGATIVE int (= -(absBit + 1)). The
-   * leaf is left unchanged. Caller must handle by splitting the leaf on the
-   * offending β.
+   * Phase 7b — Strict variant of {@link #mergeWithNodeRefs} that checks ancestor-owned bits before
+   * merging. If the key would violate a β-constancy constraint (= owned bit value disagrees with
+   * key's value), returns the offending absolute bit position as a NEGATIVE int (= -(absBit + 1)).
+   * The leaf is left unchanged. Caller must handle by splitting the leaf on the offending β.
    *
-   * <p>Returns:
+   * <p>
+   * Returns:
    * <ul>
-   *   <li>1 — merge succeeded.
-   *   <li>0 — merge failed (= overflow, etc.).
-   *   <li>≤ -1 — β-constancy break at absBit = (-return - 1).
+   * <li>1 — merge succeeded.
+   * <li>0 — merge failed (= overflow, etc.).
+   * <li>≤ -1 — β-constancy break at absBit = (-return - 1).
    * </ul>
    *
-   * <p>HFT-grade: zero allocation in the no-break path beyond what regular
-   * merge does.
+   * <p>
+   * HFT-grade: zero allocation in the no-break path beyond what regular merge does.
    */
   public int mergeWithNodeRefsStrict(byte[] key, int keyLen, byte[] value, int valueLen) {
     Objects.requireNonNull(key);
     Objects.requireNonNull(value);
-    final byte[] keySlice = keyLen == key.length ? key : Arrays.copyOf(key, keyLen);
+    final byte[] keySlice = keyLen == key.length
+        ? key
+        : Arrays.copyOf(key, keyLen);
     // β-constancy check FIRST (before any mutation).
     final int offendingBit = checkOwnedBitsAgainstKey(keySlice);
     if (offendingBit >= 0) {
       return -(offendingBit + 1);
     }
     handlePrefixForInsert(keySlice);
-    return mergeWithNodeRefsImpl(keySlice, value, valueLen) ? 1 : 0;
+    return mergeWithNodeRefsImpl(keySlice, value, valueLen)
+        ? 1
+        : 0;
   }
 
   /**
-   * Insert {@code value} under {@code key}, or REPLACE the existing value if the key is
-   * already present. Used by the split machinery for index types whose values are opaque
-   * byte payloads (PROJECTION chunks) rather than mergeable NodeReferences bitmaps.
+   * Insert {@code value} under {@code key}, or REPLACE the existing value if the key is already
+   * present. Used by the split machinery for index types whose values are opaque byte payloads
+   * (PROJECTION chunks) rather than mergeable NodeReferences bitmaps.
    *
-   * <p>Same space behavior as {@link #put}/{@link #updateValue}: prefix establishment and
-   * shrinkage are handled, compaction runs automatically when fragmented space suffices.
+   * <p>
+   * Same space behavior as {@link #put}/{@link #updateValue}: prefix establishment and shrinkage are
+   * handled, compaction runs automatically when fragmented space suffices.
    *
    * @param key the full key
    * @param value the value payload (replaces any prior value byte-for-byte)
-   * @return {@code true} if the entry was inserted or replaced; {@code false} if the page
-   *         cannot fit the entry even after compaction (caller must split further)
+   * @return {@code true} if the entry was inserted or replaced; {@code false} if the page cannot fit
+   *         the entry even after compaction (caller must split further)
    */
   public boolean putOrReplace(byte[] key, byte[] value) {
     Objects.requireNonNull(key);
@@ -2176,14 +2349,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       final byte[] existingValue = getValue(index);
 
       if (NodeReferencesSerializer.isTombstone(existingValue, 0, existingValue.length)) {
-        final byte[] valueSlice = valueLen == value.length ? value : Arrays.copyOf(value, valueLen);
+        final byte[] valueSlice = valueLen == value.length
+            ? value
+            : Arrays.copyOf(value, valueLen);
         return updateValue(index, valueSlice);
       }
 
       // HFT fast path: a single-bit packed merge into a packed bucket (the dominant churn case)
       // avoids 2 Roaring64Bitmap + 2 NodeReferences allocations. byte-identical to the slow path.
-      final byte[] fastMerged =
-          NodeReferencesSerializer.mergePackedSingleBit(existingValue, value, 0, valueLen);
+      final byte[] fastMerged = NodeReferencesSerializer.mergePackedSingleBit(existingValue, value, 0, valueLen);
       if (fastMerged == existingValue) {
         return true; // new key already present — merged set unchanged, slot rewrite unnecessary
       }
@@ -2243,7 +2417,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     final int[] newSlotOffsets = Arrays.copyOf(slotOffsets, slotOffsets.length);
 
     // Deep copy prefix
-    final byte[] newPrefix = commonPrefixLen > 0 ? Arrays.copyOf(commonPrefix, commonPrefixLen) : EMPTY_PREFIX;
+    final byte[] newPrefix = commonPrefixLen > 0
+        ? Arrays.copyOf(commonPrefix, commonPrefixLen)
+        : EMPTY_PREFIX;
 
     // Create new page with copied data
     final HOTLeafPage copy = new HOTLeafPage(recordPageKey, revision, indexType, newSlotMemory, newReleaser,
@@ -2344,15 +2520,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Route overflow-page-reference side-map entries to {@code target} after a split moved slots
-   * there. A side-map key encodes its owning slot as {@code (slotLong << 16) | subId},
-   * where the owning slot's stored key bytes are {@code PathKeySerializer.serialize(slotLong)}
-   * (the owning slot's stored-key encoding — see docs/PROJECTION_INDEX_STORAGE_REDESIGN.md §2.3
-   * for the projection index, this facility's current user). A reference must live on the page
-   * that holds its owning slot, or readers navigating to the post-split leaf would find the slot
-   * but not its overflow page. Routing by owner-slot residency (not by key-range
-   * comparison) stays correct for the disc-bit split variants, whose partition is not
-   * contiguous in key order. Called by every split variant after entry transfer.
+   * Route overflow-page-reference side-map entries to {@code target} after a split moved slots there.
+   * A side-map key encodes its owning slot as {@code (slotLong << 16) | subId}, where the owning
+   * slot's stored key bytes are {@code PathKeySerializer.serialize(slotLong)} (the owning slot's
+   * stored-key encoding — see docs/PROJECTION_INDEX_STORAGE_REDESIGN.md §2.3 for the projection
+   * index, this facility's current user). A reference must live on the page that holds its owning
+   * slot, or readers navigating to the post-split leaf would find the slot but not its overflow page.
+   * Routing by owner-slot residency (not by key-range comparison) stays correct for the disc-bit
+   * split variants, whose partition is not contiguous in key order. Called by every split variant
+   * after entry transfer.
    */
   private void moveOverflowPageRefsAfterSplit(final HOTLeafPage target) {
     if (pageReferences.isEmpty()) {
@@ -2375,15 +2551,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * Split this page AND insert the new key+value atomically using MSDB-aware splitting.
    *
    * <p>
-   * Computes the most significant discriminative bit (MSDB) including the new key's disc bits
-   * with its neighbors, splits all entries by that disc bit, and inserts the new key into the
-   * correct half. This eliminates re-navigation after a split because the BiNode's disc bit
-   * (computed from boundary keys after this method) is guaranteed to correctly route all keys.
+   * Computes the most significant discriminative bit (MSDB) including the new key's disc bits with
+   * its neighbors, splits all entries by that disc bit, and inserts the new key into the correct
+   * half. This eliminates re-navigation after a split because the BiNode's disc bit (computed from
+   * boundary keys after this method) is guaranteed to correctly route all keys.
    * </p>
    *
    * <p>
-   * Matches the C++ reference implementation's atomic split+insert approach (Binna's thesis),
-   * adapted for multi-entry leaf pages.
+   * Matches the C++ reference implementation's atomic split+insert approach (Binna's thesis), adapted
+   * for multi-entry leaf pages.
    * </p>
    *
    * @param target the empty target page to receive the right half
@@ -2393,30 +2569,28 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @param valueLen the value length
    * @return {@code true} if the split+insert succeeded, {@code false} if it failed
    */
-  public boolean splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen,
-      byte[] value, int valueLen) {
+  public boolean splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen, byte[] value, int valueLen) {
     return splitToWithInsert(target, key, keyLen, value, valueLen, null);
   }
 
   /**
-   * Same as {@link #splitToWithInsert(HOTLeafPage, byte[], int, byte[], int)} but writes
-   * which half the new key landed in to {@code newSideOut[0]} on success: {@code 0}
-   * (LEFT, β=0 — key stayed in {@code this}) or {@code 1} (RIGHT, β=1 — key went to
-   * {@code target}). Untouched on failure.
+   * Same as {@link #splitToWithInsert(HOTLeafPage, byte[], int, byte[], int)} but writes which half
+   * the new key landed in to {@code newSideOut[0]} on success: {@code 0} (LEFT, β=0 — key stayed in
+   * {@code this}) or {@code 1} (RIGHT, β=1 — key went to {@code target}). Untouched on failure.
    *
-   * <p>Phase 4b-vb consumers (the C++-faithful integration path) need this so they can
-   * compute {@code valueToInsert} / {@code valueToReplace} per
-   * {@code integrateBiNodeIntoTree}'s semantics — pass the half WITHOUT the new key as
-   * {@code valueToReplace} (replaces splitChild's slot in-place) and the half WITH the
-   * new key as {@code valueToInsert} (the single new entry added at the parent level).
+   * <p>
+   * Phase 4b-vb consumers (the C++-faithful integration path) need this so they can compute
+   * {@code valueToInsert} / {@code valueToReplace} per {@code integrateBiNodeIntoTree}'s semantics —
+   * pass the half WITHOUT the new key as {@code valueToReplace} (replaces splitChild's slot in-place)
+   * and the half WITH the new key as {@code valueToInsert} (the single new entry added at the parent
+   * level).
    *
-   * @param newSideOut optional length-1 array that receives 0 or 1 on success;
-   *                   {@code null} if caller does not need this info
+   * @param newSideOut optional length-1 array that receives 0 or 1 on success; {@code null} if caller
+   *        does not need this info
    */
-  public boolean splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen,
-      byte[] value, int valueLen, int @Nullable [] newSideOut) {
-    return splitToWithInsert(target, key, keyLen, value, valueLen, newSideOut, false)
-        == SPLIT_WITH_INSERT;
+  public boolean splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen, byte[] value, int valueLen,
+      int @Nullable [] newSideOut) {
+    return splitToWithInsert(target, key, keyLen, value, valueLen, newSideOut, false) == SPLIT_WITH_INSERT;
   }
 
   /** {@link #splitToWithInsert} outcome: nothing changed — the page could not be split. */
@@ -2426,36 +2600,37 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   public static final int SPLIT_WITH_INSERT = 1;
 
   /**
-   * {@link #splitToWithInsert} outcome: the page was split, but the pending value did not fit in
-   * the half its key routes to, so it is NOT stored. Only returned when the caller passes
+   * {@link #splitToWithInsert} outcome: the page was split, but the pending value did not fit in the
+   * half its key routes to, so it is NOT stored. Only returned when the caller passes
    * {@code keepSplitWhenValueDoesNotFit}; the caller must re-navigate and retry the write.
    */
   public static final int SPLIT_WITHOUT_INSERT = 2;
 
   /**
-   * Split-and-insert with an explicit choice of what to do when the pending value does not fit
-   * in the half its key routes to.
+   * Split-and-insert with an explicit choice of what to do when the pending value does not fit in the
+   * half its key routes to.
    *
-   * <p>An MSDB split is not guaranteed to relieve pressure: the most significant discriminative
-   * bit can be owned by a single outlier key (in the projection index, a fence chunk keyed far
-   * above every row-group slot), in which case the split moves that ONE entry out and the other
-   * half stays as full as it was. Rolling back then reports failure for a page that is perfectly
-   * splittable — just not in one step. With {@code keepSplitWhenValueDoesNotFit} the split
-   * STANDS and {@link #SPLIT_WITHOUT_INSERT} is returned: the caller re-navigates and splits
-   * again, and the next split partitions on the remaining keys' own MSDB, which is no longer the
-   * outlier's bit. Each round strictly shrinks the leaf, so the cascade terminates.
+   * <p>
+   * An MSDB split is not guaranteed to relieve pressure: the most significant discriminative bit can
+   * be owned by a single outlier key (in the projection index, a fence chunk keyed far above every
+   * row-group slot), in which case the split moves that ONE entry out and the other half stays as
+   * full as it was. Rolling back then reports failure for a page that is perfectly splittable — just
+   * not in one step. With {@code keepSplitWhenValueDoesNotFit} the split STANDS and
+   * {@link #SPLIT_WITHOUT_INSERT} is returned: the caller re-navigates and splits again, and the next
+   * split partitions on the remaining keys' own MSDB, which is no longer the outlier's bit. Each
+   * round strictly shrinks the leaf, so the cascade terminates.
    *
-   * <p>Splitting on the MSDB rather than at the midpoint is what makes this safe to repeat: the
-   * parent BiNode routes on one bit, so only an MSDB partition keeps every key on the side the
-   * BiNode will send it to.
+   * <p>
+   * Splitting on the MSDB rather than at the midpoint is what makes this safe to repeat: the parent
+   * BiNode routes on one bit, so only an MSDB partition keeps every key on the side the BiNode will
+   * send it to.
    *
    * @param keepSplitWhenValueDoesNotFit {@code false} rolls the split back and returns
    *        {@link #SPLIT_ABORTED} (the historical all-or-nothing contract)
    * @return one of {@link #SPLIT_ABORTED}, {@link #SPLIT_WITH_INSERT}, {@link #SPLIT_WITHOUT_INSERT}
    */
-  public int splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen,
-      byte[] value, int valueLen, int @Nullable [] newSideOut,
-      boolean keepSplitWhenValueDoesNotFit) {
+  public int splitToWithInsert(HOTLeafPage target, byte[] key, int keyLen, byte[] value, int valueLen,
+      int @Nullable [] newSideOut, boolean keepSplitWhenValueDoesNotFit) {
     Objects.requireNonNull(target);
 
     final int count = entryCount;
@@ -2464,16 +2639,24 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     }
 
     // Slice key/value to actual length
-    final byte[] keySlice = keyLen == key.length ? key : Arrays.copyOf(key, keyLen);
-    final byte[] valueSlice = valueLen == value.length ? value : Arrays.copyOf(value, valueLen);
+    final byte[] keySlice = keyLen == key.length
+        ? key
+        : Arrays.copyOf(key, keyLen);
+    final byte[] valueSlice = valueLen == value.length
+        ? value
+        : Arrays.copyOf(value, valueLen);
 
     // Use full keys for MSDB computation (disc bits are absolute positions)
     final int searchResult = findEntry(keySlice);
     final boolean isNew = searchResult < 0;
-    final int insertPos = isNew ? -(searchResult + 1) : searchResult;
+    final int insertPos = isNew
+        ? -(searchResult + 1)
+        : searchResult;
 
     // Compute MSDB including the new key's disc bits with its neighbors
-    final int msdb = isNew ? findMsdbWithNewKey(keySlice, insertPos) : findMsdbBit();
+    final int msdb = isNew
+        ? findMsdbWithNewKey(keySlice, insertPos)
+        : findMsdbBit();
 
     if (msdb < 0) {
       return SPLIT_ABORTED; // All keys identical — can't split
@@ -2541,7 +2724,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     // is a REPLACE; feeding chunk bytes through the NodeReferences merge would
     // deserialize random payload bytes as roaring bitmaps and corrupt the slot.
     final boolean newKeyToRight = DiscriminativeBitComputer.isBitSet(keySlice, msdb);
-    final HOTLeafPage half = newKeyToRight ? target : this;
+    final HOTLeafPage half = newKeyToRight
+        ? target
+        : this;
     final boolean insertOk;
     if (indexType == IndexType.PROJECTION) {
       insertOk = half.putOrReplace(keySlice, valueSlice);
@@ -2583,16 +2768,19 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     propagateOwnedBitsAfterSplit(target, msdb);
     moveOverflowPageRefsAfterSplit(target);
     if (insertOk && newSideOut != null && newSideOut.length > 0) {
-      newSideOut[0] = newKeyToRight ? 1 : 0;
+      newSideOut[0] = newKeyToRight
+          ? 1
+          : 0;
     }
-    return insertOk ? SPLIT_WITH_INSERT : SPLIT_WITHOUT_INSERT;
+    return insertOk
+        ? SPLIT_WITH_INSERT
+        : SPLIT_WITHOUT_INSERT;
   }
 
   /**
-   * Phase 7d — On successful splitToWithInsert, propagate parent's ancestor-owned bits to
-   * BOTH halves and add the split bit (msdb) as a new owned bit with the appropriate
-   * constant value for each half. `this` becomes the LEFT half (β=0); {@code target} is
-   * the RIGHT half (β=1).
+   * Phase 7d — On successful splitToWithInsert, propagate parent's ancestor-owned bits to BOTH halves
+   * and add the split bit (msdb) as a new owned bit with the appropriate constant value for each
+   * half. `this` becomes the LEFT half (β=0); {@code target} is the RIGHT half (β=1).
    */
   private void propagateOwnedBitsAfterSplit(HOTLeafPage target, int msdb) {
     final int[] parentBits = this.ancestorOwnedBits;
@@ -2601,8 +2789,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     // Find insertion point for msdb (sorted ascending).
     int insertPos = parentLen;
     for (int i = 0; i < parentLen; i++) {
-      if (parentBits[i] > msdb) { insertPos = i; break; }
-      if (parentBits[i] == msdb) { return; } // already present
+      if (parentBits[i] > msdb) {
+        insertPos = i;
+        break;
+      }
+      if (parentBits[i] == msdb) {
+        return;
+      } // already present
     }
     final int newLen = parentLen + 1;
     final int[] newBits = new int[newLen];
@@ -2626,50 +2819,51 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Split+insert variant that splits on a caller-supplied bit instead of the leaf's
-   * local MSDB. Phase-2-and-beyond infrastructure for the strict-Binna conformance
-   * plan: future writer-level logic chooses {@code explicitSplitBit} based on
-   * parent/sibling state (e.g., Phase 3 lazy retroactive sibling rebalance), then
-   * invokes this method to apply the split.
+   * Split+insert variant that splits on a caller-supplied bit instead of the leaf's local MSDB.
+   * Phase-2-and-beyond infrastructure for the strict-Binna conformance plan: future writer-level
+   * logic chooses {@code explicitSplitBit} based on parent/sibling state (e.g., Phase 3 lazy
+   * retroactive sibling rebalance), then invokes this method to apply the split.
    *
-   * <p><b>Important</b>: the caller is responsible for ensuring the chosen bit
-   * preserves contiguous partition (= bit equals MSDB position). Splitting on a
-   * less-significant non-constant bit yields non-contiguous partition, which breaks
-   * the parent's children-sorted-by-firstkey invariant. The writer should use
-   * {@link #computeMsdbWithOptionalNewKey} to pre-compute MSDB and only pass MSDB
+   * <p>
+   * <b>Important</b>: the caller is responsible for ensuring the chosen bit preserves contiguous
+   * partition (= bit equals MSDB position). Splitting on a less-significant non-constant bit yields
+   * non-contiguous partition, which breaks the parent's children-sorted-by-firstkey invariant. The
+   * writer should use {@link #computeMsdbWithOptionalNewKey} to pre-compute MSDB and only pass MSDB
    * itself (or refrain from calling this method).
    *
-   * <p>The partition algorithm is general (handles non-contiguous), but the post-split
-   * structure is sensible only when the partition IS contiguous.
+   * <p>
+   * The partition algorithm is general (handles non-contiguous), but the post-split structure is
+   * sensible only when the partition IS contiguous.
    *
-   * <p><b>Edge cases</b>:
+   * <p>
+   * <b>Edge cases</b>:
    * <ul>
-   *   <li>{@code explicitSplitBit < 0} → {@code -1} (caller error / sentinel).</li>
-   *   <li>Degenerate split (all keys on one side at this bit): {@code -1} so caller
-   *       falls back to standard {@link #splitToWithInsert}.</li>
+   * <li>{@code explicitSplitBit < 0} → {@code -1} (caller error / sentinel).</li>
+   * <li>Degenerate split (all keys on one side at this bit): {@code -1} so caller falls back to
+   * standard {@link #splitToWithInsert}.</li>
    * </ul>
    *
-   * <p>HFT-grade: zero allocation beyond the necessary key/value byte arrays for transfer.
-   * Bit-set checks are primitive byte loads + bit masks.
+   * <p>
+   * HFT-grade: zero allocation beyond the necessary key/value byte arrays for transfer. Bit-set
+   * checks are primitive byte loads + bit masks.
    *
    * @param target empty target page to receive the right half
    * @param key the new key to insert
    * @param keyLen the key length
    * @param value the new value to insert
    * @param valueLen the value length
-   * @param explicitSplitBit absolute MSB-first bit position to use as the split bit.
-   *        Must be a bit at which {@code leaf.keys + key} is non-constant (otherwise
-   *        the partition is degenerate and this method returns {@code -1}). Caller is
-   *        responsible for choosing a parent-friendly bit (= constant in non-split
-   *        siblings, not in parent's mask, in parent's window).
+   * @param explicitSplitBit absolute MSB-first bit position to use as the split bit. Must be a bit at
+   *        which {@code leaf.keys + key} is non-constant (otherwise the partition is degenerate and
+   *        this method returns {@code -1}). Caller is responsible for choosing a parent-friendly bit
+   *        (= constant in non-split siblings, not in parent's mask, in parent's window).
    * @return the absolute split bit position (≥ 0) on success; {@code -1} on degenerate or
    *         all-identical keys. The caller must use this bit (NOT the bit derived by
-   *         {@code computeDifferingBit(leftMax, rightMin)}) as the BiNode's disc bit
-   *         because the partition is non-contiguous when {@code explicitSplitBit} is less
-   *         significant than the leaf's MSDB.
+   *         {@code computeDifferingBit(leftMax, rightMin)}) as the BiNode's disc bit because the
+   *         partition is non-contiguous when {@code explicitSplitBit} is less significant than the
+   *         leaf's MSDB.
    */
-  public int splitToWithInsertOnBit(HOTLeafPage target, byte[] key, int keyLen,
-      byte[] value, int valueLen, int explicitSplitBit) {
+  public int splitToWithInsertOnBit(HOTLeafPage target, byte[] key, int keyLen, byte[] value, int valueLen,
+      int explicitSplitBit) {
     Objects.requireNonNull(target);
     if (explicitSplitBit < 0) {
       return -1;
@@ -2681,8 +2875,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     }
 
     // Slice key/value to actual length
-    final byte[] keySlice = keyLen == key.length ? key : Arrays.copyOf(key, keyLen);
-    final byte[] valueSlice = valueLen == value.length ? value : Arrays.copyOf(value, valueLen);
+    final byte[] keySlice = keyLen == key.length
+        ? key
+        : Arrays.copyOf(key, keyLen);
+    final byte[] valueSlice = valueLen == value.length
+        ? value
+        : Arrays.copyOf(value, valueLen);
 
     final int searchResult = findEntry(keySlice);
     final boolean isNew = searchResult < 0;
@@ -2711,8 +2909,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
     // Degenerate split guard: at least one existing key on each side, OR new key alone
     // makes one side. Check that final halves are non-empty.
-    final int finalLeft = leftN + (isNew && !newKeyOnRight ? 1 : 0);
-    final int finalRight = rightN + (isNew && newKeyOnRight ? 1 : 0);
+    final int finalLeft = leftN + (isNew && !newKeyOnRight
+        ? 1
+        : 0);
+    final int finalRight = rightN + (isNew && newKeyOnRight
+        ? 1
+        : 0);
     if (finalLeft == 0 || finalRight == 0) {
       return -1; // degenerate — caller falls back to MSDB-only split
     }
@@ -2794,31 +2996,34 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Pure no-insert split: partition this leaf's existing entries by an absolute MSB-first
-   * bit position. Right-half entries (bit value = 1) move to {@code target}; left-half
-   * entries (bit value = 0) remain in {@code this}.
+   * Pure no-insert split: partition this leaf's existing entries by an absolute MSB-first bit
+   * position. Right-half entries (bit value = 1) move to {@code target}; left-half entries (bit value
+   * = 0) remain in {@code this}.
    *
-   * <p>Used by Phase 3 lazy retroactive sibling rebalance — when an ancestor adds a new
-   * disc bit β that's non-constant in some sibling's subtree, the writer walks down to
-   * each leaf in that subtree and calls this method with β to enforce per-leaf β-constancy.
-   * No new key is inserted; the leaf is purely partitioned.
+   * <p>
+   * Used by Phase 3 lazy retroactive sibling rebalance — when an ancestor adds a new disc bit β
+   * that's non-constant in some sibling's subtree, the writer walks down to each leaf in that subtree
+   * and calls this method with β to enforce per-leaf β-constancy. No new key is inserted; the leaf is
+   * purely partitioned.
    *
-   * <p><b>Edge cases</b>:
+   * <p>
+   * <b>Edge cases</b>:
    * <ul>
-   *   <li>{@code splitBit < 0}: returns {@code false}.</li>
-   *   <li>Degenerate (all keys agree on this bit): returns {@code false} so caller knows
-   *       no split was needed.</li>
-   *   <li>Empty leaf: returns {@code false}.</li>
+   * <li>{@code splitBit < 0}: returns {@code false}.</li>
+   * <li>Degenerate (all keys agree on this bit): returns {@code false} so caller knows no split was
+   * needed.</li>
+   * <li>Empty leaf: returns {@code false}.</li>
    * </ul>
    *
-   * <p>HFT-grade: snapshot of all existing keys+values is unavoidable (re-population
-   * truncates {@code slotMemory}). All other state lives on the call stack. Two index
-   * arrays + the byte-array snapshot total ~2N pointers + N(key+value) bytes, no boxing.
+   * <p>
+   * HFT-grade: snapshot of all existing keys+values is unavoidable (re-population truncates
+   * {@code slotMemory}). All other state lives on the call stack. Two index arrays + the byte-array
+   * snapshot total ~2N pointers + N(key+value) bytes, no boxing.
    *
    * @param target empty target page to receive the right-half (β=1) entries
    * @param splitBit absolute MSB-first bit position to partition on
-   * @return {@code true} if the partition was non-degenerate and applied; {@code false}
-   *         if the leaf was empty / the bit was constant / target.put() failed
+   * @return {@code true} if the partition was non-degenerate and applied; {@code false} if the leaf
+   *         was empty / the bit was constant / target.put() failed
    */
   public boolean splitToOnBit(HOTLeafPage target, int splitBit) {
     Objects.requireNonNull(target);
@@ -2900,12 +3105,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Returns true iff this leaf's existing entries span both bit values at the given
-   * absolute MSB-first bit position. Used by Phase 3 lazy rebalance for cheap
-   * per-leaf β-constancy checks.
+   * Returns true iff this leaf's existing entries span both bit values at the given absolute
+   * MSB-first bit position. Used by Phase 3 lazy rebalance for cheap per-leaf β-constancy checks.
    *
-   * <p>HFT-grade: zero allocation, primitive byte loads + bit masks. Short-circuits as
-   * soon as both 0 and 1 are observed.
+   * <p>
+   * HFT-grade: zero allocation, primitive byte loads + bit masks. Short-circuits as soon as both 0
+   * and 1 are observed.
    */
   public boolean isBitNonConstantInLeaf(int absBit) {
     final int n = entryCount;
@@ -2917,19 +3122,23 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     boolean sawOne = firstBit;
     for (int i = 1; i < n; i++) {
       final boolean v = DiscriminativeBitComputer.isBitSet(getKeySlice(i), absBit);
-      if (v) sawOne = true;
-      else sawZero = true;
-      if (sawZero && sawOne) return true;
+      if (v)
+        sawOne = true;
+      else
+        sawZero = true;
+      if (sawZero && sawOne)
+        return true;
     }
     return false;
   }
 
   /**
-   * Returns true iff the existing leaf entries plus the new key span both bit values at
-   * absolute MSB-first bit position {@code absBit}. Public so writer code can scan
-   * candidate split bits without re-deriving leaf-private state.
+   * Returns true iff the existing leaf entries plus the new key span both bit values at absolute
+   * MSB-first bit position {@code absBit}. Public so writer code can scan candidate split bits
+   * without re-deriving leaf-private state.
    *
-   * <p>HFT-grade: zero allocation, primitive byte loads + bit masks via
+   * <p>
+   * HFT-grade: zero allocation, primitive byte loads + bit masks via
    * {@link DiscriminativeBitComputer#isBitSet}.
    */
   public boolean isBitNonConstantInLeafPlusNewKey(int absBit, byte[] newKey, boolean isNew) {
@@ -2943,30 +3152,36 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     boolean sawOne = firstBit;
     for (int i = 1; i < n; i++) {
       final boolean v = DiscriminativeBitComputer.isBitSet(getKeySlice(i), absBit);
-      if (v) sawOne = true;
-      else sawZero = true;
-      if (sawZero && sawOne) return true;
+      if (v)
+        sawOne = true;
+      else
+        sawZero = true;
+      if (sawZero && sawOne)
+        return true;
     }
     if (isNew) {
       final boolean v = DiscriminativeBitComputer.isBitSet(newKey, absBit);
-      if (v) sawOne = true;
-      else sawZero = true;
+      if (v)
+        sawOne = true;
+      else
+        sawZero = true;
     }
     return sawZero && sawOne;
   }
 
   /**
-   * Compute the MSDB (most significant disc bit) across the current leaf entries plus
-   * an optional new key. Public so writer code can pre-compute MSDB and test alternative
-   * split bits before invoking {@link #splitToWithInsertOnBit}.
+   * Compute the MSDB (most significant disc bit) across the current leaf entries plus an optional new
+   * key. Public so writer code can pre-compute MSDB and test alternative split bits before invoking
+   * {@link #splitToWithInsertOnBit}.
    *
-   * <p>If {@code newKey} is {@code null} or the leaf already contains it, the MSDB is
-   * computed across existing entries only. Otherwise the new key is virtually inserted
-   * at its sorted position and MSDB is computed across the augmented sequence.
+   * <p>
+   * If {@code newKey} is {@code null} or the leaf already contains it, the MSDB is computed across
+   * existing entries only. Otherwise the new key is virtually inserted at its sorted position and
+   * MSDB is computed across the augmented sequence.
    *
    * @param newKey optional new key being virtually inserted (may be {@code null})
-   * @return absolute MSB-first bit position of MSDB, or {@code -1} if all keys are
-   *         identical (no discriminative bit exists)
+   * @return absolute MSB-first bit position of MSDB, or {@code -1} if all keys are identical (no
+   *         discriminative bit exists)
    */
   public int computeMsdbWithOptionalNewKey(byte @Nullable [] newKey) {
     if (newKey == null) {
@@ -2998,33 +3213,41 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         bestBit = bit;
       }
     }
-    return bestBit == Integer.MAX_VALUE ? -1 : bestBit;
+    return bestBit == Integer.MAX_VALUE
+        ? -1
+        : bestBit;
   }
 
   /**
-   * Phase 2 helper: compute the MSDB this leaf would have if {@code key} were inserted.
-   * Returns {@code -1} if all keys (including {@code key}) would be identical.
+   * Phase 2 helper: compute the MSDB this leaf would have if {@code key} were inserted. Returns
+   * {@code -1} if all keys (including {@code key}) would be identical.
    *
-   * <p>Used by {@code HOTTrieWriter.findOffendingAncestorBit} to detect when an insert
-   * would introduce a new MSDB that coincides with an ancestor disc bit β — the safe-to-
-   * eager-split case (contiguous partition on β).
+   * <p>
+   * Used by {@code HOTTrieWriter.findOffendingAncestorBit} to detect when an insert would introduce a
+   * new MSDB that coincides with an ancestor disc bit β — the safe-to- eager-split case (contiguous
+   * partition on β).
    */
   public int computeMsdbWithKey(byte[] key) {
-    if (entryCount == 0) return -1;
+    if (entryCount == 0)
+      return -1;
     final int searchResult = findEntry(key);
     final boolean isNew = searchResult < 0;
-    final int insertPos = isNew ? -(searchResult + 1) : searchResult;
-    return isNew ? findMsdbWithNewKey(key, insertPos) : findMsdbBit();
+    final int insertPos = isNew
+        ? -(searchResult + 1)
+        : searchResult;
+    return isNew
+        ? findMsdbWithNewKey(key, insertPos)
+        : findMsdbBit();
   }
 
   /**
    * Compute the MSDB including a new key that would be inserted at {@code insertPos}.
    *
    * <p>
-   * Scans all adjacent pairs in the virtual sorted array (existing keys with the new key
-   * inserted), returning the most significant disc bit. The original pair
-   * {@code (keys[insertPos-1], keys[insertPos])} is replaced by
-   * {@code (keys[insertPos-1], newKey)} and {@code (newKey, keys[insertPos])}.
+   * Scans all adjacent pairs in the virtual sorted array (existing keys with the new key inserted),
+   * returning the most significant disc bit. The original pair
+   * {@code (keys[insertPos-1], keys[insertPos])} is replaced by {@code (keys[insertPos-1], newKey)}
+   * and {@code (newKey, keys[insertPos])}.
    * </p>
    *
    * @param newKey the new key being inserted
@@ -3062,14 +3285,18 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       }
     }
 
-    return bestBit == Integer.MAX_VALUE ? -1 : bestBit;
+    return bestBit == Integer.MAX_VALUE
+        ? -1
+        : bestBit;
   }
 
   /**
    * Recalculate the used slot memory size based on actual entries. Called after split to allow new
    * inserts on the truncated page.
    *
-   * <p>Uses {@link Short#toUnsignedInt} to handle lengths up to 65535 correctly.</p>
+   * <p>
+   * Uses {@link Short#toUnsignedInt} to handle lengths up to 65535 correctly.
+   * </p>
    */
   private void recalculateUsedMemory() {
     if (entryCount == 0) {
@@ -3091,13 +3318,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Recompute the common prefix after a split or truncation. After removing entries,
-   * the remaining entries may share a longer common prefix. This method computes the
-   * new LCP of all remaining entries' full keys and rebuilds entries with shorter suffixes
-   * if the prefix grew.
+   * Recompute the common prefix after a split or truncation. After removing entries, the remaining
+   * entries may share a longer common prefix. This method computes the new LCP of all remaining
+   * entries' full keys and rebuilds entries with shorter suffixes if the prefix grew.
    *
-   * <p>The prefix can only GROW after truncation (not shrink), because removing entries
-   * can only increase the LCP. Growing the prefix means shorter suffixes, which saves space.</p>
+   * <p>
+   * The prefix can only GROW after truncation (not shrink), because removing entries can only
+   * increase the LCP. Growing the prefix means shorter suffixes, which saves space.
+   * </p>
    */
   private void recomputePrefix() {
     if (entryCount == 0) {
@@ -3158,12 +3386,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         scratch[newOffset] = (byte) (newSuffixLen & 0xFF);
         scratch[newOffset + 1] = (byte) ((newSuffixLen >>> 8) & 0xFF);
         if (newSuffixLen > 0) {
-          MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, oldOffset + 2 + extensionLen,
-              scratch, newOffset + 2, newSuffixLen);
+          MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, oldOffset + 2 + extensionLen, scratch, newOffset + 2,
+              newSuffixLen);
         }
         // Copy value length + value
-        MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, valueOffset, scratch,
-            newOffset + 2 + newSuffixLen, 2 + valueLen);
+        MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, valueOffset, scratch, newOffset + 2 + newSuffixLen,
+            2 + valueLen);
 
         slotOffsets[i] = newOffset;
         newOffset += newEntrySize;
@@ -3188,8 +3416,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * @return total raw byte size of the entries marked dirty in {@link #dirtyBitmap}, computed as
-   *         the sum of {@code 2 + suffixLen + 2 + valueLen} per dirty entry.
+   * @return total raw byte size of the entries marked dirty in {@link #dirtyBitmap}, computed as the
+   *         sum of {@code 2 + suffixLen + 2 + valueLen} per dirty entry.
    */
   public int getDirtyEntriesUsedSize() {
     int total = 0;
@@ -3201,8 +3429,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         if (idx < entryCount) {
           final int off = slotOffsets[idx];
           final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, off));
-          final int valueLen =
-              Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, off + 2 + suffixLen));
+          final int valueLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, off + 2 + suffixLen));
           total += 2 + suffixLen + 2 + valueLen;
         }
         word &= word - 1L;
@@ -3226,7 +3453,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       final int wordEntryEnd = wordEntryStart + 64;
       if (wordEntryEnd > entryCount) {
         final int rem = entryCount - wordEntryStart;
-        word &= rem == 0 ? 0L : ((1L << rem) - 1L);
+        word &= rem == 0
+            ? 0L
+            : ((1L << rem) - 1L);
       }
       count += Long.bitCount(word);
     }
@@ -3234,14 +3463,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Pack the dirty entries' raw bytes into {@code dst}, starting at offset 0, and write each
-   * entry's new packed offset into {@code newOffsets} in walk order. Returns the total bytes
-   * written.
+   * Pack the dirty entries' raw bytes into {@code dst}, starting at offset 0, and write each entry's
+   * new packed offset into {@code newOffsets} in walk order. Returns the total bytes written.
    *
-   * <p>Caller must size {@code dst} &gt;= {@link #getDirtyEntriesUsedSize()} and
-   * {@code newOffsets} &gt;= {@link #getDirtyEntryCount()}.</p>
+   * <p>
+   * Caller must size {@code dst} &gt;= {@link #getDirtyEntriesUsedSize()} and {@code newOffsets}
+   * &gt;= {@link #getDirtyEntryCount()}.
+   * </p>
    *
-   * @param dst        destination byte array (typically a sink-bound scratch)
+   * @param dst destination byte array (typically a sink-bound scratch)
    * @param newOffsets per-entry packed offset (for the wire format's slotOffsets table)
    * @return total bytes packed into {@code dst}
    */
@@ -3256,8 +3486,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
         if (idx < entryCount) {
           final int srcOff = slotOffsets[idx];
           final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, srcOff));
-          final int valueLen =
-              Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, srcOff + 2 + suffixLen));
+          final int valueLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, srcOff + 2 + suffixLen));
           final int entrySize = 2 + suffixLen + 2 + valueLen;
           MemorySegment.copy(slotMemory, ValueLayout.JAVA_BYTE, srcOff, dst, writeOff, entrySize);
           newOffsets[outIdx++] = writeOff;
@@ -3311,10 +3540,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Mark every entry in {@code [0, entryCount)} as dirty. Used when a full-dump emit is needed
-   * (e.g., FULL strategy or window-edge revision under SLIDING_SNAPSHOT) — the serialize path
-   * uses {@link #hasDirty()} / {@link #iterateDirtyEntries(IntConsumer)} to decide what to write,
-   * so flipping every bit on guarantees a full-leaf fragment.
+   * Mark every entry in {@code [0, entryCount)} as dirty. Used when a full-dump emit is needed (e.g.,
+   * FULL strategy or window-edge revision under SLIDING_SNAPSHOT) — the serialize path uses
+   * {@link #hasDirty()} / {@link #iterateDirtyEntries(IntConsumer)} to decide what to write, so
+   * flipping every bit on guarantees a full-leaf fragment.
    */
   public void markAllEntriesDirty() {
     final int full = entryCount >>> 6;
@@ -3330,13 +3559,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Ensure this leaf carries every entry needed for full-fragment serialization under {@code type}.
    * Since {@link #copy()} bulk-copies the source slot heap, the modifying leaf already physically
-   * contains every entry from its {@link #completePageRef} — this hook only needs to mark all
-   * entries dirty so the sparse-emit path includes them. If {@code completePageRef} is {@code null}
-   * (fresh leaf), the writer-level mutators have already marked each insert dirty, so this is a
-   * no-op for the dirty bitmap; callers under FULL still get a full emit because every insert is
-   * naturally dirty on a fresh leaf.
+   * contains every entry from its {@link #completePageRef} — this hook only needs to mark all entries
+   * dirty so the sparse-emit path includes them. If {@code completePageRef} is {@code null} (fresh
+   * leaf), the writer-level mutators have already marked each insert dirty, so this is a no-op for
+   * the dirty bitmap; callers under FULL still get a full emit because every insert is naturally
+   * dirty on a fresh leaf.
    *
-   * <p>Centralised here so the serializer doesn't reach into private fields.</p>
+   * <p>
+   * Centralised here so the serializer doesn't reach into private fields.
+   * </p>
    *
    * @param type the active versioning strategy
    */
@@ -3426,8 +3657,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Mark page as orphaned (removed from cache but still guarded).
-   * Uses atomic close-once to prevent TOCTOU race between releaseGuard and markOrphaned.
+   * Mark page as orphaned (removed from cache but still guarded). Uses atomic close-once to prevent
+   * TOCTOU race between releaseGuard and markOrphaned.
    */
   public void markOrphaned() {
     isOrphaned = true;
@@ -3448,15 +3679,16 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Close the page and release its off-heap memory. Thread-safe; only the first effective
-   * call releases the memory segment.
+   * Close the page and release its off-heap memory. Thread-safe; only the first effective call
+   * releases the memory segment.
    *
-   * <p><b>Guard-aware teardown.</b> A page with live guards is in active use by a reader, so
-   * the slot release is deferred: the page is marked orphaned and the last {@link #releaseGuard()}
-   * performs the actual teardown. This guarantees eviction can never free a slot out from
-   * under a reader that has already acquired a guard — the reader-side eviction race that
-   * surfaced as silent key loss under memory pressure. A racing {@link #acquireGuard()} sees
-   * {@link #isOrphaned} on its post-increment re-check and retries instead.
+   * <p>
+   * <b>Guard-aware teardown.</b> A page with live guards is in active use by a reader, so the slot
+   * release is deferred: the page is marked orphaned and the last {@link #releaseGuard()} performs
+   * the actual teardown. This guarantees eviction can never free a slot out from under a reader that
+   * has already acquired a guard — the reader-side eviction race that surfaced as silent key loss
+   * under memory pressure. A racing {@link #acquireGuard()} sees {@link #isOrphaned} on its
+   * post-increment re-check and retries instead.
    */
   public void close() {
     isOrphaned = true;
@@ -3468,8 +3700,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Release off-heap memory. Must only be called once — callers must ensure
-   * single-call semantics via the {@link #closed} atomic flag.
+   * Release off-heap memory. Must only be called once — callers must ensure single-call semantics via
+   * the {@link #closed} atomic flag.
    */
   private void releaseMemory() {
     if (releaser != null) {
@@ -3630,8 +3862,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Remove a side-map reference (an overflow page no longer referenced after its owning slot
-   * shrank or was tombstoned). Returns the removed reference or {@code null} if absent.
+   * Remove a side-map reference (an overflow page no longer referenced after its owning slot shrank
+   * or was tombstoned). Returns the removed reference or {@code null} if absent.
    */
   public @Nullable PageReference removePageReference(long key) {
     return pageReferences.remove(key);
@@ -3643,8 +3875,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Side-map keys in ascending order — the serializer emits entries sorted so identical maps
-   * produce identical bytes.
+   * Side-map keys in ascending order — the serializer emits entries sorted so identical maps produce
+   * identical bytes.
    */
   public long[] overflowPageRefKeysSorted() {
     final long[] keys = pageReferences.keySet().toLongArray();
@@ -3653,13 +3885,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Commit descent into side-map references, mirroring {@code KeyValueLeafPage#commit} for
-   * overflow references (#1076): segment pages hang off this map WITHOUT a
-   * TransactionIntentLog entry (logKey stays NULL), so the default {@code Page#commit}'s
-   * logKey filter would skip them and the leaf would serialize dangling {@code -1} keys. The
-   * storage-engine writer's commit branch writes each in-memory
-   * {@link OverflowPage} and assigns its durable offset key strictly before this
-   * leaf's own bytes are produced.
+   * Commit descent into side-map references, mirroring {@code KeyValueLeafPage#commit} for overflow
+   * references (#1076): segment pages hang off this map WITHOUT a TransactionIntentLog entry (logKey
+   * stays NULL), so the default {@code Page#commit}'s logKey filter would skip them and the leaf
+   * would serialize dangling {@code -1} keys. The storage-engine writer's commit branch writes each
+   * in-memory {@link OverflowPage} and assigns its durable offset key strictly before this leaf's own
+   * bytes are produced.
    */
   @Override
   public void commit(final StorageEngineWriter pageWriteTrx) {
@@ -3686,8 +3917,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   @Override
   @SuppressWarnings("unchecked")
-  public <C extends KeyValuePage<DataRecord>> C newInstance(long recordPageKey,
-      IndexType indexType, StorageEngineReader storageEngineReader) {
+  public <C extends KeyValuePage<DataRecord>> C newInstance(long recordPageKey, IndexType indexType,
+      StorageEngineReader storageEngineReader) {
     return (C) new HOTLeafPage(recordPageKey, storageEngineReader.getRevisionNumber(), indexType);
   }
 
@@ -3744,7 +3975,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
   @Override
   public long getActualMemorySize() {
-    return slotMemory != null ? slotMemory.byteSize() : 0;
+    return slotMemory != null
+        ? slotMemory.byteSize()
+        : 0;
   }
 
   @Override
@@ -3779,12 +4012,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   // ===== Slot-granular CoW: dirty bitmap accessors =====
 
   /**
-   * Mark an entry index as dirty. Centralized in mutators so writers stay oblivious.
-   * No bounds-check — callers already validated against entryCount before invoking a mutator.
+   * Mark an entry index as dirty. Centralized in mutators so writers stay oblivious. No bounds-check
+   * — callers already validated against entryCount before invoking a mutator.
    *
-   * <p>Public so the SLIDING_SNAPSHOT carry-forward
-   * ({@link io.sirix.settings.VersioningType#carryForwardAgingHOTEntries}) can mark an aging
-   * entry for re-emission without mutating its value.</p>
+   * <p>
+   * Public so the SLIDING_SNAPSHOT carry-forward
+   * ({@link io.sirix.settings.VersioningType#carryForwardAgingHOTEntries}) can mark an aging entry
+   * for re-emission without mutating its value.
+   * </p>
    */
   public void markEntryDirty(final int index) {
     dirtyBitmap[index >>> 6] |= 1L << (index & 63);
@@ -3808,9 +4043,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Number of entries currently marked dirty in the bitmap. Used by tests pinning the
-   * slot-granular sparse-fragment invariants — a single-key write must leave dirtyEntryCount
-   * equal to 1 so the rev's on-disk fragment carries only that one slot.
+   * Number of entries currently marked dirty in the bitmap. Used by tests pinning the slot-granular
+   * sparse-fragment invariants — a single-key write must leave dirtyEntryCount equal to 1 so the
+   * rev's on-disk fragment carries only that one slot.
    *
    * @return total population count across the dirty bitmap, capped at {@link #entryCount}
    */
@@ -3842,15 +4077,16 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Set this leaf's reference to the complete (post-merge) page. The complete page supplies
-   * preserved entries when a versioning strategy needs a full-fragment emit at serialize time.
+   * Set this leaf's reference to the complete (post-merge) page. The complete page supplies preserved
+   * entries when a versioning strategy needs a full-fragment emit at serialize time.
    */
   public void setCompletePageRef(final @Nullable HOTLeafPage completePage) {
     this.completePageRef = completePage;
   }
 
   /**
-   * @return the complete page reference, or {@code null} if this is a fresh / fully-materialized leaf.
+   * @return the complete page reference, or {@code null} if this is a fresh / fully-materialized
+   *         leaf.
    */
   public @Nullable HOTLeafPage getCompletePageRef() {
     return completePageRef;
@@ -3880,12 +4116,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Shift dirtyBitmap to mirror an insert at {@code pos}: bits in {@code [pos, MAX_ENTRIES-1)}
-   * move up by 1. The bit at position {@code pos} after the shift is cleared; the caller
-   * subsequently marks the inserted index dirty.
+   * Shift dirtyBitmap to mirror an insert at {@code pos}: bits in {@code [pos, MAX_ENTRIES-1)} move
+   * up by 1. The bit at position {@code pos} after the shift is cleared; the caller subsequently
+   * marks the inserted index dirty.
    *
-   * <p>Semantically: dirtyBitmap behaves like a bitwise variant of
-   * {@code System.arraycopy(slotOffsets, pos, slotOffsets, pos + 1, entryCount - pos)}.</p>
+   * <p>
+   * Semantically: dirtyBitmap behaves like a bitwise variant of
+   * {@code System.arraycopy(slotOffsets, pos, slotOffsets, pos + 1, entryCount - pos)}.
+   * </p>
    */
   void shiftDirtyBitmapForInsert(final int pos) {
     if (pos < 0 || pos >= MAX_ENTRIES) {
@@ -3903,7 +4141,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     }
     // posWord: keep [0, posBit), shift [posBit, 62] up to [posBit+1, 63], drop original bit 63
     // (the loop above already absorbed it as carry-in).
-    final long lowMask = posBit == 0 ? 0L : (1L << posBit) - 1L;
+    final long lowMask = posBit == 0
+        ? 0L
+        : (1L << posBit) - 1L;
     final long lowBits = dirtyBitmap[posWord] & lowMask;
     final long shiftedHigh = (dirtyBitmap[posWord] & ~lowMask) << 1;
     long updated = lowBits | shiftedHigh;
@@ -3913,8 +4153,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Clear dirty-bitmap bits at indices &gt;= {@code newEntryCount}. Used after a split/truncation
-   * to drop stale bits that no longer correspond to a reachable entry.
+   * Clear dirty-bitmap bits at indices &gt;= {@code newEntryCount}. Used after a split/truncation to
+   * drop stale bits that no longer correspond to a reachable entry.
    */
   void truncateDirtyBitmap(final int newEntryCount) {
     if (newEntryCount <= 0) {
@@ -3952,11 +4192,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   }
 
   /**
-   * Shift dirtyBitmap to mirror a deletion at {@code pos}: bits in {@code (pos, MAX_ENTRIES)}
-   * move down by 1, the bit at {@code pos} is dropped, and the previously-MSB bit becomes 0.
+   * Shift dirtyBitmap to mirror a deletion at {@code pos}: bits in {@code (pos, MAX_ENTRIES)} move
+   * down by 1, the bit at {@code pos} is dropped, and the previously-MSB bit becomes 0.
    *
-   * <p>HOTLeafPage's {@link #delete(byte[])} currently tombstones in place (no slotOffsets shift);
-   * this helper exists for completeness so future compacting-delete code stays correct.</p>
+   * <p>
+   * HOTLeafPage's {@link #delete(byte[])} currently tombstones in place (no slotOffsets shift); this
+   * helper exists for completeness so future compacting-delete code stays correct.
+   * </p>
    */
   void shiftDirtyBitmapForDelete(final int pos) {
     if (pos < 0 || pos >= MAX_ENTRIES) {
@@ -3967,9 +4209,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
     // posWord: keep [0, posBit), shift (posBit, 63] down by 1 to [posBit, 62]. Bit 63 carries in
     // from posWord+1 bit 0 (if any).
-    final long lowMask = posBit == 0 ? 0L : (1L << posBit) - 1L;
+    final long lowMask = posBit == 0
+        ? 0L
+        : (1L << posBit) - 1L;
     final long lowBits = dirtyBitmap[posWord] & lowMask;
-    final long highMask = posBit == 63 ? 0L : ~((1L << (posBit + 1)) - 1L);
+    final long highMask = posBit == 63
+        ? 0L
+        : ~((1L << (posBit + 1)) - 1L);
     final long shiftedHigh = (dirtyBitmap[posWord] & highMask) >>> 1;
     long updated = lowBits | shiftedHigh;
     if (posWord + 1 < DIRTY_BITMAP_WORDS) {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -553,8 +553,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Compute PEXT partial key from a byte array suffix (starting at given offset).
    */
-  private static int computePartialKeyFromArray(byte[] key, int suffixOffset, int bytePos, long bitMask) {
-    final long suffixWord = loadWordBEFromArray(key, suffixOffset + bytePos);
+  private static int computePartialKeyFromArray(byte[] key, int keyLen, int suffixOffset, int bytePos, long bitMask) {
+    final long suffixWord = loadWordBEFromArray(key, keyLen, suffixOffset + bytePos);
     return (int) Long.compress(suffixWord, bitMask);
   }
 
@@ -602,9 +602,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   /**
    * Load up to 8 bytes from a byte array in BE word layout.
    */
-  private static long loadWordBEFromArray(byte[] key, int pos) {
+  private static long loadWordBEFromArray(byte[] key, int keyLen, int pos) {
     long result = 0;
-    final int end = Math.min(pos + 8, key.length);
+    final int end = Math.min(pos + 8, keyLen);
     for (int i = pos; i < end; i++) {
       result |= ((long) (key[i] & 0xFF)) << ((7 - (i - pos)) * 8);
     }
@@ -629,6 +629,15 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @return index if found, or -(insertionPoint + 1) if not found
    */
   public int findEntry(byte[] key) {
+    return findEntry(key, key.length);
+  }
+
+  /**
+   * {@link #findEntry(byte[])} over the first {@code keyLen} bytes of {@code key} — the insert path
+   * serializes into an oversized reusable buffer, and this overload searches straight from it without
+   * the exact-length copy the array-only signature forced per insert.
+   */
+  public int findEntry(byte[] key, int keyLen) {
     Objects.requireNonNull(key);
 
     if (entryCount == 0) {
@@ -637,9 +646,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
 
     // --- Prefix check ---
     if (commonPrefixLen > 0) {
-      if (key.length < commonPrefixLen) {
+      if (keyLen < commonPrefixLen) {
         // Key shorter than prefix → compare to determine insertion point
-        return computeInsertionPointFromPrefix(key);
+        return computeInsertionPointFromPrefix(key, keyLen);
       }
       // Compare key prefix with commonPrefix
       for (int i = 0; i < commonPrefixLen; i++) {
@@ -659,11 +668,11 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     }
 
     if (pextValid) {
-      return pextSearch(key);
+      return pextSearch(key, keyLen);
     }
 
     // --- Binary search on suffixes ---
-    return binarySearchSuffix(key);
+    return binarySearchSuffix(key, keyLen);
   }
 
   /**
@@ -671,8 +680,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * insertion point is before all entries (return -1). If key &gt; prefix, insertion point is after
    * all entries (return -(entryCount+1)).
    */
-  private int computeInsertionPointFromPrefix(byte[] key) {
-    final int minLen = Math.min(key.length, commonPrefixLen);
+  private int computeInsertionPointFromPrefix(byte[] key, int keyLen) {
+    final int minLen = Math.min(keyLen, commonPrefixLen);
     for (int i = 0; i < minLen; i++) {
       final int cmp = (key[i] & 0xFF) - (commonPrefix[i] & 0xFF);
       if (cmp < 0)
@@ -688,8 +697,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * PEXT-accelerated search: compute partial key from suffix, SIMD equality search, verify candidates
    * with full suffix comparison.
    */
-  private int pextSearch(byte[] key) {
-    final int searchPK = computePartialKeyFromArray(key, commonPrefixLen, discBytePos, discBitMask);
+  private int pextSearch(byte[] key, int keyLen) {
+    final int searchPK = computePartialKeyFromArray(key, keyLen, commonPrefixLen, discBytePos, discBitMask);
 
     // SIMD equality search on dense partial keys
     int candidates;
@@ -704,14 +713,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     // Verify candidates with full suffix comparison
     while (candidates != 0) {
       final int idx = Integer.numberOfTrailingZeros(candidates);
-      if (suffixMatchesKey(idx, key)) {
+      if (suffixMatchesKey(idx, key, keyLen)) {
         return idx;
       }
       candidates &= candidates - 1; // clear lowest bit
     }
 
     // Not found — compute insertion point via binary search
-    return binarySearchSuffix(key);
+    return binarySearchSuffix(key, keyLen);
   }
 
   /**
@@ -795,10 +804,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * Zero-allocation: compares MemorySegment suffix directly with key bytes starting at
    * commonPrefixLen.
    */
-  private boolean suffixMatchesKey(int index, byte[] key) {
+  private boolean suffixMatchesKey(int index, byte[] key, int keyLen) {
     final int offset = slotOffsets[index];
     final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
-    final int keySuffixLen = key.length - commonPrefixLen;
+    final int keySuffixLen = keyLen - commonPrefixLen;
 
     if (suffixLen != keySuffixLen) {
       return false;
@@ -821,13 +830,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @param key the full search key
    * @return index if found, or -(insertionPoint + 1) if not found
    */
-  private int binarySearchSuffix(byte[] key) {
+  private int binarySearchSuffix(byte[] key, int keyLen) {
     int low = 0;
     int high = entryCount;
 
     while (low < high) {
       final int mid = (low + high) >>> 1;
-      final int cmp = compareSuffixWithKey(mid, key);
+      final int cmp = compareSuffixWithKey(mid, key, keyLen);
       low = cmp < 0
           ? mid + 1
           : low;
@@ -849,12 +858,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @param key the full search key
    * @return negative if stored suffix &lt; key suffix, positive if &gt;, zero if equal
    */
-  private int compareSuffixWithKey(int index, byte[] key) {
+  private int compareSuffixWithKey(int index, byte[] key, int keyLen) {
     final int offset = slotOffsets[index];
     final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
     final long suffixStart = offset + 2;
     final int keySuffixStart = commonPrefixLen;
-    final int keySuffixLen = key.length - keySuffixStart;
+    final int keySuffixLen = keyLen - keySuffixStart;
     final int minLen = Math.min(suffixLen, keySuffixLen);
 
     // Fast path: compare 8 bytes at a time
@@ -1630,15 +1639,19 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * </p>
    */
   private void handlePrefixForInsert(byte[] key) {
+    handlePrefixForInsert(key, key.length);
+  }
+
+  private void handlePrefixForInsert(byte[] key, int keyLen) {
     if (entryCount == 0) {
       // First entry: set prefix to entire key
-      commonPrefix = key.clone();
-      commonPrefixLen = key.length;
+      commonPrefix = Arrays.copyOfRange(key, 0, keyLen);
+      commonPrefixLen = keyLen;
       return;
     }
 
     // Compute LCP of key with current prefix
-    final int lcp = longestCommonPrefix(commonPrefix, commonPrefixLen, key, key.length);
+    final int lcp = longestCommonPrefix(commonPrefix, commonPrefixLen, key, keyLen);
 
     if (lcp < commonPrefixLen) {
       // Prefix must shrink — extend all existing suffixes
@@ -1732,8 +1745,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    * @return true if successful
    */
   private boolean insertAtWithKey(int pos, byte[] key, byte[] value) {
+    return insertAtWithKey(pos, key, key.length, value);
+  }
+
+  private boolean insertAtWithKey(int pos, byte[] key, int keyLen, byte[] value) {
     // Extract suffix
-    final int suffixLen = key.length - commonPrefixLen;
+    final int suffixLen = keyLen - commonPrefixLen;
     return insertAtSuffix(pos, key, commonPrefixLen, suffixLen, value);
   }
 
@@ -2269,14 +2286,11 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     Objects.requireNonNull(key);
     Objects.requireNonNull(value);
 
-    // Search for existing key
-    final byte[] keySlice = keyLen == key.length
-        ? key
-        : Arrays.copyOf(key, keyLen);
-
-    // Handle prefix for the incoming key (may shrink prefix)
-    handlePrefixForInsert(keySlice);
-    return mergeWithNodeRefsImpl(keySlice, value, valueLen);
+    // Handle prefix for the incoming key (may shrink prefix). The whole merge chain is
+    // length-parameterized, so the oversized serialization buffer is searched and spliced from
+    // directly — no exact-length key copy per insert.
+    handlePrefixForInsert(key, keyLen);
+    return mergeWithNodeRefsImpl(key, keyLen, value, valueLen);
   }
 
   /**
@@ -2308,7 +2322,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       return -(offendingBit + 1);
     }
     handlePrefixForInsert(keySlice);
-    return mergeWithNodeRefsImpl(keySlice, value, valueLen)
+    return mergeWithNodeRefsImpl(keySlice, keySlice.length, value, valueLen)
         ? 1
         : 0;
   }
@@ -2340,9 +2354,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     return insertAtWithKey(-(index + 1), key, value);
   }
 
-  private boolean mergeWithNodeRefsImpl(byte[] keySlice, byte[] value, int valueLen) {
+  private boolean mergeWithNodeRefsImpl(byte[] keySlice, int keyLen, byte[] value, int valueLen) {
 
-    int index = findEntry(keySlice);
+    int index = findEntry(keySlice, keyLen);
 
     if (index >= 0) {
       // Key exists - merge NodeReferences.
@@ -2399,7 +2413,7 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
           : Arrays.copyOf(value, valueLen);
       final int insertPos = -(index + 1);
 
-      return insertAtWithKey(insertPos, keySlice, valueSlice);
+      return insertAtWithKey(insertPos, keySlice, keyLen, valueSlice);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -28,6 +28,8 @@
 
 package io.sirix.page;
 
+import io.sirix.cache.CacheablePage;
+import io.sirix.settings.VersioningType;
 import io.sirix.node.LE;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.StorageEngineWriter;
@@ -36,6 +38,7 @@ import io.sirix.cache.Allocators;
 import io.sirix.index.hot.DiscriminativeBitComputer;
 import io.sirix.index.hot.NodeReferencesSerializer;
 import io.sirix.index.hot.PathKeySerializer;
+import io.sirix.cache.FrameSlotAllocator;
 import io.sirix.cache.MemorySegmentAllocator;
 import io.sirix.index.IndexType;
 import io.sirix.node.interfaces.DataRecord;
@@ -98,7 +101,7 @@ import java.util.function.IntConsumer;
  * @see KeyValuePage
  * @see HOTIndirectPage
  */
-public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cache.CacheablePage {
+public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePage {
 
   /** Sentinel value for "not found" in binary search. */
   public static final int NOT_FOUND = -1;
@@ -965,16 +968,42 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     return slotMemory.get(ValueLayout.JAVA_BYTE, (ref >>> 32) + offsetInValue);
   }
 
-  /** A little-endian, unaligned {@code int} of the value {@code ref} resolves. */
-  public int refIntAt(long ref, int offsetInValue) {
+  /**
+   * A LITTLE-ENDIAN, unaligned {@code int} of the value {@code ref} resolves — the layout the
+   * projection-index blob marker stores its magic and length field in.
+   *
+   * <p>
+   * Spelled out in the layout rather than left to {@link ValueLayout#JAVA_INT_UNALIGNED}, which is
+   * NATIVE order and therefore only coincides with the stored format on a little-endian host. On one
+   * the JIT emits the identical single load.
+   */
+  public int refIntLEAt(long ref, int offsetInValue) {
     checkRefRange(ref, offsetInValue, Integer.BYTES);
-    return slotMemory.get(ValueLayout.JAVA_INT_UNALIGNED, (ref >>> 32) + offsetInValue);
+    return slotMemory.get(LE.INT, (ref >>> 32) + offsetInValue);
   }
 
-  /** A little-endian, unaligned {@code long} of the value {@code ref} resolves. */
-  public long refLongAt(long ref, int offsetInValue) {
+  /**
+   * A LITTLE-ENDIAN, unaligned {@code long} of the value {@code ref} resolves — the layout the
+   * projection-index blob marker stores its content hash in. Same reasoning as {@link #refIntLEAt}.
+   */
+  public long refLongLEAt(long ref, int offsetInValue) {
     checkRefRange(ref, offsetInValue, Long.BYTES);
-    return slotMemory.get(ValueLayout.JAVA_LONG_UNALIGNED, (ref >>> 32) + offsetInValue);
+    return slotMemory.get(LE.LONG, (ref >>> 32) + offsetInValue);
+  }
+
+  /**
+   * A BIG-ENDIAN, unaligned {@code long} of the value {@code ref} resolves — the layout the packed
+   * posting-list format stores node keys in.
+   *
+   * <p>
+   * Not {@code Long.reverseBytes(refLongAt(...))}: {@link ValueLayout#JAVA_LONG_UNALIGNED} is NATIVE
+   * order, so that composition silently means "swap on every host" and decodes garbage wherever the
+   * host is already big-endian. Naming the endianness in the layout costs nothing — on a
+   * little-endian host the JIT emits the same single load plus {@code bswap}.
+   */
+  public long refLongBEAt(long ref, int offsetInValue) {
+    checkRefRange(ref, offsetInValue, Long.BYTES);
+    return slotMemory.get(JAVA_LONG_BE_UNALIGNED, (ref >>> 32) + offsetInValue);
   }
 
   /** Bulk-copy {@code len} bytes of the value {@code ref} resolves into {@code dst}. */
@@ -1058,42 +1087,50 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
   public int compareKeyWithBound(final int index, final byte[] bound) {
     Objects.checkIndex(index, entryCount);
     Objects.requireNonNull(bound, "bound");
-    final int offset = slotOffsets[index];
-    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
-    final int keyLen = commonPrefixLen + suffixLen;
-    final int minLen = Math.min(keyLen, bound.length);
+    final int keyLen = commonPrefixLen + Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, slotOffsets[index]));
+    final int cmp = compareKeyBytes(index, bound, Math.min(keyLen, bound.length));
+    // Length tie-breaker: longer wins (unsigned lex).
+    return cmp != 0
+        ? cmp
+        : keyLen - bound.length;
+  }
 
-    // Phase 1: commonPrefix (on-heap byte[]) vs bound[0..commonPrefixLen)
+  /**
+   * Unsigned-lex compare of the first {@code cmpLen} bytes of the key at {@code index} against
+   * {@code probe[0..cmpLen)}, spanning the on-heap {@code commonPrefix} and the off-heap suffix.
+   * Returns {@code 0} when those bytes are equal — the caller applies its own length tie-break.
+   *
+   * <p>
+   * The single home for this leaf's key-byte addressing (the {@code u16} suffix-length header, the
+   * {@code offset + 2} suffix start): {@link #compareKeyWithBound}, {@link #compareKeyPrefix} and
+   * {@link #compareKeyPrefixPart} differ only in how far they compare and how they break a tie, so
+   * having them share this loop keeps the slot layout described once. Small enough to inline, which
+   * matters because all three sit on read hot paths.
+   */
+  private int compareKeyBytes(final int index, final byte[] probe, final int cmpLen) {
+    final int offset = slotOffsets[index];
+    final long suffixStart = offset + 2;
     int p = 0;
-    final int commonMin = Math.min(commonPrefixLen, bound.length);
+    final int commonMin = Math.min(commonPrefixLen, cmpLen);
     while (p < commonMin) {
       final int a = commonPrefix[p] & 0xFF;
-      final int b = bound[p] & 0xFF;
-      if (a != b)
+      final int b = probe[p] & 0xFF;
+      if (a != b) {
         return a - b;
+      }
       p++;
     }
-    // If bound ended within the commonPrefix, the key (which extends via
-    // its suffix) is strictly longer → key > bound.
-    if (bound.length == commonPrefixLen && suffixLen > 0)
-      return 1;
-    if (p == keyLen) {
-      // key fully consumed; equal up to keyLen → key < bound if bound longer
-      return keyLen - bound.length;
-    }
-
-    // Phase 2: suffix (off-heap) vs bound[commonPrefixLen..minLen)
-    final int suffixStart = offset + 2;
-    while (p < minLen) {
+    while (p < cmpLen) {
       final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
-      final int b = bound[p] & 0xFF;
-      if (a != b)
+      final int b = probe[p] & 0xFF;
+      if (a != b) {
         return a - b;
+      }
       p++;
     }
-    // Length tie-breaker: longer wins (unsigned lex).
-    return keyLen - bound.length;
+    return 0;
   }
+
 
   /**
    * Total key length (commonPrefix + suffix) of the entry at {@code index}, without materializing the
@@ -1125,29 +1162,13 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    */
   public int compareKeyPrefix(final int index, final byte[] prefix, final int prefixLen) {
     Objects.checkIndex(index, entryCount);
-    final int offset = slotOffsets[index];
-    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
-    final int keyLen = commonPrefixLen + suffixLen;
-    final int cmpLen = Math.min(keyLen, prefixLen);
-    int p = 0;
-    final int commonMin = Math.min(commonPrefixLen, cmpLen);
-    while (p < commonMin) {
-      final int a = commonPrefix[p] & 0xFF;
-      final int b = prefix[p] & 0xFF;
-      if (a != b) {
-        return a - b;
-      }
-      p++;
+    final int keyLen = commonPrefixLen + Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, slotOffsets[index]));
+    final int cmp = compareKeyBytes(index, prefix, Math.min(keyLen, prefixLen));
+    if (cmp != 0) {
+      return cmp;
     }
-    final long suffixStart = offset + 2;
-    while (p < cmpLen) {
-      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
-      final int b = prefix[p] & 0xFF;
-      if (a != b) {
-        return a - b;
-      }
-      p++;
-    }
+    // Equal through the compared span: a key shorter than the probe is less, otherwise it starts
+    // with the probe and counts as a match.
     return keyLen < prefixLen
         ? -1
         : 0;
@@ -1167,30 +1188,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    */
   public int compareKeyPrefixPart(final int index, final int trailerBytes, final byte[] other, final int otherLen) {
     Objects.checkIndex(index, entryCount);
-    final int offset = slotOffsets[index];
-    final int suffixLen = Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, offset));
-    final int partLen = Math.max(0, commonPrefixLen + suffixLen - Math.max(0, trailerBytes));
-    final int cmpLen = Math.min(partLen, otherLen);
-    int p = 0;
-    final int commonMin = Math.min(commonPrefixLen, cmpLen);
-    while (p < commonMin) {
-      final int a = commonPrefix[p] & 0xFF;
-      final int b = other[p] & 0xFF;
-      if (a != b) {
-        return a - b;
-      }
-      p++;
-    }
-    final long suffixStart = offset + 2;
-    while (p < cmpLen) {
-      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
-      final int b = other[p] & 0xFF;
-      if (a != b) {
-        return a - b;
-      }
-      p++;
-    }
-    return partLen - otherLen;
+    final int keyLen = commonPrefixLen + Short.toUnsignedInt(slotMemory.get(JAVA_SHORT_UNALIGNED, slotOffsets[index]));
+    final int partLen = Math.max(0, keyLen - Math.max(0, trailerBytes));
+    final int cmp = compareKeyBytes(index, other, Math.min(partLen, otherLen));
+    return cmp != 0
+        ? cmp
+        : partLen - otherLen;
   }
 
   /**
@@ -1901,7 +1904,17 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     // Capture old releaser BEFORE reassigning — release old memory AFTER assigning new
     // to prevent use-after-free if allocator.allocate() succeeds but subsequent ops fail
     final Runnable oldReleaser = releaser;
+    // ORDER: invalidate the stamp binding BEFORE the segment swap, never after. A reader that
+    // observes the OLD binding must not be able to observe the NEW segment: with the reset last,
+    // its validateStamp would consult the old slot's version — which is only bumped by the release
+    // below, i.e. after the swap — and certify reads taken from a different segment. Clearing
+    // first means any reader crossing the swap either validates against the old slot before it
+    // moves (correct) or sees UNBOUND and fails validation (correct, it retries). The new segment
+    // IS the allocation, so the zero-copy base override no longer applies.
+    stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    stampBaseSegment = null;
     slotMemory = newMemory;
+    stampCoordinates = STAMP_COORDINATES_UNBOUND;
     final MemorySegment segmentToRelease = newMemory;
     releaser = () -> allocator.release(segmentToRelease);
     // Now safe to release old memory — slotMemory already points to new allocation
@@ -3596,9 +3609,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
    *
    * @param type the active versioning strategy
    */
-  public void materializeFromCompletePageRef(final io.sirix.settings.VersioningType type) {
+  public void materializeFromCompletePageRef(final VersioningType type) {
     Objects.requireNonNull(type);
-    if (type == io.sirix.settings.VersioningType.FULL) {
+    if (type == VersioningType.FULL) {
       markAllEntriesDirty();
     }
   }
@@ -3626,6 +3639,149 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
       }
     }
     return true;
+  }
+
+  // ===== Optimistic read stamps (Umbra-style, backed by FrameSlotAllocator slot versions) =====
+
+  /**
+   * Packed {@code (classIdx << 32) | slotIdx} of the allocator slot backing {@link #slotMemory}, or
+   * {@link FrameSlotAllocator#NO_SLOT_COORDINATES} for a page whose memory is not a live frame slot
+   * (heap-backed test pages, pool-allocator rollback). Bound lazily on the first {@link #readStamp()}
+   * — one map probe per page lifetime — and re-bound after {@code growSlotMemory} swaps the segment.
+   * {@code volatile}: bound by the first reading thread, observed by all.
+   */
+  private volatile long stampCoordinates = STAMP_COORDINATES_UNBOUND;
+
+  private static final long STAMP_COORDINATES_UNBOUND = Long.MIN_VALUE;
+
+  /**
+   * Segment whose ADDRESS identifies the allocator slot backing this page, when that is not
+   * {@link #slotMemory} itself.
+   *
+   * <p>
+   * A zero-copy deserialized leaf takes {@code slotMemory} as a MID-BUFFER SLICE of the decompression
+   * buffer ({@code PageKind}: {@code sourceSegment.asSlice(source.position(), …)}), and the allocator
+   * keys its live-slot map by the ADDRESS IT HANDED OUT — the buffer's base. A slice's address is
+   * {@code base + offset}, so binding from it misses, yields
+   * {@link FrameSlotAllocator#NO_SLOT_COORDINATES}, and silently degrades {@link #validateStamp} to a
+   * bare closed-flag test for the whole page lifetime. That is the dominant read path, so the entire
+   * optimistic-stamp protocol would be inert exactly where it is needed. The deserializer therefore
+   * hands the base segment over via {@link #setStampBaseSegment}.
+   * </p>
+   */
+  private volatile MemorySegment stampBaseSegment;
+
+  /**
+   * Tell this page which segment's address identifies its allocator slot. Called by the page
+   * deserializer immediately after construction, before the page is published, whenever
+   * {@link #slotMemory} is a slice of a larger allocation rather than the allocation itself.
+   *
+   * @param base the segment as returned by the allocator; {@code null} clears the override
+   */
+  void setStampBaseSegment(final @Nullable MemorySegment base) {
+    this.stampBaseSegment = base;
+    this.stampCoordinates = STAMP_COORDINATES_UNBOUND;
+  }
+
+  /**
+   * Stamp for a page whose memory cannot be torn by slot reuse (not frame-slot-backed). Even, so it
+   * validates; distinct so the semantics are auditable.
+   */
+  private static final long STAMP_UNBACKED = 0L;
+
+  /** Stamp that never validates: returned while the page is closed or its slot is mid-teardown. */
+  public static final long STAMP_INVALID = 1L;
+
+  /**
+   * Snapshot this page's read stamp. Protocol (seqlock, reader side):
+   *
+   * <pre>{@code
+   * long stamp = leaf.readStamp();            // odd => closed/teardown in progress: re-resolve
+   * ... any number of reads of leaf content ...
+   * if (!leaf.validateStamp(stamp)) retry;    // the slot was reclaimed mid-read: re-resolve, redo
+   * }</pre>
+   *
+   * A validated stamp proves every read since the snapshot saw stable bytes — one validation covers
+   * an arbitrary batch of reads. Content per {@link PageReference} is immutable, so a retry may
+   * re-resolve the same reference and keep every slot index it had already computed.
+   */
+  public long readStamp() {
+    long coordinates = stampCoordinates;
+    if (coordinates == STAMP_COORDINATES_UNBOUND) {
+      // Safe to bind at any time: an address maps to exactly one physical slot, so the
+      // coordinates are a pure function of the segment — only the VERSION at them tells
+      // generations apart.
+      coordinates = bindStampCoordinates();
+    }
+    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
+      // Not frame-slot-backed. A live page's memory cannot be torn by slot reuse; a closed one
+      // must still never validate.
+      return closed.get()
+          ? STAMP_INVALID
+          : STAMP_UNBACKED;
+    }
+    final long stamp = FrameSlotAllocator.getInstance().acquireVersion((int) (coordinates >>> 32), (int) coordinates);
+    // ORDER IS LOAD-BEARING: the closed check must come AFTER the version acquire, never before.
+    // Teardown publishes closed=true BEFORE releasing the slot (see close()/markOrphaned()), so
+    // observing closed==false HERE proves the slot had not been released when the version was
+    // acquired — any later release bumps it and validateStamp fails. With the check first there
+    // is an ABA window: a slot torn down AND re-issued between the check and the acquire hands
+    // back a fresh, stable, EVEN version over another page's bytes, and every read of this
+    // page's stale segment then "validates". That surfaced as silent key loss under eviction
+    // pressure in HOTLeafUseAfterCloseTest.
+    if (closed.get()) {
+      return STAMP_INVALID;
+    }
+    return stamp;
+  }
+
+  /**
+   * Whether every read since {@code stamp} was taken saw stable bytes. An {@link #STAMP_UNBACKED}
+   * stamp always validates (the memory cannot be reclaimed); an odd stamp never does.
+   *
+   * @param stamp a value previously returned by {@link #readStamp()}
+   * @return {@code true} iff reads under {@code stamp} are trustworthy
+   */
+  public boolean validateStamp(final long stamp) {
+    if (stamp == STAMP_UNBACKED) {
+      // Unbacked memory has no slot version to consult; detecting a close between snapshot and
+      // validation is the strongest check available (and all the non-frame allocators need —
+      // their release path is what recycles the memory).
+      return !closed.get();
+    }
+    if ((stamp & 1L) != 0L) {
+      return false;
+    }
+    final long coordinates = stampCoordinates;
+    if (coordinates == STAMP_COORDINATES_UNBOUND || coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
+      // A backed stamp was issued, so coordinates were bound when it was read; reaching here means
+      // the binding was reset by a concurrent segment swap — the old stamp is no longer provable.
+      return false;
+    }
+    return FrameSlotAllocator.getInstance().validateVersion((int) (coordinates >>> 32), (int) coordinates, stamp);
+  }
+
+  /**
+   * Capacity of the backing slot, the hard upper bound on any length field read from slot memory. A
+   * torn read can fabricate arbitrary lengths; clamping against this before allocating turns a
+   * potential multi-gigabyte allocation into a small failed read that stamp validation resolves.
+   */
+  public long slotCapacity() {
+    return slotMemory.byteSize();
+  }
+
+  private long bindStampCoordinates() {
+    final MemorySegmentAllocator allocator = Allocators.getInstance();
+    // Resolve against the segment the ALLOCATOR handed out, which is the whole allocation — for a
+    // zero-copy leaf that is stampBaseSegment, not the slice in slotMemory. See the field javadoc.
+    final MemorySegment base = stampBaseSegment;
+    final long coordinates = allocator instanceof FrameSlotAllocator frameSlotAllocator
+        ? frameSlotAllocator.slotCoordinates(base != null
+            ? base
+            : slotMemory)
+        : FrameSlotAllocator.NO_SLOT_COORDINATES;
+    stampCoordinates = coordinates;
+    return coordinates;
   }
 
   // ===== Guard-based lifetime management =====

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -331,7 +331,9 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
     this.indexType = Objects.requireNonNull(indexType);
 
     MemorySegmentAllocator allocator = Allocators.getInstance();
-    this.slotMemory = allocator.allocate(DEFAULT_SIZE);
+    // publishSlotMemory, not a bare assignment: it binds the optimistic-read coordinates in the same
+    // step, which is what keeps that binding a publisher-only field. See the method.
+    publishSlotMemory(allocator.allocate(DEFAULT_SIZE));
     // Capture by local variable to avoid releasing wrong memory if slotMemory field is later changed
     final MemorySegment segmentToRelease = this.slotMemory;
     this.releaser = () -> allocator.release(segmentToRelease);
@@ -364,7 +366,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
     this.recordPageKey = recordPageKey;
     this.revision = revision;
     this.indexType = Objects.requireNonNull(indexType);
-    this.slotMemory = Objects.requireNonNull(slotMemory);
+    // publishSlotMemory, not a bare assignment: it binds the optimistic-read coordinates in the same
+    // step. A zero-copy leaf then corrects the binding through setStampBaseSegment, which the page
+    // deserializer calls before this leaf is published.
+    publishSlotMemory(Objects.requireNonNull(slotMemory));
     this.releaser = releaser;
     this.slotOffsets = slotOffsets;
     this.entryCount = entryCount;
@@ -1929,17 +1934,8 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
     // Capture old releaser BEFORE reassigning — release old memory AFTER assigning new
     // to prevent use-after-free if allocator.allocate() succeeds but subsequent ops fail
     final Runnable oldReleaser = releaser;
-    // ORDER: invalidate the stamp binding BEFORE the segment swap, never after. A reader that
-    // observes the OLD binding must not be able to observe the NEW segment: with the reset last,
-    // its validateStamp would consult the old slot's version — which is only bumped by the release
-    // below, i.e. after the swap — and certify reads taken from a different segment. Clearing
-    // first means any reader crossing the swap either validates against the old slot before it
-    // moves (correct) or sees UNBOUND and fails validation (correct, it retries). The new segment
-    // IS the allocation, so the zero-copy base override no longer applies.
-    stampCoordinates = STAMP_COORDINATES_UNBOUND;
-    stampBaseSegment = null;
-    slotMemory = newMemory;
-    stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    // The segment swap and the stamp re-binding are one indivisible publication; see the method.
+    publishSlotMemory(newMemory);
     final MemorySegment segmentToRelease = newMemory;
     releaser = () -> allocator.release(segmentToRelease);
     // Now safe to release old memory — slotMemory already points to new allocation
@@ -3671,13 +3667,44 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
   /**
    * Packed {@code (classIdx << 32) | slotIdx} of the allocator slot backing {@link #slotMemory}, or
    * {@link FrameSlotAllocator#NO_SLOT_COORDINATES} for a page whose memory is not a live frame slot
-   * (heap-backed test pages, pool-allocator rollback). Bound lazily on the first {@link #readStamp()}
-   * — one map probe per page lifetime — and re-bound after {@code growSlotMemory} swaps the segment.
-   * {@code volatile}: bound by the first reading thread, observed by all.
+   * (heap-backed test pages, pool-allocator rollback).
+   *
+   * <p>
+   * Written ONLY by {@link #publishSlotMemory}, in the same rebind window as the segment itself, and
+   * never by a reader. It used to be bound lazily by the first {@link #readStamp()}, which is one map
+   * probe cheaper for a page nobody ever stamps — but it also put a STORE on the reader side, and a
+   * reader's store cannot be ordered against a concurrent publisher's: a reader that computed
+   * coordinates from the old segment could land them after the publisher had already reset them,
+   * leaving the OLD slot's coordinates describing the NEW segment, so every later reader would
+   * validate its reads against a counter belonging to memory it is not reading. Identical reasoning
+   * and identical shape to {@code KeyValueLeafPage}, deliberately.
+   * </p>
    */
   private volatile long stampCoordinates = STAMP_COORDINATES_UNBOUND;
 
+  /** Coordinates of a page with no segment published at all — nothing to read, nothing to tear. */
   private static final long STAMP_COORDINATES_UNBOUND = Long.MIN_VALUE;
+
+  /**
+   * Sequence number identifying the CURRENT binding: EVEN when {@link #stampCoordinates} and
+   * {@link #slotMemory} agree, ODD while {@link #publishSlotMemory} is swapping them.
+   *
+   * <p>
+   * A slot version is meaningless on its own — it is a sequence private to one slot, and two slots
+   * can carry equal values at the same moment — so a reader must prove it is validating against the
+   * SAME binding it read under. {@link #readStampBinding()} hands it the generation, it carries both
+   * alongside its reads, and {@link #validateStamp(long, long)} rejects anything taken under a
+   * different binding. Without this, a stamp taken over slot A and validated after a rebind to slot B
+   * compares two unrelated counters and can return {@code true} by coincidence.
+   * </p>
+   *
+   * <p>
+   * The ODD phase is what makes the swap itself provable rather than merely likely: it is published
+   * BEFORE the segment store and fenced there, so a reader whose data load returned the new bytes
+   * cannot then observe the old generation at validation time. See {@link #publishSlotMemory}.
+   * </p>
+   */
+  private volatile long stampBindingGeneration;
 
   /**
    * Segment whose ADDRESS identifies the allocator slot backing this page, when that is not
@@ -3704,8 +3731,14 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
    * @param base the segment as returned by the allocator; {@code null} clears the override
    */
   void setStampBaseSegment(final @Nullable MemorySegment base) {
-    this.stampBaseSegment = base;
-    this.stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    // Changing the base changes which slot the coordinates resolve to, so it is a rebind like any
+    // other: same odd/even window, same fence, same invalidation of outstanding stamps.
+    final long generation = stampBindingGeneration;
+    stampBindingGeneration = generation + 1;
+    VarHandle.storeStoreFence();
+    stampBaseSegment = base;
+    stampCoordinates = slotCoordinatesOf(slotMemory);
+    stampBindingGeneration = generation + 2;
   }
 
   /**
@@ -3718,29 +3751,51 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
   public static final long STAMP_INVALID = 1L;
 
   /**
+   * The binding this page's stamps are currently issued against — snapshot it BEFORE
+   * {@link #readStamp()} and hand both back to {@link #validateStamp(long, long)}.
+   *
+   * <p>
+   * A stamp alone cannot be validated, and that is the shape of the problem rather than an API wart.
+   * A stamp is a per-SLOT sequence number, so it only means anything paired with the slot it came
+   * from; two slots' counters are unrelated and can hold equal values at the same instant. Validating
+   * a stamp against whatever slot the page happens to be bound to NOW therefore compares a version to
+   * a counter that never produced it, and can return {@code true} by coincidence — a reader
+   * certifying bytes from one allocation against another's sequence. Carrying the binding in the
+   * reader's own frame costs one extra {@code long} on the stack and makes that impossible.
+   * </p>
+   *
+   * @return the current binding generation; ODD means a rebind is in flight and no read taken now can
+   *         be proved, which {@link #validateStamp(long, long)} rejects
+   */
+  public long readStampBinding() {
+    return stampBindingGeneration;
+  }
+
+  /**
    * Snapshot this page's read stamp. Protocol (seqlock, reader side):
    *
    * <pre>{@code
+   * long binding = leaf.readStampBinding();   // the slot generation the stamp will belong to
    * long stamp = leaf.readStamp();            // odd => closed/teardown in progress: re-resolve
    * ... any number of reads of leaf content ...
-   * if (!leaf.validateStamp(stamp)) retry;    // the slot was reclaimed mid-read: re-resolve, redo
+   * if (!leaf.validateStamp(binding, stamp)) retry;  // torn or rebound: re-resolve, redo
    * }</pre>
    *
    * A validated stamp proves every read since the snapshot saw stable bytes — one validation covers
    * an arbitrary batch of reads. Content per {@link PageReference} is immutable, so a retry may
    * re-resolve the same reference and keep every slot index it had already computed.
+   *
+   * <p>
+   * Reading the binding FIRST is what makes the pair safe. A rebind landing between the two reads
+   * bumps the generation, so the stamp is validated against a binding that no longer matches and the
+   * reader retries — conservative in the only direction that is safe.
+   * </p>
    */
   public long readStamp() {
-    long coordinates = stampCoordinates;
-    if (coordinates == STAMP_COORDINATES_UNBOUND) {
-      // Safe to bind at any time: an address maps to exactly one physical slot, so the
-      // coordinates are a pure function of the segment — only the VERSION at them tells
-      // generations apart.
-      coordinates = bindStampCoordinates();
-    }
-    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
-      // Not frame-slot-backed. A live page's memory cannot be torn by slot reuse; a closed one
-      // must still never validate.
+    final long coordinates = stampCoordinates;
+    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES || coordinates == STAMP_COORDINATES_UNBOUND) {
+      // Not frame-slot-backed, or nothing published yet. A live page's memory cannot be torn by slot
+      // reuse; a closed one must still never validate.
       return closed.get()
           ? STAMP_INVALID
           : STAMP_UNBACKED;
@@ -3762,12 +3817,28 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
 
   /**
    * Whether every read since {@code stamp} was taken saw stable bytes. An {@link #STAMP_UNBACKED}
-   * stamp always validates (the memory cannot be reclaimed); an odd stamp never does.
+   * stamp validates as long as the page is still open (the memory cannot be reclaimed otherwise); an
+   * odd stamp never does; and neither kind validates across a rebind.
    *
+   * @param bindingAtRead the value {@link #readStampBinding()} returned before the stamp was taken
    * @param stamp a value previously returned by {@link #readStamp()}
    * @return {@code true} iff reads under {@code stamp} are trustworthy
    */
-  public boolean validateStamp(final long stamp) {
+  public boolean validateStamp(final long bindingAtRead, final long stamp) {
+    // No load taken under the stamp may sink below the generation check, or the check would be
+    // answering about a moment earlier than the reads it is certifying. A volatile load is an
+    // ACQUIRE, which stops later accesses floating up but does nothing to stop earlier ones sinking
+    // down — so the fence is not redundant with the volatile field below.
+    VarHandle.acquireFence();
+    // FIRST, and for both stamp kinds. The binding is what makes a stamp interpretable at all: if the
+    // page has been re-bound since it was taken, the stamp belongs to a slot this page no longer
+    // reads, and the version check below would compare it against an unrelated counter. This also
+    // covers the segment swap itself, so the UNBACKED branch is not a special case — a page that
+    // swapped from unbacked to frame-backed, or the reverse, changes generation like any other.
+    // An ODD binding was snapshotted mid-swap and can never be certified, whatever it compares to.
+    if (stampBindingGeneration != bindingAtRead || (bindingAtRead & 1L) != 0L) {
+      return false;
+    }
     if (stamp == STAMP_UNBACKED) {
       // Unbacked memory has no slot version to consult; detecting a close between snapshot and
       // validation is the strongest check available (and all the non-frame allocators need —
@@ -3795,18 +3866,66 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
     return slotMemory.byteSize();
   }
 
-  private long bindStampCoordinates() {
+  /**
+   * The allocator slot {@code segment} lives in, for {@link #stampCoordinates}. Publisher-side only —
+   * called inside a rebind window, never by a reader.
+   *
+   * @param segment the segment about to become {@link #slotMemory}, or {@code null}
+   * @return packed slot coordinates, {@link FrameSlotAllocator#NO_SLOT_COORDINATES} when the memory
+   *         is not a live frame slot, or {@link #STAMP_COORDINATES_UNBOUND} when there is no segment
+   */
+  private long slotCoordinatesOf(final @Nullable MemorySegment segment) {
+    if (segment == null) {
+      return STAMP_COORDINATES_UNBOUND;
+    }
     final MemorySegmentAllocator allocator = Allocators.getInstance();
+    if (!(allocator instanceof final FrameSlotAllocator frameSlotAllocator)) {
+      return FrameSlotAllocator.NO_SLOT_COORDINATES;
+    }
     // Resolve against the segment the ALLOCATOR handed out, which is the whole allocation — for a
     // zero-copy leaf that is stampBaseSegment, not the slice in slotMemory. See the field javadoc.
     final MemorySegment base = stampBaseSegment;
-    final long coordinates = allocator instanceof FrameSlotAllocator frameSlotAllocator
-        ? frameSlotAllocator.slotCoordinates(base != null
-            ? base
-            : slotMemory)
-        : FrameSlotAllocator.NO_SLOT_COORDINATES;
-    stampCoordinates = coordinates;
-    return coordinates;
+    return frameSlotAllocator.slotCoordinates(base != null
+        ? base
+        : segment);
+  }
+
+  /**
+   * Swap {@link #slotMemory}, re-binding the optimistic-read slot binding around the swap.
+   *
+   * <p>
+   * The ONLY place {@link #slotMemory} may be assigned after construction. A stale binding points at
+   * the OLD slot, whose version moves independently of the bytes now being read, so a reader would
+   * validate against a slot it is no longer reading — the false positive the protocol must never
+   * produce.
+   * </p>
+   *
+   * <p>
+   * <b>This is a seqlock write.</b> The generation is driven ODD before anything else moves and EVEN
+   * again once everything has, so the window in which segment and coordinates disagree is exactly the
+   * window in which no stamp can validate. It cannot be relaxed into a single trailing increment: a
+   * volatile store has RELEASE semantics, which stops earlier accesses sinking below it but does
+   * nothing to stop the PLAIN store to {@link #slotMemory} being hoisted above it — so with only a
+   * trailing bump, a reader whose data load already returned the NEW bytes could still read the OLD
+   * generation at validation time and certify bytes the publisher was mid-way through writing. With
+   * the odd marker published first, and the {@code storeStore} fence pinning it there, the data store
+   * cannot become visible before the odd store, so a reader that saw the new bytes must, by
+   * coherence, see at least the odd generation when it validates.
+   * </p>
+   *
+   * @param segment the new backing segment
+   */
+  private void publishSlotMemory(final MemorySegment segment) {
+    final long generation = stampBindingGeneration;
+    stampBindingGeneration = generation + 1;
+    VarHandle.storeStoreFence();
+    // The new segment IS the allocation, so any zero-copy base override no longer applies — and
+    // leaving it set would resolve the OLD, already-released allocation and hand back coordinates
+    // for a slot this page no longer reads.
+    stampBaseSegment = null;
+    slotMemory = segment;
+    stampCoordinates = slotCoordinatesOf(segment);
+    stampBindingGeneration = generation + 2;
   }
 
   // ===== Guard-based lifetime management =====

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -54,6 +54,8 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -192,6 +194,19 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
 
   private static final ValueLayout.OfShort JAVA_SHORT_BE_UNALIGNED =
       ValueLayout.JAVA_SHORT.withByteAlignment(1).withOrder(ByteOrder.BIG_ENDIAN);
+
+  /**
+   * The on-heap counterpart of {@link #JAVA_LONG_BE_UNALIGNED}: reads eight bytes of a probe key as
+   * one big-endian {@code long}, so a key comparison can consume both sides a word at a time.
+   *
+   * <p>
+   * HFT: this compiles to a single unaligned load plus a byte swap. The hand-rolled alternative —
+   * eight {@code &0xFF} loads shifted and or-ed together — is what the suffix comparator used to do,
+   * and C2 does not reliably fold that idiom back into one load, so it cost eight bounds-checked
+   * array reads per word on the hottest loop in a point lookup.
+   */
+  private static final VarHandle BYTE_ARRAY_LONG_BE =
+      MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.BIG_ENDIAN);
 
   /**
    * {@link #valueRef} sentinel for a slot that does not address a readable value. Chosen as
@@ -869,15 +884,12 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
     final int keySuffixLen = keyLen - keySuffixStart;
     final int minLen = Math.min(suffixLen, keySuffixLen);
 
-    // Fast path: compare 8 bytes at a time
+    // Fast path: compare 8 bytes at a time. Both sides are single word loads — see
+    // BYTE_ARRAY_LONG_BE for why the probe side is not assembled from eight shifted byte reads.
     int i = 0;
     for (; i + 8 <= minLen; i += 8) {
       final long aWord = slotMemory.get(JAVA_LONG_BE_UNALIGNED, suffixStart + i);
-      final long bWord = ((long) (key[keySuffixStart + i] & 0xFF) << 56)
-          | ((long) (key[keySuffixStart + i + 1] & 0xFF) << 48) | ((long) (key[keySuffixStart + i + 2] & 0xFF) << 40)
-          | ((long) (key[keySuffixStart + i + 3] & 0xFF) << 32) | ((long) (key[keySuffixStart + i + 4] & 0xFF) << 24)
-          | ((long) (key[keySuffixStart + i + 5] & 0xFF) << 16) | ((long) (key[keySuffixStart + i + 6] & 0xFF) << 8)
-          | (long) (key[keySuffixStart + i + 7] & 0xFF);
+      final long bWord = (long) BYTE_ARRAY_LONG_BE.get(key, keySuffixStart + i);
       if (aWord != bWord) {
         return Long.compareUnsigned(aWord, bWord);
       }
@@ -1104,24 +1116,37 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
    * The single home for this leaf's key-byte addressing (the {@code u16} suffix-length header, the
    * {@code offset + 2} suffix start): {@link #compareKeyWithBound}, {@link #compareKeyPrefix} and
    * {@link #compareKeyPrefixPart} differ only in how far they compare and how they break a tie, so
-   * having them share this loop keeps the slot layout described once. Small enough to inline, which
-   * matters because all three sit on read hot paths.
+   * having them share this loop keeps the slot layout described once. All three sit on read hot
+   * paths, so it stays well inside {@code FreqInlineSize} and inlines into each of them.
+   *
+   * <p>
+   * HFT: both halves consume the key wholesale rather than a byte at a time. The prefix half is a
+   * {@link Arrays#mismatch(byte[], int, int, byte[], int, int)} intrinsic; the suffix half reads
+   * eight bytes per iteration from each side, which also divides the per-access
+   * {@code MemorySegment} overhead — bounds check, session liveness check, endian conversion — by
+   * eight. Only the sign of the result is defined, as it always was: every caller feeds it into a
+   * {@code < 0} / {@code > 0} test.
    */
   private int compareKeyBytes(final int index, final byte[] probe, final int cmpLen) {
-    final int offset = slotOffsets[index];
-    final long suffixStart = offset + 2;
-    int p = 0;
     final int commonMin = Math.min(commonPrefixLen, cmpLen);
-    while (p < commonMin) {
-      final int a = commonPrefix[p] & 0xFF;
-      final int b = probe[p] & 0xFF;
+    final int prefixMismatch = Arrays.mismatch(commonPrefix, 0, commonMin, probe, 0, commonMin);
+    if (prefixMismatch >= 0) {
+      return (commonPrefix[prefixMismatch] & 0xFF) - (probe[prefixMismatch] & 0xFF);
+    }
+    if (commonMin == cmpLen) {
+      return 0;
+    }
+    final long suffixStart = slotOffsets[index] + 2L - commonPrefixLen;
+    int p = commonMin;
+    for (final int wordEnd = cmpLen - 8; p <= wordEnd; p += 8) {
+      final long a = slotMemory.get(JAVA_LONG_BE_UNALIGNED, suffixStart + p);
+      final long b = (long) BYTE_ARRAY_LONG_BE.get(probe, p);
       if (a != b) {
-        return a - b;
+        return Long.compareUnsigned(a, b);
       }
-      p++;
     }
     while (p < cmpLen) {
-      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + (p - commonPrefixLen)) & 0xFF;
+      final int a = slotMemory.get(ValueLayout.JAVA_BYTE, suffixStart + p) & 0xFF;
       final int b = probe[p] & 0xFF;
       if (a != b) {
         return a - b;

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -2345,7 +2345,28 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
     int index = findEntry(keySlice);
 
     if (index >= 0) {
-      // Key exists - merge NodeReferences
+      // Key exists - merge NodeReferences.
+      // HFT fast path: a single-bit packed merge into a packed bucket (the dominant churn case)
+      // runs straight off slot memory — no existing-value copy, no bitmap round-trip. Byte-
+      // identical to the slow path below.
+      final long existingRef = valueRef(index);
+      if (existingRef != NO_VALUE_REF) {
+        if (NodeReferencesSerializer.isTombstone(this, existingRef)) {
+          final byte[] valueSlice = valueLen == value.length
+              ? value
+              : Arrays.copyOf(value, valueLen);
+          return updateValue(index, valueSlice);
+        }
+        final byte[] fastMerged =
+            NodeReferencesSerializer.mergePackedSingleBitFromSlot(this, existingRef, value, 0, valueLen);
+        if (fastMerged == NodeReferencesSerializer.MERGE_UNCHANGED) {
+          return true; // new key already present — merged set unchanged, slot rewrite unnecessary
+        }
+        if (fastMerged != null) {
+          return updateValue(index, fastMerged);
+        }
+      }
+
       final byte[] existingValue = getValue(index);
 
       if (NodeReferencesSerializer.isTombstone(existingValue, 0, existingValue.length)) {
@@ -2353,16 +2374,6 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, io.sirix.cac
             ? value
             : Arrays.copyOf(value, valueLen);
         return updateValue(index, valueSlice);
-      }
-
-      // HFT fast path: a single-bit packed merge into a packed bucket (the dominant churn case)
-      // avoids 2 Roaring64Bitmap + 2 NodeReferences allocations. byte-identical to the slow path.
-      final byte[] fastMerged = NodeReferencesSerializer.mergePackedSingleBit(existingValue, value, 0, valueLen);
-      if (fastMerged == existingValue) {
-        return true; // new key already present — merged set unchanged, slot rewrite unnecessary
-      }
-      if (fastMerged != null) {
-        return updateValue(index, fastMerged);
       }
 
       // Deserialize both and merge

--- a/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/HOTLeafPage.java
@@ -1122,10 +1122,10 @@ public final class HOTLeafPage implements KeyValuePage<DataRecord>, CacheablePag
    * <p>
    * HFT: both halves consume the key wholesale rather than a byte at a time. The prefix half is a
    * {@link Arrays#mismatch(byte[], int, int, byte[], int, int)} intrinsic; the suffix half reads
-   * eight bytes per iteration from each side, which also divides the per-access
-   * {@code MemorySegment} overhead — bounds check, session liveness check, endian conversion — by
-   * eight. Only the sign of the result is defined, as it always was: every caller feeds it into a
-   * {@code < 0} / {@code > 0} test.
+   * eight bytes per iteration from each side, which also divides the per-access {@code MemorySegment}
+   * overhead — bounds check, session liveness check, endian conversion — by eight. Only the sign of
+   * the result is defined, as it always was: every caller feeds it into a {@code < 0} / {@code > 0}
+   * test.
    */
   private int compareKeyBytes(final int index, final byte[] probe, final int cmpLen) {
     final int commonMin = Math.min(commonPrefixLen, cmpLen);

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -1186,7 +1186,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     // Bound the view to the REAL capacity: reinterpret(Long.MAX_VALUE) disabled every FFM
     // bounds check on the hottest read/write surface, turning any directory/heap-offset bug
     // into silent cross-segment corruption inside the shared region instead of an exception.
-    slottedPage = allocated.reinterpret(slottedPageCapacity);
+    publishSlottedPage(allocated.reinterpret(slottedPageCapacity));
     cachedHeapEnd = 0;
     cachedHeapUsed = 0;
     cachedPopulatedCount = 0;
@@ -1227,11 +1227,11 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
         } catch (final Throwable e) {
           LOGGER.debug("Release of pre-existing slottedPage before copy failed: {}", e.getMessage());
         }
-        slottedPage = null;
+        publishSlottedPage(null);
       }
       dst = segmentAllocator.allocate(srcCap);
       slottedPageCapacity = (int) dst.byteSize();
-      slottedPage = dst.reinterpret(slottedPageCapacity); // capacity-bounded: keep FFM bounds checks
+      publishSlottedPage(dst.reinterpret(slottedPageCapacity)); // capacity-bounded: keep FFM bounds checks
     }
     MemorySegment.copy(srcSp, 0, dst, 0, srcCap);
     cachedHeapEnd = src.cachedHeapEnd;
@@ -1255,7 +1255,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     // Release old segment (reinterpret back to actual size for allocator)
     segmentAllocator.release(slottedPage.reinterpret(currentSize));
     slottedPageCapacity = (int) grown.byteSize();
-    slottedPage = grown.reinterpret(slottedPageCapacity); // capacity-bounded: keep FFM bounds checks
+    publishSlottedPage(grown.reinterpret(slottedPageCapacity)); // capacity-bounded: keep FFM bounds checks
     // No rebind needed: the caller (serializeToHeap) will rebind the active flyweight.
     // Cached header values remain valid — grow copies all data including header.
   }
@@ -3044,7 +3044,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
       segmentAllocator.release(this.slottedPage.reinterpret(slottedPageCapacity));
     }
     this.slottedPageCapacity = (int) newSlottedPage.byteSize();
-    this.slottedPage = newSlottedPage.reinterpret(slottedPageCapacity); // capacity-bounded view
+    publishSlottedPage(newSlottedPage.reinterpret(slottedPageCapacity)); // capacity-bounded view
     this.cachedHeapEnd = PageLayout.getHeapEnd(this.slottedPage);
     this.cachedHeapUsed = PageLayout.getHeapUsed(this.slottedPage);
     this.cachedPopulatedCount = PageLayout.getPopulatedCount(this.slottedPage);
@@ -3276,6 +3276,198 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     return ((int) STATE_FLAGS_HANDLE.getVolatile(this) & CLOSED_BIT) != 0;
   }
 
+  // ===== Optimistic read stamps (Umbra/LeanStore-style, backed by FrameSlotAllocator slot versions)
+  //
+  // The reader-side half of de-pinning this page. A pin (tryAcquireGuard) is a synchronized block
+  // plus an atomic RMW on a line every concurrent reader of the page shares — a STORE, so it
+  // invalidates that line in every other core. A version snapshot is a plain acquire-load that
+  // dirties nothing, so readers of one hot page stop contending with each other entirely. Identical
+  // protocol and identical hazards to HOTLeafPage's, deliberately: the two were kept the same shape
+  // so the ABA lesson below only has to be learned once.
+
+  private static final long STAMP_COORDINATES_UNBOUND = Long.MIN_VALUE;
+
+  /**
+   * Packed {@code (classIdx << 32) | slotIdx} of the allocator slot backing {@link #slottedPage}, or
+   * {@link FrameSlotAllocator#NO_SLOT_COORDINATES} for a page whose memory is not a live frame slot
+   * (heap-backed test pages, pool-allocator rollback). Bound lazily on the first {@link #readStamp()}
+   * — one map probe per binding — and RE-bound at every site that swaps {@link #slottedPage}, since
+   * the new segment is a different slot. {@code volatile}: bound by the first reading thread,
+   * observed by all.
+   */
+  private volatile long stampCoordinates = STAMP_COORDINATES_UNBOUND;
+
+  /**
+   * Segment whose ADDRESS identifies the allocator slot, when that is not {@link #slottedPage} itself
+   * — a zero-copy deserialized page takes its slotted region as a MID-BUFFER SLICE, and the allocator
+   * keys its live-slot map by the address it handed out. Binding from a slice misses and degrades
+   * {@link #validateStamp} to a bare closed-flag test for the page's whole lifetime, which would make
+   * the protocol inert on the dominant read path.
+   */
+  private volatile MemorySegment stampBaseSegment;
+
+  /** Stamp for a page whose memory cannot be torn by slot reuse. Even, so it validates. */
+  private static final long STAMP_UNBACKED = 0L;
+
+  /** Stamp that never validates: returned while the page is closed or its slot is mid-teardown. */
+  public static final long STAMP_INVALID = 1L;
+
+  /**
+   * Tell this page which segment's address identifies its allocator slot. Called by the page
+   * deserializer right after construction, before publication, when {@link #slottedPage} is a slice
+   * of a larger allocation rather than the allocation itself.
+   *
+   * <p>
+   * NO CALLER TODAY, and package-private so it cannot acquire one from outside: this page's
+   * deserializer allocates its slotted region whole rather than slicing a shared decompression
+   * buffer, so {@link #slottedPage} already IS the allocation. Kept rather than deleted because the
+   * failure it prevents is silent — a slicing deserializer would bind from an address the allocator
+   * never handed out, miss, and degrade {@link #validateStamp} to a bare closed-flag test for the
+   * page's whole lifetime. Any future zero-copy path here must call this.
+   * </p>
+   *
+   * @param base the segment as returned by the allocator; {@code null} clears the override
+   */
+  void setStampBaseSegment(final @Nullable MemorySegment base) {
+    this.stampBaseSegment = base;
+    this.stampCoordinates = STAMP_COORDINATES_UNBOUND;
+  }
+
+  /**
+   * Snapshot this page's read stamp. Protocol (seqlock, reader side):
+   *
+   * <pre>{@code
+   * long stamp = page.readStamp();            // odd => closed/teardown in progress: re-resolve
+   * ... any number of reads of page content ...
+   * if (!page.validateStamp(stamp)) retry;    // the slot was reclaimed mid-read: re-resolve, redo
+   * }</pre>
+   *
+   * A validated stamp proves every read since the snapshot saw stable bytes — one validation covers
+   * an arbitrary batch of reads, so a cursor may snapshot once per {@code moveTo} and validate at the
+   * end of a whole accessor rather than per field.
+   *
+   * @return the stamp to hand back to {@link #validateStamp}
+   */
+  public long readStamp() {
+    long coordinates = stampCoordinates;
+    if (coordinates == STAMP_COORDINATES_UNBOUND) {
+      // Safe to bind at any time: an address maps to exactly one physical slot, so the coordinates
+      // are a pure function of the segment — only the VERSION at them tells generations apart.
+      coordinates = bindStampCoordinates();
+    }
+    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
+      // Not frame-slot-backed. A live page's memory cannot be torn by slot reuse; a closed one must
+      // still never validate.
+      return isClosed()
+          ? STAMP_INVALID
+          : STAMP_UNBACKED;
+    }
+    final long stamp = FrameSlotAllocator.getInstance().acquireVersion((int) (coordinates >>> 32), (int) coordinates);
+    // ORDER IS LOAD-BEARING: the closed check must come AFTER the version acquire, never before.
+    // Teardown publishes CLOSED_BIT before releasing the slot, so observing it clear HERE proves the
+    // slot had not been released when the version was acquired — any later release bumps it and
+    // validateStamp fails. With the check first there is an ABA window: a slot torn down AND
+    // re-issued between check and acquire hands back a fresh, stable, EVEN version over another
+    // page's bytes, and every read of this page's stale segment then "validates". On HOTLeafPage
+    // that surfaced as silent key loss under eviction pressure (HOTLeafUseAfterCloseTest).
+    if (isClosed()) {
+      return STAMP_INVALID;
+    }
+    return stamp;
+  }
+
+  /**
+   * Whether every read since {@code stamp} was taken saw stable bytes.
+   *
+   * @param stamp a value previously returned by {@link #readStamp()}
+   * @return {@code true} iff reads under {@code stamp} are trustworthy
+   */
+  public boolean validateStamp(final long stamp) {
+    if (stamp == STAMP_UNBACKED) {
+      // Unbacked memory has no slot version to consult; detecting a close between snapshot and
+      // validation is the strongest check available, and all the non-frame allocators need — their
+      // release path is what recycles the memory.
+      return !isClosed();
+    }
+    if ((stamp & 1L) != 0L) {
+      return false;
+    }
+    final long coordinates = stampCoordinates;
+    if (coordinates == STAMP_COORDINATES_UNBOUND || coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
+      // A backed stamp was issued, so coordinates were bound when it was read; reaching here means
+      // the binding was reset by a concurrent segment swap — the old stamp is no longer provable.
+      return false;
+    }
+    return FrameSlotAllocator.getInstance().validateVersion((int) (coordinates >>> 32), (int) coordinates, stamp);
+  }
+
+  private long bindStampCoordinates() {
+    final MemorySegment segment = slottedPage;
+    if (segment == null) {
+      // Nothing allocated yet (or evicted). Do NOT cache this: a later ensureSlottedPage would find
+      // the binding already resolved to "unbacked" and the protocol would stay inert.
+      return FrameSlotAllocator.NO_SLOT_COORDINATES;
+    }
+    final MemorySegmentAllocator allocator = Allocators.getInstance();
+    // Resolve against the segment the ALLOCATOR handed out, which is the whole allocation — for a
+    // zero-copy page that is stampBaseSegment, not the slice in slottedPage. See the field javadoc.
+    final MemorySegment base = stampBaseSegment;
+    final long coordinates = allocator instanceof final FrameSlotAllocator frameSlotAllocator
+        ? frameSlotAllocator.slotCoordinates(base != null
+            ? base
+            : segment)
+        : FrameSlotAllocator.NO_SLOT_COORDINATES;
+    stampCoordinates = coordinates;
+    return coordinates;
+  }
+
+  /**
+   * Swap {@link #slottedPage}, dropping the optimistic-read slot binding on both sides of the swap.
+   *
+   * <p>
+   * The ONLY place {@link #slottedPage} may be assigned. A stale binding points at the OLD slot,
+   * whose version moves independently of the bytes now being read, so a reader would validate against
+   * a slot it is no longer reading — the false positive the protocol must never produce. Routing
+   * every site through one setter is what keeps that from depending on each caller remembering.
+   * </p>
+   *
+   * <p>
+   * <b>The double clear is defence in depth, NOT a memory-ordering proof, and the difference matters
+   * before anything is built on this.</b> A volatile store has RELEASE semantics: it stops earlier
+   * accesses sinking below it, but does nothing to stop the PLAIN store to {@link #slottedPage} that
+   * follows from being hoisted above it. So the leading clear does not by itself close the window
+   * where a reader holds stale coordinates and reads the new segment. Worse, the coordinates are not
+   * carried IN the stamp, so a reader that snapshots slot A's version and then finds the binding
+   * rebound to slot B validates A's stamp against B's counter — two unrelated per-slot sequences that
+   * can compare equal by coincidence.
+   * </p>
+   *
+   * <p>
+   * What actually makes this safe today is an INVARIANT rather than a fence: every caller here is a
+   * write or teardown path — {@code ensureSlottedPage}, {@code growSlottedPage}, the bulk copy, and
+   * {@code close} — and teardown publishes {@code CLOSED_BIT}, which makes {@link #readStamp} answer
+   * {@link #STAMP_INVALID}. A page being grown or bulk-copied is one a writer holds, not one an
+   * optimistic reader is walking. {@code HOTLeafPage} rests on the same invariant with the same
+   * non-volatile field. That invariant is adequate for the current callers and NOT adequate for the
+   * record-read path this was added to serve: wiring a reader in requires making the stamp
+   * self-describing (its slot packed alongside its version, so a rebind cannot be mistaken for a
+   * stable read) or publishing the segment with release semantics. Do that first.
+   * </p>
+   *
+   * @param segment the new backing segment, or {@code null} when the page is releasing it
+   */
+  private void publishSlottedPage(final @Nullable MemorySegment segment) {
+    // BOTH binding fields, not just the coordinates. stampBaseSegment overrides which address
+    // bindStampCoordinates resolves against, so leaving it set makes the next bind resolve the OLD,
+    // already-released allocation and hand back coordinates for a slot this page no longer reads —
+    // the very false positive the reset exists to prevent, reintroduced by the field that was
+    // supposed to make the binding accurate. HOTLeafPage nulls it for the same reason.
+    stampBaseSegment = null;
+    stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    slottedPage = segment;
+    stampCoordinates = STAMP_COORDINATES_UNBOUND;
+  }
+
   // Leak detection lives in LeakDetectorState above (registered with LEAK_CLEANER in
   // each constructor when DEBUG_MEMORY_LEAKS is on). The deprecated finalize() override
   // was removed — Cleaner is the sanctioned post-Java-9 replacement: it doesn't run on
@@ -3369,7 +3561,7 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
       } catch (Throwable e) {
         LOGGER.debug("Failed to release slotted page for page {}: {}", recordPageKey, e.getMessage());
       }
-      slottedPage = null;
+      publishSlottedPage(null);
       slottedPageCapacity = 0;
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -1199,9 +1199,10 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    *
    * <p>
    * If {@code this} already has a slotted page (via eager {@code ensureSlottedPage} in the
-   * constructor), it is released first — the constructor's allocation is wasted for the combine path,
-   * but reusing it in place requires handling size-class mismatches that rarely hit. Net: trade one
-   * 64 KiB release for a 1024× loop skip.
+   * constructor) and its capacity does not match, the replacement is allocated and published and only
+   * then is the old one released — the constructor's allocation is wasted for the combine path, but
+   * reusing it in place requires handling size-class mismatches that rarely hit. Net: trade one 64 KiB
+   * release for a 1024× loop skip.
    *
    * <p>
    * Overwrites the header's revision field after the copy so downstream readers observe this page's
@@ -1221,17 +1222,22 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     if (slottedPage != null && slottedPageCapacity == srcCap) {
       dst = slottedPage.reinterpret(srcCap);
     } else {
-      if (slottedPage != null) {
-        try {
-          segmentAllocator.release(slottedPage.reinterpret(slottedPageCapacity));
-        } catch (final Throwable e) {
-          LOGGER.debug("Release of pre-existing slottedPage before copy failed: {}", e.getMessage());
-        }
-        publishSlottedPage(null);
-      }
+      // Allocate and PUBLISH before releasing the old segment — see growSlottedPage for why a slot
+      // must not be released while the page still points at it. Also leaves the page holding its
+      // previous segment rather than nothing if the allocation throws, and saves the intermediate
+      // publish of null, which was a second rebind for no reader's benefit.
+      final MemorySegment previous = slottedPage;
+      final int previousCapacity = slottedPageCapacity;
       dst = segmentAllocator.allocate(srcCap);
       slottedPageCapacity = (int) dst.byteSize();
       publishSlottedPage(dst.reinterpret(slottedPageCapacity)); // capacity-bounded: keep FFM bounds checks
+      if (previous != null) {
+        try {
+          segmentAllocator.release(previous.reinterpret(previousCapacity));
+        } catch (final Throwable e) {
+          LOGGER.debug("Release of pre-existing slottedPage before copy failed: {}", e.getMessage());
+        }
+      }
     }
     MemorySegment.copy(srcSp, 0, dst, 0, srcCap);
     cachedHeapEnd = src.cachedHeapEnd;
@@ -1251,11 +1257,17 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     final int newSize = currentSize * 2;
     final MemorySegment grown = segmentAllocator.allocate(newSize);
     // Copy all existing data
-    MemorySegment.copy(slottedPage, 0, grown, 0, currentSize);
-    // Release old segment (reinterpret back to actual size for allocator)
-    segmentAllocator.release(slottedPage.reinterpret(currentSize));
+    final MemorySegment previous = slottedPage;
+    MemorySegment.copy(previous, 0, grown, 0, currentSize);
     slottedPageCapacity = (int) grown.byteSize();
     publishSlottedPage(grown.reinterpret(slottedPageCapacity)); // capacity-bounded: keep FFM bounds checks
+    // Release the old segment only AFTER the new one is published, not before. While the page still
+    // points at a segment, an optimistic reader's stamp resolves to that segment's slot — and a slot
+    // released under a live binding is one whose bytes can be handed to another page while the
+    // binding still certifies reads of them. Publishing first means every such reader has already
+    // been invalidated by the rebind. Costs one extra live slot for the duration of the copy.
+    // (Reinterpret back to the actual size for the allocator.)
+    segmentAllocator.release(previous.reinterpret(currentSize));
     // No rebind needed: the caller (serializeToHeap) will rebind the active flyweight.
     // Cached header values remain valid — grow copies all data including header.
   }
@@ -3039,12 +3051,21 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @param slottedPage the slotted page segment
    */
   public void setSlottedPage(final MemorySegment newSlottedPage) {
-    // Release old slotted page if different from the new one
-    if (this.slottedPage != null && this.slottedPage != newSlottedPage) {
-      segmentAllocator.release(this.slottedPage.reinterpret(slottedPageCapacity));
-    }
+    final MemorySegment previous = this.slottedPage;
+    final int previousCapacity = this.slottedPageCapacity;
     this.slottedPageCapacity = (int) newSlottedPage.byteSize();
     publishSlottedPage(newSlottedPage.reinterpret(slottedPageCapacity)); // capacity-bounded view
+    // Release the old slotted page — if there was one, and if it is not the segment just published —
+    // only AFTER the publication. See growSlottedPage: a slot released while the page still points
+    // at it can be handed to another page under a reader whose binding still certifies it.
+    //
+    // Compared by ADDRESS, not identity: a segment stored here has been through reinterpret, which
+    // returns a fresh object over the same memory, so an identity test would answer "different" for
+    // a caller re-publishing the very segment this page already holds — and then free it out from
+    // under the publication one line above.
+    if (previous != null && previous.address() != newSlottedPage.address()) {
+      segmentAllocator.release(previous.reinterpret(previousCapacity));
+    }
     this.cachedHeapEnd = PageLayout.getHeapEnd(this.slottedPage);
     this.cachedHeapUsed = PageLayout.getHeapUsed(this.slottedPage);
     this.cachedPopulatedCount = PageLayout.getPopulatedCount(this.slottedPage);
@@ -3278,37 +3299,66 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
 
   // ===== Optimistic read stamps (Umbra/LeanStore-style, backed by FrameSlotAllocator slot versions)
   //
-  // The reader-side half of de-pinning this page. A pin (tryAcquireGuard) is a synchronized block
-  // plus an atomic RMW on a line every concurrent reader of the page shares — a STORE, so it
-  // invalidates that line in every other core. A version snapshot is a plain acquire-load that
-  // dirties nothing, so readers of one hot page stop contending with each other entirely. Identical
-  // protocol and identical hazards to HOTLeafPage's, deliberately: the two were kept the same shape
-  // so the ABA lesson below only has to be learned once.
+  // A pin (tryAcquireGuard) is a synchronized block plus an atomic RMW on a line every concurrent
+  // reader of the page shares — a STORE, so it invalidates that line in every other core. A version
+  // snapshot is a plain acquire-load that dirties nothing, so readers of one hot page stop contending
+  // with each other entirely. Identical protocol and identical hazards to HOTLeafPage's,
+  // deliberately: the two were kept the same shape so the ABA lesson below only has to be learned
+  // once.
+  //
+  // NO READER OF THIS PAGE TYPE DEPENDS ON IT YET, and that is a decision rather than an omission.
+  // It was built to de-pin the record cursor, and the measurement said not to: a guard is paid per
+  // PAGE SWITCH (a record page holds 1024 records, and moveToSingleton has a within-page fast path
+  // that takes no guard at all) while a stamp would be paid per VALIDATED READ, so the trade loses by
+  // orders of magnitude on any cursor with locality. HOTLeafPage's identical protocol DOES pay,
+  // because a trie descent touches a different leaf at every level. Kept, tested and correct because
+  // the reasoning turns on locality rather than on the protocol, and a reader without locality would
+  // revive it. See docs/RECORD_PATH_DEPINNING.md.
 
+  /** Coordinates of a page with no segment published at all — nothing to read, nothing to tear. */
   private static final long STAMP_COORDINATES_UNBOUND = Long.MIN_VALUE;
 
   /**
    * Packed {@code (classIdx << 32) | slotIdx} of the allocator slot backing {@link #slottedPage}, or
    * {@link FrameSlotAllocator#NO_SLOT_COORDINATES} for a page whose memory is not a live frame slot
-   * (heap-backed test pages, pool-allocator rollback). Bound lazily on the first {@link #readStamp()}
-   * — one map probe per binding — and RE-bound at every site that swaps {@link #slottedPage}, since
-   * the new segment is a different slot. {@code volatile}: bound by the first reading thread,
-   * observed by all.
+   * (heap-backed test pages, pool-allocator rollback).
+   *
+   * <p>
+   * Written ONLY by {@link #publishSlottedPage}, in the same rebind window as the segment itself, and
+   * never by a reader. It used to be bound lazily by the first {@link #readStamp()}, which is one map
+   * probe cheaper for a page nobody ever stamps — but it also put a STORE on the reader side, and a
+   * reader's store cannot be ordered against a concurrent publisher's: a reader that computed
+   * coordinates from the old segment could land them after the publisher had already reset them,
+   * leaving the OLD slot's coordinates describing the NEW segment. Every later reader would then
+   * validate its reads against a counter belonging to memory it is not reading — the exact false
+   * positive this whole protocol exists to rule out. Binding in the publisher costs one map probe per
+   * segment swap — none of which is on a read path — and takes the store off the read path entirely.
+   * </p>
    */
   private volatile long stampCoordinates = STAMP_COORDINATES_UNBOUND;
 
   /**
-   * Monotonic counter identifying the CURRENT binding, bumped every time {@link #stampCoordinates}
-   * could come to name a different slot.
+   * Sequence number identifying the CURRENT binding: EVEN when {@link #stampCoordinates} and
+   * {@link #slottedPage} agree, ODD while {@link #publishSlottedPage} is swapping them.
    *
    * <p>
    * The piece that makes a stamp self-describing without packing two quantities into one
    * {@code long}. A slot version is meaningless on its own — it is a sequence private to one slot,
    * and two slots can carry equal values at the same moment — so a reader must prove it is validating
    * against the SAME binding it read under. It carries this alongside the stamp and hands both back;
-   * a rebind in between changes the generation and the read is retried. Monotonic rather than a flag
-   * so that a rebind back to the same slot is still detected. {@code volatile}: written under the
-   * segment swap, read by every validating reader.
+   * a rebind in between changes the generation and the read is retried. A counter rather than a flag
+   * so that a rebind back to the same slot is still detected.
+   * </p>
+   *
+   * <p>
+   * The parity is what turns the check from a likelihood into a proof, and it is worth stating why a
+   * single post-swap increment is not enough. With one increment there is no marker published BEFORE
+   * the segment store, so a reader whose data load returned the new bytes can still observe the old
+   * generation at validation time and certify bytes the publisher was mid-way through writing. With
+   * the odd marker published first — and a {@code storeStore} fence pinning it there — a data load
+   * that returned the new bytes proves the odd store was globally visible before it, hence before the
+   * reader's own validation load, which coherence then forces to observe at least that value. Both
+   * the odd generation and the later even one fail the check.
    * </p>
    */
   private volatile long stampBindingGeneration;
@@ -3345,11 +3395,14 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @param base the segment as returned by the allocator; {@code null} clears the override
    */
   void setStampBaseSegment(final @Nullable MemorySegment base) {
-    this.stampBaseSegment = base;
-    this.stampCoordinates = STAMP_COORDINATES_UNBOUND;
-    // Changing the base changes which slot the next bind resolves to, so it is a rebind like any
-    // other and must invalidate outstanding stamps.
-    this.stampBindingGeneration++;
+    // Changing the base changes which slot the coordinates resolve to, so it is a rebind like any
+    // other: same odd/even window, same fence, same invalidation of outstanding stamps.
+    final long generation = stampBindingGeneration;
+    stampBindingGeneration = generation + 1;
+    VarHandle.storeStoreFence();
+    stampBaseSegment = base;
+    stampCoordinates = slotCoordinatesOf(slottedPage);
+    stampBindingGeneration = generation + 2;
   }
 
   /**
@@ -3367,7 +3420,8 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * snapshot and validation changes the generation, so validation fails and the read is retried.
    * </p>
    *
-   * @return the current binding generation
+   * @return the current binding generation; ODD means a rebind is in flight and no read taken now can
+   *         be proved, which {@link #validateStamp(long, long)} rejects
    */
   public long readStampBinding() {
     return stampBindingGeneration;
@@ -3396,15 +3450,10 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @return the stamp to hand back to {@link #validateStamp(long, long)}
    */
   public long readStamp() {
-    long coordinates = stampCoordinates;
-    if (coordinates == STAMP_COORDINATES_UNBOUND) {
-      // Safe to bind at any time: an address maps to exactly one physical slot, so the coordinates
-      // are a pure function of the segment — only the VERSION at them tells generations apart.
-      coordinates = bindStampCoordinates();
-    }
-    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES) {
-      // Not frame-slot-backed. A live page's memory cannot be torn by slot reuse; a closed one must
-      // still never validate.
+    final long coordinates = stampCoordinates;
+    if (coordinates == FrameSlotAllocator.NO_SLOT_COORDINATES || coordinates == STAMP_COORDINATES_UNBOUND) {
+      // Not frame-slot-backed, or nothing published yet. A live page's memory cannot be torn by slot
+      // reuse; a closed one must still never validate.
       return isClosed()
           ? STAMP_INVALID
           : STAMP_UNBACKED;
@@ -3431,12 +3480,18 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * @return {@code true} iff reads under {@code stamp} are trustworthy
    */
   public boolean validateStamp(final long bindingAtRead, final long stamp) {
+    // No load taken under the stamp may sink below the generation check, or the check would be
+    // answering about a moment earlier than the reads it is certifying. A volatile load is an
+    // ACQUIRE, which stops later accesses floating up but does nothing to stop earlier ones sinking
+    // down — so the fence is not redundant with the volatile field below.
+    VarHandle.acquireFence();
     // FIRST, and for both stamp kinds. The binding is what makes a stamp interpretable at all: if the
     // page has been re-bound since it was taken, the stamp belongs to a slot this page no longer
     // reads, and the version check below would compare it against an unrelated counter. This also
     // covers the segment swap itself, so the UNBACKED branch is not a special case — a page that
     // swapped from unbacked to frame-backed, or the reverse, changes generation like any other.
-    if (stampBindingGeneration != bindingAtRead) {
+    // An ODD binding was snapshotted mid-swap and can never be certified, whatever it compares to.
+    if (stampBindingGeneration != bindingAtRead || (bindingAtRead & 1L) != 0L) {
       return false;
     }
     if (stamp == STAMP_UNBACKED) {
@@ -3457,24 +3512,29 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     return FrameSlotAllocator.getInstance().validateVersion((int) (coordinates >>> 32), (int) coordinates, stamp);
   }
 
-  private long bindStampCoordinates() {
-    final MemorySegment segment = slottedPage;
+  /**
+   * The allocator slot {@code segment} lives in, for {@link #stampCoordinates}. Publisher-side only —
+   * called inside a rebind window, never by a reader.
+   *
+   * @param segment the segment about to become {@link #slottedPage}, or {@code null} when the page is
+   *        releasing it
+   * @return packed slot coordinates, {@link FrameSlotAllocator#NO_SLOT_COORDINATES} when the memory
+   *         is not a live frame slot, or {@link #STAMP_COORDINATES_UNBOUND} when there is no segment
+   */
+  private long slotCoordinatesOf(final @Nullable MemorySegment segment) {
     if (segment == null) {
-      // Nothing allocated yet (or evicted). Do NOT cache this: a later ensureSlottedPage would find
-      // the binding already resolved to "unbacked" and the protocol would stay inert.
-      return FrameSlotAllocator.NO_SLOT_COORDINATES;
+      return STAMP_COORDINATES_UNBOUND;
     }
     final MemorySegmentAllocator allocator = Allocators.getInstance();
+    if (!(allocator instanceof final FrameSlotAllocator frameSlotAllocator)) {
+      return FrameSlotAllocator.NO_SLOT_COORDINATES;
+    }
     // Resolve against the segment the ALLOCATOR handed out, which is the whole allocation — for a
     // zero-copy page that is stampBaseSegment, not the slice in slottedPage. See the field javadoc.
     final MemorySegment base = stampBaseSegment;
-    final long coordinates = allocator instanceof final FrameSlotAllocator frameSlotAllocator
-        ? frameSlotAllocator.slotCoordinates(base != null
-            ? base
-            : segment)
-        : FrameSlotAllocator.NO_SLOT_COORDINATES;
-    stampCoordinates = coordinates;
-    return coordinates;
+    return frameSlotAllocator.slotCoordinates(base != null
+        ? base
+        : segment);
   }
 
   /**
@@ -3488,45 +3548,47 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * </p>
    *
    * <p>
-   * <b>The double clear is defence in depth, NOT a memory-ordering proof, and the difference matters
-   * before anything is built on this.</b> A volatile store has RELEASE semantics: it stops earlier
-   * accesses sinking below it, but does nothing to stop the PLAIN store to {@link #slottedPage} that
-   * follows from being hoisted above it. So the leading clear does not by itself close the window
-   * where a reader holds stale coordinates and reads the new segment. Worse, the coordinates are not
-   * carried IN the stamp, so a reader that snapshots slot A's version and then finds the binding
-   * rebound to slot B validates A's stamp against B's counter — two unrelated per-slot sequences that
-   * can compare equal by coincidence.
+   * <b>This is a seqlock write, and every part of the sequence is load-bearing.</b> The generation is
+   * driven ODD before anything else moves and EVEN again once everything has, so the window in which
+   * segment and coordinates disagree is exactly the window in which no stamp can validate. The order
+   * cannot be relaxed into a single trailing increment: a volatile store has RELEASE semantics, which
+   * stops earlier accesses sinking below it but does nothing to stop the PLAIN store to
+   * {@link #slottedPage} being hoisted above it — so with only a trailing bump, a reader whose data
+   * load already returned the NEW bytes could still read the OLD generation at validation time and
+   * certify bytes the publisher was mid-way through writing. With the odd marker published first, and
+   * the {@code storeStore} fence pinning it there, that is impossible: the data store cannot become
+   * visible before the odd store, so a reader that saw the new bytes must, by coherence, see a
+   * generation of at least the odd one when it validates.
    * </p>
    *
    * <p>
-   * What actually makes this safe today is an INVARIANT rather than a fence: every caller here is a
-   * write or teardown path — {@code ensureSlottedPage}, {@code growSlottedPage}, the bulk copy, and
-   * {@code close} — and teardown publishes {@code CLOSED_BIT}, which makes {@link #readStamp} answer
-   * {@link #STAMP_INVALID}. A page being grown or bulk-copied is one a writer holds, not one an
-   * optimistic reader is walking. {@code HOTLeafPage} rests on the same invariant with the same
-   * non-volatile field. That invariant is adequate for the current callers and NOT adequate for the
-   * record-read path this was added to serve: wiring a reader in requires making the stamp
-   * self-describing (its slot packed alongside its version, so a rebind cannot be mistaken for a
-   * stable read) or publishing the segment with release semantics. Do that first.
+   * What this replaced was an INVARIANT rather than a proof — every caller here is a write or
+   * teardown path ({@code ensureSlottedPage}, {@code growSlottedPage}, the bulk copy, {@code close}),
+   * and teardown publishes {@code CLOSED_BIT}, which makes {@link #readStamp} answer
+   * {@link #STAMP_INVALID}. That was adequate while no optimistic reader could be walking a page mid
+   * swap, and stops being adequate the moment the record-read path stops pinning.
    * </p>
    *
    * @param segment the new backing segment, or {@code null} when the page is releasing it
    */
   private void publishSlottedPage(final @Nullable MemorySegment segment) {
-    // BOTH binding fields, not just the coordinates. stampBaseSegment overrides which address
-    // bindStampCoordinates resolves against, so leaving it set makes the next bind resolve the OLD,
-    // already-released allocation and hand back coordinates for a slot this page no longer reads —
-    // the very false positive the reset exists to prevent, reintroduced by the field that was
-    // supposed to make the binding accurate. HOTLeafPage nulls it for the same reason.
+    final long generation = stampBindingGeneration;
+    // Enter the rebind. Published BEFORE the segment moves, and fenced there, which is what lets a
+    // reader conclude anything at all from having observed the new bytes (see the javadoc).
+    stampBindingGeneration = generation + 1;
+    VarHandle.storeStoreFence();
+    // BOTH binding fields, not just the coordinates. stampBaseSegment overrides which address the
+    // coordinates resolve against, so leaving it set would resolve the OLD, already-released
+    // allocation and hand back coordinates for a slot this page no longer reads — the very false
+    // positive the reset exists to prevent, reintroduced by the field that was supposed to make the
+    // binding accurate. HOTLeafPage nulls it for the same reason.
     stampBaseSegment = null;
-    stampCoordinates = STAMP_COORDINATES_UNBOUND;
     slottedPage = segment;
-    stampCoordinates = STAMP_COORDINATES_UNBOUND;
-    // LAST, so that a reader which already loaded the new generation cannot then observe the OLD
-    // coordinates: everything above is ordered before this volatile store, and a reader compares
-    // generations after its own reads. A stamp taken before the swap carries the old generation and
-    // can no longer validate.
-    stampBindingGeneration++;
+    stampCoordinates = slotCoordinatesOf(segment);
+    // Leave the rebind. Everything above is ordered before this volatile store, so a reader that
+    // observes this generation observes the segment and the coordinates that go with it. A stamp
+    // taken before the swap carries the old generation and can no longer validate.
+    stampBindingGeneration = generation + 2;
   }
 
   // Leak detection lives in LeakDetectorState above (registered with LEAK_CLEANER in

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -3298,6 +3298,22 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
   private volatile long stampCoordinates = STAMP_COORDINATES_UNBOUND;
 
   /**
+   * Monotonic counter identifying the CURRENT binding, bumped every time {@link #stampCoordinates}
+   * could come to name a different slot.
+   *
+   * <p>
+   * The piece that makes a stamp self-describing without packing two quantities into one
+   * {@code long}. A slot version is meaningless on its own — it is a sequence private to one slot,
+   * and two slots can carry equal values at the same moment — so a reader must prove it is validating
+   * against the SAME binding it read under. It carries this alongside the stamp and hands both back;
+   * a rebind in between changes the generation and the read is retried. Monotonic rather than a flag
+   * so that a rebind back to the same slot is still detected. {@code volatile}: written under the
+   * segment swap, read by every validating reader.
+   * </p>
+   */
+  private volatile long stampBindingGeneration;
+
+  /**
    * Segment whose ADDRESS identifies the allocator slot, when that is not {@link #slottedPage} itself
    * — a zero-copy deserialized page takes its slotted region as a MID-BUFFER SLICE, and the allocator
    * keys its live-slot map by the address it handed out. Binding from a slice misses and degrades
@@ -3331,22 +3347,53 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
   void setStampBaseSegment(final @Nullable MemorySegment base) {
     this.stampBaseSegment = base;
     this.stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    // Changing the base changes which slot the next bind resolves to, so it is a rebind like any
+    // other and must invalidate outstanding stamps.
+    this.stampBindingGeneration++;
+  }
+
+  /**
+   * The binding this page's stamps are currently issued against — snapshot it BEFORE
+   * {@link #readStamp()} and hand both back to {@link #validateStamp(long, long)}.
+   *
+   * <p>
+   * A stamp alone cannot be validated, and that is not an API wart but the shape of the problem. A
+   * stamp is a per-SLOT sequence number, so it only means anything paired with the slot it came from;
+   * two slots' counters are unrelated and can hold equal values at the same instant. Validating a
+   * stamp against whatever slot the page happens to be bound to NOW therefore compares a version to a
+   * counter that never produced it, and can return {@code true} by coincidence — a reader certifying
+   * bytes from one allocation against another's sequence. Carrying the binding in the reader's own
+   * frame costs one extra {@code long} on the stack and makes that impossible: any rebind between
+   * snapshot and validation changes the generation, so validation fails and the read is retried.
+   * </p>
+   *
+   * @return the current binding generation
+   */
+  public long readStampBinding() {
+    return stampBindingGeneration;
   }
 
   /**
    * Snapshot this page's read stamp. Protocol (seqlock, reader side):
    *
    * <pre>{@code
+   * long binding = page.readStampBinding();   // the slot generation the stamp will belong to
    * long stamp = page.readStamp();            // odd => closed/teardown in progress: re-resolve
    * ... any number of reads of page content ...
-   * if (!page.validateStamp(stamp)) retry;    // the slot was reclaimed mid-read: re-resolve, redo
+   * if (!page.validateStamp(binding, stamp)) retry;   // torn or rebound: re-resolve, redo
    * }</pre>
    *
    * A validated stamp proves every read since the snapshot saw stable bytes — one validation covers
    * an arbitrary batch of reads, so a cursor may snapshot once per {@code moveTo} and validate at the
    * end of a whole accessor rather than per field.
    *
-   * @return the stamp to hand back to {@link #validateStamp}
+   * <p>
+   * Reading the binding FIRST is what makes the pair safe. A rebind landing between the two reads
+   * bumps the generation, so the stamp is validated against a binding that no longer matches and the
+   * reader retries — conservative in the only direction that is safe.
+   * </p>
+   *
+   * @return the stamp to hand back to {@link #validateStamp(long, long)}
    */
   public long readStamp() {
     long coordinates = stampCoordinates;
@@ -3379,10 +3426,19 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
   /**
    * Whether every read since {@code stamp} was taken saw stable bytes.
    *
+   * @param bindingAtRead the value {@link #readStampBinding()} returned before the stamp was taken
    * @param stamp a value previously returned by {@link #readStamp()}
    * @return {@code true} iff reads under {@code stamp} are trustworthy
    */
-  public boolean validateStamp(final long stamp) {
+  public boolean validateStamp(final long bindingAtRead, final long stamp) {
+    // FIRST, and for both stamp kinds. The binding is what makes a stamp interpretable at all: if the
+    // page has been re-bound since it was taken, the stamp belongs to a slot this page no longer
+    // reads, and the version check below would compare it against an unrelated counter. This also
+    // covers the segment swap itself, so the UNBACKED branch is not a special case — a page that
+    // swapped from unbacked to frame-backed, or the reverse, changes generation like any other.
+    if (stampBindingGeneration != bindingAtRead) {
+      return false;
+    }
     if (stamp == STAMP_UNBACKED) {
       // Unbacked memory has no slot version to consult; detecting a close between snapshot and
       // validation is the strongest check available, and all the non-frame allocators need — their
@@ -3466,6 +3522,11 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
     stampCoordinates = STAMP_COORDINATES_UNBOUND;
     slottedPage = segment;
     stampCoordinates = STAMP_COORDINATES_UNBOUND;
+    // LAST, so that a reader which already loaded the new generation cannot then observe the OLD
+    // coordinates: everything above is ordered before this volatile store, and a reader compares
+    // generations after its own reads. A stamp taken before the swap carries the old generation and
+    // can no longer validate.
+    stampBindingGeneration++;
   }
 
   // Leak detection lives in LeakDetectorState above (registered with LEAK_CLEANER in

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -1201,8 +1201,8 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
    * If {@code this} already has a slotted page (via eager {@code ensureSlottedPage} in the
    * constructor) and its capacity does not match, the replacement is allocated and published and only
    * then is the old one released — the constructor's allocation is wasted for the combine path, but
-   * reusing it in place requires handling size-class mismatches that rarely hit. Net: trade one 64 KiB
-   * release for a 1024× loop skip.
+   * reusing it in place requires handling size-class mismatches that rarely hit. Net: trade one 64
+   * KiB release for a 1024× loop skip.
    *
    * <p>
    * Overwrites the header's revision field after the copy so downstream readers observe this page's

--- a/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/PageKind.java
@@ -4303,12 +4303,19 @@ public enum PageKind {
       final Runnable releaser;
 
       final boolean canZeroCopy = decompressionResult != null && source instanceof MemorySegmentBytesIn;
+      // Base of the allocation backing slotMemory, when slotMemory is only a slice of it. The
+      // allocator's live-slot map is keyed by the address it handed out, so the page has to be
+      // told the base or its optimistic read stamps silently bind to "not slot-backed" and stop
+      // validating anything. Null on the copying path, where slotMemory IS the allocation.
+      final MemorySegment stampBase;
       if (canZeroCopy) {
         final MemorySegment sourceSegment = ((MemorySegmentBytesIn) source).getSource();
         slotMemory = sourceSegment.asSlice(source.position(), usedSlotMemorySize);
+        stampBase = sourceSegment;
         source.skip(usedSlotMemorySize);
         releaser = decompressionResult.transferOwnership();
       } else {
+        stampBase = null;
         slotMemory = allocator.allocate(HOTLeafPage.DEFAULT_SIZE);
         if (source instanceof MemorySegmentBytesIn msSource) {
           MemorySegment.copy(msSource.getSource(), source.position(), slotMemory, 0, usedSlotMemorySize);
@@ -4324,6 +4331,10 @@ public enum PageKind {
 
       final HOTLeafPage page = new HOTLeafPage(recordPageKey, revision, indexType, slotMemory, releaser, slotOffsets,
           entryCount, usedSlotMemorySize, commonPrefix, commonPrefixLen);
+      // Before the page is published: without this the zero-copy leaf's stamp binds to the slice's
+      // address, which is not an allocator key, and every validateStamp degrades to a closed-flag
+      // check for the page's whole lifetime.
+      page.setStampBaseSegment(stampBase);
       page.setCompleteDump(completeDump);
       if ((envelopeFlags & HOTLeafPage.FLAG_OVERFLOW_PAGE_REFS) != 0) {
         deserializeSegmentRefs(source, page);

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/ResourceSessionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/ResourceSessionTest.java
@@ -1,8 +1,10 @@
 package io.sirix.access.node.json;
 
 import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AbstractResourceSession;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.api.ResourceSession;
+import io.sirix.api.StorageEngineReader;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.api.json.JsonNodeTrx;
@@ -27,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,7 +95,7 @@ public final class ResourceSessionTest {
    *
    * <p>The test guards three invariants that the {@code synchronized} previously hid:
    * <ul>
-   *   <li>{@code nodeTrxIDCounter} (AtomicInteger) generates unique IDs under contention.</li>
+   *   <li>{@code trxIDCounter} (AtomicInteger) generates unique IDs under contention.</li>
    *   <li>{@code nodeTrxMap.put} (ConcurrentMap) does not double-insert under contention.</li>
    *   <li>No thread observes a partially-constructed reader (publication safety).</li>
    * </ul>
@@ -176,6 +179,120 @@ public final class ResourceSessionTest {
             throw new IllegalStateException("executor did not terminate");
           }
         }
+      }
+    }
+  }
+
+  /**
+   * The session's storage-engine bookkeeping must not grow across open/close cycles.
+   *
+   * <p>Regression: the removal in {@code NodeStorageEngineReader.close()} was gated on "no node
+   * transaction carries my id" — a lookup in the node transaction map, which is keyed by a
+   * different id space than the storage-engine map being drained. On a cold session the two
+   * counters advance in exact lockstep (a read-only open draws one id from each), so the gate was
+   * a false positive on every close and NOT ONE entry was ever removed: the map grew by one per
+   * {@code beginNodeReadOnlyTrx} for the lifetime of the session, pinning a page reader and an
+   * epoch ticket per entry.
+   *
+   * <p>The cycles run before any write transaction ON PURPOSE. {@code beginNodeTrx} draws a node
+   * id without drawing a storage-engine id, which de-aligns the two counters and masks the leak —
+   * an earlier version of this test opened a write transaction first and passed against the bug.
+   */
+  @DisplayName("open/close cycles do not leak storage engine reader bookkeeping")
+  @Test
+  public void readOnlyTrxCycles_doNotLeakStorageEngineReaderEntries() {
+    final var resource = "resource";
+    final int cycles = 64;
+
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile())) {
+      database.createResource(ResourceConfiguration.newBuilder(resource)
+                                                   .storeDiffs(false)
+                                                   .hashKind(HashType.NONE)
+                                                   .buildPathSummary(false)
+                                                   .versioningApproach(VersioningType.FULL)
+                                                   .storageType(StorageType.MEMORY_MAPPED)
+                                                   .build());
+      try (final JsonResourceSession session = database.beginResourceSession(resource)) {
+        final var internals = (AbstractResourceSession<?, ?>) session;
+        assertEquals(0, internals.activeStorageEngineReaderCount(), "a fresh session tracks nothing");
+
+        // Read-only cycles on the bootstrap revision, with the id counters still aligned.
+        for (int i = 0; i < cycles; i++) {
+          try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+            assertNotNull(rtx.moveToDocumentRoot());
+          }
+          assertEquals(0, internals.activeStorageEngineReaderCount(),
+              "storage engine reader bookkeeping grew after read-only cycle " + i);
+        }
+
+        // Same for a read-write transaction, whose bound storage engine reader carries the NODE
+        // transaction's id and lives in a different map — closing it must not add an entry here.
+        for (int i = 0; i < 8; i++) {
+          try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+            wtx.commit();
+          }
+          assertEquals(0, internals.activeStorageEngineReaderCount(),
+              "storage engine reader bookkeeping grew after write cycle " + i);
+        }
+
+        // And once more with the counters de-aligned by the writes above.
+        for (int i = 0; i < cycles; i++) {
+          try (final JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+            assertNotNull(rtx.moveToDocumentRoot());
+          }
+          assertEquals(0, internals.activeStorageEngineReaderCount(),
+              "storage engine reader bookkeeping grew after post-write read-only cycle " + i);
+        }
+      }
+    }
+  }
+
+  /**
+   * Closing a read-write transaction must not evict a live, unrelated storage engine reader.
+   *
+   * <p>Regression (mirror image of the leak above): a writer-bound storage engine reader carries
+   * its NODE transaction's id, and by the time it closed, that node transaction had already been
+   * unregistered — so the stale gate opened and {@code storageEngineReaderMap.remove(nodeTrxId)}
+   * dropped whatever reader had been handed the same number by the independent storage-engine
+   * counter. That reader stayed open but untracked, so the session never closed it at teardown.
+   *
+   * <p>The standalone reader is created FIRST, on a cold session, so it holds storage-engine id 1
+   * — exactly the id the node transaction counter hands to the first {@code beginNodeTrx}.
+   */
+  @DisplayName("closing a write trx leaves unrelated storage engine readers tracked")
+  @Test
+  public void writeTrxClose_doesNotEvictLiveStorageEngineReaders() {
+    final var resource = "resource";
+
+    try (final var database = JsonTestHelper.getDatabase(PATHS.PATH1.getFile())) {
+      database.createResource(ResourceConfiguration.newBuilder(resource)
+                                                   .storeDiffs(false)
+                                                   .hashKind(HashType.NONE)
+                                                   .buildPathSummary(false)
+                                                   .versioningApproach(VersioningType.FULL)
+                                                   .storageType(StorageType.MEMORY_MAPPED)
+                                                   .build());
+      try (final JsonResourceSession session = database.beginResourceSession(resource)) {
+        final var internals = (AbstractResourceSession<?, ?>) session;
+        final StorageEngineReader standalone = session.createStorageEngineReader();
+        try {
+          assertEquals(1, internals.activeStorageEngineReaderCount(), "the standalone reader must be tracked");
+
+          for (int i = 0; i < 8; i++) {
+            try (final JsonNodeTrx wtx = session.beginNodeTrx()) {
+              wtx.commit();
+            }
+            assertEquals(1, internals.activeStorageEngineReaderCount(),
+                "a live storage engine reader was evicted by a write trx close in round " + i);
+          }
+
+          assertFalse(standalone.isClosed(), "the standalone reader must still be open");
+        } finally {
+          standalone.close();
+        }
+
+        assertEquals(0, internals.activeStorageEngineReaderCount(),
+            "closing the last standalone reader must drain the bookkeeping");
       }
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/access/node/json/ResourceSessionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/node/json/ResourceSessionTest.java
@@ -88,16 +88,16 @@ public final class ResourceSessionTest {
 
   /**
    * Pre-fix this would have run strictly serially because beginNodeReadOnlyTrx was
-   * {@code synchronized} on the per-session monitor; post-fix all opens proceed in parallel.
-   * Either way the routine must remain race-free: every opened reader gets a unique trx ID,
-   * lands in nodeTrxMap exactly once, and the activeTrxCount() observed at the end equals
-   * the number of opens.
+   * {@code synchronized} on the per-session monitor; post-fix all opens proceed in parallel. Either
+   * way the routine must remain race-free: every opened reader gets a unique trx ID, lands in
+   * nodeTrxMap exactly once, and the activeTrxCount() observed at the end equals the number of opens.
    *
-   * <p>The test guards three invariants that the {@code synchronized} previously hid:
+   * <p>
+   * The test guards three invariants that the {@code synchronized} previously hid:
    * <ul>
-   *   <li>{@code trxIDCounter} (AtomicInteger) generates unique IDs under contention.</li>
-   *   <li>{@code nodeTrxMap.put} (ConcurrentMap) does not double-insert under contention.</li>
-   *   <li>No thread observes a partially-constructed reader (publication safety).</li>
+   * <li>{@code trxIDCounter} (AtomicInteger) generates unique IDs under contention.</li>
+   * <li>{@code nodeTrxMap.put} (ConcurrentMap) does not double-insert under contention.</li>
+   * <li>No thread observes a partially-constructed reader (publication safety).</li>
    * </ul>
    */
   @DisplayName("concurrent beginNodeReadOnlyTrx is race-free and produces unique IDs")
@@ -186,17 +186,19 @@ public final class ResourceSessionTest {
   /**
    * The session's storage-engine bookkeeping must not grow across open/close cycles.
    *
-   * <p>Regression: the removal in {@code NodeStorageEngineReader.close()} was gated on "no node
-   * transaction carries my id" — a lookup in the node transaction map, which is keyed by a
-   * different id space than the storage-engine map being drained. On a cold session the two
-   * counters advance in exact lockstep (a read-only open draws one id from each), so the gate was
-   * a false positive on every close and NOT ONE entry was ever removed: the map grew by one per
-   * {@code beginNodeReadOnlyTrx} for the lifetime of the session, pinning a page reader and an
-   * epoch ticket per entry.
+   * <p>
+   * Regression: the removal in {@code NodeStorageEngineReader.close()} was gated on "no node
+   * transaction carries my id" — a lookup in the node transaction map, which is keyed by a different
+   * id space than the storage-engine map being drained. On a cold session the two counters advance in
+   * exact lockstep (a read-only open draws one id from each), so the gate was a false positive on
+   * every close and NOT ONE entry was ever removed: the map grew by one per
+   * {@code beginNodeReadOnlyTrx} for the lifetime of the session, pinning a page reader and an epoch
+   * ticket per entry.
    *
-   * <p>The cycles run before any write transaction ON PURPOSE. {@code beginNodeTrx} draws a node
-   * id without drawing a storage-engine id, which de-aligns the two counters and masks the leak —
-   * an earlier version of this test opened a write transaction first and passed against the bug.
+   * <p>
+   * The cycles run before any write transaction ON PURPOSE. {@code beginNodeTrx} draws a node id
+   * without drawing a storage-engine id, which de-aligns the two counters and masks the leak — an
+   * earlier version of this test opened a write transaction first and passed against the bug.
    */
   @DisplayName("open/close cycles do not leak storage engine reader bookkeeping")
   @Test
@@ -250,14 +252,16 @@ public final class ResourceSessionTest {
   /**
    * Closing a read-write transaction must not evict a live, unrelated storage engine reader.
    *
-   * <p>Regression (mirror image of the leak above): a writer-bound storage engine reader carries
-   * its NODE transaction's id, and by the time it closed, that node transaction had already been
+   * <p>
+   * Regression (mirror image of the leak above): a writer-bound storage engine reader carries its
+   * NODE transaction's id, and by the time it closed, that node transaction had already been
    * unregistered — so the stale gate opened and {@code storageEngineReaderMap.remove(nodeTrxId)}
    * dropped whatever reader had been handed the same number by the independent storage-engine
    * counter. That reader stayed open but untracked, so the session never closed it at teardown.
    *
-   * <p>The standalone reader is created FIRST, on a cold session, so it holds storage-engine id 1
-   * — exactly the id the node transaction counter hands to the first {@code beginNodeTrx}.
+   * <p>
+   * The standalone reader is created FIRST, on a cold session, so it holds storage-engine id 1 —
+   * exactly the id the node transaction counter hands to the first {@code beginNodeTrx}.
    */
   @DisplayName("closing a write trx leaves unrelated storage engine readers tracked")
   @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/HOTLookupCacheInvalidationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/HOTLookupCacheInvalidationTest.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.SearchMode;
+import io.sirix.index.hot.CASKeySerializer;
+import io.sirix.index.hot.HOTIndexReader;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.brackit.query.util.path.Path.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * End-to-end cover for the invalidation the HOT point-lookup cache depends on.
+ *
+ * <p>
+ * {@link HOTLookupCacheTest} proves the cache drops the right entries when told to. This proves it
+ * is actually TOLD to — that a real point lookup through a real index populates it, and that the
+ * sweeps {@code truncateTo}, crash recovery and {@code removeResource} call actually reach it.
+ * Without this the wiring is verified only by reading it, which is exactly how the cache shipped
+ * with no invalidation at all: the premise "a committed revision is immutable" is true of ordinary
+ * commits and false of rollback, which re-issues revision numbers over different content.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class HOTLookupCacheInvalidationTest {
+
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+  private static final String RESOURCE_NAME = "hotLookupCacheResource";
+  private static final String OTHER_RESOURCE_NAME = "hotLookupCacheSibling";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    // Create the database FIRST. Databases.getGlobalBufferManager() force-initialises the JVM-global
+    // buffer manager from a 2 GB fallback budget when nothing has opened a database yet, and
+    // initializeGlobalBufferManager then no-ops for the rest of the process — so touching it first
+    // would pin every later test class in this JVM to caches a quarter of their configured size,
+    // purely because io.sirix.cache.* sorts early. Creating the database applies the real budget.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    // SKIP, do not fail, when the operator disabled the cache. Every test here asserts on occupancy
+    // in BOTH directions, and a disabled cache breaks them in both: the "a lookup populated it"
+    // assertions fail outright, and — worse — the "the sweep emptied it" assertions then pass
+    // VACUOUSLY against a table that can never hold anything, so a completely broken
+    // invalidateResource would still be green. sirix.hotLookupCache.maxEntries=0 is a documented
+    // setting that HotInMemoryReadBenchmark's instructions actively use, and a disabled cache is not
+    // a broken one; an assumption is the only outcome that is honest in that configuration. Matches
+    // the guard the sibling HOTIndexMemoizationJsoniqTest already applies per assertion.
+    assumeTrue(Databases.getGlobalBufferManager().getHOTLookupCache().isEnabled(), "the HOT lookup cache is disabled ("
+        + BufferManagerImpl.HOT_LOOKUP_CACHE_ENTRIES_PROPERTY + "=0), so there is nothing to invalidate");
+    Databases.getGlobalBufferManager().getHOTLookupCache().clear();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /**
+   * Shred one JSON document into {@code resourceName} and build a CAS index over {@code /[]/title}.
+   */
+  private static IndexDef buildIndexedResource(final Database<JsonResourceSession> database, final String resourceName,
+      final String json) {
+    database.createResource(ResourceConfiguration.newBuilder(resourceName).build());
+    try (final JsonResourceSession manager = database.beginResourceSession(resourceName);
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final IndexDef casDef = IndexDefs.createCASIdxDef(false, Type.STR,
+          Collections.singleton(parse("/[]/title", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON);
+      new JsonShredder.Builder(trx, JsonShredder.createStringReader(json),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+      manager.getWtxIndexController(trx.getRevisionNumber()).createIndexes(Set.of(casDef), trx);
+      trx.commit();
+      return casDef;
+    }
+  }
+
+  private static HOTIndexReader<CASValue> readerFor(final JsonNodeReadOnlyTrx rtx, final IndexDef casDef) {
+    return HOTIndexReader.create(rtx.getStorageEngineReader(), CASKeySerializer.INSTANCE, casDef.getType(),
+        casDef.getID());
+  }
+
+  /**
+   * One point lookup through the real reader, which is what populates the cache.
+   *
+   * <p>
+   * The probe key is taken from the index's own iterator rather than constructed: a {@link CASValue}
+   * carries the PATH-CLASS RECORD of the indexed node, not the index number, and a hand-built key
+   * with the wrong PCR serializes to different bytes and silently finds nothing.
+   * </p>
+   */
+  private static @Nullable NodeReferences lookupFirstKey(final JsonNodeReadOnlyTrx rtx, final IndexDef casDef) {
+    final HOTIndexReader<CASValue> reader = readerFor(rtx, casDef);
+    final CASValue key = firstKey(reader);
+    return reader.get(key, SearchMode.EQUAL);
+  }
+
+  /**
+   * Point-look up EVERY key of the index, memoizing one entry per key.
+   *
+   * <p>
+   * Lets a test give two resources DIFFERENT cache footprints, which is what makes a scoped-sweep
+   * assertion able to tell "swept the target" from "swept the sibling" — with one entry each, both
+   * outcomes leave the same occupancy.
+   * </p>
+   *
+   * @return the number of distinct keys looked up
+   */
+  private static int lookupAllKeys(final JsonNodeReadOnlyTrx rtx, final IndexDef casDef) {
+    final HOTIndexReader<CASValue> reader = readerFor(rtx, casDef);
+    final List<CASValue> keys = new ArrayList<>();
+    for (final Iterator<Map.Entry<CASValue, NodeReferences>> it = cast(reader.iterator()); it.hasNext();) {
+      keys.add(it.next().getKey());
+    }
+    assertFalse(keys.isEmpty(), "the index is empty, so this test would prove nothing");
+    for (final CASValue key : keys) {
+      assertNotNull(reader.get(key, SearchMode.EQUAL), "an indexed key did not resolve");
+    }
+    return keys.size();
+  }
+
+  private static CASValue firstKey(final HOTIndexReader<CASValue> reader) {
+    final Iterator<Map.Entry<CASValue, NodeReferences>> entries = cast(reader.iterator());
+    assertTrue(entries.hasNext(), "the index is empty, so this test would prove nothing");
+    return entries.next().getKey();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Iterator<Map.Entry<CASValue, NodeReferences>> cast(final Iterator<?> iterator) {
+    return (Iterator<Map.Entry<CASValue, NodeReferences>>) iterator;
+  }
+
+  private static long cachedEntries() {
+    return Databases.getGlobalBufferManager().getHOTLookupCache().size();
+  }
+
+  @Test
+  @DisplayName("a point lookup populates the cache, and the resource sweep empties it")
+  void resourceSweepDropsMemoizedLookups() {
+    final IndexDef casDef;
+    final long databaseId;
+    final long resourceId;
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      casDef = buildIndexedResource(database, RESOURCE_NAME, "[{\"title\":\"Vertigo\"},{\"title\":\"Rear Window\"}]");
+      databaseId = database.getDatabaseConfig().getDatabaseId();
+
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        resourceId = rtx.getStorageEngineReader().getResourceId();
+
+        assertEquals(0L, cachedEntries(), "the cache must start cold");
+        assertNotNull(lookupFirstKey(rtx, casDef), "the index does not hold the key this test rests on");
+        assertTrue(cachedEntries() > 0, "a point lookup did not populate the cache — the wiring is dead");
+      }
+    }
+
+    // Exactly the call truncateTo, crash recovery and removeResource make.
+    Databases.clearCachesForResource(databaseId, resourceId);
+
+    assertEquals(0L, cachedEntries(), "the resource sweep did not reach the lookup cache");
+  }
+
+  @Test
+  @DisplayName("the DATABASE sweep reaches the lookup cache too, across every resource")
+  void databaseSweepDropsMemoizedLookups() {
+    // The OTHER half of the wiring. sweepHotCachesAndReport was extracted to serve two call sites
+    // that differ only in the key predicate and the invalidation lambda, and every other test here
+    // drives the RESOURCE one — so a copy-paste that handed the database site the resource lambda
+    // (or narrowed its predicate) would leave the whole class green while removeDatabase and
+    // first-commit crash recovery, which are the callers of this path, kept every memoized posting
+    // list of the old incarnation. Two resources, because the database sweep's distinguishing
+    // property is that it reaches ALL of them.
+    final long databaseId;
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      final IndexDef firstDef = buildIndexedResource(database, RESOURCE_NAME,
+          "[{\"title\":\"Vertigo\"},{\"title\":\"Rear Window\"},{\"title\":\"Notorious\"}]");
+      final IndexDef secondDef = buildIndexedResource(database, OTHER_RESOURCE_NAME, "[{\"title\":\"Psycho\"}]");
+      databaseId = database.getDatabaseConfig().getDatabaseId();
+
+      assertEquals(0L, cachedEntries(), "the cache must start cold");
+      final long afterFirst;
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        assertNotNull(lookupFirstKey(rtx, firstDef), "the index does not hold the key this test rests on");
+        afterFirst = cachedEntries();
+        assertTrue(afterFirst > 0, "a point lookup did not populate the cache — the wiring is dead");
+      }
+      try (final JsonResourceSession manager = database.beginResourceSession(OTHER_RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        assertNotNull(lookupFirstKey(rtx, secondDef), "the sibling index does not hold the key this test rests on");
+        // Strictly MORE than the first resource alone, so the sweep below has something from each
+        // to remove: an assertion of "0 afterwards" against a cache holding only one resource's
+        // entries would be satisfied by a sweep that reached that resource and no other.
+        assertTrue(cachedEntries() > afterFirst, "the sibling resource's lookup was not memoized separately");
+      }
+    }
+
+    // Exactly the call Databases.removeDatabase and first-commit crash recovery make.
+    Databases.clearCachesForDatabase(databaseId);
+
+    assertEquals(0L, cachedEntries(), "the database sweep did not reach the lookup cache");
+  }
+
+  @Test
+  @DisplayName("the resource sweep leaves a sibling resource's memoized lookups alone")
+  void resourceSweepIsScopedToOneResource() {
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      // DELIBERATELY asymmetric footprints — three keys here, one there. With one entry each, a
+      // sweep that inverted the resource comparison and dropped the SIBLING would still take
+      // occupancy 2 -> 1 and satisfy both "> 0" and "< populated": the test would be green while
+      // the target's stale entries stayed live and the sibling's work was thrown away, which is
+      // exactly the failure it is named for. Distinct counts make the two outcomes distinguishable.
+      final IndexDef firstDef = buildIndexedResource(database, RESOURCE_NAME,
+          "[{\"title\":\"Vertigo\"},{\"title\":\"Rear Window\"},{\"title\":\"Notorious\"}]");
+      final IndexDef secondDef = buildIndexedResource(database, OTHER_RESOURCE_NAME, "[{\"title\":\"Psycho\"}]");
+      final long databaseId = database.getDatabaseConfig().getDatabaseId();
+
+      final long firstResourceId;
+      final int firstKeys;
+      final int secondKeys;
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        firstResourceId = rtx.getStorageEngineReader().getResourceId();
+        firstKeys = lookupAllKeys(rtx, firstDef);
+      }
+      try (final JsonResourceSession manager = database.beginResourceSession(OTHER_RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        secondKeys = lookupAllKeys(rtx, secondDef);
+      }
+      assertTrue(firstKeys > secondKeys,
+          "the fixture must give the two resources different footprints, saw " + firstKeys + " and " + secondKeys);
+      final long populated = cachedEntries();
+      assertEquals(firstKeys + secondKeys, populated, "both resources should have memoized every key they hold");
+
+      Databases.clearCachesForResource(databaseId, firstResourceId);
+
+      // Scope matters as much as the sweep: a sweep that cleared everything would be correct but
+      // would throw away every other resource's work on any rollback — and one that swept the wrong
+      // resource would be a silent correctness bug. Only the sibling's entries may remain, and
+      // exactly as many of them as it memoized.
+      assertEquals(secondKeys, cachedEntries(),
+          "the sweep should have dropped exactly the target resource's " + firstKeys + " entries");
+    }
+  }
+
+  @Test
+  @DisplayName("a rolled-back revision is not served its pre-truncation answer when re-issued")
+  void reIssuedRevisionIsNotServedStaleAnswers() {
+    // The bug in its natural habitat. truncateTo re-issues the truncated revision numbers over
+    // different content, so an entry keyed by (database, resource, revision, key) can describe a
+    // history that no longer exists — which is why truncateTo sweeps the caches at all.
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      final IndexDef casDef = buildIndexedResource(database, RESOURCE_NAME, "[{\"title\":\"Vertigo\"}]");
+      final long databaseId = database.getDatabaseConfig().getDatabaseId();
+
+      final long resourceId;
+      final NodeReferences beforeRollback;
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        resourceId = rtx.getStorageEngineReader().getResourceId();
+        beforeRollback = lookupFirstKey(rtx, casDef);
+        assertNotNull(beforeRollback, "the index does not hold the key this test rests on");
+        assertTrue(cachedEntries() > 0, "the answer was not memoized, so this test proves nothing");
+      }
+
+      Databases.clearCachesForResource(databaseId, resourceId);
+
+      // After the sweep the same lookup must go back to the trie rather than to memory. Equality of
+      // the recomputed answer is the point: the sweep must not make lookups WRONG either.
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        assertEquals(0L, cachedEntries(), "entries survived the sweep");
+        final NodeReferences recomputed = lookupFirstKey(rtx, casDef);
+        assertNotNull(recomputed, "the recomputed lookup lost the key");
+        assertEquals(beforeRollback, recomputed, "recomputing after a sweep changed the answer");
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("clearAllCaches empties the lookup cache, so clearGlobalCaches really is a cold process")
+  void clearAllCachesDropsMemoizedLookups() {
+    // Databases.clearGlobalCaches() delegates here and is documented as making the next open read
+    // from disk "like a freshly started process would" — the contract the corruption tests rely on.
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      final IndexDef casDef = buildIndexedResource(database, RESOURCE_NAME, "[{\"title\":\"Vertigo\"}]");
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeReadOnlyTrx rtx = manager.beginNodeReadOnlyTrx()) {
+        assertNotNull(lookupFirstKey(rtx, casDef));
+        assertTrue(cachedEntries() > 0);
+      }
+    }
+
+    Databases.getGlobalBufferManager().clearAllCaches();
+
+    assertEquals(0L, cachedEntries(), "clearAllCaches left memoized lookups behind");
+  }
+
+  @Test
+  @DisplayName("a writer-backed reader neither reads nor populates the cache")
+  void writerBackedReaderBypassesTheCache() {
+    // The single property the no-invalidation-for-ordinary-commits argument rests on: an uncommitted
+    // transaction mutates the index under a revision number that is already a cache key.
+    try (final Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      final IndexDef casDef = buildIndexedResource(database, RESOURCE_NAME, "[{\"title\":\"Vertigo\"}]");
+      Databases.getGlobalBufferManager().getHOTLookupCache().clear();
+
+      try (final JsonResourceSession manager = database.beginResourceSession(RESOURCE_NAME);
+          final JsonNodeTrx wtx = manager.beginNodeTrx()) {
+        final HOTIndexReader<CASValue> reader = HOTIndexReader.create(wtx.getStorageEngineReader(),
+            CASKeySerializer.INSTANCE, casDef.getType(), casDef.getID());
+        final NodeReferences found = reader.get(firstKey(reader), SearchMode.EQUAL);
+
+        assertNotNull(found, "the writer-backed reader lost the key, so the bypass proves nothing");
+        assertEquals(0L, cachedEntries(), "a writer-backed reader populated the lookup cache");
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/HOTLookupCacheTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/HOTLookupCacheTest.java
@@ -1,0 +1,571 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.cache;
+
+import io.sirix.index.IndexType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Correctness here rests on two things, and both are silent when broken. The KEY must be exact: one
+ * that collides across revisions, indexes or resources serves one snapshot's answer to another with
+ * nothing to catch it. And INVALIDATION must be scoped: a committed revision's content is normally
+ * immutable, but {@code truncateTo} re-issues revision numbers over different content on rollback
+ * and crash recovery, and a dropped resource's id is reused — so entries have to be droppable by
+ * database and by resource. These pin both, plus the probe-versus-owned split that lets a lookup
+ * avoid copying, the admission bound, and the capacity ceiling.
+ */
+@DisplayName("HOT point-lookup cache")
+final class HOTLookupCacheTest {
+
+  private static final long DB = 7L;
+  private static final long RESOURCE = 3L;
+  private static final int REVISION = 11;
+  private static final int INDEX = 2;
+
+  private static byte[] key(final String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static HOTLookupKey probe(final byte[] bytes) {
+    return HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+  }
+
+  @Nested
+  @DisplayName("key identity")
+  final class KeyIdentityTests {
+
+    @Test
+    @DisplayName("a probe and its owned twin are the same key")
+    void ownedEqualsProbe() {
+      final HOTLookupKey p = probe(key("title"));
+      final HOTLookupKey owned = p.owned();
+      assertEquals(p, owned);
+      assertEquals(owned, p);
+      assertEquals(p.hashCode(), owned.hashCode());
+    }
+
+    @Test
+    @DisplayName("owned() copies, so overwriting the probe buffer does not change it")
+    void ownedIsInsulatedFromBufferReuse() {
+      // The real caller probes straight out of a reused thread-local serialization buffer, so an
+      // owned key that aliased it would silently change identity on the next lookup.
+      final byte[] reusable = new byte[16];
+      System.arraycopy(key("alpha"), 0, reusable, 0, 5);
+      final HOTLookupKey owned =
+          HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, reusable, 0, 5).owned();
+      final int hashBefore = owned.hashCode();
+
+      Arrays.fill(reusable, (byte) 'z');
+
+      assertEquals(hashBefore, owned.hashCode());
+      assertEquals(owned, probe(key("alpha")));
+      assertNotEquals(owned, probe(key("zzzzz")));
+    }
+
+    @Test
+    @DisplayName("a key is read from its range, not from the whole buffer")
+    void keyRangeIsHonoured() {
+      final byte[] padded = new byte[32];
+      System.arraycopy(key("beta"), 0, padded, 7, 4);
+      final HOTLookupKey ranged = HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, padded, 7, 4);
+      assertEquals(probe(key("beta")), ranged);
+    }
+
+    @Test
+    @DisplayName("revision, index number, index type and resource all discriminate")
+    void everyIdentityComponentDiscriminates() {
+      final byte[] bytes = key("same-key-bytes");
+      final HOTLookupKey base = probe(bytes);
+
+      assertNotEquals(base,
+          HOTLookupKey.probe(DB, RESOURCE, REVISION + 1, IndexType.CAS, INDEX, bytes, 0, bytes.length));
+      assertNotEquals(base,
+          HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX + 1, bytes, 0, bytes.length));
+      assertNotEquals(base, HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.NAME, INDEX, bytes, 0, bytes.length));
+      assertNotEquals(base,
+          HOTLookupKey.probe(DB, RESOURCE + 1, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length));
+      assertNotEquals(base,
+          HOTLookupKey.probe(DB + 1, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length));
+    }
+
+    @Test
+    @DisplayName("a prefix is not the key it prefixes")
+    void prefixIsNotTheKey() {
+      final byte[] longer = key("titleX");
+      assertNotEquals(probe(key("title")),
+          HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, longer, 0, longer.length));
+    }
+  }
+
+  @Nested
+  @DisplayName("concurrency")
+  final class ConcurrencyTests {
+
+    /**
+     * Hammer one cache from several threads over an overlapping key space.
+     *
+     * <p>
+     * Two properties are at stake and neither is provable by reading the code. Publication: an
+     * {@code Entry} is handed between threads through an array slot, so a reader must never see one
+     * whose fields are not yet visible. Key integrity: sets are chosen by hash and victims rotate on a
+     * deliberately racy counter, so a lost update or a doubly-chosen victim must be able to LOSE an
+     * entry but never to return one key's answer under another key — that would be silent wrong query
+     * results, which is the failure this whole class is one step away from.
+     * </p>
+     */
+    @Test
+    @DisplayName("concurrent readers and writers never see a torn entry or another key's answer")
+    void concurrentAccessKeepsEntriesIntactAndCorrectlyKeyed() throws InterruptedException {
+      final int threads = 8;
+      final int keySpace = 512;
+      final int iterations = 20_000;
+      final HOTLookupCache cache = new HOTLookupCache(256); // deliberately smaller than the key space
+      final ExecutorService pool = Executors.newFixedThreadPool(threads);
+      final CountDownLatch start = new CountDownLatch(1);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+      final AtomicLong hits = new AtomicLong();
+
+      for (int t = 0; t < threads; t++) {
+        final int seed = t;
+        pool.execute(() -> {
+          try {
+            start.await();
+            for (int i = 0; i < iterations; i++) {
+              final int id = (seed * 31 + i) % keySpace;
+              final byte[] bytes = key("concurrent-key-" + id);
+              final HOTLookupKey probe =
+                  HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+              final long[] hit = cache.get(probe);
+              if (hit != null) {
+                // The entry must be fully published AND belong to the key we asked for.
+                assertEquals(2, hit.length, "torn or foreign entry for key " + id);
+                assertEquals(id, hit[0], "entry for key " + id + " carries another key's answer");
+                assertEquals(id + 1L, hit[1], "entry for key " + id + " is half-written");
+                hits.incrementAndGet();
+              } else {
+                cache.put(probe.owned(), new long[] {id, id + 1L}, cache.generation());
+              }
+            }
+          } catch (final Throwable e) {
+            failure.compareAndSet(null, e);
+          }
+        });
+      }
+
+      start.countDown();
+      pool.shutdown();
+      assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS), "workers did not finish");
+      if (failure.get() != null) {
+        throw new AssertionError("concurrent access failed", failure.get());
+      }
+      assertTrue(hits.get() > 0, "no thread ever observed a cached entry, so nothing was exercised");
+      assertTrue(cache.size() <= 256, "capacity was exceeded under concurrency: " + cache.size());
+    }
+
+    @Test
+    @DisplayName("invalidation concurrent with lookups never yields a foreign answer")
+    void invalidationDuringLookupsStaysCorrect() throws InterruptedException {
+      // Sweeps run while readers are live — truncateTo does not stop the world — so nulling slots
+      // must never be observable as a wrong value, only as a miss.
+      final HOTLookupCache cache = new HOTLookupCache(256);
+      final ExecutorService pool = Executors.newFixedThreadPool(4);
+      final CountDownLatch start = new CountDownLatch(1);
+      final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+      // Every assertion below sits inside `if (hit != null)`, so a cache that never hits would run
+      // ZERO of them and pass. Count the hits and require some, exactly as the sibling test does.
+      final AtomicLong hits = new AtomicLong();
+      // The sweeper must stay live for the whole run rather than finishing in microseconds while the
+      // readers grind on: a fixed 200-iteration sweeper left the overwhelming majority of reader
+      // iterations running with no sweep in flight, i.e. not exercising the race the test is named
+      // for. It now sweeps until the readers signal they are done.
+      final CountDownLatch readersDone = new CountDownLatch(3);
+
+      for (int t = 0; t < 3; t++) {
+        pool.execute(() -> {
+          try {
+            start.await();
+            for (int i = 0; i < 20_000; i++) {
+              final int id = i % 256;
+              final byte[] bytes = key("swept-key-" + id);
+              final HOTLookupKey probe =
+                  HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+              final long[] hit = cache.get(probe);
+              if (hit == null) {
+                cache.put(probe.owned(), new long[] {id}, cache.generation());
+              } else {
+                hits.incrementAndGet();
+                assertEquals(1, hit.length);
+                assertEquals(id, hit[0], "a swept slot produced another key's answer");
+              }
+            }
+          } catch (final Throwable e) {
+            failure.compareAndSet(null, e);
+          } finally {
+            readersDone.countDown();
+          }
+        });
+      }
+      pool.execute(() -> {
+        try {
+          start.await();
+          while (!readersDone.await(1, TimeUnit.MILLISECONDS)) {
+            cache.invalidateResource(DB, RESOURCE);
+          }
+        } catch (final Throwable e) {
+          failure.compareAndSet(null, e);
+        }
+      });
+
+      start.countDown();
+      pool.shutdown();
+      assertTrue(pool.awaitTermination(60, TimeUnit.SECONDS), "workers did not finish");
+      if (failure.get() != null) {
+        throw new AssertionError("invalidation raced badly", failure.get());
+      }
+      assertTrue(hits.get() > 0, "no thread ever observed a cached entry, so nothing was exercised");
+    }
+  }
+
+  @Nested
+  @DisplayName("cache behaviour")
+  final class CacheTests {
+
+    @Test
+    @DisplayName("a stored answer is found by an equal probe")
+    void storedAnswerIsFoundByProbe() {
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      final long[] nodeKeys = {3L, 9L, 27L};
+      assertTrue(cache.put(probe(key("title")).owned(), nodeKeys, cache.generation()));
+
+      assertArrayEquals(nodeKeys, cache.get(probe(key("title"))));
+      assertNull(cache.get(probe(key("other"))));
+    }
+
+    @Test
+    @DisplayName("an empty array is storable, so an ABSENT key can be memoized")
+    void absentKeyIsStorable() {
+      // The reader distinguishes "asked before, not there" from "never asked" by a zero-length
+      // entry; a present key always has at least one node key.
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      assertTrue(cache.put(probe(key("gone")).owned(), new long[0], cache.generation()));
+      final long[] hit = cache.get(probe(key("gone")));
+      assertNotNull(hit, "the ABSENT sentinel must come back as an entry, not as a miss");
+      assertEquals(0, hit.length);
+    }
+
+    @Test
+    @DisplayName("a borrowing probe key cannot be stored")
+    void probeKeyIsRejectedForStorage() {
+      // Storing a probe aliases a reused serialization buffer: the next lookup rewrites the stored
+      // key's bytes while its hash stays frozen, after which the entry answers a DIFFERENT key.
+      // Previously this contract was documented in three places and enforced in none.
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      assertThrows(IllegalArgumentException.class,
+          () -> cache.put(probe(key("borrowed")), new long[] {1L}, cache.generation()));
+    }
+
+    @Test
+    @DisplayName("null arguments are rejected")
+    void nullArgumentsAreRejected() {
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      assertThrows(NullPointerException.class, () -> cache.get(null));
+      assertThrows(NullPointerException.class, () -> cache.put(null, new long[] {1L}, cache.generation()));
+      assertThrows(NullPointerException.class, () -> cache.put(probe(key("k")).owned(), null, cache.generation()));
+    }
+
+    @Test
+    @DisplayName("the table built for a requested size is the largest power-of-two set count that fits")
+    void capacityMatchesTheRequestedSize() {
+      // The slot count used to round the SET count UP to a power of two, so a request for 32776
+      // built 65536 slots — twice the operator's budget, against which the default's memory
+      // estimate is computed. Only 256 and other exact powers hid it, which is what the previous
+      // version of this test happened to use.
+      //
+      // Asserting the EXACT built capacity, not just `<= requested`: an upper bound is satisfied by
+      // a constructor regression that built one 8-slot set for every requested size (highestOneBit
+      // mistyped as numberOfTrailingZeros, say), silently shrinking the cache process-wide while
+      // every entry in this list still passed.
+      //
+      // Read straight off capacity(), NOT inferred from full occupancy. Filling the table and
+      // asserting on size() only proves the capacity if every one of up to 8192 sets happens to draw
+      // at least WAYS of the probe keys, which makes an assertion about pure constructor arithmetic
+      // depend on the distribution of HOTLookupKey#computeHash — so retuning the hash would fail
+      // THIS test and point the reader at a constructor that never changed. It also cost ~525K puts
+      // across nine tables, one of them 65536 slots, to observe a number capacity() returns directly.
+      for (final int requested : new int[] {8, 64, 100, 200, 256, 1000, 1024, 32776, 65536}) {
+        final int expectedSlots = Integer.highestOneBit(requested / 8) * 8;
+        final HOTLookupCache cache = new HOTLookupCache(requested);
+        assertTrue(cache.capacity() <= requested,
+            "requested " + requested + " but built " + cache.capacity() + " slots");
+        assertEquals(expectedSlots, cache.capacity(),
+            "requested " + requested + " should build exactly " + expectedSlots + " slots");
+      }
+    }
+
+    @Test
+    @DisplayName("a request below the associativity still gets one full set, and says so")
+    void requestBelowWaysGetsOneSet() {
+      // The documented exception to the bound above: "A value below WAYS still gets one set, since a
+      // set-associative table cannot be narrower than its associativity." That means a request of 1
+      // to 7 OVERSHOOTS — occupancy reaches 8. It is reachable (BufferManagerImpl accepts any
+      // maxEntries >= 0), so it is pinned here rather than left to a test list that starts at 8 and
+      // a DisplayName claiming "any requested size".
+      for (int requested = 1; requested < 8; requested++) {
+        final HOTLookupCache cache = new HOTLookupCache(requested);
+        assertEquals(8, cache.capacity(), "a request of " + requested + " should still build exactly one 8-way set");
+      }
+    }
+
+    @Test
+    @DisplayName("an absurd requested size is clamped, not allowed to overflow into a negative array")
+    void absurdSizeIsClamped() {
+      // sets * WAYS is int arithmetic reachable from a system property: without a ceiling,
+      // maxEntries >= 1073741832 overflowed to Integer.MIN_VALUE and the constructor threw
+      // NegativeArraySizeException out of BufferManagerImpl's constructor — one typo'd property
+      // made every database in the JVM unopenable.
+      final HOTLookupCache cache = new HOTLookupCache(Integer.MAX_VALUE);
+      assertTrue(cache.put(probe(key("survives")).owned(), new long[] {1L}, cache.generation()));
+      assertArrayEquals(new long[] {1L}, cache.get(probe(key("survives"))));
+    }
+
+    @Test
+    @DisplayName("invalidateResource drops only that resource's entries")
+    void invalidateResourceIsScoped() {
+      // The reason this method exists: truncateTo re-issues committed revision numbers over
+      // different content, and a dropped resource's id is reused — so entries keyed by
+      // (db, resource, revision) can describe a history that no longer exists.
+      final HOTLookupCache cache = new HOTLookupCache(1024);
+      final byte[] bytes = key("shared-key-bytes");
+      final HOTLookupKey mine =
+          HOTLookupKey.probe(DB, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      final HOTLookupKey otherResource =
+          HOTLookupKey.probe(DB, RESOURCE + 1, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      final HOTLookupKey otherDatabase =
+          HOTLookupKey.probe(DB + 1, RESOURCE, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      cache.put(mine.owned(), new long[] {1L}, cache.generation());
+      cache.put(otherResource.owned(), new long[] {2L}, cache.generation());
+      cache.put(otherDatabase.owned(), new long[] {3L}, cache.generation());
+
+      assertEquals(1, cache.invalidateResource(DB, RESOURCE));
+
+      assertNull(cache.get(mine), "the invalidated resource's entry survived");
+      assertArrayEquals(new long[] {2L}, cache.get(otherResource), "a sibling resource was swept");
+      assertArrayEquals(new long[] {3L}, cache.get(otherDatabase), "another database was swept");
+    }
+
+    @Test
+    @DisplayName("invalidateDatabase drops every resource of that database and nothing else")
+    void invalidateDatabaseIsScoped() {
+      final HOTLookupCache cache = new HOTLookupCache(1024);
+      final byte[] bytes = key("shared-key-bytes");
+      final HOTLookupKey res0 = HOTLookupKey.probe(DB, 0L, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      final HOTLookupKey res1 = HOTLookupKey.probe(DB, 1L, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      final HOTLookupKey otherDb =
+          HOTLookupKey.probe(DB + 1, 0L, REVISION, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      cache.put(res0.owned(), new long[] {1L}, cache.generation());
+      cache.put(res1.owned(), new long[] {2L}, cache.generation());
+      cache.put(otherDb.owned(), new long[] {3L}, cache.generation());
+
+      assertEquals(2, cache.invalidateDatabase(DB));
+
+      assertNull(cache.get(res0));
+      assertNull(cache.get(res1));
+      assertArrayEquals(new long[] {3L}, cache.get(otherDb), "another database was swept");
+    }
+
+    @Test
+    @DisplayName("a re-issued revision does not inherit the previous incarnation's answer")
+    void reIssuedRevisionIsNotServedStaleAfterInvalidation() {
+      // The end-to-end shape of the bug: revision 5 is memoized, truncateTo(4) rolls it back, the
+      // next commit re-issues 5 over different content. Without the sweep the reader is served the
+      // discarded history; with it, the key misses and recomputes.
+      final HOTLookupCache cache = new HOTLookupCache(1024);
+      final byte[] bytes = key("Vertigo");
+      final HOTLookupKey atRevision5 =
+          HOTLookupKey.probe(DB, RESOURCE, 5, IndexType.CAS, INDEX, bytes, 0, bytes.length);
+      cache.put(atRevision5.owned(), new long[] {100L, 200L}, cache.generation());
+      assertArrayEquals(new long[] {100L, 200L}, cache.get(atRevision5));
+
+      cache.invalidateResource(DB, RESOURCE); // what truncateTo's sweep now does
+
+      assertNull(cache.get(atRevision5), "a re-issued revision would be served the rolled-back answer");
+    }
+
+    @Test
+    @DisplayName("a posting list beyond the bound is refused, not stored")
+    void oversizedPostingListIsRefused() {
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      final long[] tooBig = new long[HOTLookupCache.MAX_CACHED_NODE_KEYS + 1];
+      assertFalse(cache.put(probe(key("popular")).owned(), tooBig, cache.generation()));
+      assertNull(cache.get(probe(key("popular"))));
+
+      final long[] atBound = new long[HOTLookupCache.MAX_CACHED_NODE_KEYS];
+      assertTrue(cache.put(probe(key("borderline")).owned(), atBound, cache.generation()));
+      assertSame(atBound, cache.get(probe(key("borderline"))));
+    }
+
+    @Test
+    @DisplayName("the disabled cache reports every lookup as a miss")
+    void disabledCacheNeverHits() {
+      final HOTLookupCache cache = HOTLookupCache.disabled();
+      assertFalse(cache.put(probe(key("title")).owned(), new long[] {1L}, cache.generation()));
+      assertNull(cache.get(probe(key("title"))));
+      assertEquals(0L, cache.size());
+      cache.clear(); // must not throw
+    }
+
+    @Test
+    @DisplayName("the disabled cache refuses a borrowing probe key rather than throwing at it")
+    void disabledCacheRefusesProbeKeyWithoutThrowing() {
+      // disabled() promises "refuses every admission, so callers need no null checks and no feature
+      // flag". A no-op that throws for one class of argument is not a no-op — and the argument it
+      // used to throw for, a borrowing probe key, is precisely what a caller taking that promise at
+      // face value would hand it. The ownership check ran BEFORE the disabled-table check.
+      final HOTLookupCache cache = HOTLookupCache.disabled();
+      assertFalse(cache.put(probe(key("title")), new long[] {1L}, cache.generation()),
+          "a disabled cache must decline, not reject");
+      // The enabled cache still enforces the contract the check exists for.
+      final HOTLookupCache enabled = new HOTLookupCache(64);
+      assertThrows(IllegalArgumentException.class,
+          () -> enabled.put(probe(key("title")), new long[] {1L}, enabled.generation()));
+    }
+
+    @Test
+    @DisplayName("a non-positive size is rejected rather than silently disabling the cache")
+    void nonPositiveSizeIsRejected() {
+      assertThrows(IllegalArgumentException.class, () -> new HOTLookupCache(0));
+      assertThrows(IllegalArgumentException.class, () -> new HOTLookupCache(-1));
+    }
+
+    @Test
+    @DisplayName("clear drops everything")
+    void clearDropsEverything() {
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      cache.put(probe(key("a")).owned(), new long[] {1L}, cache.generation());
+      cache.clear();
+      assertNull(cache.get(probe(key("a"))));
+    }
+
+    @Test
+    @DisplayName("admission always succeeds and capacity is never exceeded")
+    void admissionNeverDeclinesAndStaysBounded() {
+      // A set-associative table evicts rather than declining, because the whole point is that
+      // admitting costs one store — a miss must never become more expensive than the walk it
+      // replaces. The flip side is that occupancy has a hard ceiling no matter how much is offered.
+      final int capacity = 256;
+      final HOTLookupCache cache = new HOTLookupCache(capacity);
+      for (int i = 0; i < capacity * 20; i++) {
+        assertTrue(cache.put(probe(key("key-" + i)).owned(), new long[] {i}, cache.generation()),
+            "admission declined at " + i);
+      }
+      assertTrue(cache.size() <= capacity, "occupancy " + cache.size() + " exceeded capacity " + capacity);
+    }
+
+    @Test
+    @DisplayName("a re-admitted key is not duplicated across the ways of its set")
+    void reAdmittingAKeyDoesNotDuplicateIt() {
+      // Two entries for one key in the same set would waste a way and, if their answers ever
+      // diverged, make which one is found depend on probe order.
+      final HOTLookupCache cache = new HOTLookupCache(64);
+      final long[] answer = {1L, 2L};
+      for (int i = 0; i < 16; i++) {
+        assertTrue(cache.put(probe(key("stable")).owned(), answer, cache.generation()));
+      }
+      assertEquals(1L, cache.size());
+      assertArrayEquals(answer, cache.get(probe(key("stable"))));
+    }
+
+    @Test
+    @DisplayName("entries surviving eviction still answer correctly")
+    void survivorsRemainCorrect() {
+      // Eviction is allowed to lose entries; it is NOT allowed to return one key's answer for
+      // another, which is the failure a hash-indexed table with no per-entry key check would have.
+      final HOTLookupCache cache = new HOTLookupCache(1024);
+      for (int i = 0; i < 4096; i++) {
+        cache.put(probe(key("k" + i)).owned(), new long[] {i, i + 1}, cache.generation());
+      }
+      int found = 0;
+      for (int i = 0; i < 4096; i++) {
+        final long[] hit = cache.get(probe(key("k" + i)));
+        if (hit != null) {
+          assertArrayEquals(new long[] {i, i + 1}, hit, "wrong answer for k" + i);
+          found++;
+        }
+      }
+      // Not `> 0`: that passes if a single key survived, so it would miss a degenerate set index or
+      // a victim rotation stuck on one way. A 1024-slot table fed 4096 keys should retain most of
+      // its capacity.
+      assertTrue(found >= 512, "retained only " + found + " of 1024 slots — eviction is degenerate");
+    }
+
+    @Test
+    @DisplayName("an admission that straddles a sweep is refused")
+    void admissionStraddlingASweepIsRefused() {
+      // The read-through race, deterministically: capture the generation the way a lookup does before
+      // it starts reading pages, let a sweep run to completion in between, then admit. Ordering the
+      // sweep's own steps cannot catch this — the answer was computed from content the sweep is
+      // discarding, and without the generation it would be resurrected under a revision number
+      // truncateTo re-issues over different content, then served indefinitely.
+      final HOTLookupCache cache = new HOTLookupCache(256);
+      final byte[] bytes = key("straddles");
+
+      final long generation = cache.generation();
+      cache.invalidateResource(DB, RESOURCE);
+
+      assertFalse(cache.put(probe(bytes).owned(), new long[] {1L, 2L}, generation),
+          "an answer computed before the sweep must not be admitted after it");
+      assertNull(cache.get(probe(bytes)), "the refused entry must not be readable");
+    }
+
+    @Test
+    @DisplayName("an admission that does not straddle a sweep still succeeds")
+    void admissionWithoutASweepSucceeds() {
+      // The control. Without it the test above passes against a put() that refuses everything.
+      final HOTLookupCache cache = new HOTLookupCache(256);
+      final byte[] bytes = key("clean");
+
+      final long generation = cache.generation();
+      assertTrue(cache.put(probe(bytes).owned(), new long[] {1L, 2L}, generation));
+      assertArrayEquals(new long[] {1L, 2L}, cache.get(probe(bytes)));
+    }
+
+    @Test
+    @DisplayName("a database sweep bumps the generation too")
+    void databaseSweepAlsoBumpsTheGeneration() {
+      // invalidateDatabase and clear share invalidateMatching's bump, but clear() has its own path,
+      // so both scopes are pinned rather than assumed from the resource-scoped one.
+      final HOTLookupCache cache = new HOTLookupCache(256);
+
+      final long beforeDatabase = cache.generation();
+      cache.invalidateDatabase(DB);
+      assertNotEquals(beforeDatabase, cache.generation(), "invalidateDatabase must bump the generation");
+
+      final long beforeClear = cache.generation();
+      cache.clear();
+      assertNotEquals(beforeClear, cache.generation(), "clear must bump the generation");
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/CASBoundedScanSemanticsTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/CASBoundedScanSemanticsTest.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.DateTime;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.IndexController;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Bound semantics of the bounded CAS scans.
+ *
+ * <p>
+ * Two regressions are pinned here.
+ *
+ * <p>
+ * <b>The byte window is wider than the logical range.</b> Index keys are NOT prefix-free — a CAS
+ * string value is written as raw UTF-8 with no terminator or length prefix — so the cursor's
+ * composite ceiling {@code serialize(max) ‖ 0xFFFFFFFF} covers every key that byte-EXTENDS
+ * {@code max} ({@code "carpet"} sorts below the ceiling built for {@code "car"}, because
+ * {@code 'p'} &lt; {@code 0xFF}). A bounded scan that trusted the byte window, or that trimmed an
+ * excluded boundary value positionally (skip the first group if it equals min, the last if it
+ * equals max), returned values outside the requested range.
+ *
+ * <p>
+ * <b>A one-sided bound only pins the PCR at one end.</b> CAS keys serialize PCR-major (the
+ * sign-flipped pathNodeKey is the first 8 bytes), so a two-sided range over a single PCR needs no
+ * per-entry path check — both bounds carry the same 8-byte prefix. That does NOT extend to a
+ * one-sided range: a {@code >= min} cursor runs off the end of its PCR into every higher one, and a
+ * {@code <= max} cursor starts at the first key in the index, below every lower one. On an index
+ * defined over several paths those neighbours are other paths' values.
+ */
+final class CASBoundedScanSemanticsTest {
+
+  /** {@code car} is a strict prefix of {@code carpet} — the shape that breaks a byte-window bound. */
+  private static final String JSON =
+      "[{\"title\":\"apple\"},{\"title\":\"car\"},{\"title\":\"carpet\"},{\"title\":\"zebra\"}]";
+
+  private static final String TITLE_PATH = "/[]/title";
+
+  /**
+   * Two indexed paths, hence two PCRs in one CAS index. {@code title} is declared first, so it takes
+   * the lower pathNodeKey and its entries sort BELOW every {@code alias} entry — which puts one path
+   * on each side of the other's unbounded end.
+   */
+  private static final String TWO_PATH_JSON = "[{\"title\":\"apple\",\"alias\":\"bravo\"},"
+      + "{\"title\":\"car\",\"alias\":\"delta\"},{\"title\":\"zebra\",\"alias\":\"yankee\"}]";
+
+  private static final String ALIAS_PATH = "/[]/alias";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  void boundedScansExcludeValuesOutsideTheRequestedRange() {
+    withCASIndex(JSON, Set.of(TITLE_PATH), (indexController, rtx, casDef) -> {
+      // <= "car" is {apple, car}: "carpet" is greater, however its composite sorts below the
+      // ceiling built from "car".
+      assertEquals(List.of("apple", "car"),
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, TITLE_PATH, "car", SearchMode.LOWER_OR_EQUAL)),
+          "LOWER_OR_EQUAL(car)");
+
+      // < "car" is {apple}: the equal group must be excluded even though another group follows it.
+      assertEquals(List.of("apple"),
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, TITLE_PATH, "car", SearchMode.LOWER)), "LOWER(car)");
+
+      // >= "car" is {car, carpet, zebra}; > "car" drops only the equal group.
+      assertEquals(List.of("car", "carpet", "zebra"),
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, TITLE_PATH, "car", SearchMode.GREATER_OR_EQUAL)),
+          "GREATER_OR_EQUAL(car)");
+      assertEquals(List.of("carpet", "zebra"),
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, TITLE_PATH, "car", SearchMode.GREATER)),
+          "GREATER(car)");
+
+      // Range filters, each inclusivity combination.
+      assertEquals(List.of("apple", "car"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "a", "car", true, true)), "[a,car]");
+      assertEquals(List.of("apple"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "a", "car", true, false)), "[a,car)");
+      assertEquals(List.of("carpet"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "car", "zebra", false, false)),
+          "(car,zebra)");
+      assertEquals(List.of("car", "carpet", "zebra"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "car", "zebra", true, true)),
+          "[car,zebra]");
+      assertEquals(List.of("apple", "car", "carpet", "zebra"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "a", "zz", true, true)), "[a,zz]");
+
+      // A window that straddles no value at all: "car" < "d" < "e" < "zebra".
+      assertEquals(List.of(), valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "d", "e", true, true)),
+          "[d,e]");
+      // A window whose ends cross is empty, not inverted.
+      assertEquals(List.of(),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "zebra", "apple", true, true)),
+          "[zebra,apple]");
+
+      // One-sided ranges, both directions and both inclusivities.
+      assertEquals(List.of("car", "carpet", "zebra"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "car", null, true, true)), "[car,+inf)");
+      assertEquals(List.of("carpet", "zebra"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "car", null, false, true)), "(car,+inf)");
+      assertEquals(List.of("apple", "car"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, null, "car", true, true)), "(-inf,car]");
+      assertEquals(List.of("apple"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, null, "car", true, false)), "(-inf,car)");
+    });
+  }
+
+  /**
+   * A one-sided range on ONE path of a multi-path CAS index must not return the other path's values
+   * through its unbounded end. {@code title} sits below {@code alias} in the key order, so the
+   * {@code title} scan leaks upward and the {@code alias} scan leaks downward — one assertion per
+   * direction.
+   */
+  @Test
+  void oneSidedRangesOnAMultiPathIndexStayOnTheRequestedPath() {
+    final List<String> titles = List.of("apple", "car", "zebra");
+    final List<String> aliases = List.of("bravo", "delta", "yankee");
+
+    withCASIndex(TWO_PATH_JSON, Set.of(TITLE_PATH, ALIAS_PATH), (indexController, rtx, casDef) -> {
+      // The two decisive cases: `title` holds the LOWER pathNodeKey, so its `>= a` scan is the one
+      // whose open end runs up into `alias`; `alias` holds the higher one, so its `<= zz` scan is
+      // the one that starts below `title`. Every value in the document is inside both bounds, so a
+      // leak returns all six instead of the requested path's three.
+      assertEquals(titles, valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "a", null, true, true)),
+          "title >= a");
+      assertEquals(aliases, valuesOf(rtx, rangeHits(indexController, rtx, casDef, ALIAS_PATH, null, "zz", true, true)),
+          "alias <= zz");
+      // The mirror directions cannot leak (each scan's open end points away from the other path);
+      // kept as controls that the bound itself still admits everything it should.
+      assertEquals(aliases, valuesOf(rtx, rangeHits(indexController, rtx, casDef, ALIAS_PATH, "a", null, true, true)),
+          "alias >= a");
+      assertEquals(titles, valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, null, "zz", true, true)),
+          "title <= zz");
+
+      // Two-sided over one path: both bounds pin the PCR, so this was always correct — pinned so a
+      // future "optimization" cannot quietly widen it.
+      assertEquals(titles, valuesOf(rtx, rangeHits(indexController, rtx, casDef, TITLE_PATH, "a", "zz", true, true)),
+          "title in [a,zz]");
+      assertEquals(List.of("bravo", "delta"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, ALIAS_PATH, "bravo", "delta", true, true)),
+          "alias in [bravo,delta]");
+
+      // Both paths at once: the requested PCR set has two members, so the fast path is not taken at
+      // all and the full scan's filter decides.
+      assertEquals(List.of("apple", "bravo", "car", "delta", "yankee", "zebra"),
+          valuesOf(rtx, rangeHits(indexController, rtx, casDef, Set.of(TITLE_PATH, ALIAS_PATH), "a", "zz", true, true)),
+          "both paths in [a,zz]");
+
+      // The same one-sided bounds through a CASFilter (SearchMode). NOTE these do NOT reach the
+      // bounded-cursor path — openHOTIndexWithFilter gates it on the index having at most one
+      // available PCR, which a two-path index does not — so they pin the full-scan filter branch
+      // instead. The bounded CASFilter path is covered on the single-path index above.
+      assertEquals(titles,
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, TITLE_PATH, "a", SearchMode.GREATER_OR_EQUAL)),
+          "title GREATER_OR_EQUAL(a)");
+      assertEquals(aliases,
+          valuesOf(rtx, filterHits(indexController, rtx, casDef, ALIAS_PATH, "zz", SearchMode.LOWER_OR_EQUAL)),
+          "alias LOWER_OR_EQUAL(zz)");
+    });
+  }
+
+  /**
+   * The instant family is ordered CHRONOLOGICALLY, not lexically.
+   *
+   * <p>
+   * {@code CASKeySerializer} canonicalizes {@code xs:dateTime} / {@code xs:date} / {@code xs:time} to
+   * UTC and writes fixed-width components, so the bounded byte cursor — which decides ranges by
+   * unsigned byte order — agrees with the type's own order. Storing the raw lexical form instead put
+   * {@code 12:00:00.500001Z} BELOW {@code 12:00:00Z} ({@code '.'} &lt; {@code 'Z'}) and every
+   * explicit offset below both, so a one-sided bound silently dropped matching records.
+   * {@code jn:valid-at} issues exactly two one-sided DATI ranges, and its candidate re-verification
+   * cannot recover a record that never became a candidate.
+   */
+  @Test
+  void instantRangesAreChronologicalNotLexical() {
+    // 12:00:00.500001Z is chronologically ABOVE the probe 12:00:00.500Z; 12:00:00Z is below it; and
+    // 14:00:00+02:00 is the same instant as 12:00:00Z spelled with an offset.
+    final String json = "[{\"t\":\"2020-06-15T12:00:00Z\"},{\"t\":\"2020-06-15T12:00:00.500001Z\"},"
+        + "{\"t\":\"2020-06-15T14:00:00+02:00\"}]";
+
+    withCASIndex(json, Set.of(T_PATH), Type.DATI, (indexController, rtx, casDef) -> {
+      final Atomic probe = new DateTime("2020-06-15T12:00:00.500Z");
+
+      // Only the later instant is >= the probe. A lexical bound returns the "+02:00" spelling instead
+      // and drops this one.
+      assertEquals(List.of("2020-06-15T12:00:00.500001Z"),
+          valuesOf(rtx, dateRangeHits(indexController, rtx, casDef, probe, null)), "dateTime >= probe");
+
+      // The two spellings of 12:00:00Z are both below the probe, and both must come back.
+      assertEquals(List.of("2020-06-15T12:00:00Z", "2020-06-15T14:00:00+02:00"),
+          valuesOf(rtx, dateRangeHits(indexController, rtx, casDef, null, probe)), "dateTime <= probe");
+
+      // The same instant written two ways must fall on the same side of an exact bound.
+      final Atomic noon = new DateTime("2020-06-15T12:00:00Z");
+      assertEquals(List.of("2020-06-15T12:00:00Z", "2020-06-15T14:00:00+02:00"),
+          valuesOf(rtx, dateRangeHits(indexController, rtx, casDef, noon, noon)), "dateTime == noon");
+    });
+  }
+
+  private static final String T_PATH = "/[]/t";
+
+  private static Iterator<NodeReferences> dateRangeHits(final IndexController<?, ?> indexController,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef casDef, final @Nullable Atomic min, final @Nullable Atomic max) {
+    return indexController.openCASIndex(rtx.getStorageEngineReader(), casDef,
+        indexController.createCASFilterRange(Set.of(T_PATH), min, max, true, true, new JsonPCRCollector(rtx)));
+  }
+
+  /** What a test body gets once the index is built and a read-only trx is open. */
+  @FunctionalInterface
+  private interface IndexAssertions {
+    void check(IndexController<?, ?> indexController, JsonNodeReadOnlyTrx rtx, IndexDef casDef);
+  }
+
+  /**
+   * Shred {@code json}, build one CAS index over {@code paths}, commit, then run {@code assertions}
+   * against a fresh read-only transaction.
+   */
+  private static void withCASIndex(final String json, final Set<String> paths, final IndexAssertions assertions) {
+    withCASIndex(json, paths, Type.STR, assertions);
+  }
+
+  private static void withCASIndex(final String json, final Set<String> paths, final Type contentType,
+      final IndexAssertions assertions) {
+    final var dbPath = JsonTestHelper.PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    try (final var database = Databases.openJsonDatabase(dbPath)) {
+      database.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE).build());
+      final IndexDef casDef;
+      try (final var session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+          final JsonNodeTrx trx = session.beginNodeTrx()) {
+        final var indexController = session.getWtxIndexController(trx.getRevisionNumber());
+        casDef = IndexDefs.createCASIdxDef(false, contentType, parsePaths(paths), 0, IndexDef.DbType.JSON);
+        indexController.createIndexes(Set.of(casDef), trx);
+        new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD).build()
+                                                                                                           .call();
+        trx.commit();
+      }
+
+      try (final var session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+          final var rtx = session.beginNodeReadOnlyTrx()) {
+        assertions.check(session.getRtxIndexController(rtx.getRevisionNumber()), rtx, casDef);
+      }
+    }
+  }
+
+  /**
+   * Parse the index definition's paths. Deliberately no ordering ceremony: the callers pass
+   * {@code Set.of(...)}, whose iteration order the JDK randomizes per JVM, so declaration order
+   * cannot be pinned here. The PCR order the multi-path test leans on comes from the SHREDDED
+   * DOCUMENT — {@code title} appears before {@code alias} in {@link #TWO_PATH_JSON}, so the path
+   * summary gives it the lower pathNodeKey.
+   */
+  private static Set<Path<QNm>> parsePaths(final Set<String> paths) {
+    final Set<Path<QNm>> parsed = new HashSet<>(paths.size());
+    for (final String path : paths) {
+      parsed.add(Path.parse(path, PathParser.Type.JSON));
+    }
+    return parsed;
+  }
+
+  private static Iterator<NodeReferences> rangeHits(final IndexController<?, ?> indexController,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef casDef, final String path, final @Nullable String min,
+      final @Nullable String max, final boolean incMin, final boolean incMax) {
+    return rangeHits(indexController, rtx, casDef, Set.of(path), min, max, incMin, incMax);
+  }
+
+  private static Iterator<NodeReferences> rangeHits(final IndexController<?, ?> indexController,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef casDef, final Set<String> paths, final @Nullable String min,
+      final @Nullable String max, final boolean incMin, final boolean incMax) {
+    return indexController.openCASIndex(rtx.getStorageEngineReader(), casDef,
+        indexController.createCASFilterRange(paths, min == null
+            ? null
+            : new Str(min),
+            max == null
+                ? null
+                : new Str(max),
+            incMin, incMax, new JsonPCRCollector(rtx)));
+  }
+
+  private static Iterator<NodeReferences> filterHits(final IndexController<?, ?> indexController,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef casDef, final String path, final String key,
+      final SearchMode mode) {
+    return indexController.openCASIndex(rtx.getStorageEngineReader(), casDef,
+        indexController.createCASFilter(Set.of(path), new Str(key), mode, new JsonPCRCollector(rtx)));
+  }
+
+  /**
+   * Resolve every posting the scan returned to the indexed value, sorted.
+   *
+   * <p>
+   * Counting postings is not a strong enough oracle for THIS fixture: it is built around the
+   * {@code car}/{@code carpet} prefix collision, so a scan that returned {@code carpet} where
+   * {@code apple} belongs has the right cardinality and the wrong answer. A sorted list also keeps an
+   * accidental duplicate visible, which a set would swallow.
+   */
+  private static List<String> valuesOf(final JsonNodeReadOnlyTrx rtx, final Iterator<NodeReferences> hits) {
+    final List<String> values = new ArrayList<>();
+    while (hits.hasNext()) {
+      hits.next().forEachNodeKey(nodeKey -> {
+        if (!rtx.moveTo(nodeKey)) {
+          throw new IllegalStateException("index posting " + nodeKey + " does not resolve to a node");
+        }
+        values.add(rtx.getValue());
+      });
+    }
+    Collections.sort(values);
+    return values;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/CASBoundedScanSemanticsTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/CASBoundedScanSemanticsTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Bound semantics of the bounded CAS scans.

--- a/bundles/sirix-core/src/test/java/io/sirix/index/CASIndexDifferentialTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/CASIndexDifferentialTest.java
@@ -1,0 +1,536 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.DateTime;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.IndexBackendType;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.IndexController;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Differential test: every CAS query shape must give the SAME answer through the HOT backend as
+ * through the RBTree backend, and — where an independent expectation is computable — the same
+ * answer as a brute-force scan of the fixture.
+ *
+ * <h2>Why this exists</h2>
+ * <p>
+ * Three consecutive review rounds each found a wrong-results bug in the HOT CAS read path that the
+ * whole ~11,000-test suite passed straight through, because every existing test asserts a
+ * hand-written count or set for a handful of hand-picked queries. The failures were not exotic;
+ * they were <em>shapes</em> nobody had enumerated:
+ * <ul>
+ * <li>an upper bound whose value is a strict PREFIX of a stored value — index keys are raw UTF-8
+ * with no terminator, so the composite ceiling {@code serialize(max) ‖ 0xFFFFFFFF} admits every
+ * byte-extension of {@code max} ({@code "carpet"} sits under the ceiling built for
+ * {@code "car"});</li>
+ * <li>a ONE-SIDED bound on a multi-path index — CAS keys are PCR-major, so the open end runs
+ * straight out of the queried path's key range into a neighbouring path's;</li>
+ * <li>an EXCLUDED boundary value that is neither the first nor the last group emitted;</li>
+ * <li>an EMPTY string bound, whose value region is zero bytes;</li>
+ * <li>a content type whose key bytes are its raw lexical form, where byte order is not value
+ * order.</li>
+ * </ul>
+ *
+ * <p>
+ * So this test does not hand-write expectations. It enumerates the cross product of {bound shape} ×
+ * {inclusivity} × {search mode} × {path set} over a fixture built out of exactly those shapes, and
+ * checks each answer against two independent oracles. The RBTree backend is a wholly separate
+ * implementation reached through the same {@link IndexController} API, so any optimization the HOT
+ * path takes that the reference path does not is caught by construction rather than by someone
+ * thinking to write the case down.
+ */
+final class CASIndexDifferentialTest {
+
+  /**
+   * One indexed value in the fixture, as the oracle sees it: which path it hangs under and what
+   * string it holds. Kept as data so the brute-force oracle and the JSON come from one source.
+   */
+  private record Entry(String field, String value) {
+  }
+
+  /**
+   * The fixture. Every row is here for a reason:
+   * <ul>
+   * <li>{@code car} / {@code carpet} / {@code carpeting} — a prefix chain: each is a strict prefix of
+   * the next, which is the shape a byte-window bound gets wrong.</li>
+   * <li>{@code car} twice — a posting list with more than one node, so a group that must be excluded
+   * cannot be excluded by dropping a single node key.</li>
+   * <li>{@code ""} — an empty value region (a bound built from it used to throw).</li>
+   * <li>{@code a}, {@code zebra} — ordinary endpoints, so exclusive bounds have something on each
+   * side.</li>
+   * <li>{@code alias} rows interleaving the {@code title} range — a second PCR whose values sort
+   * INSIDE the first path's value range, so a PCR leak cannot hide behind a disjoint value
+   * range.</li>
+   * </ul>
+   */
+  private static final List<Entry> FIXTURE = List.of(new Entry("title", ""), new Entry("title", "a"),
+      new Entry("title", "car"), new Entry("title", "car"), new Entry("title", "carpet"),
+      new Entry("title", "carpeting"), new Entry("title", "zebra"), new Entry("alias", ""), new Entry("alias", "a"),
+      new Entry("alias", "car"), new Entry("alias", "carpet"), new Entry("alias", "zebra"));
+
+  private static final String TITLE_PATH = "/[]/title";
+  private static final String ALIAS_PATH = "/[]/alias";
+
+  /** Probes chosen to land ON a stored value, BETWEEN two, and OUTSIDE the range on each end. */
+  private static final List<String> PROBES =
+      List.of("", "a", "b", "car", "carpe", "carpet", "carpeting", "carpetings", "d", "zebra", "zz");
+
+  /**
+   * Comparisons actually performed, asserted at the end. A matrix test whose loops silently collapse
+   * (a {@code continue} that always fires, an empty probe list) passes just as green as one that ran
+   * — so the count is part of the contract.
+   */
+  private static int comparisons;
+
+  private static final String HOT_RESOURCE = "resource-hot";
+  private static final String RB_RESOURCE = "resource-rbtree";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  void everyBoundShapeAgreesWithTheReferenceBackendAndWithBruteForce() {
+    comparisons = 0;
+    final var dbPath = JsonTestHelper.PATHS.PATH1.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+
+    try (final var database = Databases.openJsonDatabase(dbPath)) {
+      // Both path sets on both backends: a single-path index cannot exhibit a cross-PCR leak, and a
+      // multi-path index cannot exhibit the single-PCR fast path — the bugs lived in each. A FRESH
+      // resource per (backend, path-set) pair, because building the index shreds the document —
+      // reusing one resource would shred it twice and quietly double every posting list.
+      final List<Set<String>> pathSets = List.of(Set.of(TITLE_PATH), Set.of(TITLE_PATH, ALIAS_PATH));
+      for (int i = 0; i < pathSets.size(); i++) {
+        final Set<String> indexedPaths = pathSets.get(i);
+        final String hotResource = HOT_RESOURCE + i;
+        final String rbResource = RB_RESOURCE + i;
+        database.createResource(
+            ResourceConfiguration.newBuilder(hotResource).indexBackendType(IndexBackendType.HOT).build());
+        database.createResource(
+            ResourceConfiguration.newBuilder(rbResource).indexBackendType(IndexBackendType.RBTREE).build());
+        final IndexDef hotDef = buildIndex(database, hotResource, indexedPaths);
+        final IndexDef rbDef = buildIndex(database, rbResource, indexedPaths);
+
+        try (final var hotSession = database.beginResourceSession(hotResource);
+            final var rbSession = database.beginResourceSession(rbResource);
+            final var hotRtx = hotSession.beginNodeReadOnlyTrx();
+            final var rbRtx = rbSession.beginNodeReadOnlyTrx()) {
+
+          final var hotCtl = hotSession.getRtxIndexController(hotRtx.getRevisionNumber());
+          final var rbCtl = rbSession.getRtxIndexController(rbRtx.getRevisionNumber());
+
+          // Query one path at a time AND both at once: a filter narrower than the index is exactly
+          // where the PCR check has to do work.
+          for (final Set<String> queried : List.of(Set.of(TITLE_PATH), Set.of(ALIAS_PATH),
+              Set.of(TITLE_PATH, ALIAS_PATH))) {
+            if (!indexedPaths.containsAll(queried)) {
+              continue;
+            }
+            checkRanges(indexedPaths, queried, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+            checkSearchModes(indexedPaths, queried, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+          }
+        }
+      }
+    }
+
+    // 4 (index shape, queried path set) combinations, each running 11x11 probe pairs x 4
+    // inclusivities + 4 one-sided shapes per probe + 11 probes x 5 search modes = 583 comparisons,
+    // i.e. 2332 in total. Asserted as a floor so a loop that silently stops iterating fails loudly
+    // instead of passing green.
+    assertTrue(comparisons >= 2_332, "the query matrix collapsed — only " + comparisons + " comparisons ran");
+    System.out.println("CASIndexDifferentialTest: " + comparisons + " HOT-vs-RBTree-vs-bruteforce comparisons");
+  }
+
+  /**
+   * The CONTENT-TYPE axis, which is what review round three broke — now asserted exactly.
+   *
+   * <p>
+   * The HOT bounded cursor decides a range by unsigned byte order over the serialized key, so a type
+   * is only safe on that path if its encoding puts byte order and value order in agreement. The
+   * instant family used to fall through to the raw-lexical string branch, where it emphatically does
+   * not: {@code 12:00:00.500001Z} sorts below {@code 12:00:00Z} because {@code '.'} &lt; {@code 'Z'},
+   * and every explicit UTC offset sorts below both. {@code CASKeySerializer} now canonicalizes to UTC
+   * and writes fixed-width components instead, so the answer must be exactly the chronological one.
+   *
+   * <p>
+   * The fixture is written so text order and chronological order disagree in both directions —
+   * fractional seconds, positive and negative offsets, and the same instant spelled three ways — so
+   * any regression to lexical ordering shows up as a wrong answer rather than a lucky pass.
+   */
+  @Test
+  void rangesOnTheInstantFamilyAreChronological() {
+    final List<String> instants = List.of("2020-06-15T12:00:00Z", "2020-06-15T12:00:00.500001Z",
+        "2020-06-15T12:00:00.5Z", "2020-06-15T14:00:00+02:00", "2020-06-15T09:00:00-03:00", "2021-01-01T00:00:00Z");
+    final List<String> probes = List.of("2020-06-15T12:00:00Z", "2020-06-15T12:00:00.500Z", "2020-06-15T13:00:00Z",
+        "2020-06-15T12:00:00+00:00", "2019-01-01T00:00:00Z", "2022-01-01T00:00:00Z");
+
+    final StringBuilder json = new StringBuilder("[");
+    for (int i = 0; i < instants.size(); i++) {
+      json.append(i > 0
+          ? ","
+          : "").append("{\"v\":\"").append(instants.get(i)).append("\"}");
+    }
+    json.append(']');
+
+    final var dbPath = JsonTestHelper.PATHS.PATH2.getFile();
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    try (final var database = Databases.openJsonDatabase(dbPath)) {
+      database.createResource(
+          ResourceConfiguration.newBuilder("dt-hot").indexBackendType(IndexBackendType.HOT).build());
+      database.createResource(
+          ResourceConfiguration.newBuilder("dt-rb").indexBackendType(IndexBackendType.RBTREE).build());
+      final IndexDef def = buildTypedIndex(database, "dt-hot", json.toString());
+      final IndexDef rbDef = buildTypedIndex(database, "dt-rb", json.toString());
+
+      try (final var session = database.beginResourceSession("dt-hot");
+          final var rbSession = database.beginResourceSession("dt-rb");
+          final var rtx = session.beginNodeReadOnlyTrx();
+          final var rbRtx = rbSession.beginNodeReadOnlyTrx()) {
+        final var controller = session.getRtxIndexController(rtx.getRevisionNumber());
+        final var rbController = rbSession.getRtxIndexController(rbRtx.getRevisionNumber());
+        final Set<String> paths = Set.of(V_PATH);
+
+        int checked = 0;
+        for (final String probe : probes) {
+          for (final boolean incMin : new boolean[] {true, false}) {
+            for (final boolean incMax : new boolean[] {true, false}) {
+              // The two one-sided shapes jn:valid-at issues...
+              checked += assertChronological(controller, rtx, def, rbController, rbRtx, rbDef, paths, probe, null,
+                  incMin, incMax, instants);
+              checked += assertChronological(controller, rtx, def, rbController, rbRtx, rbDef, paths, null, probe,
+                  incMin, incMax, instants);
+              // ...and every two-sided window over the probe set.
+              for (final String other : probes) {
+                checked += assertChronological(controller, rtx, def, rbController, rbRtx, rbDef, paths, probe, other,
+                    incMin, incMax, instants);
+              }
+            }
+          }
+        }
+        assertTrue(checked >= 192, "the instant matrix collapsed — only " + checked + " comparisons ran");
+        System.out.println("CASIndexDifferentialTest: " + checked + " chronological instant comparisons");
+      }
+    }
+  }
+
+  /**
+   * The scan must return exactly the instants chronologically inside the bounds — no more, no less.
+   */
+  private static int assertChronological(final IndexController<?, ?> controller, final JsonNodeReadOnlyTrx rtx,
+      final IndexDef def, final IndexController<?, ?> rbController, final JsonNodeReadOnlyTrx rbRtx,
+      final IndexDef rbDef, final Set<String> paths, final String min, final String max, final boolean incMin,
+      final boolean incMax, final List<String> instants) {
+    final Iterator<NodeReferences> hits = instantHits(controller, rtx, def, paths, min, max, incMin, incMax);
+    final Iterator<NodeReferences> rbHits = instantHits(rbController, rbRtx, rbDef, paths, min, max, incMin, incMax);
+
+    final List<String> expected = new ArrayList<>();
+    for (final String instant : instants) {
+      final Instant value = OffsetDateTime.parse(instant).toInstant();
+      if (min != null) {
+        final int cmp = value.compareTo(OffsetDateTime.parse(min).toInstant());
+        if (cmp < 0 || (cmp == 0 && !incMin)) {
+          continue;
+        }
+      }
+      if (max != null) {
+        final int cmp = value.compareTo(OffsetDateTime.parse(max).toInstant());
+        if (cmp > 0 || (cmp == 0 && !incMax)) {
+          continue;
+        }
+      }
+      expected.add("v=\"" + instant + "\"");
+    }
+    Collections.sort(expected);
+
+    final String what = "instant range " + (incMin
+        ? "["
+        : "(") + q(min) + "," + q(max)
+        + (incMax
+            ? "]"
+            : ")");
+    assertEquals(expected, values(rtx, hits), "HOT — " + what);
+    assertEquals(expected, values(rbRtx, rbHits), "RBTree — " + what);
+    return 1;
+  }
+
+  private static Iterator<NodeReferences> instantHits(final IndexController<?, ?> controller,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef def, final Set<String> paths, final String min, final String max,
+      final boolean incMin, final boolean incMax) {
+    return controller.openCASIndex(rtx.getStorageEngineReader(), def, controller.createCASFilterRange(paths, min == null
+        ? null
+        : new DateTime(min),
+        max == null
+            ? null
+            : new DateTime(max),
+        incMin, incMax, new JsonPCRCollector(rtx)));
+  }
+
+  private static final String V_PATH = "/[]/v";
+
+
+  private static IndexDef buildTypedIndex(final Database<JsonResourceSession> database, final String resource,
+      final String json) {
+    try (final var session = database.beginResourceSession(resource); final JsonNodeTrx trx = session.beginNodeTrx()) {
+      final var controller = session.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef def =
+          IndexDefs.createCASIdxDef(false, Type.DATI, parsePaths(Set.of(V_PATH)), 0, IndexDef.DbType.JSON);
+      controller.createIndexes(Set.of(def), trx);
+      new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD).build()
+                                                                                                         .call();
+      trx.commit();
+      return def;
+    }
+  }
+
+  /** Two-sided, min-only and max-only bounds, every inclusivity combination, every probe pair. */
+  private static void checkRanges(final Set<String> indexedPaths, final Set<String> queried,
+      final IndexController<?, ?> hotCtl, final JsonNodeReadOnlyTrx hotRtx, final IndexDef hotDef,
+      final IndexController<?, ?> rbCtl, final JsonNodeReadOnlyTrx rbRtx, final IndexDef rbDef) {
+    for (final String min : PROBES) {
+      for (final String max : PROBES) {
+        for (final boolean incMin : new boolean[] {true, false}) {
+          for (final boolean incMax : new boolean[] {true, false}) {
+            // Two-sided, plus each one-sided shape built from the same probe.
+            compare(indexedPaths, queried, min, max, incMin, incMax, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+          }
+        }
+      }
+      compare(indexedPaths, queried, min, null, true, true, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+      compare(indexedPaths, queried, min, null, false, true, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+      compare(indexedPaths, queried, null, min, true, true, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+      compare(indexedPaths, queried, null, min, true, false, hotCtl, hotRtx, hotDef, rbCtl, rbRtx, rbDef);
+    }
+  }
+
+  private static void compare(final Set<String> indexedPaths, final Set<String> queried, final String min,
+      final String max, final boolean incMin, final boolean incMax, final IndexController<?, ?> hotCtl,
+      final JsonNodeReadOnlyTrx hotRtx, final IndexDef hotDef, final IndexController<?, ?> rbCtl,
+      final JsonNodeReadOnlyTrx rbRtx, final IndexDef rbDef) {
+    final String what = "index=" + indexedPaths + " query=" + queried + " range=" + (incMin
+        ? "["
+        : "(") + q(min) + "," + q(max)
+        + (incMax
+            ? "]"
+            : ")");
+
+    comparisons++;
+    final List<String> hot = values(hotRtx, rangeHits(hotCtl, hotRtx, hotDef, queried, min, max, incMin, incMax));
+    final List<String> rb = values(rbRtx, rangeHits(rbCtl, rbRtx, rbDef, queried, min, max, incMin, incMax));
+    final List<String> expected = bruteForceRange(queried, min, max, incMin, incMax);
+
+    // Against the independent implementation first: it is the oracle that needs no reasoning about
+    // what the answer "should" be, only that two implementations cannot both be right if they differ.
+    assertEquals(rb, hot, "HOT disagrees with the RBTree backend — " + what);
+    // Then against brute force, so a bug both backends share is still caught.
+    assertEquals(expected, hot, "HOT disagrees with brute force — " + what);
+  }
+
+  /** All five {@link SearchMode}s against every probe. */
+  private static void checkSearchModes(final Set<String> indexedPaths, final Set<String> queried,
+      final IndexController<?, ?> hotCtl, final JsonNodeReadOnlyTrx hotRtx, final IndexDef hotDef,
+      final IndexController<?, ?> rbCtl, final JsonNodeReadOnlyTrx rbRtx, final IndexDef rbDef) {
+    for (final String probe : PROBES) {
+      for (final SearchMode mode : SearchMode.values()) {
+        final String what = "index=" + indexedPaths + " query=" + queried + " " + mode + "(" + q(probe) + ")";
+
+        comparisons++;
+        final List<String> hot = values(hotRtx, filterHits(hotCtl, hotRtx, hotDef, queried, probe, mode));
+        final List<String> rb = values(rbRtx, filterHits(rbCtl, rbRtx, rbDef, queried, probe, mode));
+        final List<String> expected = bruteForceMode(queried, probe, mode);
+
+        assertEquals(rb, hot, "HOT disagrees with the RBTree backend — " + what);
+        assertEquals(expected, hot, "HOT disagrees with brute force — " + what);
+      }
+    }
+  }
+
+  // ==================== oracles ====================
+
+  /**
+   * The answer computed straight off {@link #FIXTURE}, with no index involved. Plain
+   * {@link String#compareTo} is the right comparator here because every fixture value and probe is
+   * ASCII, where UTF-16 order, UTF-8 byte order and {@code Str#compareTo} all coincide.
+   */
+  private static List<String> bruteForceRange(final Set<String> queried, final String min, final String max,
+      final boolean incMin, final boolean incMax) {
+    final List<String> out = new ArrayList<>();
+    for (final Entry e : FIXTURE) {
+      if (!queried.contains("/[]/" + e.field())) {
+        continue;
+      }
+      if (min != null && (incMin
+          ? e.value().compareTo(min) < 0
+          : e.value().compareTo(min) <= 0)) {
+        continue;
+      }
+      if (max != null && (incMax
+          ? e.value().compareTo(max) > 0
+          : e.value().compareTo(max) >= 0)) {
+        continue;
+      }
+      out.add(label(e));
+    }
+    Collections.sort(out);
+    return out;
+  }
+
+  private static List<String> bruteForceMode(final Set<String> queried, final String probe, final SearchMode mode) {
+    final List<String> out = new ArrayList<>();
+    for (final Entry e : FIXTURE) {
+      if (!queried.contains("/[]/" + e.field())) {
+        continue;
+      }
+      final int cmp = e.value().compareTo(probe);
+      final boolean keep = switch (mode) {
+        case EQUAL -> cmp == 0;
+        case LOWER -> cmp < 0;
+        case LOWER_OR_EQUAL -> cmp <= 0;
+        case GREATER -> cmp > 0;
+        case GREATER_OR_EQUAL -> cmp >= 0;
+      };
+      if (keep) {
+        out.add(label(e));
+      }
+    }
+    Collections.sort(out);
+    return out;
+  }
+
+  /** The oracle's rendering of a fixture row, matching what {@link #values} produces. */
+  private static String label(final Entry e) {
+    return e.field() + "=\"" + e.value() + "\"";
+  }
+
+  // ==================== fixture + plumbing ====================
+
+  private static IndexDef buildIndex(final Database<JsonResourceSession> database, final String resource,
+      final Set<String> paths) {
+    try (final var session = database.beginResourceSession(resource); final JsonNodeTrx trx = session.beginNodeTrx()) {
+      final var controller = session.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef def = IndexDefs.createCASIdxDef(false, Type.STR, parsePaths(paths), 0, IndexDef.DbType.JSON);
+      controller.createIndexes(Set.of(def), trx);
+      new JsonShredder.Builder(trx, JsonShredder.createStringReader(json()), InsertPosition.AS_FIRST_CHILD).build()
+                                                                                                           .call();
+      trx.commit();
+      return def;
+    }
+  }
+
+  /** The fixture as a JSON array — one object per row, so each value is its own indexed node. */
+  private static String json() {
+    final StringBuilder sb = new StringBuilder("[");
+    for (int i = 0; i < FIXTURE.size(); i++) {
+      final Entry e = FIXTURE.get(i);
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append("{\"").append(e.field()).append("\":\"").append(e.value()).append("\"}");
+    }
+    return sb.append(']').toString();
+  }
+
+  private static Set<Path<QNm>> parsePaths(final Set<String> paths) {
+    final Set<Path<QNm>> parsed = new HashSet<>(paths.size());
+    for (final String path : paths) {
+      parsed.add(Path.parse(path, PathParser.Type.JSON));
+    }
+    return parsed;
+  }
+
+  private static Iterator<NodeReferences> rangeHits(final IndexController<?, ?> controller,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef def, final Set<String> paths, final String min, final String max,
+      final boolean incMin, final boolean incMax) {
+    return controller.openCASIndex(rtx.getStorageEngineReader(), def,
+        controller.createCASFilterRange(paths, atom(min), atom(max), incMin, incMax, new JsonPCRCollector(rtx)));
+  }
+
+  private static Iterator<NodeReferences> filterHits(final IndexController<?, ?> controller,
+      final JsonNodeReadOnlyTrx rtx, final IndexDef def, final Set<String> paths, final String key,
+      final SearchMode mode) {
+    return controller.openCASIndex(rtx.getStorageEngineReader(), def,
+        controller.createCASFilter(paths, new Str(key), mode, new JsonPCRCollector(rtx)));
+  }
+
+  private static Atomic atom(final String value) {
+    return value == null
+        ? null
+        : new Str(value);
+  }
+
+  /**
+   * Resolve every posting to {@code field="value"}, sorted. Resolving beats counting on both axes:
+   * the fixture is built around prefix collisions, so a scan returning {@code carpet} where
+   * {@code car} belongs has the right cardinality and the wrong answer; and it carries the FIELD, so
+   * a posting that leaked in from a neighbouring path is visible even when the two paths hold equal
+   * values (both hold {@code ""} and {@code "car"}, deliberately).
+   */
+  private static List<String> values(final JsonNodeReadOnlyTrx rtx, final Iterator<NodeReferences> hits) {
+    final List<String> out = new ArrayList<>();
+    while (hits.hasNext()) {
+      hits.next().forEachNodeKey(nodeKey -> {
+        if (!rtx.moveTo(nodeKey)) {
+          throw new IllegalStateException("index posting " + nodeKey + " does not resolve to a node");
+        }
+        final String value = rtx.getValue();
+        // The indexed node is either a plain STRING_VALUE under an OBJECT_KEY, or one of the fused
+        // OBJECT_NAMED_* kinds that carries name and value together — so look on the node first and
+        // only walk up when it has no name of its own.
+        QNm name = rtx.getName();
+        if (name == null && rtx.moveToParent()) {
+          name = rtx.getName();
+        }
+        out.add((name == null
+            ? "?"
+            : name.getLocalName()) + "=\"" + value + "\"");
+      });
+    }
+    Collections.sort(out);
+    return out;
+  }
+
+  private static String q(final String value) {
+    return value == null
+        ? "-inf"
+        : "\"" + value + "\"";
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
@@ -33,12 +33,13 @@ import static org.junit.Assert.assertTrue;
 /**
  * CAS index construction over the default (HOT) index backend.
  *
- * <p>Covers both ways an index is populated, because they run through different machinery: an
- * index created <em>before</em> the data is inserted is filled entry-by-entry by the change
- * listener, while an index created <em>over an existing revision</em> is bulk-built from the
- * traversal. Both must produce the same postings, including for values that repeat across many
- * nodes — the shape the bulk-comparison corpus has, and the one that used to make index building
- * quadratic.</p>
+ * <p>
+ * Covers both ways an index is populated, because they run through different machinery: an index
+ * created <em>before</em> the data is inserted is filled entry-by-entry by the change listener,
+ * while an index created <em>over an existing revision</em> is bulk-built from the traversal. Both
+ * must produce the same postings, including for values that repeat across many nodes — the shape
+ * the bulk-comparison corpus has, and the one that used to make index building quadratic.
+ * </p>
  */
 public final class JsonCASIndexBuildTest {
 
@@ -61,7 +62,9 @@ public final class JsonCASIndexBuildTest {
     JsonTestHelper.deleteEverything();
   }
 
-  /** A document of {@link #RECORDS} objects whose {@code category} cycles over {@link #CATEGORIES}. */
+  /**
+   * A document of {@link #RECORDS} objects whose {@code category} cycles over {@link #CATEGORIES}.
+   */
   private static String duplicateHeavyDocument() {
     final StringBuilder json = new StringBuilder(RECORDS * 48);
     json.append('[');
@@ -69,7 +72,10 @@ public final class JsonCASIndexBuildTest {
       if (i > 0) {
         json.append(',');
       }
-      json.append("{\"id\":").append(i).append(",\"category\":\"").append(CATEGORIES[i % CATEGORIES.length])
+      json.append("{\"id\":")
+          .append(i)
+          .append(",\"category\":\"")
+          .append(CATEGORIES[i % CATEGORIES.length])
           .append("\"}");
     }
     return json.append(']').toString();
@@ -83,9 +89,9 @@ public final class JsonCASIndexBuildTest {
       final JsonNodeTrx trx, final IndexDef indexDef) {
     final Map<String, TreeSet<Long>> postings = new LinkedHashMap<>(CATEGORIES.length);
     for (final String category : CATEGORIES) {
-      final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
-          indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(category), SearchMode.EQUAL,
-              new JsonPCRCollector(trx)));
+      final Iterator<NodeReferences> hits =
+          indexController.openCASIndex(trx.getStorageEngineReader(), indexDef, indexController.createCASFilter(
+              Set.of(CATEGORY_PATH), new Str(category), SearchMode.EQUAL, new JsonPCRCollector(trx)));
       final TreeSet<Long> nodeKeys = new TreeSet<>();
       while (hits.hasNext()) {
         final LongIterator it = hits.next().getNodeKeys().getLongIterator();
@@ -99,20 +105,20 @@ public final class JsonCASIndexBuildTest {
   }
 
   private static IndexDef categoryIndexDef(final int id) {
-    return IndexDefs.createCASIdxDef(false, Type.STR,
-        Collections.singleton(parse(CATEGORY_PATH, PathParser.Type.JSON)), id, IndexDef.DbType.JSON);
+    return IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(parse(CATEGORY_PATH, PathParser.Type.JSON)),
+        id, IndexDef.DbType.JSON);
   }
 
   private static void shred(final JsonNodeTrx trx, final String json) {
-    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
-        .commitAfterwards().build().call();
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json),
+        InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
   }
 
   /** Postings of an index created over an already-shredded revision (the bulk-built path). */
   private Map<String, TreeSet<Long>> buildOverExistingRevision(final Path databasePath) {
     final var database = JsonTestHelper.getDatabase(databasePath);
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       shred(trx, duplicateHeavyDocument());
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
       indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
@@ -125,7 +131,7 @@ public final class JsonCASIndexBuildTest {
   private Map<String, TreeSet<Long>> buildWhileInserting(final Path databasePath) {
     final var database = JsonTestHelper.getDatabase(databasePath);
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
       indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
       shred(trx, duplicateHeavyDocument());
@@ -135,8 +141,7 @@ public final class JsonCASIndexBuildTest {
 
   @Test
   public void buildingOverAnExistingRevisionIndexesEveryOccurrenceOfARepeatedValue() {
-    final Map<String, TreeSet<Long>> postings =
-        buildOverExistingRevision(JsonTestHelper.PATHS.PATH1.getFile());
+    final Map<String, TreeSet<Long>> postings = buildOverExistingRevision(JsonTestHelper.PATHS.PATH1.getFile());
 
     long total = 0;
     for (final String category : CATEGORIES) {
@@ -149,16 +154,16 @@ public final class JsonCASIndexBuildTest {
 
   /**
    * Building over an existing revision must materialise the trie in one canonical pass. The
-   * incremental path it replaced reached the same result by inserting entry-by-entry and healing
-   * the malformed nodes its folds produced — thousands of {@code O(subtree)} rebuilds for a
-   * document this size, which is what made building an index over a large corpus impractical.
-   * Counting rebuilds rather than milliseconds keeps the guard deterministic.
+   * incremental path it replaced reached the same result by inserting entry-by-entry and healing the
+   * malformed nodes its folds produced — thousands of {@code O(subtree)} rebuilds for a document this
+   * size, which is what made building an index over a large corpus impractical. Counting rebuilds
+   * rather than milliseconds keeps the guard deterministic.
    */
   @Test
   public void buildingOverAnExistingRevisionRebuildsNoSubtree() {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       shred(trx, duplicateHeavyDocument());
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
 
@@ -184,8 +189,8 @@ public final class JsonCASIndexBuildTest {
 
     assertEquals("both builds must cover the same values", bulk.keySet(), incremental.keySet());
     for (final String category : CATEGORIES) {
-      assertEquals("postings for " + category + " must not depend on how the index was built",
-          bulk.get(category), incremental.get(category));
+      assertEquals("postings for " + category + " must not depend on how the index was built", bulk.get(category),
+          incremental.get(category));
     }
   }
 
@@ -193,9 +198,9 @@ public final class JsonCASIndexBuildTest {
    * Every index now starts life as a {@link io.sirix.index.hot.HOTBulkBuilder}-produced trie rather
    * than as the empty leaf the incremental path used to grow from, so the first update a resource
    * takes after a build lands on a shape the incremental machinery had never been fed. This walks
-   * that transition: bulk-build, commit, then insert and delete through the change listener —
-   * merging into a key the bulk build already wrote, adding a key it never saw, and removing nodes
-   * of both — and checks the postings still describe the document.
+   * that transition: bulk-build, commit, then insert and delete through the change listener — merging
+   * into a key the bulk build already wrote, adding a key it never saw, and removing nodes of both —
+   * and checks the postings still describe the document.
    */
   @Test
   public void incrementalInsertsAndDeletesAfterABulkBuild() {
@@ -208,7 +213,7 @@ public final class JsonCASIndexBuildTest {
     expected.put(freshCategory, 0);
 
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       shred(trx, duplicateHeavyDocument());
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
       indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
@@ -221,16 +226,20 @@ public final class JsonCASIndexBuildTest {
       trx.moveToFirstChild();
       final long arrayNodeKey = trx.getNodeKey();
       for (int i = 0; i < inserts; i++) {
-        final String category = i % 2 == 0 ? CATEGORIES[0] : freshCategory;
+        final String category = i % 2 == 0
+            ? CATEGORIES[0]
+            : freshCategory;
         trx.moveTo(arrayNodeKey);
-        trx.insertSubtreeAsFirstChild(
-            JsonShredder.createStringReader("{\"category\":\"" + category + "\"}"), JsonNodeTrx.Commit.NO);
+        trx.insertSubtreeAsFirstChild(JsonShredder.createStringReader("{\"category\":\"" + category + "\"}"),
+            JsonNodeTrx.Commit.NO);
         expected.merge(category, 1, Integer::sum);
       }
 
       final int deletes = 6;
       for (int i = 0; i < deletes; i++) {
-        final String category = (inserts - 1 - i) % 2 == 0 ? CATEGORIES[0] : freshCategory;
+        final String category = (inserts - 1 - i) % 2 == 0
+            ? CATEGORIES[0]
+            : freshCategory;
         trx.moveTo(arrayNodeKey);
         trx.moveToFirstChild();
         trx.remove();
@@ -242,9 +251,9 @@ public final class JsonCASIndexBuildTest {
       long total = 0;
       for (final Map.Entry<String, Integer> entry : expected.entrySet()) {
         final TreeSet<Long> nodeKeys = new TreeSet<>();
-        final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
-            indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(entry.getKey()), SearchMode.EQUAL,
-                new JsonPCRCollector(trx)));
+        final Iterator<NodeReferences> hits =
+            indexController.openCASIndex(trx.getStorageEngineReader(), indexDef, indexController.createCASFilter(
+                Set.of(CATEGORY_PATH), new Str(entry.getKey()), SearchMode.EQUAL, new JsonPCRCollector(trx)));
         while (hits.hasNext()) {
           final LongIterator it = hits.next().getNodeKeys().getLongIterator();
           while (it.hasNext()) {
@@ -265,9 +274,9 @@ public final class JsonCASIndexBuildTest {
   /**
    * The loader keeps composite keys in fixed 1 MiB blocks, so sorting, grouping and the final key
    * copy all have to address across block boundaries. Long values reach that in a few thousand
-   * records: 10 header bytes + a 200-byte value + the 4-byte chunkIdx trailer is 214 bytes a key,
-   * so this build spans two blocks. Values are near {@code MAX_STRING_VALUE_BYTES} but under it,
-   * so nothing is truncated and every value stays distinguishable.
+   * records: 10 header bytes + a 200-byte value + the 4-byte chunkIdx trailer is 214 bytes a key, so
+   * this build spans two blocks. Values are near {@code MAX_STRING_VALUE_BYTES} but under it, so
+   * nothing is truncated and every value stays distinguishable.
    */
   @Test
   public void buildsAnIndexWhoseKeysSpanSeveralBlocks() {
@@ -288,7 +297,7 @@ public final class JsonCASIndexBuildTest {
 
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       shred(trx, json.toString());
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
       indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
@@ -299,9 +308,9 @@ public final class JsonCASIndexBuildTest {
           count(indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
               indexController.createCASFilter(Set.of(), null, SearchMode.EQUAL, new JsonPCRCollector(trx)))));
 
-      final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
-          indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(probe), SearchMode.EQUAL,
-              new JsonPCRCollector(trx)));
+      final Iterator<NodeReferences> hits =
+          indexController.openCASIndex(trx.getStorageEngineReader(), indexDef, indexController.createCASFilter(
+              Set.of(CATEGORY_PATH), new Str(probe), SearchMode.EQUAL, new JsonPCRCollector(trx)));
       final TreeSet<Long> nodeKeys = new TreeSet<>();
       while (hits.hasNext()) {
         final LongIterator it = hits.next().getNodeKeys().getLongIterator();
@@ -320,29 +329,31 @@ public final class JsonCASIndexBuildTest {
     final var jsonPath = JSON.resolve("abc-location-stations.json");
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
-      new JsonShredder.Builder(trx, JsonShredder.createFileReader(jsonPath), InsertPosition.AS_FIRST_CHILD)
-          .commitAfterwards().build().call();
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      new JsonShredder.Builder(trx, JsonShredder.createFileReader(jsonPath),
+          InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
 
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
       final var typePath = parse("/features/[]/type", PathParser.Type.JSON);
       final var namePath = parse("/features/[]/properties/name", PathParser.Type.JSON);
-      indexController.createIndexes(Set.of(
-          IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(typePath), 0, IndexDef.DbType.JSON),
-          IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(namePath), 1, IndexDef.DbType.JSON)), trx);
+      indexController.createIndexes(
+          Set.of(IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(typePath), 0, IndexDef.DbType.JSON),
+              IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(namePath), 1, IndexDef.DbType.JSON)),
+          trx);
       trx.commit();
 
       // "Feature" is the value of every /features/[]/type — the single-value extreme.
       final var typeDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
-      assertEquals(53, count(indexController.openCASIndex(trx.getStorageEngineReader(), typeDef,
-          indexController.createCASFilter(Set.of("/features/[]/type"), new Str("Feature"), SearchMode.EQUAL,
-              new JsonPCRCollector(trx)))));
+      assertEquals(53,
+          count(indexController.openCASIndex(trx.getStorageEngineReader(), typeDef, indexController.createCASFilter(
+              Set.of("/features/[]/type"), new Str("Feature"), SearchMode.EQUAL, new JsonPCRCollector(trx)))));
 
       // Names are distinct — the all-singleton extreme.
       final var nameDef = indexController.getIndexes().getIndexDef(1, IndexType.CAS);
-      assertEquals(1, count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
-          indexController.createCASFilter(Set.of("/features/[]/properties/name"), new Str("ABC Radio Adelaide"),
-              SearchMode.EQUAL, new JsonPCRCollector(trx)))));
+      assertEquals(1,
+          count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
+              indexController.createCASFilter(Set.of("/features/[]/properties/name"), new Str("ABC Radio Adelaide"),
+                  SearchMode.EQUAL, new JsonPCRCollector(trx)))));
       assertEquals(53, count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
           indexController.createCASFilter(Set.of(), null, SearchMode.EQUAL, new JsonPCRCollector(trx)))));
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
@@ -189,6 +189,132 @@ public final class JsonCASIndexBuildTest {
     }
   }
 
+  /**
+   * Every index now starts life as a {@link io.sirix.index.hot.HOTBulkBuilder}-produced trie rather
+   * than as the empty leaf the incremental path used to grow from, so the first update a resource
+   * takes after a build lands on a shape the incremental machinery had never been fed. This walks
+   * that transition: bulk-build, commit, then insert and delete through the change listener —
+   * merging into a key the bulk build already wrote, adding a key it never saw, and removing nodes
+   * of both — and checks the postings still describe the document.
+   */
+  @Test
+  public void incrementalInsertsAndDeletesAfterABulkBuild() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    final Map<String, Integer> expected = new LinkedHashMap<>();
+    for (final String category : CATEGORIES) {
+      expected.put(category, RECORDS / CATEGORIES.length);
+    }
+    final String freshCategory = "zeta";
+    expected.put(freshCategory, 0);
+
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      shred(trx, duplicateHeavyDocument());
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+      indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
+      trx.commit();
+
+      // Insert as first child, so the most recently inserted object is the array's first child —
+      // which is what the delete loop below then walks off the front.
+      final int inserts = 20;
+      trx.moveToDocumentRoot();
+      trx.moveToFirstChild();
+      final long arrayNodeKey = trx.getNodeKey();
+      for (int i = 0; i < inserts; i++) {
+        final String category = i % 2 == 0 ? CATEGORIES[0] : freshCategory;
+        trx.moveTo(arrayNodeKey);
+        trx.insertSubtreeAsFirstChild(
+            JsonShredder.createStringReader("{\"category\":\"" + category + "\"}"), JsonNodeTrx.Commit.NO);
+        expected.merge(category, 1, Integer::sum);
+      }
+
+      final int deletes = 6;
+      for (int i = 0; i < deletes; i++) {
+        final String category = (inserts - 1 - i) % 2 == 0 ? CATEGORIES[0] : freshCategory;
+        trx.moveTo(arrayNodeKey);
+        trx.moveToFirstChild();
+        trx.remove();
+        expected.merge(category, -1, Integer::sum);
+      }
+      trx.commit();
+
+      final IndexDef indexDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
+      long total = 0;
+      for (final Map.Entry<String, Integer> entry : expected.entrySet()) {
+        final TreeSet<Long> nodeKeys = new TreeSet<>();
+        final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+            indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(entry.getKey()), SearchMode.EQUAL,
+                new JsonPCRCollector(trx)));
+        while (hits.hasNext()) {
+          final LongIterator it = hits.next().getNodeKeys().getLongIterator();
+          while (it.hasNext()) {
+            nodeKeys.add(it.next());
+          }
+        }
+        assertEquals("postings for " + entry.getKey(), entry.getValue().intValue(), nodeKeys.size());
+        for (final long nodeKey : nodeKeys) {
+          assertTrue("index points at a live node", trx.moveTo(nodeKey));
+          assertEquals("indexed node still holds the value it was indexed under", entry.getKey(), trx.getValue());
+        }
+        total += nodeKeys.size();
+      }
+      assertEquals("every remaining record must be indexed exactly once", RECORDS + 20 - 6, total);
+    }
+  }
+
+  /**
+   * The loader keeps composite keys in fixed 1 MiB blocks, so sorting, grouping and the final key
+   * copy all have to address across block boundaries. Long values reach that in a few thousand
+   * records: 10 header bytes + a 200-byte value + the 4-byte chunkIdx trailer is 214 bytes a key,
+   * so this build spans two blocks. Values are near {@code MAX_STRING_VALUE_BYTES} but under it,
+   * so nothing is truncated and every value stays distinguishable.
+   */
+  @Test
+  public void buildsAnIndexWhoseKeysSpanSeveralBlocks() {
+    final int records = 6_000;
+    final int valueLength = 200;
+    final StringBuilder json = new StringBuilder(records * (valueLength + 24));
+    json.append('[');
+    for (int i = 0; i < records; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      final String suffix = Integer.toString(i);
+      json.append("{\"category\":\"").append("v".repeat(valueLength - suffix.length())).append(suffix).append("\"}");
+    }
+    json.append(']');
+
+    final String probe = "v".repeat(valueLength - 4) + "4242";
+
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      shred(trx, json.toString());
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+      indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
+      trx.commit();
+
+      final IndexDef indexDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
+      assertEquals("every long value must be indexed", records,
+          count(indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+              indexController.createCASFilter(Set.of(), null, SearchMode.EQUAL, new JsonPCRCollector(trx)))));
+
+      final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+          indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(probe), SearchMode.EQUAL,
+              new JsonPCRCollector(trx)));
+      final TreeSet<Long> nodeKeys = new TreeSet<>();
+      while (hits.hasNext()) {
+        final LongIterator it = hits.next().getNodeKeys().getLongIterator();
+        while (it.hasNext()) {
+          nodeKeys.add(it.next());
+        }
+      }
+      assertEquals("exactly one node holds the probed value", 1, nodeKeys.size());
+      assertTrue(trx.moveTo(nodeKeys.first()));
+      assertEquals("the indexed node holds the probed value", probe, trx.getValue());
+    }
+  }
+
   @Test
   public void buildsStringAndNumericIndexesOverARealCorpus() {
     final var jsonPath = JSON.resolve("abc-location-stations.json");

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASIndexBuildTest.java
@@ -1,0 +1,237 @@
+package io.sirix.index;
+
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.hot.AbstractHOTIndexWriter;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.roaringbitmap.longlong.LongIterator;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static io.brackit.query.util.path.Path.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * CAS index construction over the default (HOT) index backend.
+ *
+ * <p>Covers both ways an index is populated, because they run through different machinery: an
+ * index created <em>before</em> the data is inserted is filled entry-by-entry by the change
+ * listener, while an index created <em>over an existing revision</em> is bulk-built from the
+ * traversal. Both must produce the same postings, including for values that repeat across many
+ * nodes — the shape the bulk-comparison corpus has, and the one that used to make index building
+ * quadratic.</p>
+ */
+public final class JsonCASIndexBuildTest {
+
+  private static final Path JSON = Paths.get("src", "test", "resources", "json");
+
+  /** Field values in the synthetic document; each repeats {@link #RECORDS} / its arity times. */
+  private static final String[] CATEGORIES = {"alpha", "beta", "gamma", "delta", "epsilon"};
+
+  private static final int RECORDS = 2_000;
+
+  private static final String CATEGORY_PATH = "/[]/category";
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  /** A document of {@link #RECORDS} objects whose {@code category} cycles over {@link #CATEGORIES}. */
+  private static String duplicateHeavyDocument() {
+    final StringBuilder json = new StringBuilder(RECORDS * 48);
+    json.append('[');
+    for (int i = 0; i < RECORDS; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"id\":").append(i).append(",\"category\":\"").append(CATEGORIES[i % CATEGORIES.length])
+          .append("\"}");
+    }
+    return json.append(']').toString();
+  }
+
+  /**
+   * The node keys the CAS index holds for every value in {@link #CATEGORIES}, as a value → sorted
+   * node keys map.
+   */
+  private static Map<String, TreeSet<Long>> readPostings(final JsonIndexController indexController,
+      final JsonNodeTrx trx, final IndexDef indexDef) {
+    final Map<String, TreeSet<Long>> postings = new LinkedHashMap<>(CATEGORIES.length);
+    for (final String category : CATEGORIES) {
+      final Iterator<NodeReferences> hits = indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+          indexController.createCASFilter(Set.of(CATEGORY_PATH), new Str(category), SearchMode.EQUAL,
+              new JsonPCRCollector(trx)));
+      final TreeSet<Long> nodeKeys = new TreeSet<>();
+      while (hits.hasNext()) {
+        final LongIterator it = hits.next().getNodeKeys().getLongIterator();
+        while (it.hasNext()) {
+          nodeKeys.add(it.next());
+        }
+      }
+      postings.put(category, nodeKeys);
+    }
+    return postings;
+  }
+
+  private static IndexDef categoryIndexDef(final int id) {
+    return IndexDefs.createCASIdxDef(false, Type.STR,
+        Collections.singleton(parse(CATEGORY_PATH, PathParser.Type.JSON)), id, IndexDef.DbType.JSON);
+  }
+
+  private static void shred(final JsonNodeTrx trx, final String json) {
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
+        .commitAfterwards().build().call();
+  }
+
+  /** Postings of an index created over an already-shredded revision (the bulk-built path). */
+  private Map<String, TreeSet<Long>> buildOverExistingRevision(final Path databasePath) {
+    final var database = JsonTestHelper.getDatabase(databasePath);
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      shred(trx, duplicateHeavyDocument());
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+      indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
+      trx.commit();
+      return readPostings(indexController, trx, indexController.getIndexes().getIndexDef(0, IndexType.CAS));
+    }
+  }
+
+  /** Postings of an index created before the data existed (the change-listener path). */
+  private Map<String, TreeSet<Long>> buildWhileInserting(final Path databasePath) {
+    final var database = JsonTestHelper.getDatabase(databasePath);
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+      indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
+      shred(trx, duplicateHeavyDocument());
+      return readPostings(indexController, trx, indexController.getIndexes().getIndexDef(0, IndexType.CAS));
+    }
+  }
+
+  @Test
+  public void buildingOverAnExistingRevisionIndexesEveryOccurrenceOfARepeatedValue() {
+    final Map<String, TreeSet<Long>> postings =
+        buildOverExistingRevision(JsonTestHelper.PATHS.PATH1.getFile());
+
+    long total = 0;
+    for (final String category : CATEGORIES) {
+      final TreeSet<Long> nodeKeys = postings.get(category);
+      assertEquals("postings for " + category, RECORDS / CATEGORIES.length, nodeKeys.size());
+      total += nodeKeys.size();
+    }
+    assertEquals("every record must be indexed exactly once", RECORDS, total);
+  }
+
+  /**
+   * Building over an existing revision must materialise the trie in one canonical pass. The
+   * incremental path it replaced reached the same result by inserting entry-by-entry and healing
+   * the malformed nodes its folds produced — thousands of {@code O(subtree)} rebuilds for a
+   * document this size, which is what made building an index over a large corpus impractical.
+   * Counting rebuilds rather than milliseconds keeps the guard deterministic.
+   */
+  @Test
+  public void buildingOverAnExistingRevisionRebuildsNoSubtree() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      shred(trx, duplicateHeavyDocument());
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+
+      final long rebuildsBefore = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get();
+      final long selfHealsBefore = AbstractHOTIndexWriter.STRUCTURAL_SELFHEAL_REBUILD.get();
+      final long strandsBefore = AbstractHOTIndexWriter.STRAND_LEAF_REBUILD.get();
+
+      indexController.createIndexes(Set.of(categoryIndexDef(0)), trx);
+
+      assertEquals("subtree rebuilds during a bulk build", rebuildsBefore,
+          AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get());
+      assertEquals("structural self-heals during a bulk build", selfHealsBefore,
+          AbstractHOTIndexWriter.STRUCTURAL_SELFHEAL_REBUILD.get());
+      assertEquals("strand rebuilds during a bulk build", strandsBefore,
+          AbstractHOTIndexWriter.STRAND_LEAF_REBUILD.get());
+    }
+  }
+
+  @Test
+  public void bulkBuiltAndListenerBuiltIndexesAgree() {
+    final Map<String, TreeSet<Long>> bulk = buildOverExistingRevision(JsonTestHelper.PATHS.PATH1.getFile());
+    final Map<String, TreeSet<Long>> incremental = buildWhileInserting(JsonTestHelper.PATHS.PATH2.getFile());
+
+    assertEquals("both builds must cover the same values", bulk.keySet(), incremental.keySet());
+    for (final String category : CATEGORIES) {
+      assertEquals("postings for " + category + " must not depend on how the index was built",
+          bulk.get(category), incremental.get(category));
+    }
+  }
+
+  @Test
+  public void buildsStringAndNumericIndexesOverARealCorpus() {
+    final var jsonPath = JSON.resolve("abc-location-stations.json");
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      new JsonShredder.Builder(trx, JsonShredder.createFileReader(jsonPath), InsertPosition.AS_FIRST_CHILD)
+          .commitAfterwards().build().call();
+
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+      final var typePath = parse("/features/[]/type", PathParser.Type.JSON);
+      final var namePath = parse("/features/[]/properties/name", PathParser.Type.JSON);
+      indexController.createIndexes(Set.of(
+          IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(typePath), 0, IndexDef.DbType.JSON),
+          IndexDefs.createCASIdxDef(false, Type.STR, Collections.singleton(namePath), 1, IndexDef.DbType.JSON)), trx);
+      trx.commit();
+
+      // "Feature" is the value of every /features/[]/type — the single-value extreme.
+      final var typeDef = indexController.getIndexes().getIndexDef(0, IndexType.CAS);
+      assertEquals(53, count(indexController.openCASIndex(trx.getStorageEngineReader(), typeDef,
+          indexController.createCASFilter(Set.of("/features/[]/type"), new Str("Feature"), SearchMode.EQUAL,
+              new JsonPCRCollector(trx)))));
+
+      // Names are distinct — the all-singleton extreme.
+      final var nameDef = indexController.getIndexes().getIndexDef(1, IndexType.CAS);
+      assertEquals(1, count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
+          indexController.createCASFilter(Set.of("/features/[]/properties/name"), new Str("ABC Radio Adelaide"),
+              SearchMode.EQUAL, new JsonPCRCollector(trx)))));
+      assertEquals(53, count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
+          indexController.createCASFilter(Set.of(), null, SearchMode.EQUAL, new JsonPCRCollector(trx)))));
+
+      // A value that is not in the corpus must not be reported.
+      assertTrue(count(indexController.openCASIndex(trx.getStorageEngineReader(), nameDef,
+          indexController.createCASFilter(Set.of("/features/[]/properties/name"), new Str("no such station"),
+              SearchMode.EQUAL, new JsonPCRCollector(trx)))) == 0);
+    }
+  }
+
+  private static long count(final Iterator<NodeReferences> hits) {
+    long total = 0;
+    while (hits.hasNext()) {
+      total += hits.next().getNodeKeys().getLongCardinality();
+    }
+    return total;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASNumericLookupTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASNumericLookupTest.java
@@ -1,0 +1,114 @@
+package io.sirix.index;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Dbl;
+import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Int64;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+import static io.brackit.query.util.path.Path.parse;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Equality lookups against a numeric CAS index.
+ *
+ * <p>A HOT index key is a byte string that carries the value's type id, so a probe key has to be
+ * typed like the entries the index stores rather than like whatever atomic the caller passed —
+ * otherwise an {@code xs:decimal} index probed with a numerically equal {@code xs:double} builds a
+ * different key and the lookup silently returns nothing. The RBTree backend never had that
+ * problem, which is what made it easy to miss.</p>
+ */
+public final class JsonCASNumericLookupTest {
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  private static long count(final Iterator<NodeReferences> hits) {
+    long total = 0;
+    while (hits.hasNext()) {
+      total += hits.next().getNodeKeys().getLongCardinality();
+    }
+    return total;
+  }
+
+  /** Shred {@code json}, index {@code path} as {@code contentType}, and hand back a prober. */
+  private static Prober index(final String json, final String path, final Type contentType,
+      final JsonNodeTrx trx, final JsonResourceSession manager) {
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
+        .commitAfterwards().build().call();
+
+    final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+    indexController.createIndexes(Set.of(IndexDefs.createCASIdxDef(false, contentType,
+        Collections.singleton(parse(path, PathParser.Type.JSON)), 0, IndexDef.DbType.JSON)), trx);
+    trx.commit();
+    return new Prober(indexController, trx, indexController.getIndexes().getIndexDef(0, IndexType.CAS), path);
+  }
+
+  private record Prober(JsonIndexController indexController, JsonNodeTrx trx, IndexDef indexDef, String path) {
+    long equalTo(final Atomic key) {
+      return count(indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+          indexController.createCASFilter(Set.of(path), key, SearchMode.EQUAL, new JsonPCRCollector(trx))));
+    }
+
+    long all() {
+      return count(indexController.openCASIndex(trx.getStorageEngineReader(), indexDef,
+          indexController.createCASFilter(Set.of(), null, SearchMode.EQUAL, new JsonPCRCollector(trx))));
+    }
+  }
+
+  @Test
+  public void decimalIndexIsFoundByAnyNumericProbeType() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final Prober prober =
+          index("[{\"v\":2.33},{\"v\":7.5},{\"v\":2.33},{\"other\":1}]", "/[]/v", Type.DEC, trx, manager);
+
+      assertEquals("every v must be indexed", 3, prober.all());
+      assertEquals("probe with xs:decimal", 2, prober.equalTo(new Dec(new BigDecimal("2.33"))));
+      assertEquals("probe with xs:double", 2, prober.equalTo(new Dbl(2.33)));
+      assertEquals("probe with xs:double, singleton value", 1, prober.equalTo(new Dbl(7.5)));
+      assertEquals("value not in the index", 0, prober.equalTo(new Dbl(9.25)));
+    }
+  }
+
+  @Test
+  public void integerIndexIsFoundByAnyNumericProbeType() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final Prober prober = index("[{\"n\":3},{\"n\":10},{\"n\":3}]", "/[]/n", Type.INR, trx, manager);
+
+      assertEquals("every n must be indexed", 3, prober.all());
+      assertEquals("probe with xs:int", 2, prober.equalTo(new Int32(3)));
+      assertEquals("probe with xs:long", 1, prober.equalTo(new Int64(10)));
+      assertEquals("probe with xs:decimal", 2, prober.equalTo(new Dec(new BigDecimal("3"))));
+      assertEquals("value not in the index", 0, prober.equalTo(new Int32(4)));
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASNumericLookupTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonCASNumericLookupTest.java
@@ -30,11 +30,13 @@ import static org.junit.Assert.assertEquals;
 /**
  * Equality lookups against a numeric CAS index.
  *
- * <p>A HOT index key is a byte string that carries the value's type id, so a probe key has to be
- * typed like the entries the index stores rather than like whatever atomic the caller passed —
- * otherwise an {@code xs:decimal} index probed with a numerically equal {@code xs:double} builds a
- * different key and the lookup silently returns nothing. The RBTree backend never had that
- * problem, which is what made it easy to miss.</p>
+ * <p>
+ * A HOT index key is a byte string that carries the value's type id, so a probe key has to be typed
+ * like the entries the index stores rather than like whatever atomic the caller passed — otherwise
+ * an {@code xs:decimal} index probed with a numerically equal {@code xs:double} builds a different
+ * key and the lookup silently returns nothing. The RBTree backend never had that problem, which is
+ * what made it easy to miss.
+ * </p>
  */
 public final class JsonCASNumericLookupTest {
 
@@ -57,10 +59,10 @@ public final class JsonCASNumericLookupTest {
   }
 
   /** Shred {@code json}, index {@code path} as {@code contentType}, and hand back a prober. */
-  private static Prober index(final String json, final String path, final Type contentType,
-      final JsonNodeTrx trx, final JsonResourceSession manager) {
-    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
-        .commitAfterwards().build().call();
+  private static Prober index(final String json, final String path, final Type contentType, final JsonNodeTrx trx,
+      final JsonResourceSession manager) {
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json),
+        InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
 
     final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
     indexController.createIndexes(Set.of(IndexDefs.createCASIdxDef(false, contentType,
@@ -85,7 +87,7 @@ public final class JsonCASNumericLookupTest {
   public void decimalIndexIsFoundByAnyNumericProbeType() {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       final Prober prober =
           index("[{\"v\":2.33},{\"v\":7.5},{\"v\":2.33},{\"other\":1}]", "/[]/v", Type.DEC, trx, manager);
 
@@ -101,7 +103,7 @@ public final class JsonCASNumericLookupTest {
   public void integerIndexIsFoundByAnyNumericProbeType() {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       final Prober prober = index("[{\"n\":3},{\"n\":10},{\"n\":3}]", "/[]/n", Type.INR, trx, manager);
 
       assertEquals("every n must be indexed", 3, prober.all());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
@@ -155,6 +155,48 @@ public final class JsonPathAndNameIndexBuildTest {
     assertEquals("postings must not depend on how the index was built", incremental, bulk);
   }
 
+  /**
+   * A NAME key is the field name as raw UTF-8, so nothing bounds it but the document. Both write
+   * paths used to size their key buffer from the length the serializer <em>returned</em> — after it
+   * had already written that many bytes into a 512-byte buffer — so a field name past roughly 500
+   * characters wrote off the end. Both now size from an upper bound taken before the write, so the
+   * only thing a long name costs is a bigger buffer.
+   */
+  @Test
+  public void indexesAFieldNameLongerThanTheKeyBuffer() {
+    final String longName = "n".repeat(2_000);
+    final String json = "[{\"" + longName + "\":1},{\"" + longName + "\":2},{\"other\":3}]";
+
+    final TreeSet<Long> bulk = longNamePostings(JsonTestHelper.PATHS.PATH1.getFile(), json, longName, false);
+    final TreeSet<Long> incremental = longNamePostings(JsonTestHelper.PATHS.PATH2.getFile(), json, longName, true);
+
+    assertEquals("both fields with the long name must be indexed", 2, bulk.size());
+    assertEquals("postings must not depend on how the index was built", incremental, bulk);
+  }
+
+  private TreeSet<Long> longNamePostings(final Path databasePath, final String json, final String name,
+      final boolean indexFirst) {
+    final var database = JsonTestHelper.getDatabase(databasePath);
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final IndexDef requested = nameIndexDef();
+      final JsonIndexController indexController;
+      if (indexFirst) {
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(requested), trx);
+        shred(trx, json);
+      } else {
+        shred(trx, json);
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(requested), trx);
+        trx.commit();
+      }
+      final IndexDef def = indexController.getIndexes().getIndexDef(requested.getID(), IndexType.NAME);
+      return collect(indexController.openNameIndex(trx.getStorageEngineReader(), def,
+          indexController.createNameFilter(Set.of(name))));
+    }
+  }
+
   @Test
   public void buildingOverAnExistingRevisionRebuildsNoSubtree() {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
@@ -27,12 +27,14 @@ import static org.junit.Assert.assertFalse;
 /**
  * PATH and NAME index construction over the default (HOT) index backend.
  *
- * <p>Both families used to add a node to a key's posting list by reading the whole list back and
+ * <p>
+ * Both families used to add a node to a key's posting list by reading the whole list back and
  * re-inserting it, which is quadratic in how many nodes share the key — and sharing keys is the
  * entire point of these two indexes: every node under an indexed path shares one PATH key, and
  * every element with the same name shares one NAME key. Building over an existing revision now
- * bulk-loads instead, so the tests below pin both the postings and the absence of the trie
- * rebuilds the incremental path used to trigger.</p>
+ * bulk-loads instead, so the tests below pin both the postings and the absence of the trie rebuilds
+ * the incremental path used to trigger.
+ * </p>
  */
 public final class JsonPathAndNameIndexBuildTest {
 
@@ -60,15 +62,18 @@ public final class JsonPathAndNameIndexBuildTest {
       if (i > 0) {
         json.append(',');
       }
-      json.append("{\"title\":\"t").append(i).append("\",\"category\":\"")
-          .append(CATEGORIES[i % CATEGORIES.length]).append("\"}");
+      json.append("{\"title\":\"t")
+          .append(i)
+          .append("\",\"category\":\"")
+          .append(CATEGORIES[i % CATEGORIES.length])
+          .append("\"}");
     }
     return json.append(']').toString();
   }
 
   private static void shred(final JsonNodeTrx trx, final String json) {
-    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
-        .commitAfterwards().build().call();
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json),
+        InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
   }
 
   private static TreeSet<Long> collect(final Iterator<NodeReferences> hits) {
@@ -93,7 +98,7 @@ public final class JsonPathAndNameIndexBuildTest {
   private TreeSet<Long> pathPostings(final Path databasePath, final boolean indexFirst) {
     final var database = JsonTestHelper.getDatabase(databasePath);
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       final JsonIndexController indexController;
       if (indexFirst) {
         indexController = manager.getWtxIndexController(trx.getRevisionNumber());
@@ -114,7 +119,7 @@ public final class JsonPathAndNameIndexBuildTest {
   private TreeSet<Long> namePostings(final Path databasePath, final boolean indexFirst) {
     final var database = JsonTestHelper.getDatabase(databasePath);
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       // A NAME definition's ID is offset by the name-index page slot, so ask for the ID the
       // definition itself carries rather than assuming 0.
       final IndexDef requested = nameIndexDef();
@@ -178,7 +183,7 @@ public final class JsonPathAndNameIndexBuildTest {
       final boolean indexFirst) {
     final var database = JsonTestHelper.getDatabase(databasePath);
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       final IndexDef requested = nameIndexDef();
       final JsonIndexController indexController;
       if (indexFirst) {
@@ -201,7 +206,7 @@ public final class JsonPathAndNameIndexBuildTest {
   public void buildingOverAnExistingRevisionRebuildsNoSubtree() {
     final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
     try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
-         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+        final JsonNodeTrx trx = manager.beginNodeTrx()) {
       shred(trx, document());
       final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
 
@@ -209,8 +214,7 @@ public final class JsonPathAndNameIndexBuildTest {
       final long selfHealsBefore = AbstractHOTIndexWriter.STRUCTURAL_SELFHEAL_REBUILD.get();
       final long strandsBefore = AbstractHOTIndexWriter.STRAND_LEAF_REBUILD.get();
 
-      indexController.createIndexes(Set.of(pathIndexDef(),
-          IndexDefs.createNameIdxDef(1, IndexDef.DbType.JSON)), trx);
+      indexController.createIndexes(Set.of(pathIndexDef(), IndexDefs.createNameIdxDef(1, IndexDef.DbType.JSON)), trx);
 
       assertEquals("subtree rebuilds during a bulk build", rebuildsBefore,
           AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/JsonPathAndNameIndexBuildTest.java
@@ -1,0 +1,181 @@
+package io.sirix.index;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.hot.AbstractHOTIndexWriter;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.roaringbitmap.longlong.LongIterator;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static io.brackit.query.util.path.Path.parse;
+import static io.brackit.query.util.path.PathParser.Type.JSON;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * PATH and NAME index construction over the default (HOT) index backend.
+ *
+ * <p>Both families used to add a node to a key's posting list by reading the whole list back and
+ * re-inserting it, which is quadratic in how many nodes share the key — and sharing keys is the
+ * entire point of these two indexes: every node under an indexed path shares one PATH key, and
+ * every element with the same name shares one NAME key. Building over an existing revision now
+ * bulk-loads instead, so the tests below pin both the postings and the absence of the trie
+ * rebuilds the incremental path used to trigger.</p>
+ */
+public final class JsonPathAndNameIndexBuildTest {
+
+  private static final String[] CATEGORIES = {"alpha", "beta", "gamma", "delta"};
+
+  private static final int RECORDS = 1_200;
+
+  private static final String TITLE_PATH = "/[]/title";
+
+  @Before
+  public void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @After
+  public void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  /** {@code [{"title": "...", "category": "..."}, ...]} — every field name repeats per record. */
+  private static String document() {
+    final StringBuilder json = new StringBuilder(RECORDS * 56);
+    json.append('[');
+    for (int i = 0; i < RECORDS; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"title\":\"t").append(i).append("\",\"category\":\"")
+          .append(CATEGORIES[i % CATEGORIES.length]).append("\"}");
+    }
+    return json.append(']').toString();
+  }
+
+  private static void shred(final JsonNodeTrx trx, final String json) {
+    new JsonShredder.Builder(trx, JsonShredder.createStringReader(json), InsertPosition.AS_FIRST_CHILD)
+        .commitAfterwards().build().call();
+  }
+
+  private static TreeSet<Long> collect(final Iterator<NodeReferences> hits) {
+    final TreeSet<Long> nodeKeys = new TreeSet<>();
+    while (hits.hasNext()) {
+      final LongIterator it = hits.next().getNodeKeys().getLongIterator();
+      while (it.hasNext()) {
+        nodeKeys.add(it.next());
+      }
+    }
+    return nodeKeys;
+  }
+
+  private static IndexDef pathIndexDef() {
+    return IndexDefs.createPathIdxDef(Collections.singleton(parse(TITLE_PATH, JSON)), 0, IndexDef.DbType.JSON);
+  }
+
+  private static IndexDef nameIndexDef() {
+    return IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON);
+  }
+
+  private TreeSet<Long> pathPostings(final Path databasePath, final boolean indexFirst) {
+    final var database = JsonTestHelper.getDatabase(databasePath);
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      final JsonIndexController indexController;
+      if (indexFirst) {
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(pathIndexDef()), trx);
+        shred(trx, document());
+      } else {
+        shred(trx, document());
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(pathIndexDef()), trx);
+        trx.commit();
+      }
+      final IndexDef def = indexController.getIndexes().getIndexDef(0, IndexType.PATH);
+      return collect(indexController.openPathIndex(trx.getStorageEngineReader(), def,
+          indexController.createPathFilter(Set.of(TITLE_PATH), trx)));
+    }
+  }
+
+  private TreeSet<Long> namePostings(final Path databasePath, final boolean indexFirst) {
+    final var database = JsonTestHelper.getDatabase(databasePath);
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      // A NAME definition's ID is offset by the name-index page slot, so ask for the ID the
+      // definition itself carries rather than assuming 0.
+      final IndexDef requested = nameIndexDef();
+      final JsonIndexController indexController;
+      if (indexFirst) {
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(requested), trx);
+        shred(trx, document());
+      } else {
+        shred(trx, document());
+        indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+        indexController.createIndexes(Set.of(requested), trx);
+        trx.commit();
+      }
+      final IndexDef def = indexController.getIndexes().getIndexDef(requested.getID(), IndexType.NAME);
+      return collect(indexController.openNameIndex(trx.getStorageEngineReader(), def,
+          indexController.createNameFilter(Set.of("category"))));
+    }
+  }
+
+  @Test
+  public void bulkBuiltAndListenerBuiltPathIndexesAgree() {
+    final TreeSet<Long> bulk = pathPostings(JsonTestHelper.PATHS.PATH1.getFile(), false);
+    final TreeSet<Long> incremental = pathPostings(JsonTestHelper.PATHS.PATH2.getFile(), true);
+
+    assertFalse("the path index must not be empty", bulk.isEmpty());
+    assertEquals("one posting per title", RECORDS, bulk.size());
+    assertEquals("postings must not depend on how the index was built", incremental, bulk);
+  }
+
+  @Test
+  public void bulkBuiltAndListenerBuiltNameIndexesAgree() {
+    final TreeSet<Long> bulk = namePostings(JsonTestHelper.PATHS.PATH1.getFile(), false);
+    final TreeSet<Long> incremental = namePostings(JsonTestHelper.PATHS.PATH2.getFile(), true);
+
+    assertFalse("the name index must not be empty", bulk.isEmpty());
+    assertEquals("one posting per \"category\" field", RECORDS, bulk.size());
+    assertEquals("postings must not depend on how the index was built", incremental, bulk);
+  }
+
+  @Test
+  public void buildingOverAnExistingRevisionRebuildsNoSubtree() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession manager = database.beginResourceSession(JsonTestHelper.RESOURCE);
+         final JsonNodeTrx trx = manager.beginNodeTrx()) {
+      shred(trx, document());
+      final JsonIndexController indexController = manager.getWtxIndexController(trx.getRevisionNumber());
+
+      final long rebuildsBefore = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get();
+      final long selfHealsBefore = AbstractHOTIndexWriter.STRUCTURAL_SELFHEAL_REBUILD.get();
+      final long strandsBefore = AbstractHOTIndexWriter.STRAND_LEAF_REBUILD.get();
+
+      indexController.createIndexes(Set.of(pathIndexDef(),
+          IndexDefs.createNameIdxDef(1, IndexDef.DbType.JSON)), trx);
+
+      assertEquals("subtree rebuilds during a bulk build", rebuildsBefore,
+          AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get());
+      assertEquals("structural self-heals during a bulk build", selfHealsBefore,
+          AbstractHOTIndexWriter.STRUCTURAL_SELFHEAL_REBUILD.get());
+      assertEquals("strand rebuilds during a bulk build", strandsBefore,
+          AbstractHOTIndexWriter.STRAND_LEAF_REBUILD.get());
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
@@ -109,6 +109,43 @@ final class CASKeySerializerEdgeCaseTest {
   }
 
   @Nested
+  @DisplayName("NaN")
+  final class NotANumber {
+
+    @Test
+    @DisplayName("NaN does not share a key with the largest real value")
+    void nanKeepsItsOwnKey() {
+      // It used to be canonicalized onto Double.MAX_VALUE, which MERGED the two posting lists — the
+      // failure this class's history note calls the fatal one, because a shared key corrupts equality
+      // and deletes rather than merely mis-ordering a range. A stored NaN made
+      // `eq 1.7976931348623157E308` return it, and deleting one entry disturbed the other's list.
+      assertFalse(Arrays.equals(key(new Dbl(Double.NaN), Type.DBL), key(new Dbl(Double.MAX_VALUE), Type.DBL)),
+          "NaN and Double.MAX_VALUE must not encode to the same key");
+    }
+
+    @Test
+    @DisplayName("NaN sorts above every real value, infinities included")
+    void nanSortsLast() {
+      final byte[] nan = key(new Dbl(Double.NaN), Type.DBL);
+      for (final double real : new double[] {Double.NEGATIVE_INFINITY, -1.0, 0.0, 1.0, Double.MAX_VALUE,
+          Double.POSITIVE_INFINITY}) {
+        assertTrue(Arrays.compareUnsigned(nan, key(new Dbl(real), Type.DBL)) > 0, () -> "NaN must sort above " + real);
+      }
+    }
+
+    @Test
+    @DisplayName("every NaN payload collapses onto the one key, so the encoding stays a function")
+    void allNaNPayloadsAgree() {
+      // Java exposes distinct NaN bit patterns; if they encoded differently, one logical value would
+      // occupy several keys and a seek would find only the payload it happened to be built from.
+      final double other = Double.longBitsToDouble(0x7FF8_0000_DEAD_BEEFL);
+      assertTrue(Double.isNaN(other), "precondition: still a NaN");
+      assertArrayEquals(key(new Dbl(Double.NaN), Type.DBL), key(new Dbl(other), Type.DBL),
+          "all NaN payloads must share one key");
+    }
+  }
+
+  @Nested
   @DisplayName("float")
   final class Floats {
 
@@ -249,14 +286,26 @@ final class CASKeySerializerEdgeCaseTest {
 
     @Test
     @DisplayName("every decimal is reported lossy, including the ones a double represents exactly")
-    void everyDecimalIsLossy() {
-      // 0.5 IS exactly a double, and the round-trip test that used to stand here therefore reported
-      // it lossless and switched the re-check off — while a stored 0.5000000000000000001 encodes to
-      // the same double. The predicate cannot see stored values, so probe-only reasoning is unsound
-      // for a narrowing encoder and the only sound answer is "always".
-      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("0.5")), Type.DEC),
-          "a dyadic decimal is still a collision risk");
-      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC));
+    void onlyAnOversizedDecimalIsLossy() {
+      // This asserted the OPPOSITE until the key began carrying the exact value after the double.
+      // The old reasoning was sound for the encoding it described: a key that was only a double
+      // could not tell 0.5 from 0.5000000000000000001, the predicate cannot see stored values, and
+      // so "always lossy" was the only safe answer. It also meant every decimal `eq` re-read the
+      // candidate documents, which is why the encoding changed.
+      //
+      // Now the key is injective, so the seek settles equality by itself and nothing needs a
+      // re-check.
+      assertFalse(CASKeySerializer.losesInformation(new Dec(new BigDecimal("0.5")), Type.DEC),
+          "a decimal that fits is exact in the key");
+      assertFalse(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC),
+          "the ordinary price case must not pay for a re-check");
+      assertFalse(CASKeySerializer.losesInformation(new Dec(new BigDecimal("0.5000000000000000001")), Type.DEC),
+          "and neither must the value that used to collide with 0.5");
+
+      // The one case left: a decimal too long for the suffix budget collapses onto its prefix,
+      // exactly as an over-long string does, and only then is the re-check owed.
+      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("0." + "1".repeat(300))), Type.DEC),
+          "a decimal past the suffix budget cannot be stored exactly");
     }
 
     @Test
@@ -332,8 +381,11 @@ final class CASKeySerializerEdgeCaseTest {
       // the ordering. A range caller consulting losesInformation instead paid an O(index) scan to
       // reach the identical answer.
       assertFalse(CASKeySerializer.truncates(new Dec(new BigDecimal("19.99")), Type.DEC));
-      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC),
-          "the same bound IS lossy for equality, which is why the two predicates are separate");
+      // Lossless for equality too, now that the key carries the exact value. The two predicates stay
+      // separate because they still diverge on the LEXICAL family, where a bound past the cap
+      // truncates, and there both predicates answer true.
+      assertFalse(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC),
+          "an ordinary decimal bound is exact in the key");
     }
 
     @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
@@ -109,6 +109,34 @@ final class CASKeySerializerEdgeCaseTest {
   }
 
   @Nested
+  @DisplayName("type mismatch")
+  final class TypeMismatch {
+
+    @Test
+    @DisplayName("a probe that is not of the index's type is reported as such")
+    void aMistypedProbeIsRejected() {
+      // The encoder cannot express "no match": its per-type branches fall back to 0, false or the
+      // empty string, so a mistyped probe silently becomes a REAL key. "abc" under xs:decimal parses
+      // to 0.0 and lands on zero's key, which is why `eq "abc"` used to return every zero-valued
+      // node. CASIndex consults this and answers with an empty iterator instead.
+      assertFalse(CASKeySerializer.isOfType(new Str("abc"), Type.DEC), "a non-numeric string is not a decimal");
+      assertFalse(CASKeySerializer.isOfType(new Str("abc"), Type.INR));
+      assertFalse(CASKeySerializer.isOfType(null, Type.DEC), "an absent probe matches nothing");
+    }
+
+    @Test
+    @DisplayName("and one that is, or can be read as, the type is accepted")
+    void aWellTypedProbeIsAccepted() {
+      // The control. A predicate that simply answered false would turn every CAS equality query into
+      // an empty result, which no other test in this class would notice.
+      assertTrue(CASKeySerializer.isOfType(new Dec(new BigDecimal("19.99")), Type.DEC), "already the type");
+      assertTrue(CASKeySerializer.isOfType(new Str("19.99"), Type.DEC), "a lexical decimal reads as one");
+      assertTrue(CASKeySerializer.isOfType(new Str("abc"), Type.STR), "anything is a string");
+      assertTrue(CASKeySerializer.isOfType(new Int64(7L), Type.DEC), "an integer widens to decimal");
+    }
+  }
+
+  @Nested
   @DisplayName("NaN")
   final class NotANumber {
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
@@ -113,6 +113,25 @@ final class CASKeySerializerEdgeCaseTest {
   final class Floats {
 
     @Test
+    @DisplayName("a probe arriving as xs:double still lands on the xs:float key")
+    void anUncastProbeStillLandsOnTheDeclaredTypesKey() {
+      // ScanCASIndex casts its probe, but CASIndex builds a CASValue from whatever atomic the filter
+      // happens to hold, so a Dbl CAN reach an xs:float index uncast. This pins that it still meets
+      // the stored Flt.
+      //
+      // What makes it hold is the encoder's own `roundToFloat` narrowing, not any coercion of the
+      // atomic: both sides reach encodeNumericOrderPreserving and both are put through (float). That
+      // was measured rather than assumed — an explicit asDeclaredType coercion at the serialize()
+      // boundary was tried here and REVERTED, because removing it left this test green. It would only
+      // earn its place if the per-type lexical fallbacks were deleted, and they cannot be until a
+      // value that is not of the index's type has an explicit outcome instead of falling back to
+      // 0/false. 1.1 is the probe because it is inexact either way: (double) 1.1f is
+      // 1.100000023841858.
+      assertArrayEquals(key(new Flt(1.1f), Type.FLO), key(new Dbl(1.1d), Type.FLO),
+          "an xs:double probe against an xs:float index must land on the float key");
+    }
+
+    @Test
     @DisplayName("the stored lexical form and the typed probe agree on a non-dyadic value")
     void bothSidesAgree() {
       // 1.1 is the case that mattered: the stored Str took Double.parseDouble("1.1") = 1.1d while the

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerEdgeCaseTest.java
@@ -1,0 +1,426 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Date;
+import io.brackit.query.atomic.DateTime;
+import io.brackit.query.atomic.Dbl;
+import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.Flt;
+import io.brackit.query.atomic.Int;
+import io.brackit.query.atomic.Int32;
+import io.brackit.query.atomic.Int64;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.atomic.Time;
+import io.brackit.query.jdm.Type;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Edge cases of the CAS key encoding, at the unit level.
+ *
+ * <p>
+ * The invariant every test here serves: the two sides of a CAS index must agree. {@code
+ * CASIndexBuilder} stores every indexed value as a {@link Str} built from the node's lexical form,
+ * while {@code ScanCASIndex} casts the query's argument to the index's declared content type — so
+ * the STORED side arrives as a string and the PROBE side as a typed atomic. Any encoder behaviour
+ * that differs between those two shapes splits one logical value across two keys (the query finds
+ * nothing) or merges two logical values onto one key (the query returns rows it should not).
+ * </p>
+ *
+ * <p>
+ * Every case below is expressed as a comparison between two encodings rather than against a golden
+ * byte string, deliberately: a golden vector pins the CURRENT encoding, which is not the property
+ * that matters and would have to be rewritten the next time the layout changes. Agreement and
+ * disagreement between the two sides is the property that matters, and it survives a re-layout.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class CASKeySerializerEdgeCaseTest {
+
+  private static final long PCR = 42L;
+
+  /** Header is 8 bytes of sign-flipped pathNodeKey plus a 2-byte type id. */
+  private static final int HEADER_BYTES = 10;
+
+  /**
+   * The encoded key for {@code value} under {@code type}, header included — the header is identical
+   * across every comparison here (same PCR, same type), so including it costs nothing and keeps the
+   * helper honest about what the index actually stores.
+   */
+  private static byte[] key(final Atomic value, final Type type) {
+    final byte[] buffer = new byte[256];
+    final int length = CASKeySerializer.INSTANCE.serialize(new CASValue(value, type, PCR), buffer, 0);
+    return Arrays.copyOf(buffer, length);
+  }
+
+  @Nested
+  @DisplayName("boolean")
+  final class Booleans {
+
+    @Test
+    @DisplayName("the stored lexical form and the typed probe agree, for both values")
+    void bothSidesAgree() {
+      // The defect this pins: the encoder used Atomic#booleanValue(), XQuery's EFFECTIVE boolean
+      // value, which on a non-empty Str is true regardless of what the string says. So the stored
+      // "false" encoded as true and no probe of false() could ever reach it.
+      assertArrayEquals(key(new Bool(false), Type.BOOL), key(new Str("false"), Type.BOOL),
+          "stored \"false\" must encode like a probe of false()");
+      assertArrayEquals(key(new Bool(true), Type.BOOL), key(new Str("true"), Type.BOOL),
+          "stored \"true\" must encode like a probe of true()");
+    }
+
+    @Test
+    @DisplayName("true and false do not collide")
+    void theTwoValuesAreDistinct() {
+      // The control. An encoder mapping everything to byte 0 would satisfy the agreement test above
+      // while merging both values onto one key — which is the original defect with the sign flipped.
+      assertFalse(Arrays.equals(key(new Str("true"), Type.BOOL), key(new Str("false"), Type.BOOL)),
+          "true and false must not share a key");
+    }
+
+    @Test
+    @DisplayName("the numeric lexical forms of xs:boolean are honoured")
+    void theNumericLexicalFormsWork() {
+      // "1" and "0" are as much a part of the xs:boolean lexical space as "true"/"false", and a
+      // document may spell them either way.
+      assertArrayEquals(key(new Bool(true), Type.BOOL), key(new Str("1"), Type.BOOL));
+      assertArrayEquals(key(new Bool(false), Type.BOOL), key(new Str("0"), Type.BOOL));
+    }
+
+    @Test
+    @DisplayName("surrounding whitespace does not change the value")
+    void whitespaceIsIgnored() {
+      assertArrayEquals(key(new Bool(true), Type.BOOL), key(new Str("  true  "), Type.BOOL));
+    }
+  }
+
+  @Nested
+  @DisplayName("float")
+  final class Floats {
+
+    @Test
+    @DisplayName("the stored lexical form and the typed probe agree on a non-dyadic value")
+    void bothSidesAgree() {
+      // 1.1 is the case that mattered: the stored Str took Double.parseDouble("1.1") = 1.1d while the
+      // Flt probe gave (double) 1.1f = 1.100000023841858, so the keys differed in the low bits and
+      // `eq 1.1` found nothing at all. Rounding both through float makes them meet.
+      assertArrayEquals(key(new Flt(1.1f), Type.FLO), key(new Str("1.1"), Type.FLO));
+    }
+
+    @Test
+    @DisplayName("a dyadic value agrees too, which it always did")
+    void aDyadicValueAgrees() {
+      // The control that shows the test above is about float/double disagreement and not about
+      // encoding being broken outright: 2.5 is exact in both widths and never disagreed.
+      assertArrayEquals(key(new Flt(2.5f), Type.FLO), key(new Str("2.5"), Type.FLO));
+    }
+
+    @Test
+    @DisplayName("distinct float values keep distinct keys")
+    void distinctValuesStayDistinct() {
+      assertFalse(Arrays.equals(key(new Str("1.1"), Type.FLO), key(new Str("1.2"), Type.FLO)));
+    }
+
+    @Test
+    @DisplayName("a value that overflows float does not collide with NaN's key")
+    void anOverflowingValueKeepsItsOwnKey() {
+      // The float rounding happens BEFORE the NaN canonicalization for this reason: 1e40 is finite as
+      // a double but infinite as a float, and NaN is canonicalized onto Double.MAX_VALUE's key. If
+      // the order were reversed the infinity would be indistinguishable from a real value.
+      assertFalse(Arrays.equals(key(new Str("1e40"), Type.FLO), key(new Dbl(Double.NaN), Type.FLO)),
+          "a float overflow must not land on the NaN key");
+    }
+  }
+
+  @Nested
+  @DisplayName("integer")
+  final class Integers {
+
+    /** Beyond {@code Long.MAX_VALUE}, so {@code Long.parseLong} refuses it. */
+    private static final String ABOVE_LONG_RANGE = "92233720368547758070";
+
+    private static final String BELOW_LONG_RANGE = "-92233720368547758070";
+
+    @Test
+    @DisplayName("a value beyond long range saturates instead of landing on zero's key")
+    void outOfRangeSaturates() {
+      // The defect: the parse fallback returned 0, putting an enormous value in the MIDDLE of the key
+      // space. `eq 0` returned it, and every range query placed it on the wrong side of every bound.
+      assertFalse(Arrays.equals(key(new Str(ABOVE_LONG_RANGE), Type.INR), key(new Int32(0), Type.INR)),
+          "an out-of-range integer must not share zero's key");
+      assertArrayEquals(key(new Int64(Long.MAX_VALUE), Type.INR), key(new Str(ABOVE_LONG_RANGE), Type.INR),
+          "it saturates to the end of the key space it belongs to");
+    }
+
+    @Test
+    @DisplayName("saturation is signed, so the two ends do not meet")
+    void saturationRespectsSign() {
+      assertArrayEquals(key(new Int64(Long.MIN_VALUE), Type.INR), key(new Str(BELOW_LONG_RANGE), Type.INR));
+      assertFalse(Arrays.equals(key(new Str(ABOVE_LONG_RANGE), Type.INR), key(new Str(BELOW_LONG_RANGE), Type.INR)));
+    }
+
+    @Test
+    @DisplayName("in-range values keep byte order matching numeric order across the sign boundary")
+    void byteOrderMatchesNumericOrder() {
+      // The sign flip exists for this. Unsigned byte comparison over two's complement puts negatives
+      // above positives without it, which would invert every range query crossing zero.
+      final byte[] negative = key(new Int64(-1L), Type.INR);
+      final byte[] zero = key(new Int64(0L), Type.INR);
+      final byte[] positive = key(new Int64(1L), Type.INR);
+      assertTrue(Arrays.compareUnsigned(negative, zero) < 0, "-1 must sort below 0");
+      assertTrue(Arrays.compareUnsigned(zero, positive) < 0, "0 must sort below 1");
+    }
+
+    @Test
+    @DisplayName("the stored lexical form and the typed probe agree")
+    void bothSidesAgree() {
+      assertArrayEquals(key(new Int64(1234567890123L), Type.INR), key(new Str("1234567890123"), Type.INR));
+    }
+
+    @Test
+    @DisplayName("both sides agree BEYOND long range, where one saturated and the other wrapped")
+    void bothSidesAgreeOutOfRange() {
+      // The regression that saturating only ONE side introduced, and it was worse than the defect it
+      // replaced. CASIndexBuilder stores a Str, so the stored side took the lexical branch and
+      // saturated to Long.MAX_VALUE; ScanCASIndex casts the probe, which for a magnitude past long
+      // range is brackit's arbitrary-precision Int, whose longValue() is BigDecimal#longValue() and
+      // WRAPS — 2^63 to Long.MIN_VALUE, 2^70 to 0. The two sides landed at OPPOSITE ends of the key
+      // space, so an equality query that used to match (both collapsing onto zero) began missing
+      // outright. Cast.cast is not invoked here; Int is constructed directly, which is what it yields.
+      final Atomic probe = new Int(new BigDecimal(ABOVE_LONG_RANGE));
+      assertArrayEquals(key(new Str(ABOVE_LONG_RANGE), Type.INR), key(probe, Type.INR),
+          "the stored value and the probe must land on the same key");
+    }
+
+    @Test
+    @DisplayName("a wrapping probe does not land below zero")
+    void aWrappingProbeDoesNotInvert() {
+      // The sharpest form: 2^63 wraps to Long.MIN_VALUE, the very BOTTOM of the key space, so before
+      // the fix `>= 2^63` matched the entire index and `eq 2^63` matched nothing.
+      final Atomic probe = new Int(new BigDecimal("9223372036854775808"));
+      assertTrue(Arrays.compareUnsigned(key(probe, Type.INR), key(new Int64(0L), Type.INR)) > 0,
+          "a value above long range must sort ABOVE zero, not below it");
+    }
+  }
+
+  @Nested
+  @DisplayName("losesInformation")
+  final class LossReporting {
+
+    @Test
+    @DisplayName("a null bound loses nothing")
+    void nullIsLossless() {
+      assertFalse(CASKeySerializer.losesInformation(null, Type.STR));
+      assertFalse(CASKeySerializer.truncates(null, Type.STR));
+    }
+
+    @Test
+    @DisplayName("every decimal is reported lossy, including the ones a double represents exactly")
+    void everyDecimalIsLossy() {
+      // 0.5 IS exactly a double, and the round-trip test that used to stand here therefore reported
+      // it lossless and switched the re-check off — while a stored 0.5000000000000000001 encodes to
+      // the same double. The predicate cannot see stored values, so probe-only reasoning is unsound
+      // for a narrowing encoder and the only sound answer is "always".
+      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("0.5")), Type.DEC),
+          "a dyadic decimal is still a collision risk");
+      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC));
+    }
+
+    @Test
+    @DisplayName("an ordinary double or float is NOT reported lossy")
+    void doublesAreLossless() {
+      // The carve-out that keeps these indexes fast: for xs:double the encoder IS the double, so
+      // equality on the index is double equality and the key round-trips by construction. Reporting
+      // these lossy sent every such query through a per-candidate document re-read.
+      assertFalse(CASKeySerializer.losesInformation(new Dbl(0.1), Type.DBL));
+      assertFalse(CASKeySerializer.losesInformation(new Flt(0.1f), Type.FLO));
+    }
+
+    @Test
+    @DisplayName("NaN is reported lossy, because it is canonicalized onto a real value's key")
+    void nanIsLossy() {
+      assertTrue(CASKeySerializer.losesInformation(new Dbl(Double.NaN), Type.DBL));
+    }
+
+    @Test
+    @DisplayName("an in-range integer is lossless and an out-of-range one is not")
+    void integersReportByRange() {
+      assertFalse(CASKeySerializer.losesInformation(new Int64(1234567890123L), Type.INR),
+          "an ordinary integer round-trips exactly and pays nothing");
+      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("92233720368547758070")), Type.INR),
+          "beyond long range two values share the saturated key");
+      assertTrue(CASKeySerializer.losesInformation(new Int64(Long.MAX_VALUE), Type.INR),
+          "and the sentinel itself is shared with them, so it needs the re-check too");
+    }
+  }
+
+  @Nested
+  @DisplayName("truncates")
+  final class Truncation {
+
+    @Test
+    @DisplayName("the boundary is at the cap, not past it")
+    void theBoundaryIsInclusive() {
+      // >= and not >, and the difference is a real over-match rather than a rounding preference. A
+      // value measuring EXACTLY the cap is stored losslessly, but every LONGER value is capped to the
+      // same 246 bytes — so a 250-byte value sharing the prefix produces a byte-identical key of
+      // identical length, and nothing downstream separates them. At exactly the cap the seek is
+      // therefore guaranteed to over-match, which is precisely where a `>` test switched the caller's
+      // re-check off.
+      assertFalse(CASKeySerializer.truncates(new Str("A".repeat(245)), Type.STR), "one below the cap is safe");
+      assertTrue(CASKeySerializer.truncates(new Str("A".repeat(246)), Type.STR), "exactly at the cap collides");
+      assertTrue(CASKeySerializer.truncates(new Str("A".repeat(247)), Type.STR));
+    }
+
+    @Test
+    @DisplayName("the cap is measured in UTF-8 bytes, not characters")
+    void multiByteCharactersCountTheirBytes() {
+      // 82 three-byte characters measure exactly 246 bytes, so this collides while its character
+      // count (82) is nowhere near the cap. Measuring characters would report it safe.
+      assertTrue(CASKeySerializer.truncates(new Str("中".repeat(82)), Type.STR));
+      assertFalse(CASKeySerializer.truncates(new Str("中".repeat(81)), Type.STR));
+    }
+
+    @Test
+    @DisplayName("a type with no id truncates exactly as a string does")
+    void unrecognizedTypesTruncateToo() {
+      // The rule is "does this reach the truncating branch", NOT "is this xs:string". Every type
+      // getTypeId does not recognize falls into the encoder's default case and is capped identically;
+      // testing for xs:string alone left that whole family answering with an unchecked superset.
+      assertTrue(CASKeySerializer.truncates(new Str("A".repeat(300)), Type.AURI));
+      assertFalse(CASKeySerializer.truncates(new Str("short"), Type.AURI));
+    }
+
+    @Test
+    @DisplayName("a numeric bound never reports truncation, however lossy it is")
+    void numericBoundsDoNotTruncate() {
+      // The split that keeps range queries on the bounded cursor. Numeric narrowing is monotone, so
+      // the cursor still places every stored key correctly against the bound; only truncation breaks
+      // the ordering. A range caller consulting losesInformation instead paid an O(index) scan to
+      // reach the identical answer.
+      assertFalse(CASKeySerializer.truncates(new Dec(new BigDecimal("19.99")), Type.DEC));
+      assertTrue(CASKeySerializer.losesInformation(new Dec(new BigDecimal("19.99")), Type.DEC),
+          "the same bound IS lossy for equality, which is why the two predicates are separate");
+    }
+
+    @Test
+    @DisplayName("the empty string is not truncation")
+    void theEmptyStringIsFine() {
+      assertFalse(CASKeySerializer.truncates(new Str(""), Type.STR));
+    }
+  }
+
+  @Nested
+  @DisplayName("type predicates")
+  final class TypePredicates {
+
+    @Test
+    @DisplayName("the numeric family is exactly the four narrowing encoders")
+    void numericFamilyMembership() {
+      assertTrue(CASKeySerializer.isNumericFamily(Type.INR));
+      assertTrue(CASKeySerializer.isNumericFamily(Type.DEC));
+      assertTrue(CASKeySerializer.isNumericFamily(Type.DBL));
+      assertTrue(CASKeySerializer.isNumericFamily(Type.FLO));
+      assertFalse(CASKeySerializer.isNumericFamily(Type.STR));
+      assertFalse(CASKeySerializer.isNumericFamily(Type.BOOL));
+    }
+
+    @Test
+    @DisplayName("the families the encoder orders deliberately ARE byte-order-preserving")
+    void orderedFamiliesQualify() {
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.STR));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.INR));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DEC));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DBL));
+    }
+  }
+
+  /**
+   * The instant family, whose encoding is the one place where two comments in the serializer disagree
+   * with the code and with each other.
+   *
+   * <p>
+   * {@code isByteOrderPreserving} RETURNS true for these types, and the encoder routes them through
+   * {@code InstantKeyCodec}'s binary form — but that predicate's own javadoc says it returns false
+   * for them, and a block comment at the top of the class says the binary codec "was wrong and is
+   * reverted to the lexical form". Both statements are false about the shipped code. Rather than
+   * trust any of the three, these assert the two properties that actually matter, so whichever
+   * comment survives has to match measured behaviour.
+   * </p>
+   *
+   * <p>
+   * INJECTIVITY is the load-bearing one. Two distinct values sharing a key merge their posting lists,
+   * which corrupts equality lookups and deletes, not merely ranges — so a collision is far worse than
+   * a mis-ordered range. The cases below are exactly the ones the stale comment claimed collided.
+   * </p>
+   */
+  @Nested
+  @DisplayName("instants")
+  final class Instants {
+
+    @Test
+    @DisplayName("a timezoned date does not collide with the previous day in UTC")
+    void datesWithOffsetsStayDistinct() {
+      // The stale comment's first claim: canonicalizing to UTC moves the offset into a time-of-day
+      // that xs:date cannot hold, so 2020-01-01+02:00 was said to encode identically to 2019-12-31Z
+      // — a collision, and the reason the codec was supposedly reverted.
+      assertFalse(Arrays.equals(key(new Date("2020-01-01+02:00"), Type.DATE), key(new Date("2019-12-31Z"), Type.DATE)),
+          "distinct dates must not share a key");
+    }
+
+    @Test
+    @DisplayName("a timezoned time orders the same way brackit compares it")
+    void timesOrderChronologically() {
+      // The stale comment's second claim: the reference-date comparison carries a rollover xs:time
+      // cannot hold, so byte order came out INVERTED against compareTo for a non-UTC offset.
+      final Time earlier = new Time("08:00:00Z");
+      final Time later = new Time("10:00:00Z");
+      final int byValue = earlier.compareTo(later);
+      final int byBytes = Arrays.compareUnsigned(key(earlier, Type.TIME), key(later, Type.TIME));
+      assertTrue(byValue < 0 && byBytes < 0 || byValue > 0 && byBytes > 0,
+          "byte order must agree with brackit's own comparison, not invert it");
+    }
+
+    @Test
+    @DisplayName("dateTimes order chronologically in byte order")
+    void dateTimesOrderChronologically() {
+      // This is what isByteOrderPreserving == true actually promises, and what puts these types on
+      // the bounded cursor. If it does not hold, a range query silently drops records.
+      final byte[] earlier = key(new DateTime("2020-01-01T00:00:00Z"), Type.DATI);
+      final byte[] later = key(new DateTime("2020-06-01T00:00:00Z"), Type.DATI);
+      assertTrue(Arrays.compareUnsigned(earlier, later) < 0, "an earlier instant must sort first");
+    }
+
+    @Test
+    @DisplayName("the stored lexical form and the typed probe agree")
+    void bothSidesAgree() {
+      // The same two-sides invariant as every other family: the builder stores a Str, the scan casts
+      // the probe. InstantKeyCodec documents that it coerces a raw Str, and this is what pins it.
+      assertArrayEquals(key(new DateTime("2020-01-01T12:00:00Z"), Type.DATI),
+          key(new Str("2020-01-01T12:00:00Z"), Type.DATI));
+    }
+  }
+
+  @Test
+  @DisplayName("the empty string encodes to a bare header and sorts below every non-empty value")
+  void theEmptyStringIsABareHeader() {
+    final byte[] empty = key(new Str(""), Type.STR);
+    final byte[] nonEmpty = key(new Str("a"), Type.STR);
+    assertTrue(empty.length == HEADER_BYTES, "no value bytes at all");
+    assertTrue(Arrays.compareUnsigned(empty, nonEmpty) < 0, "and it sorts first, which is correct");
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/CASKeySerializerTest.java
@@ -6,7 +6,11 @@
 
 package io.sirix.index.hot;
 
+import io.brackit.query.atomic.Atomic;
 import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Date;
+import io.brackit.query.atomic.DateTime;
+import io.brackit.query.atomic.Time;
 import io.brackit.query.atomic.Dbl;
 import io.brackit.query.atomic.Int32;
 import io.brackit.query.atomic.Int64;
@@ -17,7 +21,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,14 +73,23 @@ class CASKeySerializerTest {
     }
 
     @Test
-    @DisplayName("Empty string throws exception (no value bytes)")
-    void testEmptyStringThrows() {
-      CASValue original = new CASValue(new Str(""), Type.STR, 1);
-      byte[] buffer = new byte[256];
+    @DisplayName("Empty string round-trips and sorts below every non-empty value")
+    void testEmptyStringIsAValue() {
+      // The empty string is a legitimate indexed value, so its key is legitimately just the 10-byte
+      // header. Rejecting a zero-length value region instead made indexing a `""` throw out of the
+      // WRITER, and made a `>= ""` range bound throw out of the reader before it returned a cursor.
+      final CASValue empty = new CASValue(new Str(""), Type.STR, 1);
+      final byte[] buffer = new byte[256];
+      final int len = serializer.serialize(empty, buffer, 0);
+      assertEquals(10, len, "an empty value region is the 10-byte header alone");
+      assertEquals(empty, serializer.deserialize(buffer, 0, len));
 
-      // Empty string produces only header bytes, which is rejected
-      assertThrows(IllegalArgumentException.class, () -> serializer.serialize(original, buffer, 0));
+      // Order is preserved: shorter-is-less puts "" below every non-empty string of the same type.
+      final byte[] other = new byte[256];
+      final int otherLen = serializer.serialize(new CASValue(new Str("a"), Type.STR, 1), other, 0);
+      assertTrue(compareBytes(buffer, len, other, otherLen) < 0, "empty string sorts first");
     }
+
   }
 
   @Nested
@@ -153,14 +171,10 @@ class CASKeySerializerTest {
     @Test
     @DisplayName("Integers above 2^53 round-trip without precision loss")
     void testLargeIntegerRoundtrip() {
-      long[] values = {
-          0L, 1L, -1L, 100L, -100L,
-          (1L << 53),       // 9007199254740992 - largest integer exactly representable as double
-          (1L << 53) + 1,   // 9007199254740993 - NOT representable as double
-          (1L << 62), -(1L << 62),
-          Long.MAX_VALUE, Long.MIN_VALUE,
-          Long.MAX_VALUE - 1, Long.MIN_VALUE + 1
-      };
+      long[] values = {0L, 1L, -1L, 100L, -100L, (1L << 53), // 9007199254740992 - largest integer exactly representable
+                                                             // as double
+          (1L << 53) + 1, // 9007199254740993 - NOT representable as double
+          (1L << 62), -(1L << 62), Long.MAX_VALUE, Long.MIN_VALUE, Long.MAX_VALUE - 1, Long.MIN_VALUE + 1};
       for (long value : values) {
         CASValue original = new CASValue(new Int64(value), Type.LON, 7);
         byte[] buffer = new byte[256];
@@ -178,8 +192,8 @@ class CASKeySerializerTest {
     void testLargeIntegerNoCollision() {
       // Both values collapse to the same double (2^53), so the old double-based
       // encoding produced identical key bytes - a silent CAS index collision.
-      long a = (1L << 53);       // 9007199254740992
-      long b = (1L << 53) + 1;   // 9007199254740993
+      long a = (1L << 53); // 9007199254740992
+      long b = (1L << 53) + 1; // 9007199254740993
 
       byte[] bufA = new byte[256];
       byte[] bufB = new byte[256];
@@ -194,17 +208,14 @@ class CASKeySerializerTest {
     @Test
     @DisplayName("Large integer order is preserved by byte comparison")
     void testLargeIntegerOrder() {
-      long[] ascending = {
-          Long.MIN_VALUE, Long.MIN_VALUE + 1, -(1L << 53), -1L, 0L, 1L,
-          (1L << 53), (1L << 53) + 1, Long.MAX_VALUE - 1, Long.MAX_VALUE
-      };
+      long[] ascending = {Long.MIN_VALUE, Long.MIN_VALUE + 1, -(1L << 53), -1L, 0L, 1L, (1L << 53), (1L << 53) + 1,
+          Long.MAX_VALUE - 1, Long.MAX_VALUE};
       for (int i = 1; i < ascending.length; i++) {
         byte[] lo = new byte[256];
         byte[] hi = new byte[256];
         int lenLo = serializer.serialize(new CASValue(new Int64(ascending[i - 1]), Type.LON, 1), lo, 0);
         int lenHi = serializer.serialize(new CASValue(new Int64(ascending[i]), Type.LON, 1), hi, 0);
-        assertTrue(compareBytes(lo, lenLo, hi, lenHi) < 0,
-            ascending[i - 1] + " must sort before " + ascending[i]);
+        assertTrue(compareBytes(lo, lenLo, hi, lenHi) < 0, ascending[i - 1] + " must sort before " + ascending[i]);
       }
     }
 
@@ -324,6 +335,113 @@ class CASKeySerializerTest {
       CASValue result = serializer.deserialize(buffer, 0, length);
 
       assertEquals("日本語", result.getAtomicValue().stringValue());
+    }
+  }
+
+
+  /**
+   * The instant family — {@code xs:dateTime}, {@code xs:date}, {@code xs:time}.
+   *
+   * <p>
+   * These exist because a binary "canonicalize to UTC then write the calendar components" key was
+   * briefly used for them and was WRONG in a way no existing test could see: the suite only ever
+   * built {@code Type.DATI} indexes with same-instant spellings, which is the one case that encoding
+   * got right. Each test below FAILS against that encoding.
+   */
+  @Nested
+  @DisplayName("Instant family")
+  class InstantTests {
+
+    /**
+     * Two values that {@code compareTo} separates must never share a key: a CAS key IS the index
+     * entry's identity, so a collision merges two values' posting lists and corrupts equality lookups
+     * and deletes, not merely ranges.
+     */
+    @Test
+    void distinctInstantsNeverShareAKey() {
+      // Both pairs are 19h / 5h apart; the old encoder collapsed each onto ONE key by discarding
+      // the time-of-day an xs:date cannot carry.
+      assertDistinct(new Date("2020-01-01+02:00"), new Date("2019-12-31Z"), Type.DATE);
+      assertDistinct(new Date("2020-01-01-05:00"), new Date("2020-01-01Z"), Type.DATE);
+      // A full day apart: the old encoder dropped the ±1-day rollover an xs:time cannot carry.
+      assertDistinct(new Time("01:00:00+02:00"), new Time("23:00:00Z"), Type.TIME);
+      assertDistinct(new DateTime("2020-01-01T12:00:00Z"), new DateTime("2020-01-01T12:00:01Z"), Type.DATI);
+    }
+
+    /**
+     * The content type has to round-trip, or {@code CASFilterRange#inRange} compares a {@code Str} and
+     * orders instants as text instead of chronologically.
+     */
+    @Test
+    void instantsRoundTripAsTypedAtomics() {
+      assertRoundTrip(new DateTime("2020-06-01T10:00:00Z"), Type.DATI);
+      assertRoundTrip(new Date("2020-06-01Z"), Type.DATE);
+      assertRoundTrip(new Time("10:00:00Z"), Type.TIME);
+      assertRoundTrip(new DateTime("2020-06-01T12:00:00+02:00"), Type.DATI);
+    }
+
+    /**
+     * The gate that keeps instant ranges off the byte-bounded cursor. Their stored form is lexical, and
+     * text order is not chronological order, so a byte-decided range would silently drop in-range
+     * records — the original defect. Equally important is the other direction: the families whose
+     * encoders DO preserve order must keep the fast path.
+     */
+    @Test
+    void onlyFamiliesWithOrderPreservingEncodersTakeTheByteBoundedPath() {
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DATI));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DATE));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.TIME));
+
+      // xs:duration is only PARTIALLY ordered (a month is not a fixed number of days), so no byte
+      // encoding can order it and it must never reach a byte-bounded cursor.
+      assertFalse(CASKeySerializer.isByteOrderPreserving(Type.DUR));
+
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.STR));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.INR));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DBL));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.BOOL));
+      assertTrue(CASKeySerializer.isByteOrderPreserving(Type.DEC));
+    }
+
+    /** Two spellings of the SAME instant must share a key, or {@code eq} misses across timezones. */
+    @Test
+    void sameInstantWrittenTwoWaysSharesAKey() {
+      assertSameKey(new DateTime("2020-06-15T12:00:00Z"), new DateTime("2020-06-15T14:00:00+02:00"), Type.DATI);
+      assertSameKey(new Time("12:00:00Z"), new Time("14:00:00+02:00"), Type.TIME);
+      // No timezone means the implicit one (UTC), so this is the same instant as its Z spelling.
+      assertSameKey(new DateTime("2020-06-15T12:00:00"), new DateTime("2020-06-15T12:00:00Z"), Type.DATI);
+    }
+
+    private void assertSameKey(final Atomic a, final Atomic b, final Type type) {
+      assertArrayEquals(keyOf(a, type), keyOf(b, type),
+          a + " and " + b + " denote the same instant, so they must serialize to the same CAS key");
+    }
+
+    private void assertDistinct(final Atomic a, final Atomic b, final Type type) {
+      assertNotEquals(0, a.compareTo(b), "fixture is wrong: " + a + " and " + b + " are the same value");
+      assertFalse(Arrays.equals(keyOf(a, type), keyOf(b, type)), "distinct " + type + " values " + a + " and " + b
+          + " serialize to the same CAS key, so they " + "would share one index entry and merge their posting lists");
+    }
+
+    /**
+     * The decoded value is the stored value's CANONICAL spelling, so it need not be textually equal —
+     * {@code 12:00+02:00} comes back as {@code 10:00Z}. What must hold is that it denotes the same
+     * instant, which re-encoding proves exactly: identical keys iff identical instants. (Comparing with
+     * {@code compareTo} would not prove it — brackit orders two timezoned spellings of one instant
+     * apart.)
+     */
+    private void assertRoundTrip(final Atomic value, final Type type) {
+      final byte[] key = keyOf(value, type);
+      final CASValue back = CASKeySerializer.INSTANCE.deserialize(key, 0, key.length);
+      assertEquals(type, back.getType(), "content type must round-trip for " + value);
+      assertArrayEquals(key, keyOf(back.getAtomicValue(), type),
+          "decoded " + back.getAtomicValue() + " does not denote the same instant as the stored " + value);
+    }
+
+    private byte[] keyOf(final Atomic value, final Type type) {
+      final byte[] buf = new byte[512];
+      final int len = CASKeySerializer.INSTANCE.serialize(new CASValue(value, type, 7L), buf, 0);
+      return Arrays.copyOf(buf, len);
     }
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/Direction1HitRateProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/Direction1HitRateProbe.java
@@ -4,6 +4,7 @@
 package io.sirix.index.hot;
 
 import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
 import io.sirix.access.DatabaseConfiguration;
 import io.sirix.access.Databases;
 import io.sirix.access.ResourceConfiguration;
@@ -22,6 +23,9 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.IntUnaryOperator;
+
+import static io.brackit.query.util.path.Path.parse;
 
 /**
  * Empirical hit-rate measurement for Direction 1 (sub-insert into affected on C2 collision) versus
@@ -71,8 +75,7 @@ final class Direction1HitRateProbe {
       try (JsonResourceSession session = database.beginResourceSession("res");
           JsonNodeTrx wtx = session.beginNodeTrx()) {
         final var ic = session.getWtxIndexController(wtx.getRevisionNumber());
-        final var pathToValue =
-            io.brackit.query.util.path.Path.parse("/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
+        final var pathToValue = parse("/k/[]/v", PathParser.Type.JSON);
         final IndexDef def =
             IndexDefs.createCASIdxDef(false, Type.INR, Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
         ic.createIndexes(Set.of(def), wtx);
@@ -134,7 +137,7 @@ final class Direction1HitRateProbe {
     System.err.println("=======================================");
   }
 
-  private static String buildArray(int n, java.util.function.IntUnaryOperator gen) {
+  private static String buildArray(int n, IntUnaryOperator gen) {
     final StringBuilder sb = new StringBuilder(n * 16);
     sb.append("{\"k\":[");
     for (int i = 0; i < n; i++) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/Direction1HitRateProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/Direction1HitRateProbe.java
@@ -24,19 +24,21 @@ import java.util.Random;
 import java.util.Set;
 
 /**
- * Empirical hit-rate measurement for Direction 1 (sub-insert into affected on C2
- * collision) versus its I8-safety fallback (scoped rebuild at insertDepth). Runs the
- * interleaved-insert-delete workload that triggered the historical ~103 C2 firings per
- * the Stage 3a measurement (commit {@code c8ac969af}) and reports the counter pair
+ * Empirical hit-rate measurement for Direction 1 (sub-insert into affected on C2 collision) versus
+ * its I8-safety fallback (scoped rebuild at insertDepth). Runs the interleaved-insert-delete
+ * workload that triggered the historical ~103 C2 firings per the Stage 3a measurement (commit
+ * {@code c8ac969af}) and reports the counter pair
  * {@link AbstractHOTIndexWriter#DIRECTION_ONE_SUBINSERT} /
  * {@link AbstractHOTIndexWriter#DIRECTION_ONE_FALLBACK}.
  *
- * <p>Purpose: validate that the I8-safety pre-check is selective -- some C2 firings
- * resolve via sub-insert (cheap), others fall back to a scoped rebuild (expensive but
- * canonical). Both modes are correct; the ratio measures how much work iteration 2
- * saved over iteration 1's always-rebuild fallback.
+ * <p>
+ * Purpose: validate that the I8-safety pre-check is selective -- some C2 firings resolve via
+ * sub-insert (cheap), others fall back to a scoped rebuild (expensive but canonical). Both modes
+ * are correct; the ratio measures how much work iteration 2 saved over iteration 1's always-rebuild
+ * fallback.
  *
- * <p>Not a correctness gate -- the canary tests cover that. This probe only reports.
+ * <p>
+ * Not a correctness gate -- the canary tests cover that. This probe only reports.
  */
 final class Direction1HitRateProbe {
 
@@ -50,7 +52,7 @@ final class Direction1HitRateProbe {
     final long offPathOkBefore = AbstractHOTIndexWriter.OFF_PATH_OVERFLOW_OK.get();
     final long offPathFallbackBefore = AbstractHOTIndexWriter.OFF_PATH_OVERFLOW_FALLBACK.get();
     final long escAvoidedBefore = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get();
-    final long propI7FbBefore = AbstractHOTIndexWriter.REBUILD_PROPAGATION_I7_FALLBACK.get();
+    final long propOrderFbBefore = AbstractHOTIndexWriter.REBUILD_PROPAGATION_ORDER_FALLBACK.get();
     final long rebuildCallsBefore = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get();
 
     final int entriesPerRev = 1_000;
@@ -62,21 +64,21 @@ final class Direction1HitRateProbe {
 
     try (Database<JsonResourceSession> database = Databases.openJsonDatabase(dbPath)) {
       database.createResource(ResourceConfiguration.newBuilder("res")
-          .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
-          .maxNumberOfRevisionsToRestore(5).build());
+                                                   .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
+                                                   .maxNumberOfRevisionsToRestore(5)
+                                                   .build());
 
       try (JsonResourceSession session = database.beginResourceSession("res");
-           JsonNodeTrx wtx = session.beginNodeTrx()) {
+          JsonNodeTrx wtx = session.beginNodeTrx()) {
         final var ic = session.getWtxIndexController(wtx.getRevisionNumber());
-        final var pathToValue = io.brackit.query.util.path.Path.parse(
-            "/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
-        final IndexDef def = IndexDefs.createCASIdxDef(false, Type.INR,
-            Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
+        final var pathToValue =
+            io.brackit.query.util.path.Path.parse("/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
+        final IndexDef def =
+            IndexDefs.createCASIdxDef(false, Type.INR, Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
         ic.createIndexes(Set.of(def), wtx);
 
         // Rev 1: bootstrap
-        wtx.insertSubtreeAsFirstChild(
-            JsonShredder.createStringReader(buildArray(entriesPerRev, i -> i)),
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(buildArray(entriesPerRev, i -> i)),
             JsonNodeTrx.Commit.NO);
         wtx.commit();
 
@@ -91,8 +93,7 @@ final class Direction1HitRateProbe {
           for (int i = 0; i < entriesPerRev; i++) {
             values[i] = offset + rng.nextInt(entriesPerRev * 2);
           }
-          wtx.insertSubtreeAsFirstChild(
-              JsonShredder.createStringReader(buildArray(entriesPerRev, i -> values[i])),
+          wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(buildArray(entriesPerRev, i -> values[i])),
               JsonNodeTrx.Commit.NO);
           wtx.commit();
         }
@@ -102,34 +103,34 @@ final class Direction1HitRateProbe {
     final long subInserts = AbstractHOTIndexWriter.DIRECTION_ONE_SUBINSERT.get() - subInsertBefore;
     final long fallbacks = AbstractHOTIndexWriter.DIRECTION_ONE_FALLBACK.get() - fallbackBefore;
     final long offPathOk = AbstractHOTIndexWriter.OFF_PATH_OVERFLOW_OK.get() - offPathOkBefore;
-    final long offPathFallback = AbstractHOTIndexWriter.OFF_PATH_OVERFLOW_FALLBACK.get()
-        - offPathFallbackBefore;
-    final long escAvoided = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get()
-        - escAvoidedBefore;
-    final long propI7Fb = AbstractHOTIndexWriter.REBUILD_PROPAGATION_I7_FALLBACK.get()
-        - propI7FbBefore;
-    final long rebuildCalls = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get()
-        - rebuildCallsBefore;
+    final long offPathFallback = AbstractHOTIndexWriter.OFF_PATH_OVERFLOW_FALLBACK.get() - offPathFallbackBefore;
+    final long escAvoided = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get() - escAvoidedBefore;
+    final long propOrderFb = AbstractHOTIndexWriter.REBUILD_PROPAGATION_ORDER_FALLBACK.get() - propOrderFbBefore;
+    final long rebuildCalls = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get() - rebuildCallsBefore;
     final long totalC2 = subInserts + fallbacks;
     final long totalIssueB = offPathOk + offPathFallback;
 
     System.err.println("=== Direction 1 + Issue B Hit Rate ===");
     System.err.println("  C2 firings (total)   : " + totalC2);
-    System.err.println("    -> sub-insert (D1) : " + subInserts
-        + (totalC2 > 0 ? String.format(" (%.1f%%)", 100.0 * subInserts / totalC2) : ""));
-    System.err.println("    -> scoped rebuild  : " + fallbacks
-        + (totalC2 > 0 ? String.format(" (%.1f%%)", 100.0 * fallbacks / totalC2) : ""));
+    System.err.println("    -> sub-insert (D1) : " + subInserts + (totalC2 > 0
+        ? String.format(" (%.1f%%)", 100.0 * subInserts / totalC2)
+        : ""));
+    System.err.println("    -> scoped rebuild  : " + fallbacks + (totalC2 > 0
+        ? String.format(" (%.1f%%)", 100.0 * fallbacks / totalC2)
+        : ""));
     System.err.println("  Issue B firings      : " + totalIssueB);
-    System.err.println("    -> incremental     : " + offPathOk
-        + (totalIssueB > 0 ? String.format(" (%.1f%%)", 100.0 * offPathOk / totalIssueB) : ""));
-    System.err.println("    -> whole rebuild   : " + offPathFallback
-        + (totalIssueB > 0 ? String.format(" (%.1f%%)", 100.0 * offPathFallback / totalIssueB) : ""));
-    System.err.println("  rebuildSubtree calls  : " + rebuildCalls
-        + " (each scoped to insertDepth, non-escalating since Stage 3c)");
-    System.err.println("  Stage 3c propagation  : " + escAvoided
-        + " ancestors re-encoded in place (escalations avoided)");
-    System.err.println("  Stage 3c I7 fallbacks : " + propI7Fb
-        + " (defensive scoped rebuild on partial-update collision)");
+    System.err.println("    -> incremental     : " + offPathOk + (totalIssueB > 0
+        ? String.format(" (%.1f%%)", 100.0 * offPathOk / totalIssueB)
+        : ""));
+    System.err.println("    -> whole rebuild   : " + offPathFallback + (totalIssueB > 0
+        ? String.format(" (%.1f%%)", 100.0 * offPathFallback / totalIssueB)
+        : ""));
+    System.err.println(
+        "  rebuildSubtree calls  : " + rebuildCalls + " (each scoped to insertDepth, non-escalating since Stage 3c)");
+    System.err.println(
+        "  Stage 3c propagation  : " + escAvoided + " ancestors re-encoded in place (escalations avoided)");
+    System.err.println(
+        "  Stage 3c I7 fallbacks : " + propOrderFb + " (defensive scoped rebuild on partial-update collision)");
     System.err.println("=======================================");
   }
 
@@ -137,7 +138,8 @@ final class Direction1HitRateProbe {
     final StringBuilder sb = new StringBuilder(n * 16);
     sb.append("{\"k\":[");
     for (int i = 0; i < n; i++) {
-      if (i > 0) sb.append(',');
+      if (i > 0)
+        sb.append(',');
       sb.append("{\"v\":").append(gen.applyAsInt(i)).append('}');
     }
     sb.append("]}");

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
@@ -391,7 +391,7 @@ class HOTLeafPageTest {
   // probe set that perturbs every byte position.
 
   /** Shared head of every {@link #alignmentLeaf} key — becomes the leaf's commonPrefix. */
-  private static final byte[] ALIGNMENT_HEAD = { 'P', 'R', 'E' };
+  private static final byte[] ALIGNMENT_HEAD = {'P', 'R', 'E'};
 
   /** Shortest and longest key in {@link #alignmentLeaf}; the span covers 0..37-byte suffixes. */
   private static final int ALIGNMENT_MIN_LEN = ALIGNMENT_HEAD.length;
@@ -422,7 +422,7 @@ class HOTLeafPageTest {
 
   private static HOTLeafPage alignmentLeaf() {
     final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.CAS);
-    final byte[] value = { 1 };
+    final byte[] value = {1};
     for (final byte[] key : alignmentKeys()) {
       assertTrue(page.put(key, value), "put failed for key of length " + key.length);
     }
@@ -437,9 +437,9 @@ class HOTLeafPageTest {
   private static List<byte[]> alignmentProbes() {
     final List<byte[]> probes = new ArrayList<>();
     probes.add(new byte[0]);
-    probes.add(new byte[] { 'P' });
-    probes.add(new byte[] { 'P', 'R' });
-    probes.add(new byte[] { 'P', 'S' });
+    probes.add(new byte[] {'P'});
+    probes.add(new byte[] {'P', 'R'});
+    probes.add(new byte[] {'P', 'S'});
     for (final byte[] key : alignmentKeys()) {
       probes.add(key);
       for (int p = 0; p < key.length; p++) {
@@ -525,9 +525,8 @@ class HOTLeafPageTest {
             final int expected = head != 0
                 ? Integer.signum(head)
                 : Integer.signum(partLen - probe.length);
-            assertEquals(expected, Integer.signum(page.compareKeyPrefixPart(i, trailer, probe, probe.length)),
-                "entry " + i + " (len " + stored.length + ") trailer " + trailer + " vs probe of length "
-                    + probe.length);
+            assertEquals(expected, Integer.signum(page.compareKeyPrefixPart(i, trailer, probe, probe.length)), "entry "
+                + i + " (len " + stored.length + ") trailer " + trailer + " vs probe of length " + probe.length);
           }
         }
       }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
@@ -345,7 +345,7 @@ class HOTLeafPageTest {
   }
 
   @Test
-  void testMergeChunkIntoPackedTombstoneAndRoaring() {
+  void testChunkAccumulatorPackedTombstoneAndRoaring() {
     final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.CAS);
 
     // Packed chunk (2 bit16 values), a tombstone, and a Roaring chunk (>64 values).
@@ -361,11 +361,12 @@ class HOTLeafPageTest {
     assertTrue(page.put(composite("k", 4), NodeReferencesSerializer.serialize(tombstone)));
     assertTrue(page.put(composite("k", 5), NodeReferencesSerializer.serialize(roaring)));
 
-    Roaring64Bitmap merged = null;
+    final NodeReferencesSerializer.ChunkAccumulator accumulator = new NodeReferencesSerializer.ChunkAccumulator();
     for (int i = 0; i < page.getEntryCount(); i++) {
       final long chunkIdx = page.readKeyIntBE(i, page.getKeyLength(i) - 4) & 0xFFFFFFFFL;
-      merged = NodeReferencesSerializer.mergeChunkInto(page, page.valueRef(i), chunkIdx << 16, merged);
+      accumulator.addChunk(page, page.valueRef(i), chunkIdx << 16);
     }
+    final NodeReferences merged = accumulator.toNodeReferencesAndReset();
 
     final Roaring64Bitmap expected = new Roaring64Bitmap();
     expected.add((3L << 16) | 0x0001);
@@ -373,7 +374,7 @@ class HOTLeafPageTest {
     for (int v = 0; v < 100; v++) {
       expected.add((5L << 16) | (v * 3));
     }
-    assertEquals(expected, merged);
+    assertEquals(NodeReferences.owning(expected), merged);
     page.close();
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
@@ -10,6 +10,7 @@ import io.sirix.index.IndexType;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.utils.OS;
+import org.roaringbitmap.longlong.Roaring64Bitmap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -247,6 +248,132 @@ class HOTLeafPageTest {
     assertEquals(key.length, keySlice.byteSize());
     assertEquals(value.length, valueSlice.byteSize());
 
+    page.close();
+  }
+
+  /** Composite key {@code logicalPrefix ‖ chunkIdx_be4}, as the chunked posting lists store them. */
+  private static byte[] composite(String logicalPrefix, int chunkIdx) {
+    final byte[] prefix = logicalPrefix.getBytes(StandardCharsets.UTF_8);
+    final byte[] key = new byte[prefix.length + 4];
+    System.arraycopy(prefix, 0, key, 0, prefix.length);
+    key[prefix.length] = (byte) (chunkIdx >>> 24);
+    key[prefix.length + 1] = (byte) (chunkIdx >>> 16);
+    key[prefix.length + 2] = (byte) (chunkIdx >>> 8);
+    key[prefix.length + 3] = (byte) chunkIdx;
+    return key;
+  }
+
+  /**
+   * A leaf whose entries share the common prefix {@code "shared/"} (maintained by {@code put}'s LCP
+   * tracking), so the zero-copy key accessors exercise BOTH regions: on-heap commonPrefix and
+   * off-heap suffix.
+   */
+  private static HOTLeafPage prefixedLeaf() {
+    final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.CAS);
+    final byte[] value = new byte[] {1};
+    assertTrue(page.put(composite("shared/alpha", 5), value));
+    assertTrue(page.put(composite("shared/alpha", 0x00010002), value));
+    assertTrue(page.put(composite("shared/alphaX", 1), value));
+    assertTrue(page.put(composite("shared/beta", 0), value));
+    return page;
+  }
+
+  @Test
+  void testGetKeyLengthMatchesMaterializedKey() {
+    final HOTLeafPage page = prefixedLeaf();
+    for (int i = 0; i < page.getEntryCount(); i++) {
+      assertEquals(page.getKey(i).length, page.getKeyLength(i), "entry " + i);
+    }
+    page.close();
+  }
+
+  @Test
+  void testCompareKeyPrefixSpansPrefixAndSuffix() {
+    final HOTLeafPage page = prefixedLeaf();
+    final byte[] alpha = "shared/alpha".getBytes(StandardCharsets.UTF_8);
+    final int alphaChunkIdx = page.findEntry(composite("shared/alpha", 5));
+    final int extensionIdx = page.findEntry(composite("shared/alphaX", 1));
+    final int betaIdx = page.findEntry(composite("shared/beta", 0));
+    assertTrue(alphaChunkIdx >= 0 && extensionIdx >= 0 && betaIdx >= 0);
+
+    // Exact chunk slot and extension slot both START WITH the logical prefix.
+    assertEquals(0, page.compareKeyPrefix(alphaChunkIdx, alpha, alpha.length));
+    assertEquals(0, page.compareKeyPrefix(extensionIdx, alpha, alpha.length));
+    // A key on a different branch compares by its first differing byte ('b' > 'a').
+    assertTrue(page.compareKeyPrefix(betaIdx, alpha, alpha.length) > 0);
+    // Divergence INSIDE the shared commonPrefix region ("shared/" vs "sharez/").
+    final byte[] sharez = "sharez/alpha".getBytes(StandardCharsets.UTF_8);
+    assertTrue(page.compareKeyPrefix(alphaChunkIdx, sharez, sharez.length) < 0);
+    // A probe longer than the key: equal through the key's bytes -> the key is less.
+    final byte[] longProbe = composite("shared/alpha", 5); // 16 bytes, == full key of alphaChunkIdx
+    final byte[] longer = new byte[longProbe.length + 2];
+    System.arraycopy(longProbe, 0, longer, 0, longProbe.length);
+    assertTrue(page.compareKeyPrefix(alphaChunkIdx, longer, longer.length) < 0);
+    page.close();
+  }
+
+  @Test
+  void testCompareKeyPrefixPartExcludesChunkTrailer() {
+    final HOTLeafPage page = prefixedLeaf();
+    final byte[] alpha = "shared/alpha".getBytes(StandardCharsets.UTF_8);
+    final int alphaChunkIdx = page.findEntry(composite("shared/alpha", 5));
+    final int extensionIdx = page.findEntry(composite("shared/alphaX", 1));
+
+    // Trimming the 4-byte trailer leaves exactly the logical prefix.
+    assertEquals(0, page.compareKeyPrefixPart(alphaChunkIdx, 4, alpha, alpha.length));
+    // The extension key's trimmed part ("shared/alphaX") is longer -> greater.
+    assertTrue(page.compareKeyPrefixPart(extensionIdx, 4, alpha, alpha.length) > 0);
+    // Against a longer probe the trimmed part is shorter -> less.
+    final byte[] alphaY = "shared/alphaY".getBytes(StandardCharsets.UTF_8);
+    assertTrue(page.compareKeyPrefixPart(alphaChunkIdx, 4, alphaY, alphaY.length) < 0);
+    page.close();
+  }
+
+  @Test
+  void testReadKeyIntBEAcrossRegions() {
+    final HOTLeafPage page = prefixedLeaf();
+    for (int i = 0; i < page.getEntryCount(); i++) {
+      final byte[] key = page.getKey(i);
+      // Every alignment: fully inside the commonPrefix, spanning the boundary, and the trailer.
+      for (final int pos : new int[] {0, 3, 5, key.length - 4}) {
+        final int expected = ((key[pos] & 0xFF) << 24) | ((key[pos + 1] & 0xFF) << 16) | ((key[pos + 2] & 0xFF) << 8)
+            | (key[pos + 3] & 0xFF);
+        assertEquals(expected, page.readKeyIntBE(i, pos), "entry " + i + " pos " + pos);
+      }
+    }
+    page.close();
+  }
+
+  @Test
+  void testMergeChunkIntoPackedTombstoneAndRoaring() {
+    final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.CAS);
+
+    // Packed chunk (2 bit16 values), a tombstone, and a Roaring chunk (>64 values).
+    final NodeReferences packed = new NodeReferences();
+    packed.addNodeKey(0x0001);
+    packed.addNodeKey(0xFFFF);
+    final NodeReferences tombstone = new NodeReferences();
+    final NodeReferences roaring = new NodeReferences();
+    for (int v = 0; v < 100; v++) {
+      roaring.addNodeKey(v * 3);
+    }
+    assertTrue(page.put(composite("k", 3), NodeReferencesSerializer.serialize(packed)));
+    assertTrue(page.put(composite("k", 4), NodeReferencesSerializer.serialize(tombstone)));
+    assertTrue(page.put(composite("k", 5), NodeReferencesSerializer.serialize(roaring)));
+
+    Roaring64Bitmap merged = null;
+    for (int i = 0; i < page.getEntryCount(); i++) {
+      final long chunkIdx = page.readKeyIntBE(i, page.getKeyLength(i) - 4) & 0xFFFFFFFFL;
+      merged = NodeReferencesSerializer.mergeChunkInto(page, page.valueRef(i), chunkIdx << 16, merged);
+    }
+
+    final Roaring64Bitmap expected = new Roaring64Bitmap();
+    expected.add((3L << 16) | 0x0001);
+    expected.add((3L << 16) | 0xFFFF);
+    for (int v = 0; v < 100; v++) {
+      expected.add((5L << 16) | (v * 3));
+    }
+    assertEquals(expected, merged);
     page.close();
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafPageTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -376,6 +379,190 @@ class HOTLeafPageTest {
     }
     assertEquals(NodeReferences.owning(expected), merged);
     page.close();
+  }
+
+  // ===== Differential coverage for the zero-alloc key comparators =====
+  //
+  // These read the suffix EIGHT BYTES AT A TIME and finish with a byte tail, so their failure modes
+  // are alignment-specific: a key whose suffix is 7, 8 or 9 bytes long exercises three different
+  // code paths, and an off-by-one in the tail is invisible to any fixed set of hand-picked keys.
+  // Everything below therefore cross-checks against Arrays.compareUnsigned over the materialized
+  // key, across a key set that lands the compare at every offset in the eight-byte stride and a
+  // probe set that perturbs every byte position.
+
+  /** Shared head of every {@link #alignmentLeaf} key — becomes the leaf's commonPrefix. */
+  private static final byte[] ALIGNMENT_HEAD = { 'P', 'R', 'E' };
+
+  /** Shortest and longest key in {@link #alignmentLeaf}; the span covers 0..37-byte suffixes. */
+  private static final int ALIGNMENT_MIN_LEN = ALIGNMENT_HEAD.length;
+  private static final int ALIGNMENT_MAX_LEN = 40;
+
+  /**
+   * A key of exactly {@code len} bytes: the shared head, then bytes derived from {@code len} so that
+   * no two keys collide and every key carries bytes above {@code 0x7F} — the comparators treat bytes
+   * as unsigned, which a purely ASCII corpus would never catch.
+   */
+  private static byte[] alignmentKey(final int len) {
+    final byte[] key = new byte[len];
+    System.arraycopy(ALIGNMENT_HEAD, 0, key, 0, Math.min(len, ALIGNMENT_HEAD.length));
+    for (int i = ALIGNMENT_HEAD.length; i < len; i++) {
+      key[i] = (byte) ((len * 31 + i * 17) & 0xFF);
+    }
+    return key;
+  }
+
+  /** Keys of every length in {@code [ALIGNMENT_MIN_LEN, ALIGNMENT_MAX_LEN]}, in insertion order. */
+  private static List<byte[]> alignmentKeys() {
+    final List<byte[]> keys = new ArrayList<>(ALIGNMENT_MAX_LEN - ALIGNMENT_MIN_LEN + 1);
+    for (int len = ALIGNMENT_MIN_LEN; len <= ALIGNMENT_MAX_LEN; len++) {
+      keys.add(alignmentKey(len));
+    }
+    return keys;
+  }
+
+  private static HOTLeafPage alignmentLeaf() {
+    final HOTLeafPage page = new HOTLeafPage(1L, 1, IndexType.CAS);
+    final byte[] value = { 1 };
+    for (final byte[] key : alignmentKeys()) {
+      assertTrue(page.put(key, value), "put failed for key of length " + key.length);
+    }
+    return page;
+  }
+
+  /**
+   * Probes derived from the stored keys: each key itself, each key with one byte bumped up and down
+   * at every position, and each key truncated and extended by up to three bytes. The truncations and
+   * extensions are what move a divergence across the eight-byte stride boundary.
+   */
+  private static List<byte[]> alignmentProbes() {
+    final List<byte[]> probes = new ArrayList<>();
+    probes.add(new byte[0]);
+    probes.add(new byte[] { 'P' });
+    probes.add(new byte[] { 'P', 'R' });
+    probes.add(new byte[] { 'P', 'S' });
+    for (final byte[] key : alignmentKeys()) {
+      probes.add(key);
+      for (int p = 0; p < key.length; p++) {
+        final byte[] lower = key.clone();
+        lower[p] = (byte) ((lower[p] & 0xFF) - 1);
+        probes.add(lower);
+        final byte[] higher = key.clone();
+        higher[p] = (byte) ((higher[p] & 0xFF) + 1);
+        probes.add(higher);
+      }
+      for (int drop = 1; drop <= 3 && key.length - drop >= 0; drop++) {
+        probes.add(Arrays.copyOf(key, key.length - drop));
+      }
+      for (int add = 1; add <= 3; add++) {
+        probes.add(Arrays.copyOf(key, key.length + add));
+      }
+    }
+    return probes;
+  }
+
+  /** Unsigned-lex comparison of the first {@code n} bytes of each side. */
+  private static int compareFirstBytes(final byte[] a, final byte[] b, final int n) {
+    for (int i = 0; i < n; i++) {
+      final int diff = (a[i] & 0xFF) - (b[i] & 0xFF);
+      if (diff != 0) {
+        return diff;
+      }
+    }
+    return 0;
+  }
+
+  @Test
+  void compareKeyWithBoundMatchesArraysCompareAtEveryAlignment() {
+    final HOTLeafPage page = alignmentLeaf();
+    try {
+      for (int i = 0; i < page.getEntryCount(); i++) {
+        final byte[] stored = page.getKey(i);
+        for (final byte[] probe : alignmentProbes()) {
+          assertEquals(Integer.signum(Arrays.compareUnsigned(stored, probe)),
+              Integer.signum(page.compareKeyWithBound(i, probe)),
+              "entry " + i + " (len " + stored.length + ") vs probe of length " + probe.length);
+        }
+      }
+    } finally {
+      page.close();
+    }
+  }
+
+  @Test
+  void compareKeyPrefixMatchesReferenceAtEveryAlignment() {
+    final HOTLeafPage page = alignmentLeaf();
+    try {
+      for (int i = 0; i < page.getEntryCount(); i++) {
+        final byte[] stored = page.getKey(i);
+        for (final byte[] probe : alignmentProbes()) {
+          final int compared = Math.min(stored.length, probe.length);
+          final int head = compareFirstBytes(stored, probe, compared);
+          final int expected = head != 0
+              ? Integer.signum(head)
+              : (stored.length < probe.length
+                  ? -1
+                  : 0);
+          assertEquals(expected, Integer.signum(page.compareKeyPrefix(i, probe, probe.length)),
+              "entry " + i + " (len " + stored.length + ") vs prefix of length " + probe.length);
+        }
+      }
+    } finally {
+      page.close();
+    }
+  }
+
+  @Test
+  void compareKeyPrefixPartMatchesReferenceAtEveryAlignment() {
+    final HOTLeafPage page = alignmentLeaf();
+    try {
+      for (int trailer = 0; trailer <= 5; trailer++) {
+        for (int i = 0; i < page.getEntryCount(); i++) {
+          final byte[] stored = page.getKey(i);
+          final int partLen = Math.max(0, stored.length - trailer);
+          for (final byte[] probe : alignmentProbes()) {
+            final int compared = Math.min(partLen, probe.length);
+            final int head = compareFirstBytes(stored, probe, compared);
+            final int expected = head != 0
+                ? Integer.signum(head)
+                : Integer.signum(partLen - probe.length);
+            assertEquals(expected, Integer.signum(page.compareKeyPrefixPart(i, trailer, probe, probe.length)),
+                "entry " + i + " (len " + stored.length + ") trailer " + trailer + " vs probe of length "
+                    + probe.length);
+          }
+        }
+      }
+    } finally {
+      page.close();
+    }
+  }
+
+  @Test
+  void findEntryMatchesLinearSearchAtEveryAlignment() {
+    final HOTLeafPage page = alignmentLeaf();
+    try {
+      final int entryCount = page.getEntryCount();
+      final byte[][] sorted = new byte[entryCount][];
+      for (int i = 0; i < entryCount; i++) {
+        sorted[i] = page.getKey(i);
+      }
+      for (final byte[] probe : alignmentProbes()) {
+        int expected = -(entryCount + 1);
+        for (int i = 0; i < entryCount; i++) {
+          final int cmp = Arrays.compareUnsigned(sorted[i], probe);
+          if (cmp == 0) {
+            expected = i;
+            break;
+          }
+          if (cmp > 0) {
+            expected = -(i + 1);
+            break;
+          }
+        }
+        assertEquals(expected, page.findEntry(probe), "probe of length " + probe.length);
+      }
+    } finally {
+      page.close();
+    }
   }
 }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafUseAfterCloseTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTLeafUseAfterCloseTest.java
@@ -40,21 +40,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * "contiguous 256/512-key run vanishes" miss seen on
  * {@code HOTMicrobenchmark.smallCombinedMicrobench}.
  *
- * <p>The HOT reader resolves a leaf, then acquires its guard in a separate step. A
- * guard-respecting evictor can close the leaf in that gap. The reader then observed
- * {@code acquireGuard() == false} and reported the key as <em>absent</em> (or iterated a
- * closed page) — but an evicted leaf is transient, not missing. The fix re-navigates and
- * reloads instead of concluding the key is gone.
+ * <p>
+ * The HOT reader resolves a leaf, then acquires its guard in a separate step. A guard-respecting
+ * evictor can close the leaf in that gap. The reader then observed {@code acquireGuard() == false}
+ * and reported the key as <em>absent</em> (or iterated a closed page) — but an evicted leaf is
+ * transient, not missing. The fix re-navigates and reloads instead of concluding the key is gone.
  *
- * <p>The miss is memory-pressure-gated: eviction only fires under pressure, and
+ * <p>
+ * The miss is memory-pressure-gated: eviction only fires under pressure, and
  * {@code FrameSlotAllocator.releaseSlot} keeps a freed slot's bytes intact, so a use-after-
  * eviction reads stale-but-valid data on an idle machine and corrupts only under load.
  *
- * <p>This test removes the timing dependence:
- * {@link FrameSlotAllocator#setPoisonOnReleaseForTesting} zero-fills every freed slot so any
- * use-after-eviction is deterministic, and a background thread evicts every unguarded cached
- * HOT leaf at maximum rate during readback. A correct reader re-resolves a transiently
- * evicted leaf from storage, so the scan must survive with zero key loss.
+ * <p>
+ * This test removes the timing dependence: {@link FrameSlotAllocator#setPoisonOnReleaseForTesting}
+ * zero-fills every freed slot so any use-after-eviction is deterministic, and a background thread
+ * evicts every unguarded cached HOT leaf at maximum rate during readback. A correct reader
+ * re-resolves a transiently evicted leaf from storage, so the scan must survive with zero key loss.
  */
 @DisplayName("HOT reader survives eviction racing the navigate-then-guard window")
 final class HOTLeafUseAfterCloseTest {
@@ -96,11 +97,10 @@ final class HOTLeafUseAfterCloseTest {
   void everyKeySurvivesReadbackUnderEviction() throws InterruptedException {
     final String prevStrictBinna = System.getProperty("hot.strict.binna");
     System.setProperty("hot.strict.binna", "true");
-    // Disable the O(total-entries) leaf-walk fallback: it masks a cursor that wrongly
-    // reports a key absent (turning a fast miss into an hours-long full-scan storm). With
-    // it off, a regression of the eviction-race bug surfaces as a fast, clean miss count.
-    final String prevFallback = System.getProperty("hot.cas.leftmostfallback.disable");
-    System.setProperty("hot.cas.leftmostfallback.disable", "true");
+    // The O(total-entries) leaf-walk fallback is opt-in (hot.cas.leftmostfallback.enable)
+    // and stays off here: it would mask a cursor that wrongly reports a key absent (turning
+    // a fast miss into an hours-long full-scan storm). A regression of the eviction-race bug
+    // surfaces as a fast, clean miss count.
     final AtomicBoolean stopEvictor = new AtomicBoolean(false);
     Thread evictor = null;
     try {
@@ -111,19 +111,18 @@ final class HOTLeafUseAfterCloseTest {
           final var trx = session.beginNodeTrx()) {
         final var ic = session.getWtxIndexController(trx.getRevisionNumber());
         final var pathToValue = Path.parse("/x/[]/v", PathParser.Type.JSON);
-        casIndexDef = IndexDefs.createCASIdxDef(false, Type.INR,
-            Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
+        casIndexDef =
+            IndexDefs.createCASIdxDef(false, Type.INR, Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
         ic.createIndexes(Set.of(casIndexDef), trx);
-        final var writer = HOTIndexWriter.create(trx.getStorageEngineWriter(),
-            CASKeySerializer.INSTANCE, IndexType.CAS, casIndexDef.getID());
+        final var writer = HOTIndexWriter.create(trx.getStorageEngineWriter(), CASKeySerializer.INSTANCE, IndexType.CAS,
+            casIndexDef.getID());
         final NodeReferences scratch = new NodeReferences();
 
         final int warmupBase = N + 1_000_000;
         for (int i = 0; i < 5_000; i++) {
           scratch.getNodeKeys().clear();
           scratch.getNodeKeys().add(warmupBase + i);
-          writer.index(new CASValue(new Int32(warmupBase + i), Type.INR, PATH_NODE_KEY), scratch,
-              null);
+          writer.index(new CASValue(new Int32(warmupBase + i), Type.INR, PATH_NODE_KEY), scratch, null);
         }
         for (int i = 0; i < N; i++) {
           scratch.getNodeKeys().clear();
@@ -137,8 +136,8 @@ final class HOTLeafUseAfterCloseTest {
       final StringBuilder firstMisses = new StringBuilder();
       try (final var session = database.beginResourceSession(JsonTestHelper.RESOURCE);
           final var rtx = session.beginNodeReadOnlyTrx()) {
-        final var reader = HOTIndexReader.create(rtx.getStorageEngineReader(),
-            CASKeySerializer.INSTANCE, IndexType.CAS, casIndexDef.getID());
+        final var reader = HOTIndexReader.create(rtx.getStorageEngineReader(), CASKeySerializer.INSTANCE, IndexType.CAS,
+            casIndexDef.getID());
         final BufferManager bufferManager = rtx.getStorageEngineReader().getBufferManager();
 
         // Maximum-rate eviction concurrent with the scan, modelling severe memory pressure.
@@ -158,8 +157,7 @@ final class HOTLeafUseAfterCloseTest {
         hammer.start();
 
         for (int v = 0; v < N; v++) {
-          if (reader.get(new CASValue(new Int32(v), Type.INR, PATH_NODE_KEY), SearchMode.EQUAL)
-              == null) {
+          if (reader.get(new CASValue(new Int32(v), Type.INR, PATH_NODE_KEY), SearchMode.EQUAL) == null) {
             if (misses < 20) {
               if (firstMisses.length() > 0) {
                 firstMisses.append(',');
@@ -173,11 +171,10 @@ final class HOTLeafUseAfterCloseTest {
         hammer.join();
       }
 
-      System.out.println("[hot-use-after-close] readback under eviction: misses=" + misses + "/"
-          + N + " first20=[" + firstMisses + "]");
-      assertEquals(0, misses,
-          "readback under concurrent eviction lost " + misses + " keys — a HOT page was used"
-              + " after it was evicted/closed; first missing: [" + firstMisses + "]");
+      System.out.println("[hot-use-after-close] readback under eviction: misses=" + misses + "/" + N + " first20=["
+          + firstMisses + "]");
+      assertEquals(0, misses, "readback under concurrent eviction lost " + misses + " keys — a HOT page was used"
+          + " after it was evicted/closed; first missing: [" + firstMisses + "]");
     } finally {
       stopEvictor.set(true);
       if (evictor != null) {
@@ -192,20 +189,15 @@ final class HOTLeafUseAfterCloseTest {
       } else {
         System.setProperty("hot.strict.binna", prevStrictBinna);
       }
-      if (prevFallback == null) {
-        System.clearProperty("hot.cas.leftmostfallback.disable");
-      } else {
-        System.setProperty("hot.cas.leftmostfallback.disable", prevFallback);
-      }
     }
   }
 
   /**
    * Evict cached HOT leaves exactly as {@code ShardedPageCache.evictUnderPressure} does —
-   * guard-respecting, with the {@code isHot()} second-chance — but without the budget gate
-   * so it sheds at maximum rate. A guarded or recently-touched (hot) leaf is spared, so the
-   * reproduction exercises the genuine navigate-then-guard race that real memory pressure
-   * produces, not an unfaithfully harsh close of leaves the reader is actively using.
+   * guard-respecting, with the {@code isHot()} second-chance — but without the budget gate so it
+   * sheds at maximum rate. A guarded or recently-touched (hot) leaf is spared, so the reproduction
+   * exercises the genuine navigate-then-guard race that real memory pressure produces, not an
+   * unfaithfully harsh close of leaves the reader is actively using.
    */
   private static void evictUnguardedLeaves(final Cache<PageReference, HOTLeafPage> cache) {
     final var entries = new ArrayList<>(cache.asMap().entrySet());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTRebuildPropagationStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTRebuildPropagationStressTest.java
@@ -30,29 +30,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Stage 3c verification stress test (docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md §12).
  *
- * <p>The Stage 3c propagation (replacement for {@code rebuildSubtree}'s height-escalation
- * cascade) is defensive code: it re-encodes each ancestor in place when a scoped rebuild
- * changes the subtree's height or leftmost firstKey. On the {@link Direction1HitRateProbe}
- * canary the 21 rebuilds per run happen to preserve both, so the propagation walks the
- * spine but never re-encodes -- the loop body is unexercised.
+ * <p>
+ * The Stage 3c propagation (replacement for {@code rebuildSubtree}'s height-escalation cascade) is
+ * defensive code: it re-encodes each ancestor in place when a scoped rebuild changes the subtree's
+ * height or leftmost firstKey. On the {@link Direction1HitRateProbe} canary the 21 rebuilds per run
+ * happen to preserve both, so the propagation walks the spine but never re-encodes -- the loop body
+ * is unexercised.
  *
- * <p>This test runs a much harder workload than the canary (50 revs × 2000 entries with
- * mixed insert/delete/reinsert + multiple value clusters per rev) to maximize the chance
- * that a rebuild changes subtree height. Regardless of whether the propagation fires the
- * test verifies:
+ * <p>
+ * This test runs a much harder workload than the canary (50 revs × 2000 entries with mixed
+ * insert/delete/reinsert + multiple value clusters per rev) to maximize the chance that a rebuild
+ * changes subtree height. Regardless of whether the propagation fires the test verifies:
  *
  * <ul>
- *   <li>Every commit succeeds without exception (Stage 3b: no catch-block self-heal arms
- *       left, so any structural-inconsistency exception would propagate).</li>
- *   <li>The final tree's range-scan results match the oracle (= the {@code TreeMap} of
- *       expected keys/values).</li>
- *   <li>Both Stage 3c counters ({@code REBUILD_HEIGHT_ESCALATION_AVOIDED},
- *       {@code REBUILD_PROPAGATION_I7_FALLBACK}) and the rebuild call count are reported
- *       for visibility.</li>
+ * <li>Every commit succeeds without exception (Stage 3b: no catch-block self-heal arms left, so any
+ * structural-inconsistency exception would propagate).</li>
+ * <li>The final tree's range-scan results match the oracle (= the {@code TreeMap} of expected
+ * keys/values).</li>
+ * <li>Both Stage 3c counters ({@code REBUILD_HEIGHT_ESCALATION_AVOIDED},
+ * {@code REBUILD_PROPAGATION_ORDER_FALLBACK}) and the rebuild call count are reported for
+ * visibility.</li>
  * </ul>
  *
- * <p>Not a correctness gate -- the other canaries cover that. This is a coverage probe
- * for Stage 3c's defensive arm.
+ * <p>
+ * Not a correctness gate -- the other canaries cover that. This is a coverage probe for Stage 3c's
+ * defensive arm.
  */
 final class HOTRebuildPropagationStressTest {
 
@@ -64,7 +66,7 @@ final class HOTRebuildPropagationStressTest {
   void rebuildPropagationUnderHeavyMutation() throws IOException {
     final long subtreeCallsBefore = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get();
     final long escAvoidedBefore = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get();
-    final long propI7FbBefore = AbstractHOTIndexWriter.REBUILD_PROPAGATION_I7_FALLBACK.get();
+    final long propOrderFbBefore = AbstractHOTIndexWriter.REBUILD_PROPAGATION_ORDER_FALLBACK.get();
 
     final int entriesPerRev = 2_000;
     final int totalRevs = 50;
@@ -75,29 +77,29 @@ final class HOTRebuildPropagationStressTest {
 
     try (Database<JsonResourceSession> database = Databases.openJsonDatabase(dbPath)) {
       database.createResource(ResourceConfiguration.newBuilder("res")
-          .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
-          .maxNumberOfRevisionsToRestore(5).build());
+                                                   .versioningApproach(VersioningType.SLIDING_SNAPSHOT)
+                                                   .maxNumberOfRevisionsToRestore(5)
+                                                   .build());
 
       try (JsonResourceSession session = database.beginResourceSession("res");
-           JsonNodeTrx wtx = session.beginNodeTrx()) {
+          JsonNodeTrx wtx = session.beginNodeTrx()) {
         final var ic = session.getWtxIndexController(wtx.getRevisionNumber());
-        final var pathToValue = io.brackit.query.util.path.Path.parse(
-            "/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
-        final IndexDef def = IndexDefs.createCASIdxDef(false, Type.INR,
-            Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
+        final var pathToValue =
+            io.brackit.query.util.path.Path.parse("/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
+        final IndexDef def =
+            IndexDefs.createCASIdxDef(false, Type.INR, Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
         ic.createIndexes(Set.of(def), wtx);
 
         // Rev 1: bootstrap with values spread across multiple clusters.
         wtx.insertSubtreeAsFirstChild(
-            JsonShredder.createStringReader(buildArray(entriesPerRev,
-                i -> clusterValue(rng, i, 5))),
+            JsonShredder.createStringReader(buildArray(entriesPerRev, i -> clusterValue(rng, i, 5))),
             JsonNodeTrx.Commit.NO);
         wtx.commit();
 
         // Revs 2..totalRevs: aggressive mutation patterns designed to stretch the trie:
-        //   * Multiple value clusters force wide disc-bit coverage.
-        //   * Periodic remove-all + reinsert produces tombstone bursts + height churn.
-        //   * Random base offsets cause overlapping inserts that exercise the C2/I8 paths.
+        // * Multiple value clusters force wide disc-bit coverage.
+        // * Periodic remove-all + reinsert produces tombstone bursts + height churn.
+        // * Random base offsets cause overlapping inserts that exercise the C2/I8 paths.
         for (int rev = 2; rev <= totalRevs; rev++) {
           wtx.moveToDocumentRoot();
           if (wtx.moveToFirstChild()) {
@@ -105,26 +107,21 @@ final class HOTRebuildPropagationStressTest {
           }
           final int clusters = 3 + (rev % 4);
           wtx.insertSubtreeAsFirstChild(
-              JsonShredder.createStringReader(buildArray(entriesPerRev,
-                  i -> clusterValue(rng, i, clusters))),
+              JsonShredder.createStringReader(buildArray(entriesPerRev, i -> clusterValue(rng, i, clusters))),
               JsonNodeTrx.Commit.NO);
           wtx.commit();
         }
       }
     }
 
-    final long subtreeCalls = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get()
-        - subtreeCallsBefore;
-    final long escAvoided = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get()
-        - escAvoidedBefore;
-    final long propI7Fb = AbstractHOTIndexWriter.REBUILD_PROPAGATION_I7_FALLBACK.get()
-        - propI7FbBefore;
+    final long subtreeCalls = AbstractHOTIndexWriter.REBUILD_SUBTREE_CALLED.get() - subtreeCallsBefore;
+    final long escAvoided = AbstractHOTIndexWriter.REBUILD_HEIGHT_ESCALATION_AVOIDED.get() - escAvoidedBefore;
+    final long propOrderFb = AbstractHOTIndexWriter.REBUILD_PROPAGATION_ORDER_FALLBACK.get() - propOrderFbBefore;
 
     System.err.println("=== Stage 3c Propagation Stress ===");
     System.err.println("  rebuildSubtree calls : " + subtreeCalls);
-    System.err.println("  propagation re-encodes : " + escAvoided
-        + " ancestors re-encoded in place");
-    System.err.println("  propagation I7 fbs   : " + propI7Fb);
+    System.err.println("  propagation re-encodes : " + escAvoided + " ancestors re-encoded in place");
+    System.err.println("  propagation I7 fbs   : " + propOrderFb);
     System.err.println("=================================");
 
     // The defensive code being unexercised is acceptable -- it just means this workload's
@@ -132,15 +129,14 @@ final class HOTRebuildPropagationStressTest {
     // (Stage 3b's catch arms are gone so any structural inconsistency would propagate).
     assertTrue(subtreeCalls >= 0, "counter should be non-negative");
     // I7 fallback must be at-most equal to total rebuild calls (it's a SUBSET of them).
-    assertTrue(propI7Fb <= subtreeCalls, "I7 fallback count exceeds total rebuilds");
+    assertTrue(propOrderFb <= subtreeCalls, "I7 fallback count exceeds total rebuilds");
   }
 
   /**
-   * Build a value mixing the bit-positions across several numeric clusters. With
-   * {@code clusters=5} and {@code i = 0..N-1}, the values cycle through 5 anchors spread
-   * across the 32-bit range, with random fan-out within each cluster. This produces wide
-   * disc-bit coverage and exercises the MSDB-closure boundary that Stage 3c's propagation
-   * defends.
+   * Build a value mixing the bit-positions across several numeric clusters. With {@code clusters=5}
+   * and {@code i = 0..N-1}, the values cycle through 5 anchors spread across the 32-bit range, with
+   * random fan-out within each cluster. This produces wide disc-bit coverage and exercises the
+   * MSDB-closure boundary that Stage 3c's propagation defends.
    */
   private static int clusterValue(Random rng, int i, int clusters) {
     final int anchor = (i % clusters) * (Integer.MAX_VALUE / clusters);
@@ -151,7 +147,8 @@ final class HOTRebuildPropagationStressTest {
     final StringBuilder sb = new StringBuilder(n * 16);
     sb.append("{\"k\":[");
     for (int i = 0; i < n; i++) {
-      if (i > 0) sb.append(',');
+      if (i > 0)
+        sb.append(',');
       sb.append("{\"v\":").append(gen.applyAsInt(i)).append('}');
     }
     sb.append("]}");

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTRebuildPropagationStressTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTRebuildPropagationStressTest.java
@@ -4,6 +4,7 @@
 package io.sirix.index.hot;
 
 import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
 import io.sirix.access.DatabaseConfiguration;
 import io.sirix.access.Databases;
 import io.sirix.access.ResourceConfiguration;
@@ -24,6 +25,9 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.IntUnaryOperator;
+
+import static io.brackit.query.util.path.Path.parse;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -84,8 +88,7 @@ final class HOTRebuildPropagationStressTest {
       try (JsonResourceSession session = database.beginResourceSession("res");
           JsonNodeTrx wtx = session.beginNodeTrx()) {
         final var ic = session.getWtxIndexController(wtx.getRevisionNumber());
-        final var pathToValue =
-            io.brackit.query.util.path.Path.parse("/k/[]/v", io.brackit.query.util.path.PathParser.Type.JSON);
+        final var pathToValue = parse("/k/[]/v", PathParser.Type.JSON);
         final IndexDef def =
             IndexDefs.createCASIdxDef(false, Type.INR, Collections.singleton(pathToValue), 0, IndexDef.DbType.JSON);
         ic.createIndexes(Set.of(def), wtx);
@@ -143,7 +146,7 @@ final class HOTRebuildPropagationStressTest {
     return anchor + rng.nextInt(8_192);
   }
 
-  private static String buildArray(int n, java.util.function.IntUnaryOperator gen) {
+  private static String buildArray(int n, IntUnaryOperator gen) {
     final StringBuilder sb = new StringBuilder(n * 16);
     sb.append("{\"k\":[");
     for (int i = 0; i < n; i++) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/KeySerializerUtf8Test.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/KeySerializerUtf8Test.java
@@ -33,12 +33,11 @@ final class KeySerializerUtf8Test {
   private static final int CAS_MAX_VALUE_BYTES = 246;
 
   private static String[] samples() {
-    return new String[] {"hello", "", "a", "Ünïcödé", "日本語のフィールド名", "emoji 🚀 rocket",
-        "unpaired \uD800 surrogate", "low \uDC00 surrogate", "mixed ascii then Ü",
-        "x".repeat(CAS_MAX_VALUE_BYTES - 1), "x".repeat(CAS_MAX_VALUE_BYTES),
-        "x".repeat(CAS_MAX_VALUE_BYTES + 50), "x".repeat(CAS_MAX_VALUE_BYTES) + "Ü",
+    return new String[] {"hello", "", "a", "Ünïcödé", "日本語のフィールド名", "emoji 🚀 rocket", "unpaired \uD800 surrogate",
+        "low \uDC00 surrogate", "mixed ascii then Ü", "x".repeat(CAS_MAX_VALUE_BYTES - 1),
+        "x".repeat(CAS_MAX_VALUE_BYTES), "x".repeat(CAS_MAX_VALUE_BYTES + 50), "x".repeat(CAS_MAX_VALUE_BYTES) + "Ü",
         "x".repeat(CAS_MAX_VALUE_BYTES - 1) + "Ü", "Ü" + "x".repeat(CAS_MAX_VALUE_BYTES)};
-    }
+  }
 
   /** What the CAS serializer's value region held before the ASCII fast path existed. */
   private static byte[] referenceCasValueBytes(final String value, final int capacity) {
@@ -57,8 +56,7 @@ final class KeySerializerUtf8Test {
       for (final int capacity : new int[] {512, CAS_HEADER_BYTES + 32, CAS_HEADER_BYTES + CAS_MAX_VALUE_BYTES}) {
         final byte[] dest = new byte[capacity];
         final int length = CASKeySerializer.INSTANCE.serialize(new CASValue(new Str(value), Type.STR, 7), dest, 0);
-        assertArrayEquals(referenceCasValueBytes(value, capacity),
-            Arrays.copyOfRange(dest, CAS_HEADER_BYTES, length),
+        assertArrayEquals(referenceCasValueBytes(value, capacity), Arrays.copyOfRange(dest, CAS_HEADER_BYTES, length),
             "value bytes for \"" + value + "\" at capacity " + capacity);
       }
     }
@@ -83,16 +81,14 @@ final class KeySerializerUtf8Test {
   void namePrefixesMatchReferenceEncoding() {
     for (final String prefix : new String[] {"ns", "nsÜ", "🚀", "unpaired \uD800"}) {
       final byte[] dest = new byte[2048];
-      final int length = NameKeySerializer.INSTANCE.serialize(new QNm("http://example.org", prefix, "local"),
-          dest, 0);
+      final int length = NameKeySerializer.INSTANCE.serialize(new QNm("http://example.org", prefix, "local"), dest, 0);
 
       final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
       final byte[] expected = new byte[2 + prefixBytes.length + "local".length()];
       expected[0] = (byte) 0xFF;
       expected[1] = (byte) prefixBytes.length;
       System.arraycopy(prefixBytes, 0, expected, 2, prefixBytes.length);
-      System.arraycopy("local".getBytes(StandardCharsets.UTF_8), 0, expected, 2 + prefixBytes.length,
-          "local".length());
+      System.arraycopy("local".getBytes(StandardCharsets.UTF_8), 0, expected, 2 + prefixBytes.length, "local".length());
 
       assertArrayEquals(expected, Arrays.copyOf(dest, length), "prefixed name bytes for \"" + prefix + '"');
     }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/KeySerializerUtf8Test.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/KeySerializerUtf8Test.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+/**
+ * The CAS and NAME key serializers write the US-ASCII case straight into the destination buffer
+ * instead of through a throwaway {@code byte[]}, because they run once per indexed node. The bytes
+ * must be exactly what {@code String.getBytes(UTF_8)} would have produced — including where the
+ * value is truncated to the key cap, and including the inputs that send the encoder down the
+ * fallback: multi-byte code points, surrogate pairs, and the unpaired surrogate that
+ * {@code getBytes} replaces with {@code '?'}.
+ */
+@DisplayName("Key serializer UTF-8 encoding")
+final class KeySerializerUtf8Test {
+
+  /** Header bytes a CAS key writes before the value: 8 for the path node key, 2 for the type. */
+  private static final int CAS_HEADER_BYTES = 10;
+
+  /** Value bytes a CAS key keeps at most; the serializer truncates past this. */
+  private static final int CAS_MAX_VALUE_BYTES = 246;
+
+  private static String[] samples() {
+    return new String[] {"hello", "", "a", "Ünïcödé", "日本語のフィールド名", "emoji 🚀 rocket",
+        "unpaired \uD800 surrogate", "low \uDC00 surrogate", "mixed ascii then Ü",
+        "x".repeat(CAS_MAX_VALUE_BYTES - 1), "x".repeat(CAS_MAX_VALUE_BYTES),
+        "x".repeat(CAS_MAX_VALUE_BYTES + 50), "x".repeat(CAS_MAX_VALUE_BYTES) + "Ü",
+        "x".repeat(CAS_MAX_VALUE_BYTES - 1) + "Ü", "Ü" + "x".repeat(CAS_MAX_VALUE_BYTES)};
+    }
+
+  /** What the CAS serializer's value region held before the ASCII fast path existed. */
+  private static byte[] referenceCasValueBytes(final String value, final int capacity) {
+    final byte[] utf8 = value.getBytes(StandardCharsets.UTF_8);
+    final int cap = Math.min(capacity - CAS_HEADER_BYTES, CAS_MAX_VALUE_BYTES);
+    return Arrays.copyOf(utf8, Math.min(utf8.length, cap));
+  }
+
+  @Test
+  @DisplayName("CAS string values encode exactly as getBytes(UTF_8), truncated to the key cap")
+  void casStringValuesMatchReferenceEncoding() {
+    for (final String value : samples()) {
+      if (value.isEmpty()) {
+        continue; // an empty value has no key; CASKeySerializer rejects it separately
+      }
+      for (final int capacity : new int[] {512, CAS_HEADER_BYTES + 32, CAS_HEADER_BYTES + CAS_MAX_VALUE_BYTES}) {
+        final byte[] dest = new byte[capacity];
+        final int length = CASKeySerializer.INSTANCE.serialize(new CASValue(new Str(value), Type.STR, 7), dest, 0);
+        assertArrayEquals(referenceCasValueBytes(value, capacity),
+            Arrays.copyOfRange(dest, CAS_HEADER_BYTES, length),
+            "value bytes for \"" + value + "\" at capacity " + capacity);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("NAME local names encode exactly as getBytes(UTF_8)")
+  void nameLocalNamesMatchReferenceEncoding() {
+    for (final String name : samples()) {
+      if (name.isEmpty()) {
+        continue; // NameKeySerializer rejects an empty local name
+      }
+      final byte[] dest = new byte[2048];
+      final int length = NameKeySerializer.INSTANCE.serialize(new QNm(name), dest, 0);
+      assertArrayEquals(name.getBytes(StandardCharsets.UTF_8), Arrays.copyOf(dest, length),
+          "name bytes for \"" + name + '"');
+    }
+  }
+
+  @Test
+  @DisplayName("NAME prefixes encode exactly as getBytes(UTF_8)")
+  void namePrefixesMatchReferenceEncoding() {
+    for (final String prefix : new String[] {"ns", "nsÜ", "🚀", "unpaired \uD800"}) {
+      final byte[] dest = new byte[2048];
+      final int length = NameKeySerializer.INSTANCE.serialize(new QNm("http://example.org", prefix, "local"),
+          dest, 0);
+
+      final byte[] prefixBytes = prefix.getBytes(StandardCharsets.UTF_8);
+      final byte[] expected = new byte[2 + prefixBytes.length + "local".length()];
+      expected[0] = (byte) 0xFF;
+      expected[1] = (byte) prefixBytes.length;
+      System.arraycopy(prefixBytes, 0, expected, 2, prefixBytes.length);
+      System.arraycopy("local".getBytes(StandardCharsets.UTF_8), 0, expected, 2 + prefixBytes.length,
+          "local".length());
+
+      assertArrayEquals(expected, Arrays.copyOf(dest, length), "prefixed name bytes for \"" + prefix + '"');
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesCompactModeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesCompactModeTest.java
@@ -37,7 +37,7 @@ class NodeReferencesCompactModeTest {
   }
 
   private static NodeReferences compact(final long... keys) {
-    return NodeReferences.ofSortedArray(keys.clone(), keys.length);
+    return NodeReferences.ofSortedArray(keys.clone());
   }
 
   @Test
@@ -101,7 +101,7 @@ class NodeReferencesCompactModeTest {
 
   @Test
   void emptyCompactBehavesLikeTombstone() {
-    final NodeReferences empty = NodeReferences.ofSortedArray(new long[0], 0);
+    final NodeReferences empty = NodeReferences.ofSortedArray(new long[0]);
     assertFalse(empty.hasNodeKeys());
     assertEquals(0, empty.cardinality());
     assertFalse(empty.nodeKeyIterator().hasNext());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesCompactModeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesCompactModeTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.sirix.cache.Allocators;
+import io.sirix.index.IndexType;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.page.HOTLeafPage;
+import io.sirix.utils.OS;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.LongIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The compact (sorted-array) representation of {@link NodeReferences} and the
+ * {@link NodeReferencesSerializer.ChunkAccumulator} that produces it must be observably identical
+ * to the bitmap-backed twin through every accessor, including equality across representations and
+ * serializer round-trips.
+ */
+class NodeReferencesCompactModeTest {
+
+  private static NodeReferences bitmapBacked(final long... keys) {
+    final NodeReferences refs = new NodeReferences();
+    for (final long k : keys) {
+      refs.addNodeKey(k);
+    }
+    return refs;
+  }
+
+  private static NodeReferences compact(final long... keys) {
+    return NodeReferences.ofSortedArray(keys.clone(), keys.length);
+  }
+
+  @Test
+  void compactAccessorsMatchBitmapTwin() {
+    final long[] keys = {3L, 70_000L, (5L << 16) | 42L, Long.MAX_VALUE - 1};
+    final NodeReferences a = compact(keys);
+    final NodeReferences b = bitmapBacked(keys);
+
+    assertEquals(keys.length, a.cardinality());
+    assertEquals(b.cardinality(), a.cardinality());
+    assertTrue(a.hasNodeKeys());
+    for (final long k : keys) {
+      assertTrue(a.contains(k), "contains " + k);
+      assertTrue(a.isPresent(k));
+    }
+    assertFalse(a.contains(4L));
+
+    final List<Long> got = new ArrayList<>();
+    a.forEachNodeKey(got::add);
+    assertEquals(keys.length, got.size());
+    final LongIterator it = a.nodeKeyIterator();
+    int i = 0;
+    while (it.hasNext()) {
+      assertEquals(keys[i], it.next());
+      assertEquals(keys[i], got.get(i));
+      i++;
+    }
+
+    // Equality and hash are representation-independent, both directions.
+    assertEquals(a, b);
+    assertEquals(b, a);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  @Test
+  void materializationAndMutationKeepOneSourceOfTruth() {
+    final NodeReferences refs = compact(1L, 2L, 3L);
+    assertEquals(3, refs.getNodeKeys().getLongCardinality()); // materializes lazily
+    refs.addNodeKey(4L); // mutation after materialization
+    assertEquals(4, refs.cardinality());
+    assertTrue(refs.contains(4L));
+    assertTrue(refs.removeNodeKey(2L));
+    assertEquals(3, refs.cardinality());
+    assertFalse(refs.contains(2L));
+
+    // Mutation on a fresh compact instance materializes first, transparently.
+    final NodeReferences refs2 = compact(10L, 20L);
+    refs2.addNodeKey(15L);
+    assertEquals(3, refs2.cardinality());
+    assertEquals(bitmapBacked(10L, 15L, 20L), refs2);
+  }
+
+  @Test
+  void serializerRoundTripIsRepresentationIndependent() {
+    final long[] keys = {7L, 8L, 9L};
+    final byte[] fromCompact = NodeReferencesSerializer.serialize(compact(keys));
+    final byte[] fromBitmap = NodeReferencesSerializer.serialize(bitmapBacked(keys));
+    assertArrayEquals(fromBitmap, fromCompact);
+    assertEquals(compact(keys), NodeReferencesSerializer.deserialize(fromCompact));
+  }
+
+  @Test
+  void emptyCompactBehavesLikeTombstone() {
+    final NodeReferences empty = NodeReferences.ofSortedArray(new long[0], 0);
+    assertFalse(empty.hasNodeKeys());
+    assertEquals(0, empty.cardinality());
+    assertFalse(empty.nodeKeyIterator().hasNext());
+    assertEquals(new NodeReferences(), empty);
+  }
+
+  @Test
+  void accumulatorEmitsCompactAndSpillsToBitmap() {
+    if (OS.isWindows()) {
+      return;
+    }
+    Allocators.getInstance().init(64L * 1024 * 1024);
+
+    // Small accumulation from real leaf slots -> compact result identical to the slow merge.
+    final HOTLeafPage leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    final NodeReferences chunkA = bitmapBacked(0x0001L, 0x00FFL);
+    final NodeReferences chunkB = bitmapBacked(0x0002L);
+    assertTrue(leaf.put(new byte[] {1}, NodeReferencesSerializer.serialize(chunkA)));
+    assertTrue(leaf.put(new byte[] {2}, NodeReferencesSerializer.serialize(chunkB)));
+
+    final NodeReferencesSerializer.ChunkAccumulator accumulator = new NodeReferencesSerializer.ChunkAccumulator();
+    accumulator.addChunk(leaf, leaf.valueRef(0), 3L << 16);
+    accumulator.addChunk(leaf, leaf.valueRef(1), 7L << 16);
+    final NodeReferences result = accumulator.toNodeReferencesAndReset();
+    assertEquals(bitmapBacked((3L << 16) | 0x0001L, (3L << 16) | 0x00FFL, (7L << 16) | 0x0002L), result);
+
+    // Reuse after reset: nothing accumulated -> null.
+    assertNull(accumulator.toNodeReferencesAndReset());
+
+    // Spill past the compact limit: accumulate 600 keys through many chunk payloads.
+    long expectedCount = 0;
+    for (int chunk = 0; chunk < 10; chunk++) {
+      final NodeReferences bits = new NodeReferences();
+      for (int v = 0; v < 60; v++) {
+        bits.addNodeKey(v * 7);
+      }
+      final byte[] serialized = NodeReferencesSerializer.serialize(bits);
+      assertTrue(leaf.put(new byte[] {(byte) (10 + chunk)}, serialized));
+      expectedCount += 60;
+    }
+    for (int chunk = 0; chunk < 10; chunk++) {
+      final int idx = leaf.findEntry(new byte[] {(byte) (10 + chunk)});
+      accumulator.addChunk(leaf, leaf.valueRef(idx), (long) (chunk + 100) << 16);
+    }
+    final NodeReferences spilled = accumulator.toNodeReferencesAndReset();
+    assertEquals(expectedCount, spilled.cardinality());
+    assertTrue(spilled.contains((100L << 16) | 0L));
+    assertTrue(spilled.contains((109L << 16) | (59 * 7)));
+    leaf.close();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesSerializerTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesSerializerTest.java
@@ -5,9 +5,14 @@
  */
 package io.sirix.index.hot;
 
+import io.sirix.cache.Allocators;
+import io.sirix.index.IndexType;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.page.HOTLeafPage;
+import io.sirix.utils.OS;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -262,8 +267,7 @@ class NodeReferencesSerializerTest {
     final byte[] twoKeys = packedOf(5L, 6L);
     assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, twoKeys, 0, twoKeys.length));
     final byte[] tombstone = NodeReferencesSerializer.serialize(new NodeReferences());
-    assertNull(
-        NodeReferencesSerializer.mergePackedSingleBit(existing, tombstone, 0, tombstone.length));
+    assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, tombstone, 0, tombstone.length));
   }
 
   @Test
@@ -298,6 +302,71 @@ class NodeReferencesSerializerTest {
         assertArrayEquals(slow, fast, "absent key must match slow path at trial " + trial);
       }
     }
+  }
+
+  // ==================== mergePackedSingleBitFromSlot (slot-memory twin) ====================
+
+  /** A leaf holding {@code payload} under a single key; caller closes. */
+  private static HOTLeafPage leafWithValue(byte[] payload) {
+    if (!OS.isWindows()) {
+      Allocators.getInstance().init(64L * 1024 * 1024);
+    }
+    final HOTLeafPage leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    assertTrue(leaf.put("k".getBytes(StandardCharsets.UTF_8), payload));
+    return leaf;
+  }
+
+  @Test
+  void mergePackedSingleBitFromSlot_matchesArrayVariant_differentialRandom() {
+    final Random rnd = new Random(0x5107);
+    for (int trial = 0; trial < 500; trial++) {
+      final int n = 1 + rnd.nextInt(63);
+      final java.util.TreeSet<Long> set = new java.util.TreeSet<>();
+      while (set.size() < n) {
+        set.add((long) rnd.nextInt(1 << 16));
+      }
+      final byte[] existing = packedOf(set.stream().mapToLong(Long::longValue).toArray());
+      final long newKey = rnd.nextInt(1 << 16);
+      final byte[] nv = singleBit(newKey);
+      final HOTLeafPage leaf = leafWithValue(existing);
+      final byte[] fromSlot =
+          NodeReferencesSerializer.mergePackedSingleBitFromSlot(leaf, leaf.valueRef(0), nv, 0, nv.length);
+      if (set.contains(newKey)) {
+        assertSame(NodeReferencesSerializer.MERGE_UNCHANGED, fromSlot,
+            "present key must return the no-op sentinel at trial " + trial);
+      } else {
+        assertArrayEquals(slowMerge(existing, nv, 0, nv.length), fromSlot,
+            "absent key must match the slow path at trial " + trial);
+      }
+      leaf.close();
+    }
+  }
+
+  @Test
+  void mergePackedSingleBitFromSlot_rejectsNonQualifyingShapes() {
+    // Roaring-format existing payload: > PACKED_THRESHOLD entries.
+    final NodeReferences big = new NodeReferences();
+    for (int i = 0; i < 100; i++) {
+      big.addNodeKey(i);
+    }
+    final byte[] nv = singleBit(7L);
+    final HOTLeafPage roaringLeaf = leafWithValue(NodeReferencesSerializer.serialize(big));
+    assertNull(
+        NodeReferencesSerializer.mergePackedSingleBitFromSlot(roaringLeaf, roaringLeaf.valueRef(0), nv, 0, nv.length));
+    roaringLeaf.close();
+
+    // Multi-entry new payload does not qualify as a single-bit merge.
+    final byte[] twoKeys = packedOf(1L, 2L);
+    final HOTLeafPage packedLeaf = leafWithValue(packedOf(10L, 30L));
+    assertNull(NodeReferencesSerializer.mergePackedSingleBitFromSlot(packedLeaf, packedLeaf.valueRef(0), twoKeys, 0,
+        twoKeys.length));
+    packedLeaf.close();
+
+    // Tombstone payloads: rejected by the merge, recognized by the slot-side tombstone probe.
+    final HOTLeafPage tombLeaf = leafWithValue(NodeReferencesSerializer.serialize(new NodeReferences()));
+    assertNull(NodeReferencesSerializer.mergePackedSingleBitFromSlot(tombLeaf, tombLeaf.valueRef(0), nv, 0, nv.length));
+    assertTrue(NodeReferencesSerializer.isTombstone(tombLeaf, tombLeaf.valueRef(0)));
+    tombLeaf.close();
   }
 }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesSerializerTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/NodeReferencesSerializerTest.java
@@ -10,10 +10,12 @@ import io.sirix.index.IndexType;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.page.HOTLeafPage;
 import io.sirix.utils.OS;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -183,7 +185,7 @@ class NodeReferencesSerializerTest {
     assertEquals((byte) 0xFF, bytes65[0]); // Roaring format
   }
 
-  // ==================== mergePackedSingleBit fast path ====================
+  // ==================== packed-payload fixtures ====================
 
   private static byte[] packedOf(long... keys) {
     final NodeReferences refs = new NodeReferences();
@@ -205,40 +207,50 @@ class NodeReferencesSerializerTest {
     return NodeReferencesSerializer.serialize(a);
   }
 
+  /** Run the slot-based single-bit merge against a leaf holding {@code existing}. */
+  private static byte @Nullable [] mergeFromSlot(byte[] existing, byte[] newValue, int off, int len) {
+    final HOTLeafPage leaf = leafWithValue(existing);
+    try {
+      return NodeReferencesSerializer.mergePackedSingleBitFromSlot(leaf, leaf.valueRef(0), newValue, off, len);
+    } finally {
+      leaf.close();
+    }
+  }
+
   @Test
-  void mergePackedSingleBit_insertsAbsentKey_byteIdenticalToSlowPath() {
+  void packedSingleBitMerge_insertsAbsentKey_byteIdenticalToSlowPath() {
     final byte[] existing = packedOf(10L, 30L, 50L);
     // Insert before-all, middle, and after-all positions.
     for (final long k : new long[] {5L, 20L, 40L, 60L}) {
       final byte[] nv = singleBit(k);
-      final byte[] fast = NodeReferencesSerializer.mergePackedSingleBit(existing, nv, 0, nv.length);
+      final byte[] fast = mergeFromSlot(existing, nv, 0, nv.length);
       assertArrayEquals(slowMerge(existing, nv, 0, nv.length), fast,
           "fast path must be byte-identical to slow path for key " + k);
     }
   }
 
   @Test
-  void mergePackedSingleBit_presentKey_returnsSameReferenceNoOp() {
+  void packedSingleBitMerge_presentKey_returnsSameReferenceNoOp() {
     final byte[] existing = packedOf(10L, 30L, 50L);
     final byte[] nv = singleBit(30L);
-    final byte[] fast = NodeReferencesSerializer.mergePackedSingleBit(existing, nv, 0, nv.length);
-    assertSame(existing, fast, "present key must be a no-op (same reference)");
+    final byte[] fast = mergeFromSlot(existing, nv, 0, nv.length);
+    assertSame(NodeReferencesSerializer.MERGE_UNCHANGED, fast, "present key must be a no-op");
     // Slow path leaves the set unchanged, so existing is already its own serialization.
     assertArrayEquals(slowMerge(existing, nv, 0, nv.length), existing);
   }
 
   @Test
-  void mergePackedSingleBit_honorsOffsetIntoNewBuffer() {
+  void packedSingleBitMerge_honorsOffsetIntoNewBuffer() {
     final byte[] existing = packedOf(100L, 200L);
     final byte[] one = singleBit(150L);
     final byte[] buf = new byte[3 + one.length + 4];
     System.arraycopy(one, 0, buf, 3, one.length);
-    final byte[] fast = NodeReferencesSerializer.mergePackedSingleBit(existing, buf, 3, one.length);
+    final byte[] fast = mergeFromSlot(existing, buf, 3, one.length);
     assertArrayEquals(slowMerge(existing, buf, 3, one.length), fast);
   }
 
   @Test
-  void mergePackedSingleBit_bailsWhenBucketWouldOverflowToRoaring() {
+  void packedSingleBitMerge_bailsWhenBucketWouldOverflowToRoaring() {
     final long[] keys = new long[64];
     for (int i = 0; i < 64; i++) {
       keys[i] = i;
@@ -246,11 +258,11 @@ class NodeReferencesSerializerTest {
     final byte[] existing = packedOf(keys); // exactly PACKED_THRESHOLD entries
     assertEquals(0x00, existing[0]);
     final byte[] nv = singleBit(1000L);
-    assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, nv, 0, nv.length));
+    assertNull(mergeFromSlot(existing, nv, 0, nv.length));
   }
 
   @Test
-  void mergePackedSingleBit_bailsOnRoaringExisting() {
+  void packedSingleBitMerge_bailsOnRoaringExisting() {
     final long[] keys = new long[65];
     for (int i = 0; i < 65; i++) {
       keys[i] = i;
@@ -258,50 +270,25 @@ class NodeReferencesSerializerTest {
     final byte[] existing = packedOf(keys); // 65 entries -> Roaring format
     assertEquals((byte) 0xFF, existing[0]);
     final byte[] nv = singleBit(1000L);
-    assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, nv, 0, nv.length));
+    assertNull(mergeFromSlot(existing, nv, 0, nv.length));
   }
 
   @Test
-  void mergePackedSingleBit_bailsWhenNewValueIsNotASinglePackedKey() {
+  void packedSingleBitMerge_bailsWhenNewValueIsNotASinglePackedKey() {
     final byte[] existing = packedOf(10L, 20L);
     final byte[] twoKeys = packedOf(5L, 6L);
-    assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, twoKeys, 0, twoKeys.length));
+    assertNull(mergeFromSlot(existing, twoKeys, 0, twoKeys.length));
     final byte[] tombstone = NodeReferencesSerializer.serialize(new NodeReferences());
-    assertNull(NodeReferencesSerializer.mergePackedSingleBit(existing, tombstone, 0, tombstone.length));
+    assertNull(mergeFromSlot(existing, tombstone, 0, tombstone.length));
   }
 
   @Test
-  void mergePackedSingleBit_bailsOnTombstoneExisting() {
+  void packedSingleBitMerge_bailsOnTombstoneExisting() {
     // Precondition: callers handle tombstone-existing before the fast path. The method still
     // defensively bails (a tombstone is not PACKED_FORMAT), deferring to the slow path.
     final byte[] tombstone = NodeReferencesSerializer.serialize(new NodeReferences());
     final byte[] nv = singleBit(7L);
-    assertNull(NodeReferencesSerializer.mergePackedSingleBit(tombstone, nv, 0, nv.length));
-  }
-
-  @Test
-  void mergePackedSingleBit_differentialRandom() {
-    final Random rnd = new Random(0xC0FFEE);
-    for (int trial = 0; trial < 5000; trial++) {
-      // 1..63 entries: existing is genuinely packed (n==0 would be a tombstone, out of contract)
-      // and stays packed after one insert (<= PACKED_THRESHOLD).
-      final int n = 1 + rnd.nextInt(63);
-      final java.util.TreeSet<Long> set = new java.util.TreeSet<>();
-      while (set.size() < n) {
-        set.add((long) rnd.nextInt(1 << 16)); // chunk-local 16-bit values, as on the live path
-      }
-      final byte[] existing = packedOf(set.stream().mapToLong(Long::longValue).toArray());
-      final long newKey = rnd.nextInt(1 << 16);
-      final byte[] nv = singleBit(newKey);
-      final byte[] fast = NodeReferencesSerializer.mergePackedSingleBit(existing, nv, 0, nv.length);
-      final byte[] slow = slowMerge(existing, nv, 0, nv.length);
-      if (set.contains(newKey)) {
-        assertSame(existing, fast, "present key must be a no-op at trial " + trial);
-        assertArrayEquals(slow, existing);
-      } else {
-        assertArrayEquals(slow, fast, "absent key must match slow path at trial " + trial);
-      }
-    }
+    assertNull(mergeFromSlot(tombstone, nv, 0, nv.length));
   }
 
   // ==================== mergePackedSingleBitFromSlot (slot-memory twin) ====================
@@ -317,11 +304,11 @@ class NodeReferencesSerializerTest {
   }
 
   @Test
-  void mergePackedSingleBitFromSlot_matchesArrayVariant_differentialRandom() {
+  void packedSingleBitMerge_fromSlot_matchesSlowPath_differentialRandom() {
     final Random rnd = new Random(0x5107);
     for (int trial = 0; trial < 500; trial++) {
       final int n = 1 + rnd.nextInt(63);
-      final java.util.TreeSet<Long> set = new java.util.TreeSet<>();
+      final TreeSet<Long> set = new TreeSet<>();
       while (set.size() < n) {
         set.add((long) rnd.nextInt(1 << 16));
       }
@@ -343,7 +330,7 @@ class NodeReferencesSerializerTest {
   }
 
   @Test
-  void mergePackedSingleBitFromSlot_rejectsNonQualifyingShapes() {
+  void packedSingleBitMerge_fromSlot_rejectsNonQualifyingShapes() {
     // Roaring-format existing payload: > PACKED_THRESHOLD entries.
     final NodeReferences big = new NodeReferences();
     for (int i = 0; i < 100; i++) {

--- a/bundles/sirix-core/src/test/java/io/sirix/page/HOTLeafPageStampTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/HOTLeafPageStampTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page;
+
+import io.sirix.cache.Allocators;
+import io.sirix.cache.FrameSlotAllocator;
+import io.sirix.index.IndexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The reader side of the optimistic-read protocol on {@link HOTLeafPage}.
+ *
+ * <p>
+ * This is the protocol {@code HOTTrieReader} already runs in production: it resolves a leaf without
+ * pinning it, snapshots {@link HOTLeafPage#readStampBinding()} and {@link HOTLeafPage#readStamp()},
+ * reads leaf bytes, and asks {@link HOTLeafPage#validateStamp(long, long)} whether those bytes were
+ * stable. It is only worth anything if a stamp REFUSES to validate whenever the bytes could have
+ * moved, so that is what these pin down — the two ways they can move, and the one case where
+ * nothing moved at all.
+ * </p>
+ *
+ * <p>
+ * The binding half is the part these were written for. A stamp is a per-SLOT sequence number, so it
+ * means nothing without the slot it was issued against; validating one against whatever slot the
+ * leaf happens to be bound to NOW compares two unrelated counters and can answer {@code true} by
+ * coincidence. {@code KeyValueLeafPageStampTest} states the same contract for the sibling page
+ * type, and both pages run the identical protocol so the lesson only has to be learned once.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class HOTLeafPageStampTest {
+
+  /** Smaller than {@link HOTLeafPage#DEFAULT_SIZE}, so the first mutation must grow and re-bind. */
+  private static final int UNDERSIZED = 4 * 1024;
+
+  private HOTLeafPage leaf;
+
+  @AfterEach
+  void tearDown() {
+    if (leaf != null) {
+      leaf.close();
+      leaf = null;
+    }
+  }
+
+  /**
+   * A leaf whose slot memory is deliberately too small to mutate, so that the first {@code put}
+   * forces {@code ensureMutableSlotMemory} to swap the segment — the one re-binding event a HOT leaf
+   * has, and the event the binding generation exists to make visible.
+   */
+  private static HOTLeafPage undersizedLeaf() {
+    final MemorySegment memory = Allocators.getInstance().allocate(UNDERSIZED);
+    return new HOTLeafPage(1L, 1, IndexType.CAS, memory, null, new int[HOTLeafPage.MAX_ENTRIES], 0, 0);
+  }
+
+  private static byte[] key(final int i) {
+    return ("key-" + i).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  @DisplayName("a stamp taken over an untouched leaf validates")
+  void anUndisturbedStampValidates() {
+    leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    assertTrue(leaf.put(key(0), new byte[] {1, 2, 3, 4}), "precondition: the entry fits");
+
+    final long binding = leaf.readStampBinding();
+    final long stamp = leaf.readStamp();
+
+    assertTrue(leaf.validateStamp(binding, stamp), "nothing moved, so the read was stable");
+  }
+
+  @Test
+  @DisplayName("a live leaf issues a usable stamp, and one bound to a real allocator slot")
+  void aLiveLeafIssuesAUsableStamp() {
+    // The control that keeps the rejection tests honest: a readStamp that simply always answered
+    // STAMP_INVALID would satisfy every one of them while making the protocol useless, since every
+    // read would retry forever.
+    leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    final long stamp = leaf.readStamp();
+
+    assertNotEquals(HOTLeafPage.STAMP_INVALID, stamp, "a live leaf must issue a usable stamp");
+    // And the stronger control: the stamp must be a real frame-slot version, not the UNBACKED
+    // sentinel. A leaf whose coordinates fail to resolve degrades validateStamp to a bare
+    // closed-flag test — it still passes every assertion here while detecting no torn read at all,
+    // which is exactly the silent failure setStampBaseSegment exists to prevent.
+    assertNotEquals(0L, stamp, "the leaf's memory came from the frame-slot allocator, so its stamp must be a version");
+  }
+
+  @Test
+  @DisplayName("a stamp taken before close does not validate after it")
+  void closingInvalidatesAnOutstandingStamp() {
+    leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    assertTrue(leaf.put(key(0), new byte[] {1, 2, 3, 4}), "precondition: the entry fits");
+    final long binding = leaf.readStampBinding();
+    final long stamp = leaf.readStamp();
+    assertTrue(leaf.validateStamp(binding, stamp), "precondition: the stamp is good while the leaf is live");
+
+    leaf.close();
+
+    // The whole point of the protocol. A reader that had already snapshotted this stamp and was
+    // about to read the segment must be told to re-resolve rather than read a recycled slot.
+    assertFalse(leaf.validateStamp(binding, stamp), "the leaf was closed under the reader");
+    leaf = null; // tearDown must not close it twice
+  }
+
+  @Test
+  @DisplayName("a closed leaf issues only the never-validating stamp")
+  void aClosedLeafIssuesNoUsableStamp() {
+    leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+    leaf.close();
+
+    final long binding = leaf.readStampBinding();
+    final long stamp = leaf.readStamp();
+
+    assertFalse(leaf.validateStamp(binding, stamp), "a stamp taken from a closed leaf can never be trusted");
+    leaf = null;
+  }
+
+  @Test
+  @DisplayName("a stamp does not survive the leaf being re-bound to another segment")
+  void rebindingInvalidatesAnOutstandingStamp() {
+    // The hole a bare validateStamp(stamp) cannot close, and the reason this test class exists. Once
+    // the leaf is bound elsewhere the old stamp names a counter it no longer reads, so validating it
+    // against the NEW slot compares two unrelated sequences.
+    //
+    // WHAT THIS PROVES, precisely: the GUARANTEE, not the mechanism. Deleting the generation check
+    // would not reliably fail this assertion — the answer would then depend on whether the two
+    // slots' versions happen to differ, which is exactly the coincidence the check rules out and
+    // exactly why no deterministic assertion can pin it. Do not read a green run as proof of the
+    // check itself.
+    leaf = undersizedLeaf();
+    final long binding = leaf.readStampBinding();
+    final long stamp = leaf.readStamp();
+    assertTrue(leaf.validateStamp(binding, stamp), "precondition: good before the rebind");
+
+    // Undersized slot memory cannot be mutated in place, so the first put must grow and re-bind.
+    assertTrue(leaf.put(key(0), new byte[] {1, 2, 3, 4}), "precondition: the entry fits after the grow");
+    assertNotEquals(binding, leaf.readStampBinding(), "growing the leaf must re-bind it");
+
+    final long afterBinding = leaf.readStampBinding();
+    final long afterStamp = leaf.readStamp();
+    assertTrue(leaf.validateStamp(afterBinding, afterStamp), "the new binding is usable");
+
+    assertFalse(leaf.validateStamp(binding, stamp), "a stamp from the previous binding must not validate");
+  }
+
+  @Test
+  @DisplayName("a published binding is always even, so no reader can snapshot one mid-swap")
+  void aPublishedBindingIsEven() {
+    // The parity is the load-bearing half of the publication order: the generation goes ODD before
+    // the segment moves and EVEN once it and the coordinates agree again, so the window in which
+    // they disagree is exactly the window in which validateStamp refuses. A single-threaded test
+    // cannot schedule itself inside that window, so what it CAN pin is the invariant that makes the
+    // window meaningful — every binding a reader can observe outside it is even, before and after a
+    // re-bind alike. A publication that bumped by one instead of two would fail here.
+    leaf = undersizedLeaf();
+    assertEquals(0L, leaf.readStampBinding() & 1L, "a quiescent leaf must publish an even binding");
+
+    assertTrue(leaf.put(key(0), new byte[] {1, 2, 3, 4}), "precondition: the entry fits after the grow");
+
+    assertEquals(0L, leaf.readStampBinding() & 1L, "a re-bound leaf must publish an even binding again");
+  }
+
+  @Test
+  @DisplayName("correcting the zero-copy stamp base is itself a re-bind")
+  void settingTheStampBaseInvalidatesAnOutstandingStamp() {
+    // A zero-copy deserialized leaf takes its slot memory as a mid-buffer SLICE, whose address the
+    // allocator never handed out; the deserializer corrects that through setStampBaseSegment before
+    // publishing the leaf. That correction changes which slot the coordinates name, so it is a
+    // re-bind like any other and must invalidate anything outstanding — otherwise a stamp taken
+    // against the (unresolvable) slice would survive into a binding that resolves.
+    final MemorySegment base = Allocators.getInstance().allocate(HOTLeafPage.DEFAULT_SIZE);
+    final MemorySegment slice = base.asSlice(64, UNDERSIZED);
+    leaf = new HOTLeafPage(1L, 1, IndexType.CAS, slice, null, new int[HOTLeafPage.MAX_ENTRIES], 0, 0);
+    try {
+      final long binding = leaf.readStampBinding();
+      final long stamp = leaf.readStamp();
+
+      leaf.setStampBaseSegment(base);
+
+      assertNotEquals(binding, leaf.readStampBinding(), "correcting the base must re-bind the leaf");
+      assertFalse(leaf.validateStamp(binding, stamp), "a stamp from before the correction must not validate");
+      assertNotEquals(0L, leaf.readStamp(),
+          "with the base corrected the leaf must stamp against a real slot version, not the UNBACKED sentinel");
+    } finally {
+      // The leaf holds a slice and no releaser, so the base is this test's to give back.
+      leaf.close();
+      leaf = null;
+      Allocators.getInstance().release(base);
+    }
+  }
+
+  @Test
+  @DisplayName("an outstanding stamp does not survive the slot being recycled under it")
+  void recyclingTheSlotInvalidatesAnOutstandingStamp() {
+    // The event the whole protocol is aimed at, spelled out end to end: a reader snapshots a stamp,
+    // the page it was reading is closed, its frame slot goes back to the allocator and is handed to
+    // somebody else — and the reader must be told, because the bytes at that address are now another
+    // page's. Poison-on-release makes the recycling unambiguous rather than merely likely.
+    FrameSlotAllocator.setPoisonOnReleaseForTesting(true);
+    try {
+      leaf = new HOTLeafPage(1L, 1, IndexType.CAS);
+      assertTrue(leaf.put(key(0), new byte[] {1, 2, 3, 4}), "precondition: the entry fits");
+      final long binding = leaf.readStampBinding();
+      final long stamp = leaf.readStamp();
+      assertTrue(leaf.validateStamp(binding, stamp), "precondition: good while the slot is the leaf's");
+
+      leaf.close();
+      // Re-issue the slot. FrameSlotAllocator hands the freed slot back out for a same-class
+      // request, so this is the reader's worst case: the same address, another page's bytes.
+      final MemorySegment reissued = Allocators.getInstance().allocate(HOTLeafPage.DEFAULT_SIZE);
+      try {
+        assertFalse(leaf.validateStamp(binding, stamp), "the slot was recycled under the reader");
+      } finally {
+        Allocators.getInstance().release(reissued);
+      }
+      leaf = null;
+    } finally {
+      FrameSlotAllocator.setPoisonOnReleaseForTesting(false);
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageGuardStateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageGuardStateTest.java
@@ -32,8 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Today these invariants hold largely for free: {@code acquireGuard} and {@code close} are
  * {@code synchronized} on the page, so every check-then-act is atomic by mutual exclusion — at 31.6
  * ns per uncontended acquire/release pair ({@code CursorGuardCostBenchmark}). That cost is the
- * reason to move the count out of its own {@link java.util.concurrent.atomic.AtomicInteger} and in
- * beside the orphaned and closed bits, so each operation becomes a single CAS on one word.
+ * reason to move the count out of its own {@link AtomicInteger} and in beside the orphaned and
+ * closed bits, so each operation becomes a single CAS on one word.
  *
  * <p>
  * These tests exist AHEAD of that change, and deliberately: they pin the invariants against the

--- a/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageGuardStateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageGuardStateTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.index.IndexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The guard protocol on {@link KeyValueLeafPage}, and the three things it must never do: hand out a
+ * guard on a page that closed, close a page a guard is held on, or lose a count to a race.
+ *
+ * <p>
+ * Today these invariants hold largely for free: {@code acquireGuard} and {@code close} are
+ * {@code synchronized} on the page, so every check-then-act is atomic by mutual exclusion — at 31.6
+ * ns per uncontended acquire/release pair ({@code CursorGuardCostBenchmark}). That cost is the
+ * reason to move the count out of its own {@link java.util.concurrent.atomic.AtomicInteger} and in
+ * beside the orphaned and closed bits, so each operation becomes a single CAS on one word.
+ *
+ * <p>
+ * These tests exist AHEAD of that change, and deliberately: they pin the invariants against the
+ * implementation that is known to satisfy them, so the refactor has something to be judged by
+ * rather than being argued from first principles afterwards. They must keep passing across it — a
+ * green run here before and after is the whole point.
+ */
+public final class KeyValueLeafPageGuardStateTest {
+
+  private static final int SIXTY_FOUR_KB = 64 * 1024;
+
+  private Arena arena;
+
+  @BeforeEach
+  void setUp() {
+    arena = Arena.ofConfined();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (arena != null) {
+      arena.close();
+    }
+  }
+
+  private KeyValueLeafPage newPage() {
+    return new KeyValueLeafPage(1L, IndexType.DOCUMENT,
+        new ResourceConfiguration.Builder("keyValueLeafPageGuardStateResource").build(), 1,
+        arena.allocate(SIXTY_FOUR_KB), null);
+  }
+
+  @DisplayName("concurrent acquire/release pairs balance out to a count of zero")
+  @Test
+  void concurrentAcquireReleasePairsBalance() throws Exception {
+    final int threadCount = 8;
+    final int pairsPerThread = 20_000;
+    final KeyValueLeafPage page = newPage();
+
+    final ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+    try {
+      final CountDownLatch start = new CountDownLatch(1);
+      final AtomicInteger failedAcquires = new AtomicInteger();
+      final List<Future<?>> futures = new ArrayList<>(threadCount);
+      for (int t = 0; t < threadCount; t++) {
+        futures.add(pool.submit(() -> {
+          start.await();
+          for (int i = 0; i < pairsPerThread; i++) {
+            if (page.acquireGuard()) {
+              page.releaseGuard();
+            } else {
+              failedAcquires.incrementAndGet();
+            }
+          }
+          return null;
+        }));
+      }
+      start.countDown();
+      for (final Future<?> f : futures) {
+        f.get(60, TimeUnit.SECONDS);
+      }
+
+      assertEquals(0, failedAcquires.get(), "a live, unorphaned page must never refuse a guard");
+      assertEquals(0, page.getGuardCount(), "every acquire was paired with a release");
+      assertFalse(page.isClosed(), "nothing orphaned the page, so nothing may have closed it");
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @DisplayName("close is declined while a guard is held and succeeds once it is released")
+  @Test
+  void closeIsDeclinedWhileGuarded() {
+    final KeyValueLeafPage page = newPage();
+    assertTrue(page.acquireGuard(), "precondition: the page can be guarded");
+
+    page.close();
+    assertFalse(page.isClosed(), "a guarded page must not close");
+    assertEquals(1, page.getGuardCount(), "a declined close must not disturb the count");
+
+    page.releaseGuard();
+    assertFalse(page.isClosed(), "releasing the last guard on a LIVE page does not close it");
+
+    page.close();
+    assertTrue(page.isClosed(), "an unguarded page closes");
+
+    page.close();
+    assertTrue(page.isClosed(), "close is idempotent");
+  }
+
+  @DisplayName("an orphan closes on the last release, and not before")
+  @Test
+  void orphanClosesOnTheLastRelease() {
+    final KeyValueLeafPage page = newPage();
+    assertTrue(page.acquireGuard(), "first guard");
+    // The documented write-cursor case: the page is orphaned by a TIL copy-on-write while the
+    // cursor holds it, and a second guard on that same page is still required.
+    assertTrue(page.acquireGuard(), "an additional guard on a GUARDED orphan is allowed");
+
+    page.markOrphaned();
+    assertTrue(page.isOrphaned());
+    assertEquals(2, page.getGuardCount());
+
+    page.releaseGuard();
+    assertFalse(page.isClosed(), "an orphan with a guard left must stay open");
+
+    page.releaseGuard();
+    assertTrue(page.isClosed(), "the last release closes the orphan");
+  }
+
+  @DisplayName("an orphan at zero guards cannot be resurrected")
+  @Test
+  void orphanAtZeroCannotBeResurrected() {
+    final KeyValueLeafPage page = newPage();
+    page.markOrphaned();
+
+    assertFalse(page.acquireGuard(), "at zero an orphan may already be mid-teardown");
+    assertEquals(0, page.getGuardCount(), "a refused acquire must not leave a count behind");
+  }
+
+  @DisplayName("acquire racing close never leaves a page both closed and guarded")
+  @Test
+  void acquireRacingCloseIsAtomic() throws Exception {
+    final int rounds = 4000;
+    final ExecutorService pool = Executors.newFixedThreadPool(2);
+    try {
+      int acquiredCount = 0;
+      int closedCount = 0;
+      for (int round = 0; round < rounds; round++) {
+        final KeyValueLeafPage page = newPage();
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final Future<Boolean> acquirer = pool.submit(() -> {
+          start.await();
+          return page.acquireGuard();
+        });
+        final Future<?> closer = pool.submit(() -> {
+          start.await();
+          page.close();
+          return null;
+        });
+
+        start.countDown();
+        final boolean acquired = acquirer.get(30, TimeUnit.SECONDS);
+        closer.get(30, TimeUnit.SECONDS);
+
+        // The invariant: the two outcomes are mutually exclusive. A page that closed cannot have
+        // handed out a guard, and a page that handed out a guard cannot have closed under it.
+        if (acquired) {
+          acquiredCount++;
+          assertFalse(page.isClosed(), "round " + round + ": guard acquired, so close must have been declined");
+          assertEquals(1, page.getGuardCount(), "round " + round + ": the acquired guard must be counted");
+          page.releaseGuard();
+        } else {
+          closedCount++;
+          assertTrue(page.isClosed(), "round " + round + ": acquire was refused, so the page must be closed");
+          assertEquals(0, page.getGuardCount(), "round " + round + ": a refused acquire leaves no count");
+        }
+      }
+      // Not an assertion on the split — the scheduler decides that — but a run in which one side
+      // never won would be testing nothing, and silence about it is how such a test rots.
+      System.out.printf("%nacquireRacingCloseIsAtomic: acquirer won %d, closer won %d of %d rounds%n", acquiredCount,
+          closedCount, rounds);
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
@@ -70,9 +70,10 @@ final class KeyValueLeafPageStampTest {
   void anUndisturbedStampValidates() {
     page.setSlot(new byte[] {1, 2, 3, 4}, 0);
 
+    final long binding = page.readStampBinding();
     final long stamp = page.readStamp();
 
-    assertTrue(page.validateStamp(stamp), "nothing moved, so the read was stable");
+    assertTrue(page.validateStamp(binding, stamp), "nothing moved, so the read was stable");
   }
 
   @Test
@@ -88,16 +89,53 @@ final class KeyValueLeafPageStampTest {
   @DisplayName("a stamp taken before close does not validate after it")
   void closingInvalidatesAnOutstandingStamp() {
     page.setSlot(new byte[] {1, 2, 3, 4}, 0);
+    final long binding = page.readStampBinding();
     final long stamp = page.readStamp();
-    assertTrue(page.validateStamp(stamp), "precondition: the stamp is good while the page is live");
+    assertTrue(page.validateStamp(binding, stamp), "precondition: the stamp is good while the page is live");
 
     page.close();
 
     // This is the whole point of the protocol. A reader that had already snapshotted this stamp and
     // was about to read the segment must be told to re-resolve rather than read freed memory — which
     // is what the page guard used to prevent by keeping the page alive instead.
-    assertFalse(page.validateStamp(stamp), "the page was closed under the reader");
+    assertFalse(page.validateStamp(binding, stamp), "the page was closed under the reader");
     page = null; // tearDown must not close it twice
+  }
+
+  @Test
+  @DisplayName("a stamp does not survive the page being re-bound to another segment")
+  void rebindingInvalidatesAnOutstandingStamp() {
+    // The hole a bare `validateStamp(stamp)` cannot close. A stamp is a per-SLOT sequence number, so
+    // once the page is bound elsewhere the stamp names a counter this page no longer reads, and
+    // validating it against the NEW slot compares two unrelated sequences.
+    //
+    // WHAT THIS PROVES, precisely, because the distinction cost a wrong claim once already: the
+    // re-bind is what matters, not the swap. Immediately after a swap `stampCoordinates` is UNBOUND
+    // and validateStamp already rejects on that alone — deleting the generation check does NOT fail
+    // that case. It is the readStamp() below, which re-binds the coordinates to the NEW slot, that
+    // leaves the old stamp facing a live and unrelated counter. Deleting the generation check does
+    // not reliably fail THIS case either: without it the answer depends on whether the two slots'
+    // versions happen to coincide, which is exactly the coincidence the check exists to rule out and
+    // exactly why it cannot be pinned by a deterministic assertion. This test pins the GUARANTEE;
+    // the mutation argument for it is that a passing run must not depend on two counters differing.
+    page.setSlot(new byte[] {1, 2, 3, 4}, 0);
+    final long binding = page.readStampBinding();
+    final long stamp = page.readStamp();
+    assertTrue(page.validateStamp(binding, stamp), "precondition: good before the rebind");
+
+    // Force a segment swap: fill past the initial capacity so the page must grow.
+    final byte[] filler = new byte[512];
+    for (int slot = 1; slot < 200; slot++) {
+      page.setSlot(filler, slot);
+    }
+    assertNotEquals(binding, page.readStampBinding(), "growing the page must re-bind it");
+
+    // Re-bind the coordinates onto the new slot, as any concurrent reader's first stamp would.
+    final long afterBinding = page.readStampBinding();
+    final long afterStamp = page.readStamp();
+    assertTrue(page.validateStamp(afterBinding, afterStamp), "the new binding is usable");
+
+    assertFalse(page.validateStamp(binding, stamp), "a stamp from the previous binding must not validate");
   }
 
   @Test
@@ -105,9 +143,10 @@ final class KeyValueLeafPageStampTest {
   void aClosedPageIssuesNoUsableStamp() {
     page.close();
 
+    final long binding = page.readStampBinding();
     final long stamp = page.readStamp();
 
-    assertFalse(page.validateStamp(stamp), "a stamp taken from a closed page can never be trusted");
+    assertFalse(page.validateStamp(binding, stamp), "a stamp taken from a closed page can never be trusted");
     page = null;
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
@@ -22,20 +22,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>
  * This is the machinery that replaces reference-counted pinning on the record path: a reader
- * snapshots {@link KeyValueLeafPage#readStamp()}, reads page bytes without acquiring anything, and
- * asks {@link KeyValueLeafPage#validateStamp(long)} whether those bytes were stable. The protocol
+ * snapshots {@link KeyValueLeafPage#readStampBinding()} and {@link KeyValueLeafPage#readStamp()},
+ * reads page bytes without acquiring anything, and asks
+ * {@link KeyValueLeafPage#validateStamp(long, long)} whether those bytes were stable. The protocol
  * is only worth anything if a stamp REFUSES to validate whenever the bytes could have moved, so
- * that is what these pin down — the two ways they can move, and the one case where nothing moved at
+ * that is what these pin down — the ways they can move, and the one case where nothing moved at
  * all.
  * </p>
  *
  * <p>
- * The page here is Arena-backed rather than frame-slot-backed, so it takes the
- * {@code STAMP_UNBACKED} branch: its memory cannot be torn by slot reuse, and closing is the only
- * event that can invalidate it. That is the branch these tests exercise. The frame-slot branch —
- * where a stamp is a real allocator slot version — is covered for the sibling page type by
- * {@code HOTLeafUseAfterCloseTest}, which is where the ABA ordering hazard in {@code readStamp} was
- * found; both pages run the identical protocol so that lesson does not have to be re-learned here.
+ * The Arena segment the constructor takes is the LEGACY slot memory, which the page releases; the
+ * slotted page these stamps actually cover is allocated by {@code ensureSlottedPage} from
+ * {@code Allocators.getInstance()}, so on a normal run these exercise the frame-slot branch, where
+ * a stamp is a real allocator slot version. The sibling page type runs the identical protocol and
+ * is pinned by {@code HOTLeafPageStampTest}; the ABA ordering hazard in {@code readStamp} was found
+ * on that side, in {@code HOTLeafUseAfterCloseTest}, and does not have to be re-learned here.
  * </p>
  *
  * @author Johannes Lichtenberger
@@ -109,15 +110,11 @@ final class KeyValueLeafPageStampTest {
     // once the page is bound elsewhere the stamp names a counter this page no longer reads, and
     // validating it against the NEW slot compares two unrelated sequences.
     //
-    // WHAT THIS PROVES, precisely, because the distinction cost a wrong claim once already: the
-    // re-bind is what matters, not the swap. Immediately after a swap `stampCoordinates` is UNBOUND
-    // and validateStamp already rejects on that alone — deleting the generation check does NOT fail
-    // that case. It is the readStamp() below, which re-binds the coordinates to the NEW slot, that
-    // leaves the old stamp facing a live and unrelated counter. Deleting the generation check does
-    // not reliably fail THIS case either: without it the answer depends on whether the two slots'
+    // WHAT THIS PROVES, precisely: the GUARANTEE, not the mechanism. Deleting the generation check
+    // does not reliably fail THIS case — without it the answer depends on whether the two slots'
     // versions happen to coincide, which is exactly the coincidence the check exists to rule out and
-    // exactly why it cannot be pinned by a deterministic assertion. This test pins the GUARANTEE;
-    // the mutation argument for it is that a passing run must not depend on two counters differing.
+    // exactly why it cannot be pinned here. The case that DOES pin it deterministically is the
+    // unbacked/backed swap below; read the two together.
     page.setSlot(new byte[] {1, 2, 3, 4}, 0);
     final long binding = page.readStampBinding();
     final long stamp = page.readStamp();
@@ -136,6 +133,32 @@ final class KeyValueLeafPageStampTest {
     assertTrue(page.validateStamp(afterBinding, afterStamp), "the new binding is usable");
 
     assertFalse(page.validateStamp(binding, stamp), "a stamp from the previous binding must not validate");
+  }
+
+  @Test
+  @DisplayName("a stamp does not survive the page swapping between unbacked and frame-backed")
+  void swappingBetweenUnbackedAndBackedInvalidatesAnOutstandingStamp() {
+    // The case that pins the generation check DETERMINISTICALLY, which the sibling rebind test
+    // above cannot. Point the binding at a segment the allocator never handed out — a mid-buffer
+    // slice, which is exactly what a zero-copy deserializer produces — and the page has no slot
+    // version to consult, so readStamp answers with the UNBACKED sentinel. Correct the base
+    // afterwards and the page IS frame-backed again.
+    //
+    // Without the generation check, that outstanding UNBACKED stamp validates on the strength of
+    // the page merely still being open, certifying reads taken while the page could not detect a
+    // torn one at all. This is the false positive the field javadoc claims is covered, and it needs
+    // no coincidence to reproduce.
+    page.setSlot(new byte[] {1, 2, 3, 4}, 0);
+    page.setStampBaseSegment(arena.allocate(SIXTYFOUR_KB).asSlice(64, 1024));
+    final long unbackedBinding = page.readStampBinding();
+    final long unbackedStamp = page.readStamp();
+    assertTrue(page.validateStamp(unbackedBinding, unbackedStamp), "precondition: usable while unbacked");
+
+    page.setStampBaseSegment(null); // back to the page's own, allocator-issued slotted page
+
+    assertNotEquals(unbackedBinding, page.readStampBinding(), "clearing the base must re-bind the page");
+    assertFalse(page.validateStamp(unbackedBinding, unbackedStamp),
+        "an unbacked stamp must not validate once the page is frame-backed again");
   }
 
   @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/KeyValueLeafPageStampTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.index.IndexType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.Arena;
+
+import static io.sirix.cache.LinuxMemorySegmentAllocator.SIXTYFOUR_KB;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The reader side of the optimistic-read protocol on {@link KeyValueLeafPage}.
+ *
+ * <p>
+ * This is the machinery that replaces reference-counted pinning on the record path: a reader
+ * snapshots {@link KeyValueLeafPage#readStamp()}, reads page bytes without acquiring anything, and
+ * asks {@link KeyValueLeafPage#validateStamp(long)} whether those bytes were stable. The protocol
+ * is only worth anything if a stamp REFUSES to validate whenever the bytes could have moved, so
+ * that is what these pin down — the two ways they can move, and the one case where nothing moved at
+ * all.
+ * </p>
+ *
+ * <p>
+ * The page here is Arena-backed rather than frame-slot-backed, so it takes the
+ * {@code STAMP_UNBACKED} branch: its memory cannot be torn by slot reuse, and closing is the only
+ * event that can invalidate it. That is the branch these tests exercise. The frame-slot branch —
+ * where a stamp is a real allocator slot version — is covered for the sibling page type by
+ * {@code HOTLeafUseAfterCloseTest}, which is where the ABA ordering hazard in {@code readStamp} was
+ * found; both pages run the identical protocol so that lesson does not have to be re-learned here.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class KeyValueLeafPageStampTest {
+
+  private KeyValueLeafPage page;
+
+  private Arena arena;
+
+  @BeforeEach
+  void setUp() {
+    arena = Arena.ofConfined();
+    page = new KeyValueLeafPage(1L, IndexType.DOCUMENT, new ResourceConfiguration.Builder("testResource").build(), 1,
+        arena.allocate(SIXTYFOUR_KB), null);
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (page != null) {
+      page.close();
+      page = null;
+    }
+    if (arena != null) {
+      arena.close();
+      arena = null;
+    }
+  }
+
+  @Test
+  @DisplayName("a stamp taken over an untouched page validates")
+  void anUndisturbedStampValidates() {
+    page.setSlot(new byte[] {1, 2, 3, 4}, 0);
+
+    final long stamp = page.readStamp();
+
+    assertTrue(page.validateStamp(stamp), "nothing moved, so the read was stable");
+  }
+
+  @Test
+  @DisplayName("a stamp is never the never-validating sentinel while the page is live")
+  void aLivePageIssuesAUsableStamp() {
+    // The control that keeps the other two honest. A readStamp that simply always answered
+    // STAMP_INVALID would satisfy every rejection test in this class while making the protocol
+    // useless — every read would retry forever.
+    assertNotEquals(KeyValueLeafPage.STAMP_INVALID, page.readStamp(), "a live page must issue a usable stamp");
+  }
+
+  @Test
+  @DisplayName("a stamp taken before close does not validate after it")
+  void closingInvalidatesAnOutstandingStamp() {
+    page.setSlot(new byte[] {1, 2, 3, 4}, 0);
+    final long stamp = page.readStamp();
+    assertTrue(page.validateStamp(stamp), "precondition: the stamp is good while the page is live");
+
+    page.close();
+
+    // This is the whole point of the protocol. A reader that had already snapshotted this stamp and
+    // was about to read the segment must be told to re-resolve rather than read freed memory — which
+    // is what the page guard used to prevent by keeping the page alive instead.
+    assertFalse(page.validateStamp(stamp), "the page was closed under the reader");
+    page = null; // tearDown must not close it twice
+  }
+
+  @Test
+  @DisplayName("a closed page issues only the never-validating stamp")
+  void aClosedPageIssuesNoUsableStamp() {
+    page.close();
+
+    final long stamp = page.readStamp();
+
+    assertFalse(page.validateStamp(stamp), "a stamp taken from a closed page can never be trusted");
+    page = null;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
@@ -246,10 +246,30 @@ final class CASKeySerializerPropertyTest {
    * generator gap hid a real defect — the first was {@code -0.0} — so the lesson is worth stating
    * where the next person will read it: a property is only as strong as the values it is fed.
    * </p>
+   *
+   * <p>
+   * The pairs come in two SHAPES, and the second shape is here because the first alone was not
+   * enough. In an EXTENSION pair one value is a textual prefix of the other, so their suffixes first
+   * differ where the shorter one has ended — the comparison lands on the terminator, and only the
+   * terminator's side of the encoding is under test. Every original pair was of that shape, which
+   * left the digit comparison itself unexercised: perturbing the suffix bytes with an
+   * order-inverting but bijective transform kept this property green, because the transform never
+   * reached a position where two DIGITS met. The DIVERGENT pairs collide on the same double and
+   * differ at a digit instead, in both signs, so the complement now has to be right for digits as
+   * well as for lengths.
+   * </p>
    */
   private static Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> collidingDecimalPairs() {
-    return Arbitraries.of(Tuple.of("0.5", "0.5000000000000000001"), Tuple.of("19.99", "19.990000000000000001"),
-        Tuple.of("0.1", "0.1000000000000000001"), Tuple.of("-3.25", "-3.250000000000000001"))
+    return Arbitraries.of(
+        // Extension: the shorter value's terminator meets the longer value's next digit.
+        Tuple.of("0.5", "0.5000000000000000001"), Tuple.of("19.99", "19.990000000000000001"),
+        Tuple.of("0.1", "0.1000000000000000001"), Tuple.of("-3.25", "-3.250000000000000001"),
+        // Divergent: equal length, differing at a digit past double precision. '0' against '1' on
+        // purpose — adjacent codes, so a transform that merely permutes bytes locally shows up.
+        Tuple.of("0.5000000000000000001", "0.5000000000000000011"),
+        Tuple.of("19.990000000000000001", "19.990000000000000011"),
+        Tuple.of("-3.250000000000000001", "-3.250000000000000011"),
+        Tuple.of("-0.1000000000000000011", "-0.1000000000000000001"))
                       .map(pair -> Tuple.of(Tuple.of((Atomic) new Dec(new BigDecimal(pair.get1())),
                           (Atomic) new Dec(new BigDecimal(pair.get2()))), Type.DEC));
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
@@ -170,7 +170,8 @@ final class CASKeySerializerPropertyTest {
         Arbitraries.longs().map(v -> Tuple.of((Atomic) new Int64(v), String.valueOf(v), Type.INR)),
         bigIntegerValues().map(v -> Tuple.of((Atomic) new Int(new BigDecimal(v)), v.toString(), Type.INR)),
         decimalValues().map(v -> Tuple.of((Atomic) new Dec(v), v.toString(), Type.DEC)),
-        Arbitraries.doubles().map(v -> Tuple.of((Atomic) new Dbl(v), String.valueOf(v), Type.DBL)),
+        Arbitraries.oneOf(Arbitraries.doubles(), Arbitraries.of(-0.0d, 0.0d))
+                   .map(v -> Tuple.of((Atomic) new Dbl(v), String.valueOf(v), Type.DBL)),
         Arbitraries.floats().map(v -> Tuple.of((Atomic) new Flt(v), String.valueOf(v), Type.FLO)));
   }
 
@@ -198,7 +199,27 @@ final class CASKeySerializerPropertyTest {
   Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> distinctLosslessPairs() {
     return Arbitraries.oneOf(pairsOf(shortStrings(), Type.STR), pairsOf(longs(), Type.INR),
         pairsOf(finiteDoubles(), Type.DBL), pairsOf(booleans(), Type.BOOL))
-                      .filter(p -> p.get1().get1().compareTo(p.get1().get2()) != 0);
+                      .filter(p -> areDistinctValues(p.get1().get1(), p.get1().get2()));
+  }
+
+  /**
+   * Whether two atomics are distinct VALUES, which is not the same question as
+   * {@code compareTo != 0}.
+   *
+   * <p>
+   * {@code Double.compare} is a TOTAL order and separates {@code -0.0} from {@code 0.0}; XQuery's
+   * {@code eq} does not — {@code -0.0 eq 0.0} is true. Injectivity is a statement about equality, so
+   * the zero pair must be excluded here, and in fact the encoder is required to give it ONE key:
+   * canonicalizing {@code -0.0} is what stops it landing on the minimum key, below {@code -Infinity}.
+   * The sibling ordering property uses {@code compareTo} precisely because ordering IS the total
+   * order. The two properties disagree about this pair on purpose.
+   * </p>
+   */
+  private static boolean areDistinctValues(final Atomic a, final Atomic b) {
+    if (a instanceof final Dbl left && b instanceof final Dbl right) {
+      return left.doubleValue() != right.doubleValue();
+    }
+    return a.compareTo(b) != 0;
   }
 
   private static <A extends Atomic> Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> pairsOf(final Arbitrary<A> values,
@@ -255,10 +276,26 @@ final class CASKeySerializerPropertyTest {
     return Arbitraries.doubles().map(Dbl::new);
   }
 
+  /**
+   * Doubles with the two ZEROS forced in.
+   *
+   * <p>
+   * {@code Arbitraries.doubles()} does not reliably produce {@code -0.0}, and its absence is exactly
+   * why these properties passed over an encoder that mapped it to the minimum key — below
+   * {@code -Infinity}. A generator that never emits the interesting value makes a property a
+   * decoration, which is the failure mode jqwik's {@code Statistics.collect} exists to expose.
+   * </p>
+   */
+  private static Arbitrary<Dbl> doublesWithZeros() {
+    return Arbitraries.oneOf(Arbitraries.doubles(), Arbitraries.of(-0.0d, 0.0d)).map(Dbl::new);
+  }
+
   private static Arbitrary<Dbl> finiteDoubles() {
     // NaN is canonicalized onto Double.MAX_VALUE's key by design, so it is neither ordered nor
     // injective and is excluded from those two properties rather than asserted about wrongly.
-    return Arbitraries.doubles().filter(d -> !Double.isNaN(d)).map(Dbl::new);
+    return Arbitraries.oneOf(Arbitraries.doubles(), Arbitraries.of(-0.0d, 0.0d))
+                      .filter(d -> !Double.isNaN(d))
+                      .map(Dbl::new);
   }
 
   private static Arbitrary<Flt> floats() {

--- a/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
@@ -133,10 +133,16 @@ final class CASKeySerializerPropertyTest {
    * </p>
    *
    * <p>
-   * Restricted to the lossless families on purpose. {@code xs:decimal} and {@code xs:float} narrow by
-   * design and {@code xs:string} truncates past {@link #MAX_STRING_VALUE_BYTES}, so asserting
-   * injectivity there would be asserting something false — which is why the equality path re-checks
-   * its candidates against the real values instead.
+   * Restricted to the lossless families on purpose. {@code xs:float} narrows by design and
+   * {@code xs:string} truncates past {@link #MAX_STRING_VALUE_BYTES}, so asserting injectivity there
+   * would be asserting something false — which is why the equality path re-checks those candidates
+   * against the real values instead.
+   *
+   * <p>
+   * {@code xs:decimal} was in that excluded set until the key began carrying the exact value after
+   * the order-preserving double. It is included now, and that inclusion IS the proof the encoding
+   * change worked: the property could not even be stated for decimals before, because two values
+   * differing past double precision genuinely shared a key.
    * </p>
    */
   @Property
@@ -191,15 +197,20 @@ final class CASKeySerializerPropertyTest {
   @Provide
   Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> orderedPairs() {
     return Arbitraries.oneOf(pairsOf(shortStrings(), Type.STR), pairsOf(longs(), Type.INR),
-        pairsOf(bigIntegers(), Type.INR), pairsOf(decimals(), Type.DEC), pairsOf(finiteDoubles(), Type.DBL));
+        pairsOf(bigIntegers(), Type.INR), pairsOf(decimals(), Type.DEC), pairsOf(finiteDoubles(), Type.DBL),
+        // The pairs that share a double, NEGATIVES INCLUDED. Their absence here is what let an
+        // ordering inversion through: the colliding pairs were added to the injectivity generator
+        // only, so the ordering property never saw a case where the suffix decides. Within one
+        // double the suffix IS the comparison, and for negatives a naive byte compare inverts it.
+        collidingDecimalPairs());
   }
 
   /** Pairs over the families whose encoding is injective, so a collision is a real defect. */
   @Provide
   Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> distinctLosslessPairs() {
     return Arbitraries.oneOf(pairsOf(shortStrings(), Type.STR), pairsOf(longs(), Type.INR),
-        pairsOf(finiteDoubles(), Type.DBL), pairsOf(booleans(), Type.BOOL))
-                      .filter(p -> areDistinctValues(p.get1().get1(), p.get1().get2()));
+        pairsOf(finiteDoubles(), Type.DBL), pairsOf(booleans(), Type.BOOL), pairsOf(decimals(), Type.DEC),
+        collidingDecimalPairs()).filter(p -> areDistinctValues(p.get1().get1(), p.get1().get2()));
   }
 
   /**
@@ -220,6 +231,27 @@ final class CASKeySerializerPropertyTest {
       return left.doubleValue() != right.doubleValue();
     }
     return a.compareTo(b) != 0;
+  }
+
+
+  /**
+   * Decimal pairs that share a {@code double}, which is the ONLY interesting case for decimal
+   * injectivity — and one a random generator will not produce.
+   *
+   * <p>
+   * Without these the property is a decoration: {@code decimals()} generates at scale 6 within
+   * +/-1e12, and no two such values collide, so the assertion passed just as happily over the old
+   * bare-double key that could not tell them apart. Deleting the exact suffix from the encoder left
+   * the whole property green until these pairs were added. That is the second time in this file a
+   * generator gap hid a real defect — the first was {@code -0.0} — so the lesson is worth stating
+   * where the next person will read it: a property is only as strong as the values it is fed.
+   * </p>
+   */
+  private static Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> collidingDecimalPairs() {
+    return Arbitraries.of(Tuple.of("0.5", "0.5000000000000000001"), Tuple.of("19.99", "19.990000000000000001"),
+        Tuple.of("0.1", "0.1000000000000000001"), Tuple.of("-3.25", "-3.250000000000000001"))
+                      .map(pair -> Tuple.of(Tuple.of((Atomic) new Dec(new BigDecimal(pair.get1())),
+                          (Atomic) new Dec(new BigDecimal(pair.get2()))), Type.DEC));
   }
 
   private static <A extends Atomic> Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> pairsOf(final Arbitrary<A> values,

--- a/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
@@ -252,11 +252,10 @@ final class CASKeySerializerPropertyTest {
    * enough. In an EXTENSION pair one value is a textual prefix of the other, so their suffixes first
    * differ where the shorter one has ended — the comparison lands on the terminator, and only the
    * terminator's side of the encoding is under test. Every original pair was of that shape, which
-   * left the digit comparison itself unexercised: perturbing the suffix bytes with an
-   * order-inverting but bijective transform kept this property green, because the transform never
-   * reached a position where two DIGITS met. The DIVERGENT pairs collide on the same double and
-   * differ at a digit instead, in both signs, so the complement now has to be right for digits as
-   * well as for lengths.
+   * left the digit comparison itself unexercised: perturbing the suffix bytes with an order-inverting
+   * but bijective transform kept this property green, because the transform never reached a position
+   * where two DIGITS met. The DIVERGENT pairs collide on the same double and differ at a digit
+   * instead, in both signs, so the complement now has to be right for digits as well as for lengths.
    * </p>
    */
   private static Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> collidingDecimalPairs() {

--- a/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/property/CASKeySerializerPropertyTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.property;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.Bool;
+import io.brackit.query.atomic.Dbl;
+import io.brackit.query.atomic.Dec;
+import io.brackit.query.atomic.Flt;
+import io.brackit.query.atomic.Int;
+import io.brackit.query.atomic.Int64;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.sirix.index.hot.CASKeySerializer;
+import io.sirix.index.redblacktree.keyvalue.CASValue;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.Tuple;
+import net.jqwik.api.Tuple.Tuple2;
+import net.jqwik.api.Tuple.Tuple3;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The three properties a CAS key encoding has to have, checked over generated values rather than
+ * chosen ones.
+ *
+ * <p>
+ * These exist because the example-based tests next door did not find the bugs they were written
+ * after. Three encodings shipped returning wrong answers — {@code xs:boolean} mapped every value
+ * onto one key, {@code xs:float} put the stored and probe sides on different keys, and an
+ * out-of-range {@code xs:integer} saturated on one side while wrapping on the other — and every one
+ * of them is a counterexample to {@link #storedAndProbeSidesAgree} that a generator stumbles into
+ * immediately. The integer one in particular needs a magnitude past {@code Long.MAX_VALUE}, which
+ * is a value nobody writes down by hand and every {@code BigInteger} generator produces.
+ * </p>
+ *
+ * <p>
+ * On failure jqwik shrinks to a minimal counterexample and records the seed, so a found defect
+ * stays found — which is the property the hand-written cases lacked.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+final class CASKeySerializerPropertyTest {
+
+  /** Arbitrary, fixed: these properties are about the VALUE region, which follows the PCR prefix. */
+  private static final long PCR = 42L;
+
+  /** The serializer's string cap. Past it two values share a key BY DESIGN, so order and */
+  private static final int MAX_STRING_VALUE_BYTES = 246;
+
+  private static byte[] key(final Atomic value, final Type type) {
+    final byte[] buffer = new byte[256];
+    final int length = CASKeySerializer.INSTANCE.serialize(new CASValue(value, type, PCR), buffer, 0);
+    return Arrays.copyOf(buffer, length);
+  }
+
+  /**
+   * The strongest property here, and the one that catches all three shipped defects.
+   *
+   * <p>
+   * {@code CASIndexBuilder} stores every indexed value as a {@link Str} built from the node's lexical
+   * form, while {@code ScanCASIndex} casts the query's argument to the index's content type. So the
+   * two sides of every CAS index reach the serializer in DIFFERENT shapes and must still land on one
+   * key. Anything in the encoder that behaves differently for a {@code Str} than for the typed atomic
+   * splits them apart, and the index silently stops matching.
+   * </p>
+   */
+  @Property
+  void storedAndProbeSidesAgree(@ForAll("typedValues") final Tuple3<Atomic, String, Type> sample) {
+    final Atomic probe = sample.get1();
+    final Type type = sample.get3();
+    // The lexical form CASIndexBuilder would have stored, which is String.valueOf of the node's
+    // primitive -- NOT the atomic's stringValue(). The distinction is load-bearing: brackit's
+    // Flt#stringValue() truncates the exponent to a single digit, so 1.0E10 comes back as "1.0E1",
+    // and building the stored side from it would test a value no document ever holds.
+    final Atomic stored = new Str(sample.get2());
+
+    assertArrayEquals(key(stored, type), key(probe, type),
+        () -> "stored \"" + sample.get2() + "\" and probe " + probe + " of type " + type + " must share a key");
+  }
+
+  /**
+   * Byte order over the encoded value is value order.
+   *
+   * <p>
+   * Stated as MONOTONICITY rather than a strict isomorphism, because two of these encoders narrow on
+   * purpose: {@code xs:decimal} funnels through {@code double} and {@code xs:float} through
+   * {@code float}, so distinct values can share a key. Narrowing is order-preserving even where it is
+   * not injective, and that is exactly the guarantee a bounded range cursor rests on — it may return
+   * a value it cannot distinguish from the bound, but it must never place one on the wrong side.
+   * </p>
+   */
+  @Property
+  void byteOrderIsValueOrder(@ForAll("orderedPairs") final Tuple2<Tuple2<Atomic, Atomic>, Type> pair) {
+    final Atomic a = pair.get1().get1();
+    final Atomic b = pair.get1().get2();
+    final Type type = pair.get2();
+
+    final int valueOrder = Integer.signum(a.compareTo(b));
+    final int byteOrder = Integer.signum(Arrays.compareUnsigned(key(a, type), key(b, type)));
+
+    if (valueOrder < 0) {
+      assertTrue(byteOrder <= 0,
+          () -> a + " < " + b + " of type " + type + ", so its key must not sort above the other's");
+    } else if (valueOrder > 0) {
+      assertTrue(byteOrder >= 0,
+          () -> a + " > " + b + " of type " + type + ", so its key must not sort below the other's");
+    } else {
+      assertTrue(byteOrder == 0, () -> a + " equals " + b + " of type " + type + ", so the keys must be equal");
+    }
+  }
+
+  /**
+   * Distinct values keep distinct keys, for the families that encode losslessly.
+   *
+   * <p>
+   * The property that matters MOST, per the instant-codec history in {@code CASKeySerializer}: two
+   * values sharing one key merge their posting lists, which corrupts equality lookups and deletes,
+   * not merely ranges. A mis-ordered range costs the range; a collision costs the data.
+   * </p>
+   *
+   * <p>
+   * Restricted to the lossless families on purpose. {@code xs:decimal} and {@code xs:float} narrow by
+   * design and {@code xs:string} truncates past {@link #MAX_STRING_VALUE_BYTES}, so asserting
+   * injectivity there would be asserting something false — which is why the equality path re-checks
+   * its candidates against the real values instead.
+   * </p>
+   */
+  @Property
+  void distinctValuesKeepDistinctKeys(
+      @ForAll("distinctLosslessPairs") final Tuple2<Tuple2<Atomic, Atomic>, Type> pair) {
+    final Atomic a = pair.get1().get1();
+    final Atomic b = pair.get1().get2();
+    final Type type = pair.get2();
+
+    assertNotEquals(Arrays.toString(key(a, type)), Arrays.toString(key(b, type)),
+        () -> a + " and " + b + " are distinct " + type + " values and must not share a key");
+  }
+
+  // ===== generators =====
+
+  /**
+   * One value per encoder branch, typed as the probe side would arrive.
+   *
+   * <p>
+   * The integer arbitrary deliberately reaches past {@code Long} range: that is where the saturating
+   * and wrapping conversions disagreed, and it is not a region hand-written cases visit.
+   * </p>
+   */
+  @Provide
+  Arbitrary<Tuple3<Atomic, String, Type>> typedValues() {
+    return Arbitraries.oneOf(
+        Arbitraries.of(true, false).map(v -> Tuple.of((Atomic) new Bool(v), String.valueOf(v), Type.BOOL)),
+        Arbitraries.strings()
+                   .ofMaxLength(MAX_STRING_VALUE_BYTES + 40)
+                   .map(v -> Tuple.of((Atomic) new Str(v), v, Type.STR)),
+        Arbitraries.longs().map(v -> Tuple.of((Atomic) new Int64(v), String.valueOf(v), Type.INR)),
+        bigIntegerValues().map(v -> Tuple.of((Atomic) new Int(new BigDecimal(v)), v.toString(), Type.INR)),
+        decimalValues().map(v -> Tuple.of((Atomic) new Dec(v), v.toString(), Type.DEC)),
+        Arbitraries.doubles().map(v -> Tuple.of((Atomic) new Dbl(v), String.valueOf(v), Type.DBL)),
+        Arbitraries.floats().map(v -> Tuple.of((Atomic) new Flt(v), String.valueOf(v), Type.FLO)));
+  }
+
+  /**
+   * Pairs over the byte-order-preserving families, strings kept inside the truncation cap.
+   *
+   * <p>
+   * {@code xs:boolean} is EXCLUDED, and not because the encoding is wrong. brackit's
+   * {@code Bool#compareTo} answers that {@code false} is GREATER than {@code true} — inverted against
+   * XQuery, where {@code false() lt true()}. The encoder is right by the spec (false to byte 0, true
+   * to byte 1) and the comparator is not, so asserting agreement between them here would be asserting
+   * brackit's inversion. It is recorded rather than encoded: the two index backends genuinely
+   * disagree on boolean range order, since the HOT cursor decides by byte order while
+   * {@code CASFilterRange#inRange} decides by that comparator.
+   * </p>
+   */
+  @Provide
+  Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> orderedPairs() {
+    return Arbitraries.oneOf(pairsOf(shortStrings(), Type.STR), pairsOf(longs(), Type.INR),
+        pairsOf(bigIntegers(), Type.INR), pairsOf(decimals(), Type.DEC), pairsOf(finiteDoubles(), Type.DBL));
+  }
+
+  /** Pairs over the families whose encoding is injective, so a collision is a real defect. */
+  @Provide
+  Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> distinctLosslessPairs() {
+    return Arbitraries.oneOf(pairsOf(shortStrings(), Type.STR), pairsOf(longs(), Type.INR),
+        pairsOf(finiteDoubles(), Type.DBL), pairsOf(booleans(), Type.BOOL))
+                      .filter(p -> p.get1().get1().compareTo(p.get1().get2()) != 0);
+  }
+
+  private static <A extends Atomic> Arbitrary<Tuple2<Tuple2<Atomic, Atomic>, Type>> pairsOf(final Arbitrary<A> values,
+      final Type type) {
+    return Combinators.combine(values, values).as((a, b) -> Tuple.of(Tuple.of((Atomic) a, (Atomic) b), type));
+  }
+
+  private static Arbitrary<Bool> booleans() {
+    return Arbitraries.of(true, false).map(Bool::new);
+  }
+
+  private static Arbitrary<Str> strings() {
+    // Past the cap as well as inside it: truncation is legal, but the two SIDES must still agree,
+    // which is what storedAndProbeSidesAgree asks of these.
+    return Arbitraries.strings().ofMaxLength(MAX_STRING_VALUE_BYTES + 40).map(Str::new);
+  }
+
+  private static Arbitrary<Str> shortStrings() {
+    // ASCII and comfortably inside the cap, so ordering and injectivity are genuine expectations.
+    // A multi-byte char could push the UTF-8 length past the cap while the char count stays under it.
+    return Arbitraries.strings().ascii().ofMaxLength(MAX_STRING_VALUE_BYTES / 4).map(Str::new);
+  }
+
+  private static Arbitrary<Int64> longs() {
+    return Arbitraries.longs().map(Int64::new);
+  }
+
+  private static Arbitrary<BigInteger> bigIntegerValues() {
+    return Arbitraries.bigIntegers()
+                      .between(BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.valueOf(4)),
+                          BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(4)));
+  }
+
+  private static Arbitrary<BigDecimal> decimalValues() {
+    return Arbitraries.bigDecimals().ofScale(6).between(BigDecimal.valueOf(-1e12), BigDecimal.valueOf(1e12));
+  }
+
+  private static Arbitrary<Int> bigIntegers() {
+    // Straddles Long range on purpose — the saturate-versus-wrap split lived entirely out here.
+    return Arbitraries.bigIntegers()
+                      .between(BigInteger.valueOf(Long.MIN_VALUE).multiply(BigInteger.valueOf(4)),
+                          BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.valueOf(4)))
+                      .map(v -> new Int(new BigDecimal(v)));
+  }
+
+  private static Arbitrary<Dec> decimals() {
+    return Arbitraries.bigDecimals()
+                      .ofScale(6)
+                      .between(BigDecimal.valueOf(-1e12), BigDecimal.valueOf(1e12))
+                      .map(Dec::new);
+  }
+
+  private static Arbitrary<Dbl> doubles() {
+    return Arbitraries.doubles().map(Dbl::new);
+  }
+
+  private static Arbitrary<Dbl> finiteDoubles() {
+    // NaN is canonicalized onto Double.MAX_VALUE's key by design, so it is neither ordered nor
+    // injective and is excluded from those two properties rather than asserted about wrongly.
+    return Arbitraries.doubles().filter(d -> !Double.isNaN(d)).map(Dbl::new);
+  }
+
+  private static Arbitrary<Flt> floats() {
+    return Arbitraries.floats().map(Flt::new);
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/expression/IndexExpr.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/expression/IndexExpr.java
@@ -101,11 +101,11 @@ public final class IndexExpr implements Expr {
 
         switch (indexType) {
           case PATH -> {
-            final Iterator<NodeReferences> nodeReferencesIterator = indexController.openPathIndex(rtx.getStorageEngineReader(),
-                entrySet.getKey(), indexController.createPathFilter(pathStrings, rtx));
+            final Iterator<NodeReferences> nodeReferencesIterator = indexController.openPathIndex(
+                rtx.getStorageEngineReader(), entrySet.getKey(), indexController.createPathFilter(pathStrings, rtx));
 
-            checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator, nodeKeys,
-                false);
+            checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator,
+                nodeKeys, false);
           }
           case CAS -> {
             final var atomic = (Atomic) properties.get("atomic");
@@ -129,8 +129,8 @@ public final class IndexExpr implements Expr {
               final Iterator<NodeReferences> nodeReferencesIterator =
                   indexController.openCASIndex(rtx.getStorageEngineReader(), entrySet.getKey(), casFilter);
 
-              checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator, nodeKeys,
-                  false);
+              checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator,
+                  nodeKeys, false);
 
             } else {
 
@@ -140,8 +140,8 @@ public final class IndexExpr implements Expr {
               final Iterator<NodeReferences> nodeReferencesIterator =
                   indexController.openCASIndex(rtx.getStorageEngineReader(), entrySet.getKey(), casFilter);
 
-              checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator, nodeKeys,
-                  false);
+              checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator,
+                  nodeKeys, false);
 
             }
             indexTypeToNodeKeys.put(entrySet.getKey(), nodeKeys);
@@ -152,8 +152,8 @@ public final class IndexExpr implements Expr {
                 indexController.openNameIndex(rtx.getStorageEngineReader(), entrySet.getKey(),
                     new NameFilter(Set.of(entrySet.getValue().get(entrySet.getValue().size() - 1).tail()), Set.of()));
 
-            checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator, nodeKeys,
-                true);
+            checkIfIndexNodeIsApplicable(resourceSession, rtx, pathSegmentNamesToArrayIndexes, nodeReferencesIterator,
+                nodeKeys, true);
 
           }
           default -> throw new IllegalStateException("Index type " + indexType + " not known");
@@ -199,8 +199,8 @@ public final class IndexExpr implements Expr {
             for (; k <= index; k++) {
               if (!rtx.moveToRightSibling()) {
                 throw new QueryException(JNFun.ERR_INVALID_ARGUMENT,
-                    new QNm("Index expression: moveToRightSibling failed at position " + k
-                        + " of " + index + " for nodeKey " + nodeKey));
+                    new QNm("Index expression: moveToRightSibling failed at position " + k + " of " + index
+                        + " for nodeKey " + nodeKey));
               }
             }
             sequence.add(jsonItemFactory.getSequence(rtx, jsonCollection));
@@ -239,8 +239,7 @@ public final class IndexExpr implements Expr {
               // hop becomes a no-op when the predicate target is itself a fused
               // OBJECT_NAMED_OBJECT — the named-OBJECT pair is already represented by the same
               // record. Skip the FINAL hop to avoid over-shooting into the parent OBJECT.
-              if (rtx.getKind() != NodeKind.OBJECT_NAMED_OBJECT
-                  && rtx.getKind() != NodeKind.OBJECT_NAMED_ARRAY) {
+              if (rtx.getKind() != NodeKind.OBJECT_NAMED_OBJECT && rtx.getKind() != NodeKind.OBJECT_NAMED_ARRAY) {
                 rtx.moveToParent();
               }
             }
@@ -257,8 +256,16 @@ public final class IndexExpr implements Expr {
       return new ItemSequence(sequence.toArray(new Item[0]));
     } catch (final Exception e) {
       // Close resources with proper exception suppression to avoid masking the original error
-      try { rtx.close(); } catch (final Exception s) { e.addSuppressed(s); }
-      try { resourceSession.close(); } catch (final Exception s) { e.addSuppressed(s); }
+      try {
+        rtx.close();
+      } catch (final Exception s) {
+        e.addSuppressed(s);
+      }
+      try {
+        resourceSession.close();
+      } catch (final Exception s) {
+        e.addSuppressed(s);
+      }
       throw e;
     }
   }
@@ -327,8 +334,7 @@ public final class IndexExpr implements Expr {
             // matches the FIELD step before that trailing {@code []}. Skip the trailing
             // {@code []} when walking back so the segment pointers line up.
             int startIdx = steps.size() - 1;
-            if (rtx.getKind() == NodeKind.OBJECT_NAMED_ARRAY
-                && startIdx >= 1
+            if (rtx.getKind() == NodeKind.OBJECT_NAMED_ARRAY && startIdx >= 1
                 && steps.get(startIdx).getAxis() == Path.Axis.CHILD_ARRAY) {
               startIdx--;
             }
@@ -419,8 +425,8 @@ public final class IndexExpr implements Expr {
                 // moveToParent here would skip over the OBJECT_KEY layer too — but under
                 // fusion that layer is already part of the same record. Skip ONLY for
                 // the CHILD_ARRAY follow-up, not for FIELD steps.
-                final boolean fusedSkip = step.getAxis() == Path.Axis.CHILD_ARRAY
-                    && rtx.getKind() == NodeKind.OBJECT_NAMED_ARRAY;
+                final boolean fusedSkip =
+                    step.getAxis() == Path.Axis.CHILD_ARRAY && rtx.getKind() == NodeKind.OBJECT_NAMED_ARRAY;
                 if (!fusedSkip) {
                   rtx.moveToParent();
                 }
@@ -431,8 +437,7 @@ public final class IndexExpr implements Expr {
               // record collapses both layers — the parent moveToParent already lands on the
               // GRANDPARENT object, so the extra hop would over-shoot. Restrict the extra hop
               // to bare OBJECT records only.
-              if (rtx.getKind() == NodeKind.OBJECT
-                  && i - 1 > 0
+              if (rtx.getKind() == NodeKind.OBJECT && i - 1 > 0
                   && steps.get(i - 1).getAxis() == Path.Axis.CHILD_OBJECT_FIELD) {
                 rtx.moveToParent();
               }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/compiler/expression/IndexExpr.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/compiler/expression/IndexExpr.java
@@ -282,11 +282,12 @@ public final class IndexExpr implements Expr {
         ? resourceSession.openPathSummary()
         : resourceSession.openPathSummary(revision)) {
       nodeReferencesIterator.forEachRemaining(currentNodeReferences -> {
-        final var currNodeKeys = new LongLinkedOpenHashSet(currentNodeReferences.getNodeKeys().toArray());
+        final var currNodeKeys = new LongLinkedOpenHashSet((int) currentNodeReferences.cardinality());
+        currentNodeReferences.forEachNodeKey(currNodeKeys::add);
         // if array numberOfArrayIndexes are given (only some might be specified we have to drop false
         // positive nodes
         if (numberOfArrayIndexes != 0 || checkPathBecauseOfFieldNameChecks) {
-          final var nodeKeyIter = currentNodeReferences.getNodeKeys().getLongIterator();
+          final var nodeKeyIter = currentNodeReferences.nodeKeyIterator();
           while (nodeKeyIter.hasNext()) {
             final var nodeKey = nodeKeyIter.next();
             final var currentPathSegmentNamesToArrayIndexes = new ArrayDeque<QueryPathSegment>();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/scan/ScanCASIndexRange.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/index/scan/ScanCASIndexRange.java
@@ -41,13 +41,29 @@ public final class ScanCASIndexRange extends AbstractScanIndex {
   public final static QNm DEFAULT_NAME = new QNm(JSONFun.JSON_NSURI, JSONFun.JSON_PREFIX, "scan-cas-index-range");
 
   public ScanCASIndexRange() {
-    super(DEFAULT_NAME,
-        new Signature(new SequenceType(AnyJsonItemType.ANY_JSON_ITEM, Cardinality.ZeroOrMany), SequenceType.NODE,
-            new SequenceType(AtomicType.INR, Cardinality.One), new SequenceType(AtomicType.ANA, Cardinality.One),
-            new SequenceType(AtomicType.ANA, Cardinality.One), new SequenceType(AtomicType.BOOL, Cardinality.One),
-            new SequenceType(AtomicType.BOOL, Cardinality.One),
-            new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne)),
+    super(DEFAULT_NAME, new Signature(new SequenceType(AnyJsonItemType.ANY_JSON_ITEM, Cardinality.ZeroOrMany),
+        SequenceType.NODE, new SequenceType(AtomicType.INR, Cardinality.One),
+        // Bounds are ZeroOrOne, not One: an empty sequence means "unbounded on this end". The
+        // index has always supported a one-sided range — CASFilterRange treats a null bound as
+        // unbounded, and the valid-time scan relies on exactly that — but this signature made
+        // the shape unreachable from a query, so `$x >= 'a'` could not be expressed as a range
+        // scan and the one-sided code path had no query-level coverage at all.
+        new SequenceType(AtomicType.ANA, Cardinality.ZeroOrOne),
+        new SequenceType(AtomicType.ANA, Cardinality.ZeroOrOne), new SequenceType(AtomicType.BOOL, Cardinality.One),
+        new SequenceType(AtomicType.BOOL, Cardinality.One), new SequenceType(AtomicType.STR, Cardinality.ZeroOrOne)),
         true);
+  }
+
+  /**
+   * Cast a bound to the index's content type, mapping an absent argument to {@code null}.
+   *
+   * @param arg the argument, or {@code null} when the caller passed {@code ()}
+   * @return the cast bound, or {@code null} for an unbounded end
+   */
+  private static Atomic castBound(final StaticContext sctx, final Sequence arg, final Type keyType) {
+    return arg == null
+        ? null
+        : Cast.cast(sctx, (Atomic) arg, keyType, true);
   }
 
   @Override
@@ -76,8 +92,12 @@ public final class ScanCASIndexRange extends AbstractScanIndex {
     }
 
     final Type keyType = indexDef.getContentType();
-    final Atomic min = Cast.cast(sctx, (Atomic) args[2], keyType, true);
-    final Atomic max = Cast.cast(sctx, (Atomic) args[3], keyType, true);
+    final Atomic min = castBound(sctx, args[2], keyType);
+    final Atomic max = castBound(sctx, args[3], keyType);
+    if (min == null && max == null) {
+      throw new QueryException(SDBFun.ERR_INVALID_ARGUMENT,
+          "At least one of $low-key / $high-key must be given; an unbounded range is a full index scan.");
+    }
     final boolean incMin = FunUtil.getBoolean(args, 4, "$include-low-key", true, true);
     final boolean incMax = FunUtil.getBoolean(args, 5, "$include-high-key", true, true);
     final String paths = FunUtil.getString(args, 6, "$paths", null, null, false);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
@@ -35,8 +35,8 @@ import java.util.Set;
  * <h2>Index shape</h2>
  * <p>
  * The scan requires the PAIR of {@link Type#DATI xs:dateTime} CAS indexes over the valid-time
- * fields — the kind the store layers auto-create for valid-time resources. Candidates are the
- * UNION of two exact one-sided temporal ranges: {@code validTo >= t} on the validTo index and
+ * fields — the kind the store layers auto-create for valid-time resources. Candidates are the UNION
+ * of two exact one-sided temporal ranges: {@code validTo >= t} on the validTo index and
  * {@code validFrom <= t} on the validFrom index.
  * </p>
  *
@@ -51,8 +51,8 @@ import java.util.Set;
  * containing OBJECT record</em>. The CAS index records that leaf's own node key. Hence
  * {@code moveTo(leafKey)} then {@code getParentKey()} reaches the record OBJECT.</li>
  * <li><b>Legacy</b> (non-fused): the indexed node is the {@code STRING_VALUE}, whose parent is the
- * {@code OBJECT_KEY}, whose parent is the record OBJECT. So we walk parents until {@link
- * JsonNodeReadOnlyTrx#isObject()} holds.</li>
+ * {@code OBJECT_KEY}, whose parent is the record OBJECT. So we walk parents until
+ * {@link JsonNodeReadOnlyTrx#isObject()} holds.</li>
  * </ul>
  * <p>
  * Both shapes are handled by {@link #moveToContainingObjectKey(JsonNodeReadOnlyTrx, long)} which
@@ -108,8 +108,7 @@ public final class ValidTimeIndexScan {
     }
   }
 
-  private ValidTimeIndexScan() {
-  }
+  private ValidTimeIndexScan() {}
 
   /**
    * Try to evaluate the valid-time point-in-time predicate via CAS index range scans.
@@ -160,8 +159,8 @@ public final class ValidTimeIndexScan {
    *
    * <p>
    * Matching on the path's {@link Path#tail() tail} (last step name) avoids reconstructing the full
-   * document-shape-dependent path string and works for any nesting where the valid-time field is
-   * the leaf of the indexed path.
+   * document-shape-dependent path string and works for any nesting where the valid-time field is the
+   * leaf of the indexed path.
    * </p>
    */
   private static IndexDef findCasIndexForField(final JsonIndexController controller, final String field) {
@@ -184,8 +183,8 @@ public final class ValidTimeIndexScan {
 
   /**
    * Run one CAS range scan and add every candidate record OBJECT key within the linear-scan domain
-   * (the document item itself or its direct array children) to {@code candidateObjectKeys}. The
-   * set de-dups records hit via multiple indexed values or via both indexes.
+   * (the document item itself or its direct array children) to {@code candidateObjectKeys}. The set
+   * de-dups records hit via multiple indexed values or via both indexes.
    */
   private static void collectCandidates(final JsonNodeReadOnlyTrx rtx, final JsonIndexController controller,
       final IndexDef indexDef, final Atomic min, final Atomic max, final long documentItemKey,
@@ -196,7 +195,8 @@ public final class ValidTimeIndexScan {
       paths.add(path.toString());
     }
 
-    final CASFilterRange filter = controller.createCASFilterRange(paths, min, max, true, true, new JsonPCRCollector(rtx));
+    final CASFilterRange filter =
+        controller.createCASFilterRange(paths, min, max, true, true, new JsonPCRCollector(rtx));
     final Iterator<NodeReferences> index = controller.openCASIndex(rtx.getStorageEngineReader(), indexDef, filter);
 
     while (index.hasNext()) {
@@ -218,8 +218,8 @@ public final class ValidTimeIndexScan {
   }
 
   /**
-   * Verify each candidate by reading BOTH fields and applying the exact instant predicate; build
-   * the matching items. Sorting by node key gives a deterministic order.
+   * Verify each candidate by reading BOTH fields and applying the exact instant predicate; build the
+   * matching items. Sorting by node key gives a deterministic order.
    */
   private static Result verifyCandidates(final JsonNodeReadOnlyTrx rtx, final JsonDBCollection collection,
       final Set<Long> candidateObjectKeys, final Instant validTime, final String validFromField,
@@ -250,10 +250,10 @@ public final class ValidTimeIndexScan {
    * Walk up from an indexed valid-time node to the node key of its containing OBJECT record.
    *
    * <p>
-   * Under fusion the indexed {@code OBJECT_NAMED_STRING} leaf is already a direct child of the
-   * record OBJECT (one hop). In the legacy shape the indexed {@code STRING_VALUE} sits under an
-   * {@code OBJECT_KEY} under the record OBJECT (two hops). We therefore walk parents until {@link
-   * JsonNodeReadOnlyTrx#isObject()} holds, capping at a few hops as a guard.
+   * Under fusion the indexed {@code OBJECT_NAMED_STRING} leaf is already a direct child of the record
+   * OBJECT (one hop). In the legacy shape the indexed {@code STRING_VALUE} sits under an
+   * {@code OBJECT_KEY} under the record OBJECT (two hops). We therefore walk parents until
+   * {@link JsonNodeReadOnlyTrx#isObject()} holds, capping at a few hops as a guard.
    * </p>
    *
    * @return the containing object's node key, or {@link Long#MIN_VALUE} if none was found
@@ -300,8 +300,8 @@ public final class ValidTimeIndexScan {
    * registration: reads the configured valid-time fields off {@code obj} and tests
    * {@code validFrom <= validTime <= validTo}, where an <em>absent</em> (or unparseable) bound is
    * treated as unbounded on that side — a missing {@code validTo} is "valid from {@code validFrom}
-   * onward", a missing {@code validFrom} is "valid up to {@code validTo}". A record with neither bound
-   * carries no interval and never matches.
+   * onward", a missing {@code validFrom} is "valid up to {@code validTo}". A record with neither
+   * bound carries no interval and never matches.
    *
    * <p>
    * Data-shape problems (absent fields, non-string values, unparseable dates) are handled explicitly
@@ -319,8 +319,12 @@ public final class ValidTimeIndexScan {
     // Open-ended intervals: a null (absent/unparseable) bound is unbounded on that side. This mirrors
     // the interval index exactly — its writer maps a null bound to the domain min/max and registers
     // the record (ValidTimeIntervalIndexWriter.toInterval) — so all paths still return the same set.
-    final Instant validFrom = validFromSeq == null ? null : parseInstant(validFromSeq);
-    final Instant validTo = validToSeq == null ? null : parseInstant(validToSeq);
+    final Instant validFrom = validFromSeq == null
+        ? null
+        : parseInstant(validFromSeq);
+    final Instant validTo = validToSeq == null
+        ? null
+        : parseInstant(validToSeq);
 
     if (validFrom == null && validTo == null) {
       return false;

--- a/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/function/jn/temporal/ValidTimeIndexScan.java
@@ -201,7 +201,7 @@ public final class ValidTimeIndexScan {
 
     while (index.hasNext()) {
       final NodeReferences refs = index.next();
-      final var it = refs.getNodeKeys().getLongIterator();
+      final var it = refs.nodeKeyIterator();
       while (it.hasNext()) {
         final long indexedNodeKey = it.next();
         final long objectKey = moveToContainingObjectKey(rtx, indexedNodeKey);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/SirixJsonItemKeyStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/json/SirixJsonItemKeyStream.java
@@ -5,6 +5,7 @@ import io.brackit.query.jdm.Stream;
 import org.jspecify.annotations.Nullable;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import org.roaringbitmap.longlong.LongIterator;
 import io.sirix.query.json.JsonDBCollection;
 import io.sirix.query.json.JsonItemFactory;
 
@@ -22,7 +23,7 @@ public final class SirixJsonItemKeyStream implements Stream<Item> {
 
   private final JsonNodeReadOnlyTrx rtx;
 
-  private Iterator<Long> nodeKeys;
+  private LongIterator nodeKeys;
 
   public SirixJsonItemKeyStream(final Iterator<NodeReferences> iter, final JsonDBCollection collection,
       final JsonNodeReadOnlyTrx rtx) {
@@ -49,7 +50,7 @@ public final class SirixJsonItemKeyStream implements Stream<Item> {
       if (!iter.hasNext()) {
         return null;
       }
-      nodeKeys = iter.next().getNodeKeys().iterator();
+      nodeKeys = iter.next().nodeKeyIterator();
     }
   }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/stream/node/SirixNodeKeyStream.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/stream/node/SirixNodeKeyStream.java
@@ -1,7 +1,7 @@
 package io.sirix.query.stream.node;
 
 import io.brackit.query.jdm.Stream;
-import org.roaringbitmap.longlong.PeekableLongIterator;
+import org.roaringbitmap.longlong.LongIterator;
 import io.sirix.api.xml.XmlNodeReadOnlyTrx;
 import io.sirix.index.redblacktree.keyvalue.NodeReferences;
 import io.sirix.query.node.XmlDBCollection;
@@ -19,7 +19,7 @@ public final class SirixNodeKeyStream implements Stream<XmlDBNode> {
 
   private final XmlNodeReadOnlyTrx rtx;
 
-  private PeekableLongIterator nodeKeyIterator;
+  private LongIterator nodeKeyIterator;
 
   public SirixNodeKeyStream(final Iterator<NodeReferences> iter, final XmlDBCollection collection,
       final XmlNodeReadOnlyTrx rtx) {
@@ -37,7 +37,7 @@ public final class SirixNodeKeyStream implements Stream<XmlDBNode> {
     }
     while (iter.hasNext()) {
       final NodeReferences nodeReferences = iter.next();
-      nodeKeyIterator = nodeReferences.getNodeKeys().getLongIterator();
+      nodeKeyIterator = nodeReferences.nodeKeyIterator();
       if (nodeKeyIterator.hasNext()) {
         var nodeKey = nodeKeyIterator.next();
         rtx.moveTo(nodeKey);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTruncationTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTruncationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.function.jn.index;
+
+import io.sirix.query.AbstractJsonTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Pins that a CAS equality query stays exact for values the key encoding cannot represent.
+ *
+ * <p>
+ * {@code CASKeySerializer} truncates a string value at {@code MAX_STRING_VALUE_BYTES} (246), so two
+ * values sharing that prefix serialize to ONE key and share one posting list. The HOT equality
+ * branch in {@code CASIndex#openHOTIndexWithFilter} used to return that list as-is, handing the
+ * query both values' nodes for a probe that matches only one of them.
+ * </p>
+ *
+ * <p>
+ * That over-match is now corrected rather than merely documented. The fix does not change the key
+ * format — the disambiguating bytes genuinely are not stored, so no index-only path can be exact.
+ * Instead {@code CASKeySerializer#losesInformation} reports when a probe cannot be represented, and
+ * only then does the seek re-check its candidates against the real node values. A value inside the
+ * cap is decided by the seek alone and pays nothing.
+ * </p>
+ *
+ * <p>
+ * Both index shapes are covered because the two were easy to confuse while the defect stood.
+ * Measured on this fixture, asking for one of the two long values: single-path returned 2 both
+ * before and after the {@code pcrsAvailable} gate relaxation — it has always taken the seek, so the
+ * relaxation could not have caused it. Multi-path returned 0 before (the scan compares the
+ * truncated STORED value against the full probe and matches nothing) and 2 after. Both are 1 now.
+ * </p>
+ *
+ * <p>
+ * The third test is the control that keeps the other two honest: a value inside the cap must stay
+ * exact, so a re-check that simply dropped everything — or a seek that stopped matching at all —
+ * cannot pass this class.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class CASKeyTruncationTest extends AbstractJsonTest {
+
+  /**
+   * Exactly {@code CASKeySerializer.MAX_STRING_VALUE_BYTES}, so the two values differ only past it.
+   */
+  private static final String SHARED_PREFIX = "A".repeat(246);
+
+  private static final String LONG_VALUE_ONE = SHARED_PREFIX + "X";
+
+  private static final String LONG_VALUE_TWO = SHARED_PREFIX + "Y";
+
+  private static final String DOC = "[{\"title\":\"" + LONG_VALUE_ONE + "\"},{\"title\":\"" + LONG_VALUE_TWO
+      + "\"},{\"alias\":\"z\",\"title\":\"short\"}]";
+
+  private static final String STORE = "jn:store('json-path1','mydoc.jn','" + DOC + "')";
+
+  private static final String CREATE_SINGLE_PATH = "let $doc := jn:doc('json-path1','mydoc.jn') "
+      + "let $i := jn:create-cas-index($doc,'xs:string','/[]/title') return sdb:commit($doc)";
+
+  private static final String CREATE_MULTI_PATH = "let $doc := jn:doc('json-path1','mydoc.jn') "
+      + "let $i := jn:create-cas-index($doc,'xs:string',('/[]/title','/[]/alias')) return sdb:commit($doc)";
+
+  private static String countOfTitle(final String value) {
+    return "let $doc := jn:doc('json-path1','mydoc.jn') return fn:count(jn:scan-cas-index($doc,"
+        + "jn:find-cas-index($doc,'xs:string','/[]/title'),'" + value + "','==','/[]/title'))";
+  }
+
+  @Test
+  @DisplayName("a single-path index does not return other values sharing the truncated prefix")
+  void singlePathIndexIsExactPastTheTruncationCap() throws IOException {
+    test(STORE, CREATE_SINGLE_PATH, countOfTitle(LONG_VALUE_ONE), "1");
+  }
+
+  @Test
+  @DisplayName("a multi-path index does not either, having returned 0 before the gate relaxation and 2 after")
+  void multiPathIndexIsExactPastTheTruncationCap() throws IOException {
+    test(STORE, CREATE_MULTI_PATH, countOfTitle(LONG_VALUE_ONE), "1");
+  }
+
+  @Test
+  @DisplayName("a value inside the bound is unaffected")
+  void aValueShorterThanTheBoundIsExact() throws IOException {
+    // The control: truncation only bites past the bound, so an ordinary value must still be exact.
+    // Without this, a regression that broke equality outright would leave the two tests above green.
+    test(STORE, CREATE_SINGLE_PATH, countOfTitle("short"), "1");
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTypedEncodingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTypedEncodingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.function.jn.index;
+
+import io.sirix.query.AbstractJsonTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * Pins that a CAS index over a NON-string content type answers the value the document holds.
+ *
+ * <p>
+ * The two sides of a CAS index reach {@code CASKeySerializer} in different shapes, and each defect
+ * below is one place where they encoded the same logical value to different keys — or two different
+ * values to the same key. {@code CASIndexBuilder} stores every indexed value as a {@code Str} (it
+ * builds one from the node's lexical form), while {@code ScanCASIndex} casts the query's argument to
+ * the index's declared content type, so the probe arrives as a {@code Bool}, {@code Flt}, {@code Dbl}
+ * or {@code Dec}. Anything in the encoder that behaves differently for a {@code Str} than for the
+ * typed atomic splits the two sides apart, and the query silently returns the wrong rows.
+ * </p>
+ *
+ * <p>
+ * These are equality queries with unambiguous answers, so each test pins a count against a fixture
+ * whose contents are visible above it. All three failed before the encoder fixes:
+ * </p>
+ * <ul>
+ * <li><b>boolean</b> — the encoder called {@code Atomic#booleanValue()}, which is XQuery's EFFECTIVE
+ * boolean value. On the stored {@code Str} that is "the string is non-empty", so {@code "false"}
+ * encoded to byte 1 exactly as {@code "true"} did: both values shared one key and one posting list.
+ * The probe, a real {@code Bool}, encoded {@code false()} to byte 0 and matched nothing, so
+ * {@code = false()} returned 0 rows and {@code = true()} returned every boolean node.</li>
+ * <li><b>float</b> — the stored {@code Str} took the parse branch and gave
+ * {@code Double.parseDouble("1.1")}, while the {@code Flt} probe gave {@code (double) 1.1f}. Those
+ * differ in the low bits, so the keys differed and {@code = 1.1} found nothing at all.</li>
+ * <li><b>decimal</b> — the equality re-check is gated on
+ * {@code CASKeySerializer#losesInformation}, which used to ask whether the PROBE was exactly a
+ * double. {@code 0.5} is, so the re-check was switched off for it — while a stored value differing
+ * only past double precision encodes to that same double and came back as a hit.</li>
+ * </ul>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class CASKeyTypedEncodingTest extends AbstractJsonTest {
+
+  private static final String BOOL_DOC = "[{\"flag\":true},{\"flag\":false},{\"flag\":false}]";
+
+  /**
+   * {@code 1.1} is the point: it is not exactly representable in binary, so the float and double
+   * parses of the same literal disagree. A dyadic value such as {@code 1.5} would have passed
+   * throughout and proved nothing.
+   */
+  private static final String FLOAT_DOC = "[{\"m\":1.1},{\"m\":2.5},{\"m\":1.1}]";
+
+  /**
+   * {@code 0.5} is exactly a double — that is what made the old probe-only test report the key
+   * lossless and skip the re-check. Its neighbour differs only past double precision, so the two
+   * share one key: the index alone cannot separate them and only the re-check can.
+   */
+  private static final String DECIMAL_DOC = "[{\"p\":0.5},{\"p\":0.5000000000000000001},{\"p\":0.25}]";
+
+  private static String store(final String doc) {
+    return "jn:store('json-path1','mydoc.jn','" + doc + "')";
+  }
+
+  private static String createIndex(final String type, final String path) {
+    return "let $doc := jn:doc('json-path1','mydoc.jn') " + "let $i := jn:create-cas-index($doc,'" + type + "','"
+        + path + "') return sdb:commit($doc)";
+  }
+
+  private static String countMatching(final String type, final String path, final String probe) {
+    return "let $doc := jn:doc('json-path1','mydoc.jn') return fn:count(jn:scan-cas-index($doc,"
+        + "jn:find-cas-index($doc,'" + type + "','" + path + "')," + probe + ",'==','" + path + "'))";
+  }
+
+  @Test
+  @DisplayName("a boolean index separates false from true, having merged both onto one key before")
+  void aBooleanIndexSeparatesFalseFromTrue() throws IOException {
+    test(store(BOOL_DOC), createIndex("xs:boolean", "/[]/flag"),
+        countMatching("xs:boolean", "/[]/flag", "false()"), "2");
+  }
+
+  @Test
+  @DisplayName("and finds the true one too, so the fix is not simply an inverted encoding")
+  void aBooleanIndexStillFindsTrue() throws IOException {
+    // The control. Mapping every value onto byte 0 instead of byte 1 would satisfy the test above on
+    // its own, and would be just as wrong.
+    test(store(BOOL_DOC), createIndex("xs:boolean", "/[]/flag"), countMatching("xs:boolean", "/[]/flag", "true()"),
+        "1");
+  }
+
+  @Test
+  @DisplayName("a float index finds a value whose float and double parses differ")
+  void aFloatIndexFindsANonDyadicValue() throws IOException {
+    test(store(FLOAT_DOC), createIndex("xs:float", "/[]/m"),
+        countMatching("xs:float", "/[]/m", "xs:float('1.1')"), "2");
+  }
+
+  @Test
+  @DisplayName("a decimal index does not return a neighbour that shares the probe's double")
+  void aDecimalIndexIsExactAgainstADoubleCollision() throws IOException {
+    // 0.5 and 0.5000000000000000001 encode to the same 8 key bytes, so the seek returns both and only
+    // the value re-check can tell them apart. Answering 2 here is the collision going unchecked.
+    test(store(DECIMAL_DOC), createIndex("xs:decimal", "/[]/p"),
+        countMatching("xs:decimal", "/[]/p", "xs:decimal('0.5')"), "1");
+  }
+
+  @Test
+  @DisplayName("a decimal index still matches a value that needs no disambiguation")
+  void aDecimalIndexStillMatchesAnUncontestedValue() throws IOException {
+    // The control for the re-check: 0.25 shares its key with nothing, so a re-check that dropped
+    // candidates indiscriminately would show up here rather than in the test above.
+    test(store(DECIMAL_DOC), createIndex("xs:decimal", "/[]/p"),
+        countMatching("xs:decimal", "/[]/p", "xs:decimal('0.25')"), "1");
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTypedEncodingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/CASKeyTypedEncodingTest.java
@@ -16,10 +16,11 @@ import java.io.IOException;
  * The two sides of a CAS index reach {@code CASKeySerializer} in different shapes, and each defect
  * below is one place where they encoded the same logical value to different keys — or two different
  * values to the same key. {@code CASIndexBuilder} stores every indexed value as a {@code Str} (it
- * builds one from the node's lexical form), while {@code ScanCASIndex} casts the query's argument to
- * the index's declared content type, so the probe arrives as a {@code Bool}, {@code Flt}, {@code Dbl}
- * or {@code Dec}. Anything in the encoder that behaves differently for a {@code Str} than for the
- * typed atomic splits the two sides apart, and the query silently returns the wrong rows.
+ * builds one from the node's lexical form), while {@code ScanCASIndex} casts the query's argument
+ * to the index's declared content type, so the probe arrives as a {@code Bool}, {@code Flt},
+ * {@code Dbl} or {@code Dec}. Anything in the encoder that behaves differently for a {@code Str}
+ * than for the typed atomic splits the two sides apart, and the query silently returns the wrong
+ * rows.
  * </p>
  *
  * <p>
@@ -27,18 +28,19 @@ import java.io.IOException;
  * whose contents are visible above it. All three failed before the encoder fixes:
  * </p>
  * <ul>
- * <li><b>boolean</b> — the encoder called {@code Atomic#booleanValue()}, which is XQuery's EFFECTIVE
- * boolean value. On the stored {@code Str} that is "the string is non-empty", so {@code "false"}
- * encoded to byte 1 exactly as {@code "true"} did: both values shared one key and one posting list.
- * The probe, a real {@code Bool}, encoded {@code false()} to byte 0 and matched nothing, so
- * {@code = false()} returned 0 rows and {@code = true()} returned every boolean node.</li>
+ * <li><b>boolean</b> — the encoder called {@code Atomic#booleanValue()}, which is XQuery's
+ * EFFECTIVE boolean value. On the stored {@code Str} that is "the string is non-empty", so
+ * {@code "false"} encoded to byte 1 exactly as {@code "true"} did: both values shared one key and
+ * one posting list. The probe, a real {@code Bool}, encoded {@code false()} to byte 0 and matched
+ * nothing, so {@code = false()} returned 0 rows and {@code = true()} returned every boolean
+ * node.</li>
  * <li><b>float</b> — the stored {@code Str} took the parse branch and gave
  * {@code Double.parseDouble("1.1")}, while the {@code Flt} probe gave {@code (double) 1.1f}. Those
  * differ in the low bits, so the keys differed and {@code = 1.1} found nothing at all.</li>
- * <li><b>decimal</b> — the equality re-check is gated on
- * {@code CASKeySerializer#losesInformation}, which used to ask whether the PROBE was exactly a
- * double. {@code 0.5} is, so the re-check was switched off for it — while a stored value differing
- * only past double precision encodes to that same double and came back as a hit.</li>
+ * <li><b>decimal</b> — the equality re-check is gated on {@code CASKeySerializer#losesInformation},
+ * which used to ask whether the PROBE was exactly a double. {@code 0.5} is, so the re-check was
+ * switched off for it — while a stored value differing only past double precision encodes to that
+ * same double and came back as a hit.</li>
  * </ul>
  *
  * @author Johannes Lichtenberger
@@ -66,8 +68,8 @@ public final class CASKeyTypedEncodingTest extends AbstractJsonTest {
   }
 
   private static String createIndex(final String type, final String path) {
-    return "let $doc := jn:doc('json-path1','mydoc.jn') " + "let $i := jn:create-cas-index($doc,'" + type + "','"
-        + path + "') return sdb:commit($doc)";
+    return "let $doc := jn:doc('json-path1','mydoc.jn') " + "let $i := jn:create-cas-index($doc,'" + type + "','" + path
+        + "') return sdb:commit($doc)";
   }
 
   private static String countMatching(final String type, final String path, final String probe) {
@@ -78,8 +80,8 @@ public final class CASKeyTypedEncodingTest extends AbstractJsonTest {
   @Test
   @DisplayName("a boolean index separates false from true, having merged both onto one key before")
   void aBooleanIndexSeparatesFalseFromTrue() throws IOException {
-    test(store(BOOL_DOC), createIndex("xs:boolean", "/[]/flag"),
-        countMatching("xs:boolean", "/[]/flag", "false()"), "2");
+    test(store(BOOL_DOC), createIndex("xs:boolean", "/[]/flag"), countMatching("xs:boolean", "/[]/flag", "false()"),
+        "2");
   }
 
   @Test
@@ -94,8 +96,8 @@ public final class CASKeyTypedEncodingTest extends AbstractJsonTest {
   @Test
   @DisplayName("a float index finds a value whose float and double parses differ")
   void aFloatIndexFindsANonDyadicValue() throws IOException {
-    test(store(FLOAT_DOC), createIndex("xs:float", "/[]/m"),
-        countMatching("xs:float", "/[]/m", "xs:float('1.1')"), "2");
+    test(store(FLOAT_DOC), createIndex("xs:float", "/[]/m"), countMatching("xs:float", "/[]/m", "xs:float('1.1')"),
+        "2");
   }
 
   @Test

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/HOTIndexJsoniqDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/HOTIndexJsoniqDifferentialTest.java
@@ -1,0 +1,253 @@
+package io.sirix.query.function.jn.index;
+
+import io.sirix.query.AbstractJsonTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+/**
+ * JSONiq-level differential tests for the HOT index backend.
+ *
+ * <h2>What these add over the unit tests</h2>
+ * <p>
+ * {@code CASIndexDifferentialTest} drives the index through the {@code IndexController} API. These
+ * drive it through the QUERY LANGUAGE — the path a user actually takes — which pulls in layers the
+ * unit tests bypass entirely: the index-scan functions, the sequence plumbing that wraps a
+ * {@code NodeReferences} stream into a JSONiq sequence, and the optimizer that turns a comparison
+ * into an index scan in the first place.
+ *
+ * <h2>How they assert</h2>
+ * <p>
+ * Not against hand-written answers. Each query computes BOTH the indexed answer and the same answer
+ * by plain traversal of the same document, and returns whether they agree, so the expected string
+ * is always {@code true}. A wrong answer therefore cannot be masked by an expectation someone
+ * copied out of a failing run — which is how hand-written counts silently accepted the byte-window
+ * and cross-path defects that three review rounds had to find by reading code.
+ *
+ * <p>
+ * The fixture is deliberately the shape that broke those rounds: a prefix chain
+ * ({@code car}/{@code carpet}/{@code carpeting}), a duplicated value so a group holds more than one
+ * node, an empty string, and a second field whose values interleave the first's so a scan that
+ * escapes its own path shows up in the ANSWER, not merely in the count.
+ */
+public final class HOTIndexJsoniqDifferentialTest extends AbstractJsonTest {
+
+  private static final String DOC = "[" + "{\"title\":\"\",\"alias\":\"zulu\"},"
+      + "{\"title\":\"a\",\"alias\":\"yankee\"}," + "{\"title\":\"car\",\"alias\":\"car\"},"
+      + "{\"title\":\"car\",\"alias\":\"alpha\"}," + "{\"title\":\"carpet\",\"alias\":\"\"},"
+      + "{\"title\":\"carpeting\",\"alias\":\"bravo\"}," + "{\"title\":\"zebra\",\"alias\":\"carpet\"}]";
+
+  private static final String STORE = "jn:store('json-path1','mydoc.jn','" + DOC + "')";
+
+  /**
+   * The index-creation step. The {@code sdb:commit($doc)} is load-bearing: creating an index is a
+   * WRITE, so without the commit the index definition dies with the query context and the following
+   * scan reports {@code Index no 0 ... not found} — which looks exactly like a lost index but is only
+   * an uncommitted transaction.
+   */
+  private static String create(final String paths, final String type) {
+    return "let $doc := jn:doc('json-path1','mydoc.jn') let $idx := jn:create-cas-index($doc,'" + type + "'," + paths
+        + ") return sdb:commit($doc)";
+  }
+
+  private static final String CREATE_TITLE = create("'/[]/title'", "xs:string");
+  private static final String CREATE_BOTH = create("('/[]/title','/[]/alias')", "xs:string");
+  private static final String CREATE_INSTANT = create("'/[]/t'", "xs:dateTime");
+
+  /** Re-open the document for the scan step; {@code $d} is the same handle, for plain traversal. */
+  private static final String HEAD = "let $doc := jn:doc('json-path1','mydoc.jn') let $d := $doc ";
+
+  private static String idx(final String path, final String type) {
+    return "jn:find-cas-index($doc,'" + type + "','" + path + "')";
+  }
+
+  /** Compare an index scan over {@code field} against the same question asked of the document. */
+  private static String agree(final String scan, final String field, final String predicate) {
+    return HEAD + "let $indexed := for $v in " + scan + " order by $v return $v "
+        + "let $plain := for $o in $d[] where " + predicate + " order by $o." + field + " return $o." + field + " "
+        // Joined rather than compared positionally: in JSONiq `$seq[$i]` is ARRAY access, so it
+        // raises XPTY0004 on a sequence. Joining compares order and content in one go.
+        + "return fn:string-join($indexed,'|') eq fn:string-join($plain,'|')";
+  }
+
+  private static String scan(final String value, final String op, final String path) {
+    return "jn:scan-cas-index($doc," + idx(path, "xs:string") + ",'" + value + "','" + op + "','" + path + "')";
+  }
+
+  private static String range(final String min, final String max, final boolean incMin, final boolean incMax,
+      final String path) {
+    return "jn:scan-cas-index-range($doc," + idx(path, "xs:string") + ",'" + min + "','" + max + "'," + incMin + "(),"
+        + incMax + "(),'" + path + "')";
+  }
+
+  /** A range with one end left unbounded, expressed as {@code ()}. */
+  private static String openRange(final String bound, final boolean isMin, final boolean inclusive, final String path) {
+    final String min = isMin
+        ? "'" + bound + "'"
+        : "()";
+    final String max = isMin
+        ? "()"
+        : "'" + bound + "'";
+    return "jn:scan-cas-index-range($doc," + idx(path, "xs:string") + "," + min + "," + max + "," + (isMin
+        ? inclusive
+        : true) + "(),"
+        + (isMin
+            ? true
+            : inclusive)
+        + "(),'" + path + "')";
+  }
+
+  private static String onTitle(final String scanExpr, final String predicate) {
+    return agree(scanExpr, "title", predicate);
+  }
+
+  // ==================== the byte-window shapes ====================
+
+  @Test
+  @DisplayName("<= a value that is a strict PREFIX of other stored values")
+  void lowerOrEqualOnAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("car", "<=", "/[]/title"), "$o.title le 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("< a prefix value: the equal group goes, the extensions stay out")
+  void lowerThanAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("car", "<", "/[]/title"), "$o.title lt 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName(">= a prefix value keeps the equal group and every extension")
+  void greaterOrEqualOnAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("car", ">=", "/[]/title"), "$o.title ge 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("> a prefix value drops only the equal group")
+  void greaterThanAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("car", ">", "/[]/title"), "$o.title gt 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("== a value stored on more than one node returns the whole group")
+  void equalOnADuplicatedValue() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("car", "==", "/[]/title"), "$o.title eq 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("== the empty string, whose key is a bare header")
+  void equalOnTheEmptyString() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("", "==", "/[]/title"), "$o.title eq ''"), "true");
+  }
+
+  @Test
+  @DisplayName(">= the empty string returns every entry")
+  void greaterOrEqualOnTheEmptyString() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(scan("", ">=", "/[]/title"), "$o.title ge ''"), "true");
+  }
+
+  // ==================== range inclusivity ====================
+
+  @Test
+  @DisplayName("closed range ending on a prefix value")
+  void closedRangeToAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE,
+        onTitle(range("a", "car", true, true, "/[]/title"), "$o.title ge 'a' and $o.title le 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("half-open range excluding a prefix value that is not the last group")
+  void halfOpenRangeExcludingAPrefixValue() throws IOException {
+    test(STORE, CREATE_TITLE,
+        onTitle(range("a", "car", true, false, "/[]/title"), "$o.title ge 'a' and $o.title lt 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("open range excluding a value that is neither first nor last")
+  void openRangeExcludingAMiddleValue() throws IOException {
+    test(STORE, CREATE_TITLE,
+        onTitle(range("car", "zebra", false, false, "/[]/title"), "$o.title gt 'car' and $o.title lt 'zebra'"), "true");
+  }
+
+  @Test
+  @DisplayName("range that straddles no stored value at all")
+  void emptyRange() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(range("d", "e", true, true, "/[]/title"), "$o.title ge 'd' and $o.title le 'e'"),
+        "true");
+  }
+
+  // ==================== the cross-path shapes ====================
+
+  @Test
+  @DisplayName("one-sided >= on ONE path of a two-path index must not return the other path's values")
+  void oneSidedScanStaysOnItsPath() throws IOException {
+    test(STORE, CREATE_BOTH, agree(scan("a", ">=", "/[]/title"), "title", "$o.title ge 'a'"), "true");
+  }
+
+  @Test
+  @DisplayName("one-sided <= on the other path, whose open end points the other way")
+  void oneSidedScanStaysOnItsPathDownwards() throws IOException {
+    test(STORE, CREATE_BOTH, agree(scan("zz", "<=", "/[]/alias"), "alias", "$o.alias le 'zz'"), "true");
+  }
+
+  @Test
+  @DisplayName("a two-sided range on one path of a two-path index")
+  void twoSidedScanOnOnePathOfATwoPathIndex() throws IOException {
+    test(STORE, CREATE_BOTH,
+        agree(range("a", "zz", true, true, "/[]/title"), "title", "$o.title ge 'a' and $o.title le 'zz'"), "true");
+  }
+
+  // ==================== one-sided ranges, now expressible ====================
+
+  @Test
+  @DisplayName("min-only range on a single-path index")
+  void minOnlyRange() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(openRange("car", true, true, "/[]/title"), "$o.title ge 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("max-only range on a single-path index")
+  void maxOnlyRange() throws IOException {
+    test(STORE, CREATE_TITLE, onTitle(openRange("car", false, true, "/[]/title"), "$o.title le 'car'"), "true");
+  }
+
+  @Test
+  @DisplayName("min-only range on ONE path of a two-path index must not leak the other path")
+  void minOnlyRangeStaysOnItsPath() throws IOException {
+    test(STORE, CREATE_BOTH, agree(openRange("a", true, true, "/[]/title"), "title", "$o.title ge 'a'"), "true");
+  }
+
+  @Test
+  @DisplayName("max-only range on the other path, whose open end points the other way")
+  void maxOnlyRangeStaysOnItsPath() throws IOException {
+    test(STORE, CREATE_BOTH, agree(openRange("zz", false, true, "/[]/alias"), "alias", "$o.alias le 'zz'"), "true");
+  }
+
+  // ==================== the instant family, end to end ====================
+
+  @Test
+  @DisplayName("a dateTime range is chronological, not lexical, through the query layer")
+  void dateTimeRangeIsChronological() throws IOException {
+    // 14:00:00+02:00 is the same instant as 12:00:00Z written with an offset, so >= noon UTC is all
+    // four. A lexical bound orders the offset spelling apart from the Z one and returns fewer.
+    final String doc = "[{\"t\":\"2020-06-15T12:00:00Z\"},{\"t\":\"2020-06-15T12:00:00.5Z\"},"
+        + "{\"t\":\"2020-06-15T14:00:00+02:00\"},{\"t\":\"2021-01-01T00:00:00Z\"}]";
+    test("jn:store('json-path1','mydoc.jn','" + doc + "')", CREATE_INSTANT,
+        HEAD + "return count(jn:scan-cas-index($doc," + idx("/[]/t", "xs:dateTime")
+            + ",'2020-06-15T12:00:00Z','>=','/[]/t'))",
+        "4");
+  }
+
+  @Test
+  @DisplayName("a dateTime scan keeps the sub-second value a lexical bound would drop")
+  void dateTimeScanKeepsSubSecondValues() throws IOException {
+    // >= 12:00:00.500Z is {12:00:00.500001Z, 13:00:00Z}. A lexical bound drops the first, because
+    // '.' (0x2E) sorts below 'Z' (0x5A).
+    final String doc = "[{\"t\":\"2020-06-15T12:00:00Z\"},{\"t\":\"2020-06-15T12:00:00.500001Z\"},"
+        + "{\"t\":\"2020-06-15T13:00:00Z\"}]";
+    test("jn:store('json-path1','mydoc.jn','" + doc + "')", CREATE_INSTANT,
+        HEAD + "return count(jn:scan-cas-index($doc," + idx("/[]/t", "xs:dateTime")
+            + ",'2020-06-15T12:00:00.500Z','>=','/[]/t'))",
+        "2");
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/HOTIndexMemoizationJsoniqTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/function/jn/index/HOTIndexMemoizationJsoniqTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.function.jn.index;
+
+import io.sirix.access.Databases;
+import io.sirix.cache.BufferManager;
+import io.sirix.cache.HOTLookupCache;
+import io.sirix.query.AbstractJsonTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * JSONiq-level cover for the parts of the CAS index read path that unit tests cannot reach.
+ *
+ * <p>
+ * The point-lookup memoization sits between {@code jn:scan-cas-index} and the trie, and its failure
+ * mode is not an exception — it is a query that returns the right shape of answer with the wrong
+ * contents: a previous revision's postings, or another key's. {@code HOTLookupCacheTest} pins the
+ * data structure and {@code HOTLookupCacheInvalidationTest} pins the sweeps, but neither runs a
+ * query, so neither would catch a reader that consults the cache with a key that fails to
+ * discriminate what the query actually varies. These do, by asking the index a question and asking
+ * the document the same question, exactly as {@link HOTIndexJsoniqDifferentialTest} does.
+ * </p>
+ *
+ * <p>
+ * The other half is encoding. A CAS key is bytes, and the paths that produce those bytes were
+ * rewritten for speed — the ASCII fast path now writes through {@code String.getBytes} and falls
+ * back for anything above {@code 0x7F}, and the comparators read eight bytes at a time. A value
+ * that takes the fallback, or one whose length straddles the eight-byte stride, is where an
+ * encoding regression shows up as "the query silently finds nothing".
+ * </p>
+ *
+ * <p>
+ * Every assertion here is pinned to a literal rather than to a second reading of the same query.
+ * The natural shape for a memoization test — ask twice, compare the answers — is satisfied by a
+ * cache that returns the same WRONG list both times, and by an encoding bug that makes both sides
+ * empty, which are the two failures actually worth catching.
+ * </p>
+ *
+ * <p>
+ * The revision-discrimination claim was checked by mutation rather than assumed: dropping the
+ * revision from the memoization key ({@code AbstractHOTIndexReader}) fails
+ * {@link #insertAfterIndexCreationIsVisible()} (3 → 2) and
+ * {@link #replaceMovesTheValueBetweenKeys()} while leaving the rest green. Those two carry the
+ * weight; see {@link #deleteAfterIndexCreationIsVisible()} for why deletion structurally cannot.
+ * </p>
+ *
+ * <p>
+ * The key's INDEX NUMBER needs a test shaped deliberately to reach it, and
+ * {@link #aCrossedProbeDoesNotBorrowTheOtherIndexsAnswer()} is that test. Two indexes are two
+ * independent tries, so the field is what says which trie a memoized posting list came from — but a
+ * scan phrased the obvious way never demonstrates it, because a CAS key already opens with the path
+ * class record and matched index/path pairs therefore differ in their key bytes anyway. Crossing
+ * the probe removes that second discriminator: asking the alias index a question phrased in title's
+ * path class produces byte-identical keys with different answers (1 and 0), and dropping the index
+ * number alone then fails that test and no other.
+ * </p>
+ *
+ * <p>
+ * Worth stating because the weaker arrangement is the tempting one to write: with matched pairs, a
+ * mutation of the index number OR of the path class record alone leaves everything green, and only
+ * dropping both together fails {@link #twoIndexesEachAnswerForTheirOwnPath()}. Read on its own that
+ * looks like evidence the index number is inert. It is not — it is only evidence that those
+ * particular queries never put it under load.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class HOTIndexMemoizationJsoniqTest extends AbstractJsonTest {
+
+  /**
+   * Values chosen for what they exercise, not for realism: a non-ASCII value and an emoji take the
+   * UTF-8 fallback out of the ASCII fast path; the {@code stride*} values sit at 7, 8 and 9 bytes so
+   * the word-at-a-time comparators are driven either side of their stride boundary; two entries share
+   * a value so the posting list has more than one node key.
+   */
+  private static final String DOC = "[" + "{\"title\":\"alpha\",\"n\":1}," + "{\"title\":\"alpha\",\"n\":2},"
+      + "{\"title\":\"Ünïcödé\",\"n\":3}," + "{\"title\":\"日本語\",\"n\":4}," + "{\"title\":\"emoji 🚀 here\",\"n\":5},"
+      + "{\"title\":\"stride7\",\"n\":6}," + "{\"title\":\"stride08\",\"n\":7}," + "{\"title\":\"stride009\",\"n\":8},"
+      + "{\"title\":\"zulu\",\"n\":9}]";
+
+  private static final String STORE = "jn:store('json-path1','mydoc.jn','" + DOC + "')";
+
+  private static final String CREATE_TITLE =
+      "let $doc := jn:doc('json-path1','mydoc.jn') let $idx := jn:create-cas-index($doc,'xs:string','/[]/title') "
+          + "return sdb:commit($doc)";
+
+  private static final String HEAD = "let $doc := jn:doc('json-path1','mydoc.jn') let $d := $doc ";
+
+  private static final String IDX = "jn:find-cas-index($doc,'xs:string','/[]/title')";
+
+  /** An equality scan for {@code value}. */
+  private static String eq(final String value) {
+    return "jn:scan-cas-index($doc," + IDX + ",'" + value + "','==','/[]/title')";
+  }
+
+  /**
+   * The titles the index returns for {@code value}, ordered, joined — a comparable scalar.
+   *
+   * <p>
+   * Deliberately a different expression shape from {@link #countFor(String)} even though both ask the
+   * trie the same question. The memoized answer is only exercised when a second lookup actually
+   * reaches the reader, so the two forms in a single query must not be foldable into one evaluation.
+   * </p>
+   */
+  private static String titlesFor(final String value) {
+    return "fn:string-join(for $v in " + eq(value) + " order by $v return $v,'|')";
+  }
+
+  /** How many entries the index returns for {@code value}. */
+  private static String countFor(final String value) {
+    return "fn:count(" + eq(value) + ")";
+  }
+
+  /** The same question asked of the document rather than the index. */
+  private static String plainTitlesFor(final String value) {
+    return "fn:string-join(for $o in $d[] where $o.title eq '" + value + "' order by $o.title return $o.title,'|')";
+  }
+
+  // ==================== a second document, for the multi-index cases ====================
+
+  /**
+   * {@code shared} deliberately occurs under BOTH indexed fields, with a different number of hits
+   * under each — one title, two aliases. A key that failed to separate the two paths would answer one
+   * scan with the other's postings, and only differing counts make that visible.
+   */
+  private static final String MULTI_DOC = "[" + "{\"title\":\"shared\",\"alias\":\"one\",\"n\":10},"
+      + "{\"title\":\"other\",\"alias\":\"shared\",\"n\":20}," + "{\"title\":\"third\",\"alias\":\"shared\",\"n\":20}]";
+
+  private static final String MULTI_STORE = "jn:store('json-path1','mydoc.jn','" + MULTI_DOC + "')";
+
+  /** Two SEPARATE calls, so the resource carries two CAS indexes with distinct index numbers. */
+  private static final String CREATE_TITLE_AND_ALIAS =
+      "let $doc := jn:doc('json-path1','mydoc.jn') let $a := jn:create-cas-index($doc,'xs:string','/[]/title') "
+          + "let $b := jn:create-cas-index($doc,'xs:string','/[]/alias') return sdb:commit($doc)";
+
+  /** ONE index spanning both paths, so both values live in the same trie under one index number. */
+  private static final String CREATE_SPANNING = "let $doc := jn:doc('json-path1','mydoc.jn') "
+      + "let $idx := jn:create-cas-index($doc,'xs:string',('/[]/title','/[]/alias')) return sdb:commit($doc)";
+
+  private static final String CREATE_N = "let $doc := jn:doc('json-path1','mydoc.jn') "
+      + "let $idx := jn:create-cas-index($doc,'xs:integer','/[]/n') return sdb:commit($doc)";
+
+  private static final String CREATE_NAMES = "let $doc := jn:doc('json-path1','mydoc.jn') "
+      + "let $idx := jn:create-name-index($doc,('title','alias')) return sdb:commit($doc)";
+
+  private static final String MULTI_HEAD = "let $doc := jn:doc('json-path1','mydoc.jn') ";
+
+  /** An equality scan of the CAS index over {@code path} for a string {@code value}. */
+  private static String eqOn(final String path, final String value) {
+    return "jn:scan-cas-index($doc,jn:find-cas-index($doc,'xs:string','" + path + "'),'" + value + "','==','" + path
+        + "')";
+  }
+
+  /**
+   * An equality scan that probes the index built over {@code indexPath} using {@code probePath} to
+   * form the key — deliberately crossed.
+   *
+   * <p>
+   * The index number and the path are independent arguments to {@code jn:scan-cas-index}, so a scan
+   * can ask one index a question phrased in another index's path class. The probe key is then
+   * byte-for-byte what the other index would have been asked, which is the only arrangement in which
+   * the index number of the memoization key is the sole thing telling the two lookups apart.
+   * </p>
+   */
+  private static String eqCrossed(final String indexPath, final String probePath, final String value) {
+    return "jn:scan-cas-index($doc,jn:find-cas-index($doc,'xs:string','" + indexPath + "'),'" + value + "','==','"
+        + probePath + "')";
+  }
+
+  // ==================== the feature is actually switched on ====================
+
+  @Test
+  @DisplayName("a scan actually populates the memoization cache")
+  void aScanPopulatesTheCache() throws IOException {
+    // The one test here that fails if memoization is DEAD rather than wrong. Every other assertion in
+    // this class compares query results, and a query is answered identically whether the cache served
+    // it or the trie did — so wiring lookupCache to null (an inverted isEnabled(), an
+    // EmptyBufferManager, hasTrxIntentLog() flipping for read-only readers) would leave the whole
+    // class green while the feature does nothing. That also silently voids the mutation evidence in
+    // the class javadoc, since a bypassed cache makes every key-corrupting mutation inert.
+    query(STORE);
+    query(CREATE_TITLE);
+    query(HEAD + "return " + countFor("alpha"));
+
+    final BufferManager bufferManager = Databases.peekGlobalBufferManager();
+    assertNotNull(bufferManager, "no global buffer manager after a query — the wiring changed");
+    final HOTLookupCache cache = bufferManager.getHOTLookupCache();
+    assertNotNull(cache, "the buffer manager exposes no lookup cache");
+    // Skipped rather than failed when the operator disabled the cache: sirix.hotLookupCache.maxEntries
+    // = 0 is a documented setting the benchmark instructions actively use, and a disabled cache is not
+    // a broken one.
+    if (cache.isEnabled()) {
+      assertTrue(cache.size() > 0, "a point lookup did not memoize anything — the cache is bypassed");
+    }
+  }
+
+  // ==================== memoization seen through queries ====================
+
+  @Test
+  @DisplayName("asking the index the same question twice gives the same answer")
+  void repeatedLookupIsStable() throws IOException {
+    // The second lookup is answered from the memoization cache rather than the trie, so this is the
+    // one query shape that compares the cached path against the computed one. A cache that returned
+    // a stale or foreign posting list passes every unit test and fails here.
+    //
+    // Both readings are pinned to literals rather than to each other: "the same wrong answer twice"
+    // would satisfy an equality between the two readings, and that is precisely the failure a
+    // memoization bug produces.
+    test(STORE, CREATE_TITLE, HEAD + "let $n := " + countFor("alpha") + " let $t := " + titlesFor("alpha")
+        + " return $n eq 2 and $t eq 'alpha|alpha'", "true");
+  }
+
+  @Test
+  @DisplayName("a memoized answer still agrees with the document")
+  void repeatedLookupAgreesWithTheDocument() throws IOException {
+    // The second reading is checked against the document itself, so this fails both when the cache
+    // returns the wrong list and when index and document have drifted apart for any other reason.
+    test(STORE, CREATE_TITLE, HEAD + "let $n := " + countFor("alpha") + " let $second := " + titlesFor("alpha")
+        + " return $n eq 2 and $second eq " + plainTitlesFor("alpha") + " and $second eq 'alpha|alpha'", "true");
+  }
+
+  @Test
+  @DisplayName("two different values do not share a memoized answer")
+  void distinctValuesDoNotShareAnAnswer() throws IOException {
+    // The cache is indexed by a hash of the serialized key; a set collision that skipped the
+    // per-entry key comparison would surface exactly here, as one value answering for another.
+    test(STORE, CREATE_TITLE,
+        HEAD + "return " + titlesFor("alpha") + " eq 'alpha|alpha' and " + titlesFor("zulu") + " eq 'zulu'", "true");
+  }
+
+  @Test
+  @DisplayName("a value that is absent stays absent when asked twice")
+  void absentValueIsStableAndEmpty() throws IOException {
+    // Absent keys are memoized too, under a zero-length sentinel that has to decode back to "no
+    // matches" rather than to an empty-but-present posting list.
+    // The trailing present-value check is a positive control: an index that answered nothing for
+    // everything would satisfy the two zero counts on its own.
+    test(STORE, CREATE_TITLE, HEAD + "let $a := " + countFor("nosuchvalue") + " let $b := " + titlesFor("nosuchvalue")
+        + " return $a eq 0 and $b eq '' and " + countFor("alpha") + " eq 2", "true");
+  }
+
+  @Test
+  @DisplayName("an absent lookup does not poison a neighbouring present one")
+  void absentLookupDoesNotDisturbAPresentOne() throws IOException {
+    test(STORE, CREATE_TITLE, HEAD + "let $missing := fn:count(" + eq("alphaX") + ") return $missing eq 0 and "
+        + titlesFor("alpha") + " eq 'alpha|alpha'", "true");
+  }
+
+  // ==================== the answer must follow the revision ====================
+
+  @Test
+  @DisplayName("a value inserted after the index was built is found, not answered from the old revision")
+  void insertAfterIndexCreationIsVisible() throws IOException {
+    // The memoization key carries the revision number. If it did not, the pre-insert answer for
+    // 'alpha' would still be served after the commit that adds a third one — which is why the read
+    // below the update is deliberately preceded by one above it.
+    query(STORE);
+    query(CREATE_TITLE);
+    query(HEAD + "return fn:count(" + eq("alpha") + ")"); // warms revision N
+    query("let $doc := jn:doc('json-path1','mydoc.jn') return insert json {\"title\":\"alpha\",\"n\":99} into $doc");
+    test(HEAD + "return fn:count(" + eq("alpha") + ")", "3");
+  }
+
+  @Test
+  @DisplayName("a value deleted after the index was built disappears from the index")
+  void deleteAfterIndexCreationIsVisible() throws IOException {
+    // Unlike its insert and replace siblings this one does NOT discriminate a stale answer, and the
+    // reason is worth writing down: a posting list is node keys, and the scan materializes each one
+    // against the current revision. A stale list names a node that the delete removed, materialization
+    // drops it, and the count collapses to the correct value anyway — the staleness is masked no
+    // matter how the assertion is phrased. Verified by mutation: with the revision dropped from the
+    // memoization key, insertAfterIndexCreationIsVisible and replaceMovesTheValueBetweenKeys both
+    // fail and this one still passes. It stays because "the index follows deletions end to end" is
+    // worth pinning on its own; it just is not the revision-discrimination test.
+    query(STORE);
+    query(CREATE_TITLE);
+    query(HEAD + "return fn:count(" + eq("alpha") + ")");
+    query("delete json jn:doc('json-path1','mydoc.jn')[0]");
+    test(HEAD + "return fn:count(" + eq("alpha") + ")", "1");
+  }
+
+  @Test
+  @DisplayName("a replaced value moves from its old key to its new one across revisions")
+  void replaceMovesTheValueBetweenKeys() throws IOException {
+    // Both keys are read BEFORE the update, so both are memoized for the old revision; the
+    // assertions afterwards are what a revision-blind cache would get wrong in both directions.
+    query(STORE);
+    query(CREATE_TITLE);
+    query(HEAD + "return fn:count(" + eq("zulu") + ")");
+    query(HEAD + "return fn:count(" + eq("alpha") + ")");
+    query("replace json value of jn:doc('json-path1','mydoc.jn')[0].title with \"zulu\"");
+    test(HEAD + "return fn:count(" + eq("zulu") + ") eq 2 and fn:count(" + eq("alpha") + ") eq 1", "true");
+  }
+
+  // ==================== key encoding through the query stack ====================
+
+  @Test
+  @DisplayName("a non-ASCII value round-trips through the index")
+  void nonAsciiValueIsFound() throws IOException {
+    // Takes the UTF-8 fallback rather than the ASCII fast path: every char above 0x7F must make the
+    // serializer abandon the byte-per-char write, or the stored bytes and the probe bytes diverge.
+    //
+    // Pinned to the literal as well as to the document: a serializer that mangled the value would
+    // make BOTH sides of a pure index-vs-document comparison empty, and the test would pass blind.
+    test(STORE, CREATE_TITLE, HEAD + "return " + titlesFor("Ünïcödé") + " eq 'Ünïcödé' and " + titlesFor("Ünïcödé")
+        + " eq " + plainTitlesFor("Ünïcödé"), "true");
+  }
+
+  @Test
+  @DisplayName("a multi-byte CJK value round-trips through the index")
+  void cjkValueIsFound() throws IOException {
+    test(STORE, CREATE_TITLE,
+        HEAD + "return " + titlesFor("日本語") + " eq '日本語' and " + titlesFor("日本語") + " eq " + plainTitlesFor("日本語"),
+        "true");
+  }
+
+  @Test
+  @DisplayName("a value containing a surrogate pair round-trips through the index")
+  void surrogatePairValueIsFound() throws IOException {
+    // An emoji is two chars and four UTF-8 bytes, so it also proves the truncation cap counts BYTES
+    // consistently on both the stored and the probe side.
+    test(STORE, CREATE_TITLE, HEAD + "return " + titlesFor("emoji 🚀 here") + " eq 'emoji 🚀 here' and "
+        + titlesFor("emoji 🚀 here") + " eq " + plainTitlesFor("emoji 🚀 here"), "true");
+  }
+
+  @Test
+  @DisplayName("values either side of the eight-byte comparison stride are distinguished")
+  void valuesAcrossTheWordStrideAreDistinguished() throws IOException {
+    // The in-leaf comparators consume keys eight bytes at a time with a byte tail. Values of 7, 8
+    // and 9 bytes land before, on and after that boundary, which is where an off-by-one in the tail
+    // shows up as one value matching another.
+    test(STORE, CREATE_TITLE, HEAD + "return " + titlesFor("stride7") + " eq 'stride7' and " + titlesFor("stride08")
+        + " eq 'stride08' and " + titlesFor("stride009") + " eq 'stride009'", "true");
+  }
+
+  @Test
+  @DisplayName("a prefix of a stored value does not match that value")
+  void aPrefixDoesNotMatchTheLongerValue() throws IOException {
+    // 'stride' prefixes three stored values. Equality must not be satisfied by a prefix compare that
+    // forgot its length tie-break. The second clause is the positive control that keeps the zero
+    // honest.
+    test(STORE, CREATE_TITLE, HEAD + "return " + countFor("stride") + " eq 0 and " + countFor("stride7") + " eq 1",
+        "true");
+  }
+
+  // ==================== more than one index over the same resource ====================
+
+  @Test
+  @DisplayName("one value under two paths of a single index keeps two separate answers")
+  void oneIndexTwoPathsAreNotConflated() throws IOException {
+    // ONE index, one trie, one index number, and the value 'shared' reachable under two paths. The
+    // only thing separating the two probes is the path class record in the first eight bytes of the
+    // key, so a key that lost it would answer the second scan with the first's postings — 1 where 2
+    // is right. Verified by mutation: dropping those bytes from the memoization key fails this test.
+    //
+    // This test is also what found the multi-path full-scan bug. Until CASIndex#openHOTIndexWithFilter
+    // stopped gating on how many path classes the INDEX spans, a spanning index never reached the
+    // point lookup at all, and this stayed green under every corruption of the memoization key
+    // because it was being served by the full scan instead.
+    test(MULTI_STORE, CREATE_SPANNING, MULTI_HEAD + "let $t := fn:count(" + eqOn("/[]/title", "shared")
+        + ") let $a := fn:count(" + eqOn("/[]/alias", "shared") + ") return $t eq 1 and $a eq 2", "true");
+  }
+
+  @Test
+  @DisplayName("two indexes over one resource each answer for their own path")
+  void twoIndexesEachAnswerForTheirOwnPath() throws IOException {
+    // Two single-path indexes, so both scans DO take the memoized point-lookup branch, and the same
+    // value 'shared' resolves to a different count under each. Note this is the WEAK arrangement:
+    // matched index/path pairs already differ in their key bytes, so it takes the loss of both the
+    // index number and the path class record to fail this. The crossed probe above is what puts the
+    // index number under load on its own.
+    test(MULTI_STORE, CREATE_TITLE_AND_ALIAS, MULTI_HEAD + "let $t := fn:count(" + eqOn("/[]/title", "shared")
+        + ") let $a := fn:count(" + eqOn("/[]/alias", "shared") + ") return $t eq 1 and $a eq 2", "true");
+  }
+
+  @Test
+  @DisplayName("an index asked in another index's path class does not answer for it")
+  void aCrossedProbeDoesNotBorrowTheOtherIndexsAnswer() throws IOException {
+    // The one arrangement that isolates the index number. Both scans probe the SAME key bytes —
+    // title's path class record, the type id, then 'shared' — because the second one deliberately
+    // asks the alias index a title-shaped question. The alias index holds nothing under title's path
+    // class, so the honest answers are 1 and 0; the key bytes cannot tell those two lookups apart,
+    // and neither can the path class record inside them. Only the index number can.
+    //
+    // Order matters here in a way it does not elsewhere: the absent answer is memoized under a
+    // sentinel, so running the crossed probe FIRST is what makes a shared key poison the real
+    // lookup rather than merely duplicate it.
+    test(MULTI_STORE, CREATE_TITLE_AND_ALIAS,
+        MULTI_HEAD + "let $crossed := fn:count(" + eqCrossed("/[]/alias", "/[]/title", "shared")
+            + ") let $honest := fn:count(" + eqOn("/[]/title", "shared") + ") return $crossed eq 0 and $honest eq 1",
+        "true");
+  }
+
+  @Test
+  @DisplayName("the same holds when the second index is read first")
+  void twoIndexesEachAnswerForTheirOwnPathReversed() throws IOException {
+    // The mirror image: whichever scan runs first is the one that populates the cache, so both
+    // orders are pinned rather than just the one that happened to be written first.
+    test(MULTI_STORE, CREATE_TITLE_AND_ALIAS, MULTI_HEAD + "let $a := fn:count(" + eqOn("/[]/alias", "shared")
+        + ") let $t := fn:count(" + eqOn("/[]/title", "shared") + ") return $a eq 2 and $t eq 1", "true");
+  }
+
+  @Test
+  @DisplayName("a name-index lookup is memoized without changing its answer")
+  void nameIndexLookupIsStable() throws IOException {
+    // The name index reaches the trie through the same reader base class, so it shares the
+    // memoization path with the CAS index while serializing an entirely different kind of key.
+    // Nothing else in this class exercises that reader.
+    test(MULTI_STORE, CREATE_NAMES, MULTI_HEAD
+        + "let $n := fn:count(jn:scan-name-index($doc,jn:find-name-index($doc,'title'),'title')) "
+        + "let $m := fn:count(for $x in jn:scan-name-index($doc,jn:find-name-index($doc,'title'),'title') return $x) "
+        + "return $n eq 3 and $m eq 3", "true");
+  }
+
+  @Test
+  @DisplayName("an integer-typed CAS lookup is memoized without changing its answer")
+  void integerCasLookupIsStable() throws IOException {
+    // A numeric CAS index serializes its keys through a different path from the string one, and a
+    // memoized answer has to survive that too. 20 occurs twice and 10 once, so a shared answer
+    // between the two probes would show up as a wrong count rather than as no result at all.
+    test(MULTI_STORE, CREATE_N,
+        MULTI_HEAD + "let $idx := jn:find-cas-index($doc,'xs:integer','/[]/n') "
+            + "let $a := fn:count(jn:scan-cas-index($doc,$idx,20,'==','/[]/n')) "
+            + "let $b := fn:count(for $x in jn:scan-cas-index($doc,$idx,20,'==','/[]/n') return $x) "
+            + "let $c := fn:count(jn:scan-cas-index($doc,$idx,10,'==','/[]/n')) "
+            + "return $a eq 2 and $b eq 2 and $c eq 1",
+        "true");
+  }
+
+  @Test
+  @DisplayName("a repeated lookup of a non-ASCII value is also stable")
+  void repeatedNonAsciiLookupIsStable() throws IOException {
+    // The memoization key is the SERIALIZED key, so a value whose encoding takes the fallback is
+    // also the one most likely to hash or compare differently between the probe and the stored copy.
+    test(STORE, CREATE_TITLE,
+        HEAD + "let $n := " + countFor("日本語") + " let $t := " + titlesFor("日本語") + " return $n eq 1 and $t eq '日本語'",
+        "true");
+  }
+}

--- a/docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md
+++ b/docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md
@@ -1,5 +1,47 @@
 # HOT rebuild-fallback elimination — design plan
 
+## Status snapshot (2026-08-12, Stage 5 — the spine propagation was the mass producer)
+
+Attribution instrumentation (a per-`(invariant | handler)` tally at the `detectAndHeal`
+discharge) on a 36K-insert CAS listener shred (movies corpus, `/[]/title`, variable-length
+string keys) overturned the working model of where malformations come from. The workload
+fired 1,354 detector heals + 1,622 strand discharges + 718 scoped rebuilds — three orders
+of magnitude above the rates §8.4a of `HOT_PAPER_IMPOSSIBILITY.md` reports for the
+fixed-width microbenches — and 91% of every heal attributed to ONE line:
+
+- **`propagateRebuildUpSpine` recomputed a slot's stored partial as
+  `densePK(new firstKey)`.** A stored partial is Binna's *sparse-path encoding* — the
+  slot's position in the block trie, with off-path bits zero by convention
+  (`HOT_FORMAL_FOUNDATION.md` §1). `densePK` stamps the first key's values at off-path
+  mask bits into it, so every subtree key differing from the first key at an off-path bit
+  fails I5's subset condition (1,151 heals), and a non-zero recompute at slot 0 breaks I4
+  (80 heals). The recompute also fired when the first key had NOT changed (any off-path
+  1-bit in it made `densePK ≠` the sparse encoding), so nearly every
+  `leafScopedRebuild` / `rebuildSubtree` splice corrupted its parent. **Fix: a stored
+  partial is a position, never a content fingerprint — the propagation keeps it verbatim.**
+  What a content change CAN break is sibling *order* (the Direction-1 shape): checked as an
+  edge-descent boundary comparison, discharging via the existing scoped rebuild.
+- **The tier-1 strand discharge (`leafScopedRebuild`) was self-seeding.** Splicing
+  `leaf ∪ {K}` into the leaf's slot routes correctly but leaves a leaf spanning a bit above
+  its cut point — a shape the strand guard re-fires on for every later key branching at
+  that bit. The discharge now splits the union at its own key-set MSDB and integrates the
+  BiNode at the leaf's depth (`strandDischargeSplitIntegrate` — the merge path's own
+  primitives, i.e. Binna's actual insert), leaving no straddled leaf behind. Strand
+  firings: 1,622 → 166, all discharged canonically (`STRAND_SPLIT_INTEGRATE`); the splice
+  fallback did not fire once.
+
+Net effect on the movies CAS shred: detector heals 1,354 → 19, scoped rebuilds 718 → 26,
+wall clock 16.2–17.1 s → **3.3–3.5 s** (~4.9×; idle-machine `git stash` A/B on identical
+conditions — the propagation's order-boundary fallback fired **0** times, so the check is
+pure insurance on this workload). The bulk-build path is untouched: 2.97 s → 2.77 s, zero
+heals/rebuilds in both, as Binna's bottom-up construction promises. The residual 19 heals
+per 36K inserts are deterministic across runs and attribute to `h:pair-leaf` (9 I8 + 4
+I12), `h:combo-site1` (4 I12), `h:combo-site2-fold` (1 I12) and `h:merge-integrate`
+(1 I8) — I8/I12 boundary shapes out of the integrate cascade and combo folds, the Class-1
+territory of `HOT_PAPER_IMPOSSIBILITY.md` §8.4, detected and discharged by the bounded
+rebuild as designed. The impossibility analysis stands for *repairing* a firing
+configuration; what this stage removed was a producer that *manufactured* them.
+
 ## Status snapshot (2026-05-20, post Stages 3c + 3b LANDED `d61a92e6f`)
 
 - **Stage 3c (A) — in-spine propagation LANDED.** `rebuildSubtree`'s height-escalation

--- a/docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md
+++ b/docs/HOT_REBUILD_FALLBACK_ELIMINATION_PLAN.md
@@ -1,5 +1,42 @@
 # HOT rebuild-fallback elimination — design plan
 
+## Status snapshot (2026-08-12, Stage 6 — zero detector heals on the shred workload)
+
+Per-firing dumps (`-Dhot.diag.healDump=true`, threaded the inserted key K into
+`detectAndHeal`) classified all 19 residual Stage-5 heals; none were Class-1 after all —
+each was a producer whose *predicate* was too weak, and both predicates are now fixed:
+
+- **13 × `h:pair-leaf` — the clean-pairing predicate was wrong.** The pairing put the
+  whole descended leaf beside K under a BiNode on `beta` whenever the leaf was
+  bit-constant at `beta` on the opposite side. Necessary, not sufficient: Binna's BiNode
+  pairing is the R(S) recursion step only when `beta` is the MSDB of the union
+  `leaf ∪ {K}`. A multi-value leaf buckets keys across bits the trie never discriminated,
+  so its internal spread can cross a bit MORE significant than `beta` (which is computed
+  against the leaf's *discriminated prefix*, not its content) — bit-constancy at `beta`
+  still holds, yet the union's true MSDB lies inside the leaf and K lands lex-inside the
+  leaf's range (every dump: K beside a leaf whose `[first..last]` covers it, e.g.
+  `"Youth's Endearing Charm"` paired after a leaf spanning up to `"Zaza"`). **Fix: the
+  canonical-cut guard — pair only when `msdb(min(union), max(union)) == beta`; otherwise
+  discharge via `strandDischargeSplitIntegrate`, which cuts the union at its own MSDB —
+  the same R(S) cut, taken at the right bit.**
+- **5 × combo folds (`h:combo-site1`, `h:combo-site2-fold`) — the pre-commit guard
+  checked I8, not I12.** Every dump was an I12 interleave with first-key order intact: the
+  fresh combo child for K started *below the preceding sibling's subtree maximum* (e.g.
+  `"Fruits of Desire"` slotted after a subtree spanning up to `"Fun on Board a Fishing
+  Smack"`). **Fix: `nodeStructurallyMalformed` (the shared guard behind all five combo/fold
+  sites and the path probe) now also tracks the preceding sibling's subtree last-key and
+  flags range interleaves — the same merged I8+I12 loop the detector runs.**
+- **1 × `h:merge-integrate` — disappeared with the other 18.** It was seeded by an earlier
+  manufactured malformation, not an independent producer.
+
+Movies CAS listener shred, 36K inserts: **detector heals 19 → 0**, scoped rebuilds
+26 → 25, strand discharges 166 → 136 (the healed-over malformations had been seeding
+downstream strand firings), wall clock ~3.1–3.3 s (slightly better than Stage 5 — the
+guards cost less than the repairs they replace). Bulk build unchanged: 2.77 s, zero
+heals/rebuilds. The detector + heal machinery stays in as the safety net for workloads
+that still reach an unguarded shape, but on this workload every committed page is now
+well-formed on first write — no post-hoc repair at all.
+
 ## Status snapshot (2026-08-12, Stage 5 — the spine propagation was the mass producer)
 
 Attribution instrumentation (a per-`(invariant | handler)` tally at the `detectAndHeal`
@@ -37,10 +74,12 @@ pure insurance on this workload). The bulk-build path is untouched: 2.97 s → 2
 heals/rebuilds in both, as Binna's bottom-up construction promises. The residual 19 heals
 per 36K inserts are deterministic across runs and attribute to `h:pair-leaf` (9 I8 + 4
 I12), `h:combo-site1` (4 I12), `h:combo-site2-fold` (1 I12) and `h:merge-integrate`
-(1 I8) — I8/I12 boundary shapes out of the integrate cascade and combo folds, the Class-1
-territory of `HOT_PAPER_IMPOSSIBILITY.md` §8.4, detected and discharged by the bounded
-rebuild as designed. The impossibility analysis stands for *repairing* a firing
-configuration; what this stage removed was a producer that *manufactured* them.
+(1 I8) — I8/I12 boundary shapes out of the integrate cascade and combo folds, at the time
+presumed Class-1 territory of `HOT_PAPER_IMPOSSIBILITY.md` §8.4 and discharged by the
+bounded rebuild as designed. (Superseded by Stage 6: per-firing dumps showed none of the
+19 were genuinely Class-1 — all were weak-predicate producers, since fixed.) The
+impossibility analysis stands for *repairing* a firing configuration; what this stage
+removed was a producer that *manufactured* them.
 
 ## Status snapshot (2026-05-20, post Stages 3c + 3b LANDED `d61a92e6f`)
 

--- a/docs/RECORD_PATH_DEPINNING.md
+++ b/docs/RECORD_PATH_DEPINNING.md
@@ -7,6 +7,11 @@ where readers never write to shared state.
 This document exists so the work can be resumed cold. It records what was measured, which designs
 are dead and why, and what is left in the order it has to happen.
 
+**Status: the reader-side protocol is finished and correct on both page types; the cursor rewrite it
+was built for is measured as a LOSS and is not being done.** Read *The verdict* before starting on
+the remaining list — the list is kept because the reasoning behind each step is still worth having,
+not because the steps are queued.
+
 ## Why: measured, not argued
 
 `CursorGuardCostBenchmark` (commit `d725d97`), on a 4-core box:
@@ -28,6 +33,58 @@ entire thesis of the protocol, and it is now measured rather than asserted.
 The 190× gap is at four cores and widens with the number of cores that must invalidate the line.
 Thread count is deliberately matched to core count: oversubscribing measures the scheduler, not the
 protocol.
+
+## The verdict: the primitive wins, the cursor does not
+
+The table above prices the two primitives against each other and the stamp wins on both axes. It
+does **not** price the swap, because the two are not paid at the same rate, and that is what decides
+it:
+
+- **The guard is paid per PAGE SWITCH.** `moveToSingleton` has a within-page fast path that skips
+  guard management entirely, and a record page holds 1024 records.
+- **The stamp would be paid per VALIDATED READ.** A stamp proves nothing until it is validated and
+  the value it protects must not escape before then, so every accessor reading through page memory —
+  the four structural keys, the value, the name — needs its own validate.
+
+The same benchmark's end-to-end stages, from the run recorded in its javadoc:
+
+```
+withinPageWalk        25.9 ± 1.6  ns/hop   the bind floor, zero guard traffic
+pageSwitchWalk       247.9 ± 31.5 ns/hop   + guard pair + page re-resolution, EVERY hop
+```
+
+A walk with any locality pays the guard once per ~1024 hops — **0.03 ns/hop** amortized uncontended,
+**0.9 ns/hop** at the contended 907 ns — and would pay a validate on every accessor of every node,
+which at three to six accessors is **13–26 ns/hop added** onto a 25.9 ns/hop floor. That is a 50–100 %
+slowdown of the dominant case to recover under a nanosecond. Even in the shape most favourable to
+de-pinning — `pageSwitchWalk`, a page switch on *every single hop* — a node touching four structural
+keys and a value pays ~22 ns to save 31.6, netting under 4 % of the hop.
+
+Batching to one validate per `moveTo` does not rescue it, because it is not sound: the accessors read
+*after* the validate. The only way to make one validate cover them is to copy the record out at bind
+time, which is the design rejected below, and pricing it does not save the trade either — a ~48-byte
+header copy plus one validate is, on an unmeasured but generous estimate, still ~6 ns added per hop
+against ~0.9 ns removed.
+
+**So the protocol is right where locality is absent and wrong where it is high.** `HOTTrieReader` is
+the former: a descent resolves a *different* leaf at every level, and one validation covers a whole
+positioning decision. A record cursor is the latter, by construction — 1024 records to a page is the
+locality the page size exists to create.
+
+What the numbers indict is the guard's **implementation**, not its existence. 31 ns for an
+UNCONTENDED acquire/release pair is enormous for what it does: `tryAcquireGuard` is a `synchronized`
+method delegating to `acquireGuard`, itself `synchronized`, around a volatile read and an
+`AtomicInteger`; `releaseGuard` is a third monitor entry plus an atomic decrement plus another
+volatile read. `KeyValueLeafPage` has nine further `synchronized (this)` regions on that same
+monitor, so contention on any of them inflates the lock that every `tryAcquireGuard` then pays for —
+which is the shape of both the 31 ns and the 907 ns. Folding the guard count into the existing
+packed state word (`stateFlags` uses three bits of an `int`; a `long` carries the count in the high
+half) makes acquire and release a single CAS with no monitor, recovers most of that on this path AND
+on `NodeStorageEngineReader.getRecordPage`, which pays the same pair per page resolution, and **also
+closes a TOCTOU the monitor is currently papering over**: `close()` reads the flags, then reads the
+count, then CASes the closed bit, and only the monitor keeps an `acquireGuard` out of that gap. That
+is the change the measurements actually point at, and it keeps pinning rather than putting a retry
+loop under every accessor.
 
 ## The design, and the two options that are dead
 
@@ -72,20 +129,77 @@ deserialize branch and the header reads saves nothing, because the pin is taken 
   if (!page.validateStamp(binding, stamp)) retry;
   ```
 
-  `stampBindingGeneration` is monotonic, bumped in `publishSlottedPage` (last, after the coordinate
-  resets) and in `setStampBaseSegment`, and checked **first** — ahead of both stamp kinds, so a page
-  swapping between unbacked and frame-backed is covered like any other rebind.
+  `stampBindingGeneration` is bumped by `publishSlottedPage` and `setStampBaseSegment`, and checked
+  **first** — ahead of both stamp kinds, so a page swapping between unbacked and frame-backed is
+  covered like any other rebind.
 - **`d725d97`** — the benchmark above.
+- **The publication is a seqlock, not an invariant** (both page types). The generation is driven
+  ODD before the segment moves and EVEN once it and the coordinates agree again, with a
+  `storeStore` fence pinning the odd marker ahead of the segment store and an `acquireFence` in
+  `validateStamp` keeping the reader's loads from sinking below its check. A single trailing
+  increment is not equivalent and the difference is the whole proof: with no marker published
+  *before* the segment store, a reader whose data load already returned the new bytes can still
+  observe the old generation at validation time and certify bytes the publisher was mid-way through
+  writing. With the odd marker fenced ahead of it, a data load that returned the new bytes proves
+  the odd store was globally visible first, and coherence then forces the reader's validation load
+  to see at least that value. `validateStamp` rejects an odd binding outright.
+- **The coordinates are bound by the PUBLISHER, never by a reader** (both page types). Lazy binding
+  on first `readStamp()` is one map probe cheaper for a page nobody ever stamps, but it puts a STORE
+  on the reader side, and a reader's store cannot be ordered against a concurrent publisher's: a
+  reader that computed coordinates from the old segment can land them *after* the publisher has
+  reset them, leaving the OLD slot's coordinates describing the NEW segment — after which every
+  later reader validates its reads against a counter belonging to memory it is not reading. Binding
+  inside the rebind window costs one `ConcurrentHashMap` probe per segment swap — allocate, grow and
+  bulk-copy, each of which already does one on the allocator's own map, and none of which is on a
+  read path — and takes a branch and a store off the read path.
+- **The old segment is released AFTER the new one is published, not before.** `growSlottedPage`,
+  `copySlottedPageFrom` and `setSlottedPage` all released first, leaving a window in which the page
+  still pointed at — and still bound its stamp coordinates to — a slot the allocator had already
+  taken back and could hand to another page, while a reader's stamp over it still validated. Only
+  `close` was covered, and only because it publishes `CLOSED_BIT` before releasing, which makes
+  `readStamp` answer `STAMP_INVALID`; it keeps that order for the same reason. The reorder costs one
+  extra live slot for the duration of a copy and leaves the page holding its previous segment rather
+  than nothing if the allocation throws. `copySlottedPageFrom` also loses an intermediate
+  `publishSlottedPage(null)` that was a second rebind for no reader's benefit, and `setSlottedPage`
+  now decides whether to release by ADDRESS rather than by identity — a stored segment has been
+  through `reinterpret`, which returns a fresh object over the same memory, so an identity test
+  answers "different" for a caller re-publishing the very segment the page already holds.
+- **`HOTLeafPage` carries the binding too, and `HOTTrieReader` carries it through.** This was the
+  live one: `validateStamp(long)` took no binding, and it is shipped code behind every HOT index
+  read. `HOTTrieReader.loadPage` now snapshots `readStampBinding()` immediately before `readStamp()`,
+  stores both, retries when either is odd, and hands both to `validateStamp`. Every other consumer
+  (`HOTRangeCursor`, `AbstractHOTIndexReader`, `ProjectionIndexHOTStorage`,
+  `NodeReferencesSerializer`) validates through `validateCurrentLeaf()` and needed no change. Every
+  `slotMemory` assignment now routes through `publishSlotMemory`, the way `slottedPage` routes
+  through `publishSlottedPage`.
 
-### An honest limit on the test
+### The test limit, and the case that closed it
 
-Deleting the generation check **fails nothing** in `KeyValueLeafPageStampTest`. Straight after a
-swap the coordinates are `UNBOUND` and `validateStamp` already rejects on that alone; after a
-re-bind, the old stamp fails only because the two slots' versions happen to differ. The check
-converts a coincidence into a guarantee, and no deterministic assertion can pin it. Do not read the
-green run as proof of the check — the reasoning is recorded beside the assertions in the test.
+The previous pass recorded that deleting the generation check **failed nothing**, because after a
+swap the coordinates were `UNBOUND` and `validateStamp` rejected on that alone, and after a re-bind
+the old stamp failed only because two slots' versions happened to differ. That gap is now closed by
+the **unbacked ↔ frame-backed swap**, which needs no coincidence:
 
-## Remaining, in order
+`setStampBaseSegment` pointed at a mid-buffer slice — exactly what a zero-copy deserializer produces
+— resolves to no allocator slot, so `readStamp` answers with the UNBACKED sentinel, whose validation
+rule is "is the page still open?". Correct the base afterwards and the page IS frame-backed again.
+Without the generation check that outstanding UNBACKED stamp validates on the strength of the page
+merely still being open, certifying reads taken while the page could not detect a torn one at all.
+`KeyValueLeafPageStampTest.swappingBetweenUnbackedAndBackedInvalidatesAnOutstandingStamp` and
+`HOTLeafPageStampTest.settingTheStampBaseInvalidatesAnOutstandingStamp` both fail deterministically
+when the check is removed — verified by mutation, not by assumption.
+
+What still has **no** deterministic test is the odd-generation rejection inside `validateStamp`: a
+single thread cannot schedule itself inside a publication window, and there is no interposition hook
+on the publisher. `aPublishedBindingIsEven` pins the half that is observable — every binding a reader
+can see outside the window is even, so a publication that bumped by one instead of two fails — and
+the rejection itself rests on the argument above rather than on an assertion. Do not read the green
+run as proof of it.
+
+## Remaining, in order — NOT queued; see *The verdict*
+
+Kept because each step's reasoning outlives the decision, and because a future workload with no
+record-page locality would revive the question.
 
 - **(a)** Guard-free page resolve on `NodeStorageEngineReader`: a `getRecordPage` variant that does
   not touch `currentPageGuard`.
@@ -93,7 +207,8 @@ green run as proof of the check — the reasoning is recorded beside the asserti
   `validateCurrentNode()`.
 - **(c)** Convert the accessors to snapshot → read → validate → retry. The model is
   `HOTTrieReader.containsKey`: swallow `RuntimeException` unless the stamp validates, because a torn
-  read can fabricate offsets and lengths, and bound the retries (`MAX_STAMP_RETRIES = 64`).
+  read can fabricate offsets and lengths, and bound the retries (`MAX_STAMP_RETRIES = 64`). **This is
+  the step the measurement rejects** — it is where the per-read cost enters.
 - **(d)** Retry path is the existing `moveToSingletonSlowPath` rebind.
 - **(e)** **The two escape routes — both must be closed before the guard can go, and this is where
   scope grows.** `getRecordFromSlottedPage`'s non-singleton branch binds a flyweight directly to page
@@ -102,20 +217,20 @@ green run as proof of the check — the reasoning is recorded beside the asserti
   close it. Each needs a copy-out projection or its own validation.
 - **(f)** Delete `currentPageGuard` / `closeCurrentPageGuard`. This also dissolves the
   `CASIndex.exactMatches` writer-backed carve-out, which exists only because an index scan inside an
-  updating transaction cannot borrow the caller's reader while guards are in play.
+  updating transaction cannot borrow the caller's reader while guards are in play. That carve-out is
+  the one benefit of (a)–(f) the measurement does not weigh against; it is a correctness/coverage
+  wart, not a throughput one, and it can also be fixed by giving `exactMatches` its own reader on the
+  writer-backed path rather than declining to filter.
 - **(g)** Re-run `CursorGuardCostBenchmark`'s `withinPageWalk` / `pageSwitchWalk` — the end-to-end
-  cursor, not the primitive. A 190× gap on the primitive does not imply the same on a real `moveTo`,
-  and this is the check that says whether the win survives where it counts.
+  cursor, not the primitive. **Answered ahead of the rewrite, in *The verdict*, from the stages the
+  benchmark already measures.** A 190× gap on the primitive does not imply the same on a real
+  `moveTo`, and it does not: the two are paid at rates that differ by three orders of magnitude.
 
-## Also outstanding
+## Next, if this is picked up again
 
-`HOTLeafPage` carries the **same latent hole**: its `validateStamp(long)` takes no binding, and its
-`slotMemory` is likewise non-volatile. It is live behind `HOTTrieReader`, so it is shipped code and
-wants its own pass, but the fix and the reasoning are identical.
-
-Note also what currently makes `publishSlottedPage` safe: an **invariant**, not a fence. Every caller
-is a write or teardown path, and teardown publishes `CLOSED_BIT` so `readStamp` answers
-`STAMP_INVALID`. A volatile store has release semantics only — it does not stop the following plain
-store to `slottedPage` from being hoisted above it. That invariant is adequate for the current
-callers and is *not* adequate once step (b) puts a reader on this path; publishing the segment with
-release semantics is the remedy.
+Fold the guard count into the packed state word and re-run the two primitive stages. That is the
+change the numbers point at, it keeps pinning, and it needs no reader-side retry loop. Two things to
+respect while doing it: `close()` must keep its `synchronized` (it is cold, and the monitor also
+excludes the class's other `synchronized (this)` regions from running against a teardown), and the
+closed bit must be taken by a CAS that *requires* a zero guard count, which is what makes the
+lock-free acquire safe against it.

--- a/docs/RECORD_PATH_DEPINNING.md
+++ b/docs/RECORD_PATH_DEPINNING.md
@@ -1,0 +1,121 @@
+# De-pinning the record-page read path
+
+Replacing reference-counted `PageGuard` pinning on the record path with the stamp-validated
+optimistic reads that `HOTLeafPage` and `HOTTrieReader` already use — the LeanStore/Umbra protocol,
+where readers never write to shared state.
+
+This document exists so the work can be resumed cold. It records what was measured, which designs
+are dead and why, and what is left in the order it has to happen.
+
+## Why: measured, not argued
+
+`CursorGuardCostBenchmark` (commit `d725d97`), on a 4-core box:
+
+| | uncontended | 4 threads, one page |
+|---|---|---|
+| `guardAcquireRelease` | 31.0 ns | 907.4 ns |
+| `stampReadValidate` | 4.7 ns | 4.8 ns |
+
+Two results matter. Uncontended, the stamp is **6.6× faster** — a monitor plus an atomic RMW costs
+far more than an acquire-load and a compare even with nobody to contend with. This was predicted to
+be a wash; it is not.
+
+Under contention the guard degrades to **29× its own uncontended cost**, because the pair is a
+*store* to a line every reader of the page shares, so each acquire invalidates it in every other
+core. The stamp is **flat** — 4.711 → 4.772 ns, inside measurement error. That flatness is the
+entire thesis of the protocol, and it is now measured rather than asserted.
+
+The 190× gap is at four cores and widens with the number of cores that must invalidate the line.
+Thread count is deliberately matched to core count: oversubscribing measures the scheduler, not the
+protocol.
+
+## The design, and the two options that are dead
+
+`AbstractNodeReadOnlyTrx` keeps **one singleton shell per node kind** and rebinds it on every
+`moveTo` (`readSingletonBinder` / `writeSingletonBinder`). `createSingletonSnapshot()` deep-copies
+only when a caller retains a node across a move.
+
+That fact kills one option and collapses two others:
+
+- **Copying fixed-width header fields into the shell at bind time — REJECTED.** There is no
+  per-record allocation to piggyback on, so it would add a memcpy to every `moveTo`, which is
+  precisely what the singleton design exists to avoid.
+- **"Validate on access" and "retain nothing" are the same design here.** The cursor already retains
+  nothing across a move — it re-derives its binding each `moveTo`, and callers that genuinely hold a
+  node past a move already have a snapshot with no page pointer in it. So there is **no `NodeCursor`
+  API change**, and the retry machinery (`moveToSingletonSlowPath`) already exists.
+
+The window needing protection is therefore `moveTo(k)` → accessors → next `moveTo`, which is exactly
+what the guard covers today.
+
+One earlier plan stage was dropped as a **no-op**: converting the slot-population probe, the legacy
+deserialize branch and the header reads saves nothing, because the pin is taken in `getRecordPage`,
+*upstream* of all of them.
+
+## Done
+
+- **`d6fe90f`** — `KeyValueLeafPage` gains the stamp binding (`stampCoordinates`,
+  `stampBaseSegment`, `readStamp`, `validateStamp`), bound lazily to `FrameSlotAllocator` slot
+  versions, with the ABA ordering (version acquire *before* the closed check) mirrored from
+  `HOTLeafPage`. All six `slottedPage` assignments route through `publishSlottedPage`, which drops
+  the binding — a stale binding validates against a slot no longer being read.
+- **`384e64b`** — the stamp is made **self-describing**, which was the precondition for any reader
+  depending on it. A stamp is a per-slot sequence number and means nothing without its slot; two
+  slots' counters are unrelated and can hold equal values at once. One `long` cannot carry both, and
+  packing a truncated coordinate hash would leave a false validation per rebind at the hash's
+  collision rate — not a rate a database may accept. The reader carries the binding instead:
+
+  ```java
+  long binding = page.readStampBinding();
+  long stamp   = page.readStamp();
+  // ... any number of reads ...
+  if (!page.validateStamp(binding, stamp)) retry;
+  ```
+
+  `stampBindingGeneration` is monotonic, bumped in `publishSlottedPage` (last, after the coordinate
+  resets) and in `setStampBaseSegment`, and checked **first** — ahead of both stamp kinds, so a page
+  swapping between unbacked and frame-backed is covered like any other rebind.
+- **`d725d97`** — the benchmark above.
+
+### An honest limit on the test
+
+Deleting the generation check **fails nothing** in `KeyValueLeafPageStampTest`. Straight after a
+swap the coordinates are `UNBOUND` and `validateStamp` already rejects on that alone; after a
+re-bind, the old stamp fails only because the two slots' versions happen to differ. The check
+converts a coincidence into a guarantee, and no deterministic assertion can pin it. Do not read the
+green run as proof of the check — the reasoning is recorded beside the assertions in the test.
+
+## Remaining, in order
+
+- **(a)** Guard-free page resolve on `NodeStorageEngineReader`: a `getRecordPage` variant that does
+  not touch `currentPageGuard`.
+- **(b)** Hold `(page, binding, stamp)` beside `currentSingleton` at `moveTo`; add
+  `validateCurrentNode()`.
+- **(c)** Convert the accessors to snapshot → read → validate → retry. The model is
+  `HOTTrieReader.containsKey`: swallow `RuntimeException` unless the stamp validates, because a torn
+  read can fabricate offsets and lengths, and bound the retries (`MAX_STAMP_RETRIES = 64`).
+- **(d)** Retry path is the existing `moveToSingletonSlowPath` rebind.
+- **(e)** **The two escape routes — both must be closed before the guard can go, and this is where
+  scope grows.** `getRecordFromSlottedPage`'s non-singleton branch binds a flyweight directly to page
+  memory and hands it to arbitrary callers (`CASIndex.exactMatches` among them); and
+  `lookupSlotWithGuard` hands a guard to callers **by contract** — its javadoc instructs them to
+  close it. Each needs a copy-out projection or its own validation.
+- **(f)** Delete `currentPageGuard` / `closeCurrentPageGuard`. This also dissolves the
+  `CASIndex.exactMatches` writer-backed carve-out, which exists only because an index scan inside an
+  updating transaction cannot borrow the caller's reader while guards are in play.
+- **(g)** Re-run `CursorGuardCostBenchmark`'s `withinPageWalk` / `pageSwitchWalk` — the end-to-end
+  cursor, not the primitive. A 190× gap on the primitive does not imply the same on a real `moveTo`,
+  and this is the check that says whether the win survives where it counts.
+
+## Also outstanding
+
+`HOTLeafPage` carries the **same latent hole**: its `validateStamp(long)` takes no binding, and its
+`slotMemory` is likewise non-volatile. It is live behind `HOTTrieReader`, so it is shipped code and
+wants its own pass, but the fix and the reasoning are identical.
+
+Note also what currently makes `publishSlottedPage` safe: an **invariant**, not a fence. Every caller
+is a write or teardown path, and teardown publishes `CLOSED_BIT` so `readStamp` answers
+`STAMP_INVALID`. A volatile store has release semantics only — it does not stop the following plain
+store to `slottedPage` from being hoisted above it. That invariant is adequate for the current
+callers and is *not* adequate once step (b) puts a reader on this path; publishing the segment with
+release semantics is the remedy.

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -294,7 +294,7 @@ without observing any prefetched results. `close()` after `close()` is a no-op.
 **Inv 4a (uniqueness):** for any sequence of concurrent `beginNodeReadOnlyTrx`
 calls on the same session, every returned reader has a unique trx ID.
 
-**Pf:** the ID is allocated via `nodeTrxIDCounter.incrementAndGet()`, which is
+**Pf:** the ID is allocated via `trxIDCounter.incrementAndGet()`, which is
 atomic on the underlying `AtomicInteger`. The post-allocation `nodeTrxMap.put`
 is guarded by a duplicate-detection check (`throw new SirixUsageException` if
 `put` returns non-null), giving a second line of defence against any future
@@ -313,7 +313,7 @@ subsequent observation by the calling thread. ∎
 with it. Pre-fix the synchronized on `beginNodeReadOnlyTrx` did serialize
 against the writer. Post-fix the reader path has no monitor.
 
-**Pf:** the `nodeTrxIDCounter` increment, the storage-engine reader
+**Pf:** the `trxIDCounter` increment, the storage-engine reader
 construction, and the `ConcurrentHashMap.put` are all lock-free. The writer's
 `beginNodeTrx` still holds the per-session monitor, but it touches no field
 that a reader-path racing it could observe in an inconsistent state — the only
@@ -322,6 +322,48 @@ shared mutable structure is `nodeTrxMap`, which is concurrent. ∎
 - **Test (4a + 4b):** `ResourceSessionTest.concurrentReaderOpens_areRaceFreeAndProduceUniqueIds`
   — 16 threads × 64 opens = 1024 concurrent `beginNodeReadOnlyTrx`, asserts
   unique IDs, exact `activeTrxCount()`, and clean teardown back to baseline.
+
+**Inv 4d (id uniqueness across BOTH bookkeeping spaces):** no node transaction
+id ever equals the id of a *different* storage engine reader/writer in the same
+session.
+
+**Pf:** every id in the session — node transactions (`beginNodeReadOnlyTrx`,
+`beginNodeTrx`) and storage engine instances (`createStorageEngineReader`,
+`createStorageEngineWriter`) alike — comes from a single `trxIDCounter`
+`incrementAndGet()`, which is strictly monotonic. The one case where two objects
+share an id is a read-write node transaction and its bound storage engine
+writer, which are handed the SAME single increment on purpose. ∎
+
+**Inv 4e (bookkeeping is bounded):** `storageEngineReaderMap` contains an entry
+for a storage engine reader iff that reader has not been closed; in particular a
+loop of open/close leaves its size constant.
+
+**Pf:** `createStorageEngineReader` / `createStorageEngineWriter` are the only
+producers, each inserting under the id it just drew. `NodeStorageEngineReader.close()`
+removes unconditionally — no predicate can suppress it — and
+`NodeStorageEngineWriter.close()` removes the unbound writer it registered.
+Removal is `ConcurrentMap.remove(key, value)`, so it drops an entry only while
+that entry still maps to the closing instance; neither class overrides `equals`,
+so this is reference identity. Hence removal is idempotent under double close and
+cannot touch a foreign entry, while Inv 4d independently guarantees no foreign
+entry shares the id. ∎
+
+This replaces a gate that asked `getNodeReadTrxByTrxId(trxId).isEmpty()` before
+removing — a lookup in `nodeTrxMap` (node ids) keyed by a storage engine id.
+With two independent counters those spaces collided: on a cold session a
+read-only open drew one id from each, so the numbers matched and the gate
+suppressed **every** removal (unbounded growth, one pinned page reader and epoch
+ticket per open); a writer-bound reader, whose node transaction was unregistered
+first, instead passed the gate and removed the *live* reader holding the same
+number.
+
+- **Test (4e):** `ResourceSessionTest.readOnlyTrxCycles_doNotLeakStorageEngineReaderEntries`
+  — 64 read-only cycles on a cold session (counters aligned, the alignment that
+  made the leak deterministic), then write cycles, then 64 more with the counters
+  de-aligned; `activeStorageEngineReaderCount()` must stay 0 throughout.
+- **Test (4d + 4e):** `ResourceSessionTest.writeTrxClose_doesNotEvictLiveStorageEngineReaders`
+  — a standalone storage engine reader taking the id the first `beginNodeTrx` is
+  about to draw must survive eight write-transaction closes still tracked and open.
 
 ---
 

--- a/jmh-result.text
+++ b/jmh-result.text
@@ -1,0 +1,19 @@
+Benchmark                                                   Mode  Cnt    Score     Error   Units
+HotInMemoryReadBenchmark.descendToLeaf                      avgt    4   78.713 ±  32.607   ns/op
+HotInMemoryReadBenchmark.descendToLeaf:gc.alloc.rate        avgt    4    0.009 ±   0.048  MB/sec
+HotInMemoryReadBenchmark.descendToLeaf:gc.alloc.rate.norm   avgt    4    0.001 ±   0.004    B/op
+HotInMemoryReadBenchmark.descendToLeaf:gc.count             avgt    4      ≈ 0            counts
+HotInMemoryReadBenchmark.lowerBoundSeek                     avgt    4  385.790 ±  92.848   ns/op
+HotInMemoryReadBenchmark.lowerBoundSeek:gc.alloc.rate       avgt    4   69.752 ±  16.280  MB/sec
+HotInMemoryReadBenchmark.lowerBoundSeek:gc.alloc.rate.norm  avgt    4   28.200 ±   0.021    B/op
+HotInMemoryReadBenchmark.lowerBoundSeek:gc.count            avgt    4    3.000            counts
+HotInMemoryReadBenchmark.lowerBoundSeek:gc.time             avgt    4   16.000                ms
+HotInMemoryReadBenchmark.pointGet                           avgt    4  562.906 ± 313.739   ns/op
+HotInMemoryReadBenchmark.pointGet:gc.alloc.rate             avgt    4  162.088 ±  98.398  MB/sec
+HotInMemoryReadBenchmark.pointGet:gc.alloc.rate.norm        avgt    4   95.125 ±   0.024    B/op
+HotInMemoryReadBenchmark.pointGet:gc.count                  avgt    4    5.000            counts
+HotInMemoryReadBenchmark.pointGet:gc.time                   avgt    4   25.000                ms
+HotInMemoryReadBenchmark.serializeKey                       avgt    4  134.249 ±   4.537   ns/op
+HotInMemoryReadBenchmark.serializeKey:gc.alloc.rate         avgt    4    2.150 ±   0.038  MB/sec
+HotInMemoryReadBenchmark.serializeKey:gc.alloc.rate.norm    avgt    4    0.303 ±   0.007    B/op
+HotInMemoryReadBenchmark.serializeKey:gc.count              avgt    4      ≈ 0            counts

--- a/jmh-result.text
+++ b/jmh-result.text
@@ -1,19 +1,5 @@
-Benchmark                                                   Mode  Cnt    Score     Error   Units
-HotInMemoryReadBenchmark.descendToLeaf                      avgt    4   78.713 ±  32.607   ns/op
-HotInMemoryReadBenchmark.descendToLeaf:gc.alloc.rate        avgt    4    0.009 ±   0.048  MB/sec
-HotInMemoryReadBenchmark.descendToLeaf:gc.alloc.rate.norm   avgt    4    0.001 ±   0.004    B/op
-HotInMemoryReadBenchmark.descendToLeaf:gc.count             avgt    4      ≈ 0            counts
-HotInMemoryReadBenchmark.lowerBoundSeek                     avgt    4  385.790 ±  92.848   ns/op
-HotInMemoryReadBenchmark.lowerBoundSeek:gc.alloc.rate       avgt    4   69.752 ±  16.280  MB/sec
-HotInMemoryReadBenchmark.lowerBoundSeek:gc.alloc.rate.norm  avgt    4   28.200 ±   0.021    B/op
-HotInMemoryReadBenchmark.lowerBoundSeek:gc.count            avgt    4    3.000            counts
-HotInMemoryReadBenchmark.lowerBoundSeek:gc.time             avgt    4   16.000                ms
-HotInMemoryReadBenchmark.pointGet                           avgt    4  562.906 ± 313.739   ns/op
-HotInMemoryReadBenchmark.pointGet:gc.alloc.rate             avgt    4  162.088 ±  98.398  MB/sec
-HotInMemoryReadBenchmark.pointGet:gc.alloc.rate.norm        avgt    4   95.125 ±   0.024    B/op
-HotInMemoryReadBenchmark.pointGet:gc.count                  avgt    4    5.000            counts
-HotInMemoryReadBenchmark.pointGet:gc.time                   avgt    4   25.000                ms
-HotInMemoryReadBenchmark.serializeKey                       avgt    4  134.249 ±   4.537   ns/op
-HotInMemoryReadBenchmark.serializeKey:gc.alloc.rate         avgt    4    2.150 ±   0.038  MB/sec
-HotInMemoryReadBenchmark.serializeKey:gc.alloc.rate.norm    avgt    4    0.303 ±   0.007    B/op
-HotInMemoryReadBenchmark.serializeKey:gc.count              avgt    4      ≈ 0            counts
+Benchmark                                              Mode  Cnt    Score     Error  Units
+CursorGuardCostBenchmark.guardAcquireRelease           avgt    5   31.023 ±   0.166  ns/op
+CursorGuardCostBenchmark.guardAcquireReleaseContended  avgt    5  907.363 ± 188.135  ns/op
+CursorGuardCostBenchmark.stampReadValidate             avgt    5    4.711 ±   0.092  ns/op
+CursorGuardCostBenchmark.stampReadValidateContended    avgt    5    4.772 ±   0.087  ns/op


### PR DESCRIPTION
Creating a CAS index over an already-shredded revision fed every
(value, nodeKey) pair through the HOT trie's incremental-insert path.
That path is built for updates: per entry it descends, decides
merge-vs-branch, and — whenever a structural fold leaves a node
malformed — discharges it with a scoped O(subtree) rebuild. Those
rebuilds do not stay rare as the entry count grows, so index creation
degraded far worse than linearly, and each rebuild also swept the whole
transaction-intent log to release the leaves it orphaned.

Two CAS indexes (title, year) over the 36,273-record movies corpus, on
the same machine and through the same driver:

  before  38.9 s   572 subtree rebuilds, 1,096 self-heals, 1,293 strand
                   rebuilds; 139,834 transaction-intent-log entries
  after    3.8 s   0 rebuilds of any kind; 554 log entries

A bulk load is the right shape for this: the whole entry set is known
before the first byte is written. HOTBulkIndexLoader collects the pairs
into a byte arena, sorts once, folds the node keys sharing a chunk slot
into one Roaring bitmap, and hands the result to HOTBulkBuilder, whose
output is invariant-clean by construction — so nothing ever needs
healing. IndexBuilder gains an IndexBuildFinalizer hook to tell a
builder the traversal is over; the loader only ever replaces an empty
tree, and an index def built over a populated one keeps the incremental
path.

Two more defects on the same path, both found while measuring:

- The builder and the change listener read a value's entire posting
  list back and re-inserted it just to add one node key. A HOT slot
  write is an OR-merge, so the read-back was pure waste — and
  quadratic in how often a value repeats, which is exactly the shape
  of the bulk-comparison corpus. Adding the single node key is enough.

- An equality lookup built its probe key from the type of the atomic
  the caller passed rather than the index definition's content type. A
  HOT key is a byte string carrying the type id, so probing an
  xs:decimal index with a numerically equal xs:double produced a
  different key and the lookup silently returned nothing. The RBTree
  backend never had this problem — CASValue#compareTo coerces both
  sides — which is what made it easy to miss.

Also resolves the builder's path-class-record set once per build rather
than allocating and filling it per value node.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QTdJDbTunrqd3Fm14Qk7jx