### PR TITLE
feat(sirix-core): maintain every index family in the parallel bulk import's single pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,23 @@ All notable changes to SirixDB are documented in this file.
   so nested columns sharing a trailing name with another path are accepted. See
   `docs/PROJECTION_INDEXES.md` and `docs/PROJECTION_INDEX_INCREMENTAL_MAINTENANCE.md`.
 - **Load-time projection builds** — `BasicJsonDBStore#create(collection, resource, reader|parser,
-  ProjectionSpec)` catalogues a projection on the still-empty resource and lets the shred's own
-  change notifications fill it, so a load plus its projection is ONE pass instead of a shred
-  followed by a full `jn:create-projection-index` walk. Until the load's final commit the
-  projection's metadata slot holds the stale tombstone, so an interrupted load leaves queries on
-  the generic pipeline rather than on a half-filled index. See `docs/PROJECTION_INDEXES.md`.
+  ProjectionSpec)` catalogues a projection on the still-empty resource and lets the load fill it,
+  so a load plus its projection is ONE pass instead of a shred followed by a full
+  `jn:create-projection-index` walk. Until the load's final commit the projection's metadata slot
+  holds the stale tombstone, so an interrupted load leaves queries on the generic pipeline rather
+  than on a half-filled index. See `docs/PROJECTION_INDEXES.md`.
+- **Bulk JSON loaders for fresh resources** — `BulkJsonTreeAssembler` (sequential) and
+  `ParallelBulkJsonImporter` (feeder scan + worker page builders + ordered adoption, for corpora
+  whose top level is an array; NDJSON rides `NdjsonAsArrayInputStream`). Both build trees
+  structurally identical to cursor-based insertion, enforced by a full-field differential oracle,
+  and refuse up front what they do not reproduce faithfully (`hashType` other than `NONE`, stored
+  DeweyIDs, node history, path statistics, a non-empty target). The parallel importer **maintains
+  PATH, CAS and NAME definitions and armed projection builds in the load's single pass** — the
+  workers extract each family's tuples from the primitives they already hold and the coordinator
+  drains them into the families' ordinary bulk loaders; a catalogued projection with no armed
+  load-time build is refused rather than silently left unmaintained, and valid-time interval
+  maintenance is the one family that still refuses. API, scope, verification, tuning and measured
+  numbers: `docs/BULK_IMPORT.md`.
 - **Asynchronous durable commits** (`AfterCommitState.KEEP_OPEN_ASYNC_COMMIT`) — the middle
   ground between synchronous auto-commits and the async pre-flush: every threshold crossing
   creates a real, durable, queryable revision, but the durability barriers (index-catalogue
@@ -45,6 +57,21 @@ All notable changes to SirixDB are documented in this file.
 
 ### Changed
 
+- **Wide projection string columns serve through windowed leaf loads** instead of whole-column
+  eager materialization. A projection whose worst-case resident size exceeds
+  `-Dsirix.projection.eagerMaterializeBytes` (default: the smaller of half the projection cache
+  budget and a quarter of the heap) is served from bounded 128-leaf windows, and a column fill
+  that would exceed the budget declines — the query re-enters the windowed whole-leaf route where
+  one exists, otherwise the record path answers. A decline is a routing decision, not a corruption
+  signal, so the index stays valid. Whole-column materialization is unchanged below the budget.
+  See `docs/PROJECTION_INDEXES.md`.
+- **A projection abandoned mid-load reports unconditionally.** The one silent load-degradation —
+  a resource-wide value dictionary breaching its byte budget, which abandons the projection while
+  the load still succeeds — now prints `[proj] PROJECTION ABANDONED` on stderr with the quantity
+  that breached the budget (the shipped log configuration discards the warning), and the stale
+  tombstone records a machine-readable `StaleReason` plus its remedy. The reason rides previously
+  reserved flag bits, so the `PIXM` wire format is unchanged for existing tombstones
+  (`docs/DISK_FORMAT.md`).
 - **JSON revision-diff sidecars carry an integrity envelope** (`sirix-diff-format`,
   `operation-count`, `operations-sha256`). Readers (`jn:diff`, the REST diff handler,
   multi-revision resource copy) validate identity, count and digest before use and fall back to

--- a/bundles/sirix-core/build.gradle
+++ b/bundles/sirix-core/build.gradle
@@ -129,7 +129,16 @@ test {
             excludeTags 'heavy'
         }
     }
-    
+
+    // HOT fragment-merge / eviction / split counters are OFF in production: they sit on the default
+    // read path and inside a per-entry commit loop, so they are gated behind a static-final flag
+    // that folds the branch away entirely. The suites asserting on them need the flag ON — and they
+    // ASSERT it is on rather than trusting it, because with the gate off every counter reads zero
+    // and "zero walked past a complete dump" from a disabled instrument is indistinguishable from
+    // the same reading from a healthy one. This line is the "provide" half of assert-and-provide.
+    // An explicit -Dsirix.hot.mergeDiag=false still wins, so the gated-off path stays testable.
+    systemProperty 'sirix.hot.mergeDiag', System.getProperty('sirix.hot.mergeDiag', 'true')
+
     // Add async-profiler if ASYNC_PROFILER env var is set
     // Usage: ASYNC_PROFILER=/path/to/async-profiler PROFILE_EVENT=cpu|alloc PROFILE_OUTPUT=/tmp/profile.txt ./gradlew test
     def profilerPath = System.getenv("ASYNC_PROFILER")

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractNodeTrxImpl.java
@@ -733,6 +733,35 @@ public abstract class AbstractNodeTrxImpl<R extends NodeReadOnlyTrx & NodeCursor
   }
 
   /**
+   * Bulk-assembly epoch driver: account a whole completed record's mutations in one call and rotate
+   * the intermediate epoch under EXACTLY the same predicate the per-insert path uses — same count
+   * threshold, same TIL page-work boundary, same flush dispatch. The assembler computes its pointers
+   * from a stack instead of per-insert bookkeeping, so it accounts at record boundaries; the only
+   * semantic difference to the cursor path is that rotation happens AFTER accounting the
+   * just-completed record, so an epoch may exceed the threshold by at most one record's node count
+   * (records are orders of magnitude smaller than an epoch).
+   *
+   * @param mutations completed node creations since the previous call; must be positive
+   */
+  protected final void bulkAccountMutations(final int mutations) {
+    if (mutations <= 0) {
+      throw new IllegalArgumentException("mutations must be positive: " + mutations);
+    }
+    assertNotRollbackOnly();
+    mutationSequence += mutations;
+    modificationCount += mutations;
+    if (shouldRotateIntermediateEpoch()) {
+      if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_COMMIT) {
+        asyncCommitInternal("autoCommit");
+      } else if (afterCommitState == AfterCommitState.KEEP_OPEN_ASYNC_FLUSH) {
+        flushIntermediateAsyncEpoch();
+      } else {
+        commitInternal("autoCommit", null, true);
+      }
+    }
+  }
+
+  /**
    * Shared insertion preflight. A subtree shredder already established that the transaction is open
    * and running before enabling bulk mode, so its per-node inserts retain count-based rotation while
    * avoiding two redundant state checks. Standalone JSON/XML insertions keep the full public-mutator

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -968,50 +968,53 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   @Override
   public synchronized void close() {
     if (!isClosed) {
-      // NOTE: ClockSweepers are GLOBAL now - don't stop them per-session
-      // They continue running, managed by BufferManager lifecycle
+      try {
+        // NOTE: ClockSweepers are GLOBAL now - don't stop them per-session
+        // They continue running, managed by BufferManager lifecycle
 
-      // Close all shared per-thread read-only transactions.
-      for (final NodeReadOnlyTrx rtx : sharedTrxMap.values()) {
-        rtx.close();
-      }
-      sharedTrxMap.clear();
-
-      // Close all open node transactions.
-      for (NodeReadOnlyTrx rtx : nodeTrxMap.values()) {
-        if (rtx instanceof XmlNodeTrx xmlNodeTrx) {
-          xmlNodeTrx.rollback();
-        } else if (rtx instanceof JsonNodeTrx jsonNodeTrx) {
-          jsonNodeTrx.rollback();
+        // Close all shared per-thread read-only transactions.
+        for (final NodeReadOnlyTrx rtx : sharedTrxMap.values()) {
+          rtx.close();
         }
-        rtx.close();
-      }
-      // Close all open storage engine writers.
-      for (StorageEngineReader rtx : storageEngineWriterMap.values()) {
-        rtx.close();
-      }
-      // Close all open storage engine readers.
-      for (StorageEngineReader rtx : storageEngineReaderMap.values()) {
-        rtx.close();
-      }
+        sharedTrxMap.clear();
 
-      // NOTE: Don't clear BufferManager caches here - other sessions might be using same resource!
-      // Pages will be evicted by normal cache LRU policy or cleaned up at database close
-      // PostgreSQL-style: buffers released when ALL sessions release them, not when one closes
+        // Close all open node transactions.
+        for (NodeReadOnlyTrx rtx : nodeTrxMap.values()) {
+          if (rtx instanceof XmlNodeTrx xmlNodeTrx) {
+            xmlNodeTrx.rollback();
+          } else if (rtx instanceof JsonNodeTrx jsonNodeTrx) {
+            jsonNodeTrx.rollback();
+          }
+          rtx.close();
+        }
+        // Close all open storage engine writers.
+        for (StorageEngineReader rtx : storageEngineWriterMap.values()) {
+          rtx.close();
+        }
+        // Close all open storage engine readers.
+        for (StorageEngineReader rtx : storageEngineReaderMap.values()) {
+          rtx.close();
+        }
 
-      // Immediately release all resources.
-      nodeTrxMap.clear();
-      storageEngineReaderMap.clear();
-      storageEngineWriterMap.clear();
-      ProjectionIndexCatalog.invalidateSessionWindowedPayloads(this);
-      resourceStore.closeResourceSession(resourceConfig.getResource());
+        // NOTE: Don't clear BufferManager caches here - other sessions might be using same resource!
+        // Pages will be evicted by normal cache LRU policy or cleaned up at database close
+        // PostgreSQL-style: buffers released when ALL sessions release them, not when one closes
 
-      storage.close();
+        // Immediately release all resources.
+        nodeTrxMap.clear();
+        storageEngineReaderMap.clear();
+        storageEngineWriterMap.clear();
+        resourceStore.closeResourceSession(resourceConfig.getResource());
 
-      if (pool.get() != null) {
-        pool.get().close();
+        storage.close();
+
+        if (pool.get() != null) {
+          pool.get().close();
+        }
+        isClosed = true;
+      } finally {
+        ProjectionIndexCatalog.invalidateSessionWindowedPayloads(this);
       }
-      isClosed = true;
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -33,6 +33,7 @@ import io.sirix.exception.SirixThreadedException;
 import io.sirix.exception.SirixUsageException;
 import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.io.IOStorage;
 import io.sirix.io.Reader;
 import io.sirix.io.RevisionIndex;
@@ -1002,6 +1003,7 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
       nodeTrxMap.clear();
       storageEngineReaderMap.clear();
       storageEngineWriterMap.clear();
+      ProjectionIndexCatalog.invalidateSessionWindowedPayloads(this);
       resourceStore.closeResourceSession(resourceConfig.getResource());
 
       storage.close();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AbstractResourceSession.java
@@ -33,7 +33,6 @@ import io.sirix.exception.SirixThreadedException;
 import io.sirix.exception.SirixUsageException;
 import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathSummaryReader;
-import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.io.IOStorage;
 import io.sirix.io.Reader;
 import io.sirix.io.RevisionIndex;
@@ -968,53 +967,49 @@ public abstract class AbstractResourceSession<R extends NodeReadOnlyTrx & NodeCu
   @Override
   public synchronized void close() {
     if (!isClosed) {
-      try {
-        // NOTE: ClockSweepers are GLOBAL now - don't stop them per-session
-        // They continue running, managed by BufferManager lifecycle
+      // NOTE: ClockSweepers are GLOBAL now - don't stop them per-session
+      // They continue running, managed by BufferManager lifecycle
 
-        // Close all shared per-thread read-only transactions.
-        for (final NodeReadOnlyTrx rtx : sharedTrxMap.values()) {
-          rtx.close();
-        }
-        sharedTrxMap.clear();
-
-        // Close all open node transactions.
-        for (NodeReadOnlyTrx rtx : nodeTrxMap.values()) {
-          if (rtx instanceof XmlNodeTrx xmlNodeTrx) {
-            xmlNodeTrx.rollback();
-          } else if (rtx instanceof JsonNodeTrx jsonNodeTrx) {
-            jsonNodeTrx.rollback();
-          }
-          rtx.close();
-        }
-        // Close all open storage engine writers.
-        for (StorageEngineReader rtx : storageEngineWriterMap.values()) {
-          rtx.close();
-        }
-        // Close all open storage engine readers.
-        for (StorageEngineReader rtx : storageEngineReaderMap.values()) {
-          rtx.close();
-        }
-
-        // NOTE: Don't clear BufferManager caches here - other sessions might be using same resource!
-        // Pages will be evicted by normal cache LRU policy or cleaned up at database close
-        // PostgreSQL-style: buffers released when ALL sessions release them, not when one closes
-
-        // Immediately release all resources.
-        nodeTrxMap.clear();
-        storageEngineReaderMap.clear();
-        storageEngineWriterMap.clear();
-        resourceStore.closeResourceSession(resourceConfig.getResource());
-
-        storage.close();
-
-        if (pool.get() != null) {
-          pool.get().close();
-        }
-        isClosed = true;
-      } finally {
-        ProjectionIndexCatalog.invalidateSessionWindowedPayloads(this);
+      // Close all shared per-thread read-only transactions.
+      for (final NodeReadOnlyTrx rtx : sharedTrxMap.values()) {
+        rtx.close();
       }
+      sharedTrxMap.clear();
+
+      // Close all open node transactions.
+      for (NodeReadOnlyTrx rtx : nodeTrxMap.values()) {
+        if (rtx instanceof XmlNodeTrx xmlNodeTrx) {
+          xmlNodeTrx.rollback();
+        } else if (rtx instanceof JsonNodeTrx jsonNodeTrx) {
+          jsonNodeTrx.rollback();
+        }
+        rtx.close();
+      }
+      // Close all open storage engine writers.
+      for (StorageEngineReader rtx : storageEngineWriterMap.values()) {
+        rtx.close();
+      }
+      // Close all open storage engine readers.
+      for (StorageEngineReader rtx : storageEngineReaderMap.values()) {
+        rtx.close();
+      }
+
+      // NOTE: Don't clear BufferManager caches here - other sessions might be using same resource!
+      // Pages will be evicted by normal cache LRU policy or cleaned up at database close
+      // PostgreSQL-style: buffers released when ALL sessions release them, not when one closes
+
+      // Immediately release all resources.
+      nodeTrxMap.clear();
+      storageEngineReaderMap.clear();
+      storageEngineWriterMap.clear();
+      resourceStore.closeResourceSession(resourceConfig.getResource());
+
+      storage.close();
+
+      if (pool.get() != null) {
+        pool.get().close();
+      }
+      isClosed = true;
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/AfterCommitState.java
@@ -49,6 +49,14 @@ public enum AfterCommitState {
    * page-work bound. This second bound limits foreground index/projection maintenance even when a
    * workload modifies relatively few storage pages.
    * </p>
+   *
+   * <p>
+   * Overridable for measurement via {@code -Dsirix.asyncFlush.maxNodeCount}. The default keeps the
+   * historical bound; the ClickBench hits shape it implies is an epoch every ~78 rows, which makes a
+   * PARTITIONED parallel ingest submit a flush every few milliseconds per writer and starve on the
+   * global append executor's admissions (measured: 16 writers spent 76% of a 1M-row load in
+   * submitWait). A larger epoch trades bounded in-flight frozen-TIL memory for admission pressure.
+   * </p>
    */
-  public static final int MAX_ASYNC_FLUSH_NODE_COUNT = 1 << 14;
+  public static final int MAX_ASYNC_FLUSH_NODE_COUNT = Integer.getInteger("sirix.asyncFlush.maxNodeCount", 1 << 14);
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonScanner.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonScanner.java
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.sirix.service.json.JsonNumber;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Minimal strict-JSON scanner for the bulk assembler: one forward pass over a {@link Reader},
+ * emitting structural events without the general-purpose tokenizer overhead the profile charged at
+ * ~25% of fill time — no per-token enum peek state machine, no {@code String} materialization for
+ * values (UTF-8 bytes are encoded straight from the char buffer into a reusable array), and field
+ * names resolve through an intern table so each distinct name allocates exactly once.
+ *
+ * <p>
+ * EQUIVALENCE CONTRACT (oracle-enforced: the cursor arm still parses with Gson, so every
+ * differential fixture doubles as a tokenizer-equivalence test):
+ * <ul>
+ * <li>Escape decoding matches JSON exactly — {@code \" \\ \/ \b \f \n \r \t \/uXXXX} including
+ * surrogate pairs assembled from consecutive escapes.</li>
+ * <li>UTF-8 value bytes are byte-identical to {@code String.getBytes(UTF_8)} over the decoded
+ * chars, INCLUDING the {@code '?'} replacement byte for unpaired surrogates.</li>
+ * <li>Numbers are delegated verbatim to {@link JsonNumber#stringToNumber(String)} — identical
+ * {@code Number} types and values by construction.</li>
+ * </ul>
+ *
+ * <p>
+ * Single-threaded; the value/name buffers are reused between events, so callers must consume an
+ * event's data before requesting the next.
+ */
+final class BulkJsonScanner {
+
+  static final int EVENT_BEGIN_OBJECT = 0;
+  static final int EVENT_END_OBJECT = 1;
+  static final int EVENT_BEGIN_ARRAY = 2;
+  static final int EVENT_END_ARRAY = 3;
+  static final int EVENT_NAME = 4;
+  static final int EVENT_STRING = 5;
+  static final int EVENT_NUMBER = 6;
+  static final int EVENT_TRUE = 7;
+  static final int EVENT_FALSE = 8;
+  static final int EVENT_NULL = 9;
+  static final int EVENT_END_DOCUMENT = 10;
+
+  private static final int DEFAULT_BUFFER_CHARS = 1 << 16;
+
+  private final Reader in;
+  private final char[] buffer;
+  private int position;
+  private int limit;
+
+  /** Decoded chars of the current string/number token (escape-processed). */
+  private char[] token = new char[256];
+  private int tokenLength;
+
+  /**
+   * Exposed state of the CURRENT event vs scratch state of a scanned-ahead event. One-event
+   * lookahead must never clobber what the caller has not yet consumed: the aliasing bug this
+   * structure exists for was a peeked STRING re-encoding over the byte buffer of the string the
+   * factory was about to write — consecutive array strings shifted by one, pinned by the oracle's
+   * lone-surrogate fixture. {@link #next()} promotes scratch to current by SWAPPING the byte
+   * arrays, so the zero-copy property survives.
+   */
+  private byte[] utf8 = new byte[512];
+  private int utf8Length;
+  private byte[] scratchUtf8 = new byte[512];
+  private int scratchUtf8Length;
+
+  /** Canonical name strings, one allocation per distinct field name. */
+  private final Map<String, String> nameInterns = new HashMap<>();
+
+  private String currentName;
+  private Number currentNumber;
+  private String scratchName;
+  private Number scratchNumber;
+
+  private int peekedEvent = -1;
+
+  BulkJsonScanner(final Reader in) {
+    this(in, DEFAULT_BUFFER_CHARS);
+  }
+
+  /** Buffer size is a test seam: tiny buffers force refills inside tokens. */
+  BulkJsonScanner(final Reader in, final int bufferChars) {
+    this.in = in;
+    this.buffer = new char[Math.max(16, bufferChars)];
+  }
+
+  int peek() throws IOException {
+    if (peekedEvent < 0) {
+      peekedEvent = advance();
+    }
+    return peekedEvent;
+  }
+
+  int next() throws IOException {
+    final int event;
+    if (peekedEvent >= 0) {
+      event = peekedEvent;
+      peekedEvent = -1;
+    } else {
+      event = advance();
+    }
+    // Promote the scanned event's scratch state to the exposed slots. Swapping the arrays keeps
+    // the encoding zero-copy while guaranteeing a later peek can never touch what we return now.
+    final byte[] previouslyExposed = utf8;
+    utf8 = scratchUtf8;
+    utf8Length = scratchUtf8Length;
+    scratchUtf8 = previouslyExposed;
+    currentName = scratchName;
+    currentNumber = scratchNumber;
+    return event;
+  }
+
+  /** Valid after {@link #next()} returned {@link #EVENT_NAME}; canonical (interned) instance. */
+  String name() {
+    return currentName;
+  }
+
+  /** Valid after {@link #next()} returned {@link #EVENT_NUMBER}. */
+  Number number() {
+    return currentNumber;
+  }
+
+  /** Valid after {@link #next()} returned {@link #EVENT_STRING}; reused buffer. */
+  byte[] stringUtf8() {
+    return utf8;
+  }
+
+  int stringUtf8Length() {
+    return utf8Length;
+  }
+
+  // ==== scanning ==============================================================================
+
+  private int advance() throws IOException {
+    while (true) {
+      final int c = nextNonWhitespace();
+      switch (c) {
+        case -1 -> {
+          return EVENT_END_DOCUMENT;
+        }
+        case '{' -> {
+          return EVENT_BEGIN_OBJECT;
+        }
+        case '}' -> {
+          return EVENT_END_OBJECT;
+        }
+        case '[' -> {
+          return EVENT_BEGIN_ARRAY;
+        }
+        case ']' -> {
+          return EVENT_END_ARRAY;
+        }
+        case ',', ':' -> {
+          // Structural separators carry no event; strictness (matching them to context) is the
+          // parser-level concern the assembler's own stack enforces structurally.
+        }
+        case '"' -> {
+          scanQuoted();
+          if (peekNonWhitespaceIsColon()) {
+            scratchName = intern(token, tokenLength);
+            return EVENT_NAME;
+          }
+          encodeUtf8();
+          return EVENT_STRING;
+        }
+        case 't' -> {
+          expect("rue");
+          return EVENT_TRUE;
+        }
+        case 'f' -> {
+          expect("alse");
+          return EVENT_FALSE;
+        }
+        case 'n' -> {
+          expect("ull");
+          return EVENT_NULL;
+        }
+        default -> {
+          if (c == '-' || (c >= '0' && c <= '9')) {
+            scanNumber((char) c);
+            scratchNumber = JsonNumber.stringToNumber(new String(token, 0, tokenLength));
+            return EVENT_NUMBER;
+          }
+          throw new IOException("unexpected character '" + (char) c + "' in JSON input");
+        }
+      }
+    }
+  }
+
+  private int nextNonWhitespace() throws IOException {
+    while (true) {
+      if (position == limit && !fill()) {
+        return -1;
+      }
+      final char c = buffer[position++];
+      if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+        return c;
+      }
+    }
+  }
+
+  /** After a closing quote: does a colon follow (name) or not (string value)? Consumes nothing. */
+  private boolean peekNonWhitespaceIsColon() throws IOException {
+    while (true) {
+      for (int i = position; i < limit; i++) {
+        final char c = buffer[i];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+          continue;
+        }
+        return c == ':';
+      }
+      // The colon (or the next value) may sit beyond the buffered window: compact + refill and
+      // look again. Position is preserved because fill() compacts from `position`.
+      if (!fill()) {
+        return false;
+      }
+    }
+  }
+
+  private void scanQuoted() throws IOException {
+    tokenLength = 0;
+    while (true) {
+      if (position == limit && !fill()) {
+        throw new IOException("unterminated string");
+      }
+      final char c = buffer[position++];
+      if (c == '"') {
+        return;
+      }
+      if (c == '\\') {
+        appendToken(readEscape());
+      } else {
+        appendToken(c);
+      }
+    }
+  }
+
+  private char readEscape() throws IOException {
+    if (position == limit && !fill()) {
+      throw new IOException("unterminated escape");
+    }
+    final char c = buffer[position++];
+    return switch (c) {
+      case '"' -> '"';
+      case '\\' -> '\\';
+      case '/' -> '/';
+      case 'b' -> '\b';
+      case 'f' -> '\f';
+      case 'n' -> '\n';
+      case 'r' -> '\r';
+      case 't' -> '\t';
+      case 'u' -> readUnicodeEscape();
+      default -> throw new IOException("invalid escape \\" + c);
+    };
+  }
+
+  private char readUnicodeEscape() throws IOException {
+    int value = 0;
+    for (int i = 0; i < 4; i++) {
+      if (position == limit && !fill()) {
+        throw new IOException("unterminated unicode escape");
+      }
+      final char c = buffer[position++];
+      final int digit = Character.digit(c, 16);
+      if (digit < 0) {
+        throw new IOException("invalid unicode escape digit '" + c + "'");
+      }
+      value = (value << 4) | digit;
+    }
+    return (char) value;
+  }
+
+  private void scanNumber(final char first) throws IOException {
+    tokenLength = 0;
+    appendToken(first);
+    while (true) {
+      if (position == limit && !fill()) {
+        return;
+      }
+      final char c = buffer[position];
+      if ((c >= '0' && c <= '9') || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+        appendToken(c);
+        position++;
+      } else {
+        return;
+      }
+    }
+  }
+
+  private void expect(final String rest) throws IOException {
+    for (int i = 0; i < rest.length(); i++) {
+      if (position == limit && !fill()) {
+        throw new IOException("truncated literal");
+      }
+      if (buffer[position++] != rest.charAt(i)) {
+        throw new IOException("malformed literal");
+      }
+    }
+  }
+
+  private void appendToken(final char c) {
+    if (tokenLength == token.length) {
+      token = Arrays.copyOf(token, token.length << 1);
+    }
+    token[tokenLength++] = c;
+  }
+
+  /** Compact unconsumed chars to the front and refill; false at end of input. */
+  private boolean fill() throws IOException {
+    if (position < limit) {
+      System.arraycopy(buffer, position, buffer, 0, limit - position);
+    }
+    limit -= position;
+    position = 0;
+    final int read = in.read(buffer, limit, buffer.length - limit);
+    if (read <= 0) {
+      return false;
+    }
+    limit += read;
+    return true;
+  }
+
+  private String intern(final char[] chars, final int length) {
+    // One transient String per LOOKUP would defeat the point for repeats; but name lookups need a
+    // map key. A tiny open-addressing char-slice table would avoid it entirely — measured later;
+    // v1 accepts one short-lived String per name occurrence and keeps the CANONICAL instance
+    // stable so downstream maps (PCR memo, name memo) hash the same object every time.
+    final String candidate = new String(chars, 0, length);
+    final String canonical = nameInterns.get(candidate);
+    if (canonical != null) {
+      return canonical;
+    }
+    nameInterns.put(candidate, candidate);
+    return candidate;
+  }
+
+  /**
+   * Encode {@link #token} to UTF-8, byte-identical to {@code new String(chars).getBytes(UTF_8)} —
+   * including the {@code '?'} replacement for unpaired surrogates.
+   */
+  private void encodeUtf8() {
+    final int worstCase = tokenLength * 3 + 4;
+    if (scratchUtf8.length < worstCase) {
+      scratchUtf8 = new byte[Integer.highestOneBit(worstCase) << 1];
+    }
+    final byte[] target = scratchUtf8;
+    int out = 0;
+    for (int i = 0; i < tokenLength; i++) {
+      final char c = token[i];
+      if (c < 0x80) {
+        target[out++] = (byte) c;
+      } else if (c < 0x800) {
+        target[out++] = (byte) (0xC0 | (c >> 6));
+        target[out++] = (byte) (0x80 | (c & 0x3F));
+      } else if (Character.isHighSurrogate(c)) {
+        if (i + 1 < tokenLength && Character.isLowSurrogate(token[i + 1])) {
+          final int codePoint = Character.toCodePoint(c, token[++i]);
+          target[out++] = (byte) (0xF0 | (codePoint >> 18));
+          target[out++] = (byte) (0x80 | ((codePoint >> 12) & 0x3F));
+          target[out++] = (byte) (0x80 | ((codePoint >> 6) & 0x3F));
+          target[out++] = (byte) (0x80 | (codePoint & 0x3F));
+        } else {
+          target[out++] = '?';
+        }
+      } else if (Character.isLowSurrogate(c)) {
+        target[out++] = '?';
+      } else {
+        target[out++] = (byte) (0xE0 | (c >> 12));
+        target[out++] = (byte) (0x80 | ((c >> 6) & 0x3F));
+        target[out++] = (byte) (0x80 | (c & 0x3F));
+      }
+    }
+    scratchUtf8Length = out;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonScanner.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonScanner.java
@@ -60,12 +60,12 @@ final class BulkJsonScanner {
   private int tokenLength;
 
   /**
-   * Exposed state of the CURRENT event vs scratch state of a scanned-ahead event. One-event
-   * lookahead must never clobber what the caller has not yet consumed: the aliasing bug this
-   * structure exists for was a peeked STRING re-encoding over the byte buffer of the string the
-   * factory was about to write — consecutive array strings shifted by one, pinned by the oracle's
-   * lone-surrogate fixture. {@link #next()} promotes scratch to current by SWAPPING the byte
-   * arrays, so the zero-copy property survives.
+   * Exposed state of the CURRENT event vs scratch state of a scanned-ahead event. One-event lookahead
+   * must never clobber what the caller has not yet consumed: the aliasing bug this structure exists
+   * for was a peeked STRING re-encoding over the byte buffer of the string the factory was about to
+   * write — consecutive array strings shifted by one, pinned by the oracle's lone-surrogate fixture.
+   * {@link #next()} promotes scratch to current by SWAPPING the byte arrays, so the zero-copy
+   * property survives.
    */
   private byte[] utf8 = new byte[512];
   private int utf8Length;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonTreeAssembler.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonTreeAssembler.java
@@ -31,42 +31,40 @@ import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
  * {@code prepareRecordForModification} page-container resolutions (parent childCount/firstChild,
  * left sibling rightSib), cursor repositioning, a per-node epoch check, and — when notifications
  * need it — a parent walk for the path class. This assembler computes every pointer from its own
- * container stack BEFORE a record is first written, so leaves are created with FINAL pointers,
- * and each CONTAINER takes exactly ONE in-place fixup at its close
+ * container stack BEFORE a record is first written, so leaves are created with FINAL pointers, and
+ * each CONTAINER takes exactly ONE in-place fixup at its close
  * (firstChild/lastChild/childCount/rightSib together) instead of one per child.
  *
  * <p>
  * <b>The sink seam.</b> Record emission goes through a {@link BulkRecordSink}: the
  * transaction-backed sink is the original sequential behavior; a counting sink gives the parallel
  * importer's Stage-A its node counts through the SAME code path that later builds (so a count can
- * never disagree with a build by construction); a worker page-builder sink emits standalone
- * pages for pre-reserved key ranges. The assembler core — scanner drive, key prediction,
- * container stack, PCR memoization — is identical for all three.
+ * never disagree with a build by construction); a worker page-builder sink emits standalone pages
+ * for pre-reserved key ranges. The assembler core — scanner drive, key prediction, container stack,
+ * PCR memoization — is identical for all three.
  *
  * <p>
- * <b>Key prediction.</b> Node keys mint sequentially and deterministically. The assembler
- * predicts forward references — a record's right sibling — as {@code expectedNextKey} under
- * one-token lookahead, and ASSERTS the prediction against the key the sink actually minted at
- * every creation. A violated prediction is a hard {@link IllegalStateException}; a silent
- * mis-pointer is impossible by construction.
+ * <b>Key prediction.</b> Node keys mint sequentially and deterministically. The assembler predicts
+ * forward references — a record's right sibling — as {@code expectedNextKey} under one-token
+ * lookahead, and ASSERTS the prediction against the key the sink actually minted at every creation.
+ * A violated prediction is a hard {@link IllegalStateException}; a silent mis-pointer is impossible
+ * by construction.
  *
  * <p>
  * <b>Path summary.</b> Resolution uses only the KEYED writer API
  * ({@link PathSummaryWriter#getPathNodeKey(long, QNm, NodeKind)} under a stack-carried context
  * PCR), never the cursor-positional variant. The context rules mirror the cursor path exactly,
- * including its as-built quirks: plain {@code OBJECT} is transparent (inherits the parent
- * context), the four stop kinds anchor their own; ALL arrays resolve one {@code __array__} step
- * under the parent context (user-ruled unification); a fused named array stores the
- * {@code __array__}-layer PCR obtained via
- * {@link PathSummaryWriter#getArrayChildPathNodeKey(long)}. The keyed calls are made once per
- * record occurrence — the writer's reference counting must observe the same call sequence the
- * cursor path produces.
+ * including its as-built quirks: plain {@code OBJECT} is transparent (inherits the parent context),
+ * the four stop kinds anchor their own; ALL arrays resolve one {@code __array__} step under the
+ * parent context (user-ruled unification); a fused named array stores the {@code __array__}-layer
+ * PCR obtained via {@link PathSummaryWriter#getArrayChildPathNodeKey(long)}. The keyed calls are
+ * made once per record occurrence — the writer's reference counting must observe the same call
+ * sequence the cursor path produces.
  *
  * <p>
- * <b>Scope guard.</b> Refuses up front — before writing anything — any configuration this
- * version does not faithfully reproduce: hashes, DeweyIDs, path statistics, node history, or a
- * non-empty target document. Mutating existing nodes is permanently out of scope; that is the
- * cursor's job.
+ * <b>Scope guard.</b> Refuses up front — before writing anything — any configuration this version
+ * does not faithfully reproduce: hashes, DeweyIDs, path statistics, node history, or a non-empty
+ * target document. Mutating existing nodes is permanently out of scope; that is the cursor's job.
  */
 public final class BulkJsonTreeAssembler {
 
@@ -102,13 +100,13 @@ public final class BulkJsonTreeAssembler {
   private String pendingName;
 
   /**
-   * (parent PCR, step name) → PCR memo with DEFERRED reference counting: a miss resolves through
-   * the ordinary summary path (which counts that first occurrence), a hit only bumps a local
-   * pending counter, and {@link #flushPendingPathReferences()} applies the accumulated repeats in
-   * one record touch per path node BEFORE every epoch rotation and at the end of the run. The
-   * committed reference counts are exactly per-occurrence counting's — the oracle's summary dump
-   * (references included) pins it — while the measured 13.7%% of fill time spent in per-node
-   * summary resolution collapses to a hash probe.
+   * (parent PCR, step name) → PCR memo with DEFERRED reference counting: a miss resolves through the
+   * ordinary summary path (which counts that first occurrence), a hit only bumps a local pending
+   * counter, and {@link #flushPendingPathReferences()} applies the accumulated repeats in one record
+   * touch per path node BEFORE every epoch rotation and at the end of the run. The committed
+   * reference counts are exactly per-occurrence counting's — the oracle's summary dump (references
+   * included) pins it — while the measured 13.7%% of fill time spent in per-node summary resolution
+   * collapses to a hash probe.
    */
   private final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> pcrMemo = new Long2ObjectOpenHashMap<>();
 
@@ -129,8 +127,8 @@ public final class BulkJsonTreeAssembler {
 
   /**
    * MEMBER MODE (parallel import): frame 0 is a pre-existing top-level ARRAY rather than the
-   * document, the drive consumes a sequence of that array's members, and the final member's
-   * right sibling comes from OUTSIDE (the next chunk's first key) instead of the lookahead.
+   * document, the drive consumes a sequence of that array's members, and the final member's right
+   * sibling comes from OUTSIDE (the next chunk's first key) instead of the lookahead.
    */
   private final boolean memberMode;
   private final long memberRootKey;
@@ -191,8 +189,8 @@ public final class BulkJsonTreeAssembler {
   }
 
   /**
-   * Assemble ONE top-level JSON value from {@code input} into the fresh resource behind
-   * {@code wtx}. The caller commits.
+   * Assemble ONE top-level JSON value from {@code input} into the fresh resource behind {@code wtx}.
+   * The caller commits.
    *
    * @param wtx a write transaction on a FRESH resource; must be the standard implementation, since
    *        bulk assembly drives its internal factory/summary/notification machinery
@@ -210,8 +208,8 @@ public final class BulkJsonTreeAssembler {
     }
     refuseUnsupportedShape(impl);
     try {
-      new BulkJsonTreeAssembler(new WtxBulkRecordSink(impl), impl.bulkPathSummaryWriter(),
-          impl.bulkBuildPathSummary(), scanner, impl.getMaxNodeKey() + 1).run();
+      new BulkJsonTreeAssembler(new WtxBulkRecordSink(impl), impl.bulkPathSummaryWriter(), impl.bulkBuildPathSummary(),
+          scanner, impl.getMaxNodeKey() + 1).run();
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -407,8 +405,8 @@ public final class BulkJsonTreeAssembler {
       final String name = takePendingName();
       final long fieldPcr = resolveFieldPcr(name);
       final long rightSibKey = predictedLeafRightSibling();
-      recordChildInParent(assertMinted(sink.createObjectNamedStringNode(levelContainerKey[depth],
-          levelLastChild[depth], rightSibKey, fieldPcr, name, utf8, utf8Length)));
+      recordChildInParent(assertMinted(sink.createObjectNamedStringNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, fieldPcr, name, utf8, utf8Length)));
     } else {
       final long rightSibKey = predictedLeafRightSibling();
       recordChildInParent(assertMinted(sink.createStringNode(levelContainerKey[depth], levelLastChild[depth],
@@ -421,8 +419,8 @@ public final class BulkJsonTreeAssembler {
       final String name = takePendingName();
       final long fieldPcr = resolveFieldPcr(name);
       final long rightSibKey = predictedLeafRightSibling();
-      recordChildInParent(assertMinted(sink.createObjectNamedNumberNode(levelContainerKey[depth],
-          levelLastChild[depth], rightSibKey, fieldPcr, name, value)));
+      recordChildInParent(assertMinted(sink.createObjectNamedNumberNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, fieldPcr, name, value)));
     } else {
       final long rightSibKey = predictedLeafRightSibling();
       recordChildInParent(assertMinted(sink.createNumberNode(levelContainerKey[depth], levelLastChild[depth],
@@ -461,8 +459,8 @@ public final class BulkJsonTreeAssembler {
   // ==== shared mechanics ======================================================================
 
   /**
-   * A leaf occupies exactly one key, so if the lookahead shows another sibling, that sibling's key
-   * is the one AFTER this leaf's. The prediction is verified when the sibling actually mints.
+   * A leaf occupies exactly one key, so if the lookahead shows another sibling, that sibling's key is
+   * the one AFTER this leaf's. The prediction is verified when the sibling actually mints.
    */
   private long predictedLeafRightSibling() throws IOException {
     if (peekSiblingFollows()) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonTreeAssembler.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkJsonTreeAssembler.java
@@ -1,0 +1,611 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.index.path.summary.PathSummaryWriter;
+import io.sirix.node.NodeKind;
+import io.sirix.settings.Fixed;
+import io.brackit.query.atomic.QNm;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+
+/**
+ * Bulk page-assembly loader, v0.1: append-only construction of a FRESH resource from a JSON token
+ * stream, producing a tree STRUCTURALLY IDENTICAL to what the cursor inserts build — same node
+ * keys, kinds, names, values, pointers, counts, path summary and notifications — while touching
+ * each record's slot essentially once.
+ *
+ * <p>
+ * <b>Why it is faster than the cursor path.</b> A cursor insert pays, per node: 2–3
+ * {@code prepareRecordForModification} page-container resolutions (parent childCount/firstChild,
+ * left sibling rightSib), cursor repositioning, a per-node epoch check, and — when notifications
+ * need it — a parent walk for the path class. This assembler computes every pointer from its own
+ * container stack BEFORE a record is first written, so leaves are created with FINAL pointers,
+ * and each CONTAINER takes exactly ONE in-place fixup at its close
+ * (firstChild/lastChild/childCount/rightSib together) instead of one per child.
+ *
+ * <p>
+ * <b>The sink seam.</b> Record emission goes through a {@link BulkRecordSink}: the
+ * transaction-backed sink is the original sequential behavior; a counting sink gives the parallel
+ * importer's Stage-A its node counts through the SAME code path that later builds (so a count can
+ * never disagree with a build by construction); a worker page-builder sink emits standalone
+ * pages for pre-reserved key ranges. The assembler core — scanner drive, key prediction,
+ * container stack, PCR memoization — is identical for all three.
+ *
+ * <p>
+ * <b>Key prediction.</b> Node keys mint sequentially and deterministically. The assembler
+ * predicts forward references — a record's right sibling — as {@code expectedNextKey} under
+ * one-token lookahead, and ASSERTS the prediction against the key the sink actually minted at
+ * every creation. A violated prediction is a hard {@link IllegalStateException}; a silent
+ * mis-pointer is impossible by construction.
+ *
+ * <p>
+ * <b>Path summary.</b> Resolution uses only the KEYED writer API
+ * ({@link PathSummaryWriter#getPathNodeKey(long, QNm, NodeKind)} under a stack-carried context
+ * PCR), never the cursor-positional variant. The context rules mirror the cursor path exactly,
+ * including its as-built quirks: plain {@code OBJECT} is transparent (inherits the parent
+ * context), the four stop kinds anchor their own; ALL arrays resolve one {@code __array__} step
+ * under the parent context (user-ruled unification); a fused named array stores the
+ * {@code __array__}-layer PCR obtained via
+ * {@link PathSummaryWriter#getArrayChildPathNodeKey(long)}. The keyed calls are made once per
+ * record occurrence — the writer's reference counting must observe the same call sequence the
+ * cursor path produces.
+ *
+ * <p>
+ * <b>Scope guard.</b> Refuses up front — before writing anything — any configuration this
+ * version does not faithfully reproduce: hashes, DeweyIDs, path statistics, node history, or a
+ * non-empty target document. Mutating existing nodes is permanently out of scope; that is the
+ * cursor's job.
+ */
+public final class BulkJsonTreeAssembler {
+
+  private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
+
+  /** Mirrors the cursor path's first-child array path step ({@code ARRAY_PATH_QNM}). */
+  private static final QNm ARRAY_PATH_QNM = new QNm("__array__");
+
+  private static final int INITIAL_DEPTH_CAPACITY = 64;
+
+  private static final byte LEVEL_DOCUMENT = 0;
+  private static final byte LEVEL_OBJECT = 1;
+  private static final byte LEVEL_ARRAY = 2;
+
+  private final BulkRecordSink sink;
+  private final PathSummaryWriter<JsonNodeReadOnlyTrx> pathSummaryWriter;
+  private final boolean buildPathSummary;
+  private final BulkJsonScanner scanner;
+
+  /** The key the NEXT sink creation must mint; every creation asserts and advances it. */
+  private long expectedNextKey;
+
+  // One frame per open container (document = frame 0). Parallel arrays, grown by doubling.
+  private byte[] levelKind = new byte[INITIAL_DEPTH_CAPACITY];
+  private long[] levelContainerKey = new long[INITIAL_DEPTH_CAPACITY];
+  private long[] levelContentPcr = new long[INITIAL_DEPTH_CAPACITY];
+  private long[] levelFirstChild = new long[INITIAL_DEPTH_CAPACITY];
+  private long[] levelLastChild = new long[INITIAL_DEPTH_CAPACITY];
+  private long[] levelChildCount = new long[INITIAL_DEPTH_CAPACITY];
+  private int depth;
+
+  /** Field name consumed from the reader, pending until its value token arrives. */
+  private String pendingName;
+
+  /**
+   * (parent PCR, step name) → PCR memo with DEFERRED reference counting: a miss resolves through
+   * the ordinary summary path (which counts that first occurrence), a hit only bumps a local
+   * pending counter, and {@link #flushPendingPathReferences()} applies the accumulated repeats in
+   * one record touch per path node BEFORE every epoch rotation and at the end of the run. The
+   * committed reference counts are exactly per-occurrence counting's — the oracle's summary dump
+   * (references included) pins it — while the measured 13.7%% of fill time spent in per-node
+   * summary resolution collapses to a hash probe.
+   */
+  private final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> pcrMemo = new Long2ObjectOpenHashMap<>();
+
+  private final Long2IntOpenHashMap pendingPathReferences = new Long2IntOpenHashMap();
+
+  /** Key AFTER the last record boundary accounted to the epoch machinery. */
+  private long epochAccountedUpToKey;
+
+  /** Member mode: first key of the member currently being driven. */
+  private long memberStartKey;
+
+  private long lastMemberStartKey() {
+    return memberStartKey;
+  }
+
+  /** Member mode: the run's first key, for the first member's node-count computation. */
+  private long expectedNextKeyAtRunStart;
+
+  /**
+   * MEMBER MODE (parallel import): frame 0 is a pre-existing top-level ARRAY rather than the
+   * document, the drive consumes a sequence of that array's members, and the final member's
+   * right sibling comes from OUTSIDE (the next chunk's first key) instead of the lookahead.
+   */
+  private final boolean memberMode;
+  private final long memberRootKey;
+  private final long memberRootPcr;
+  private final long memberLeftBoundaryKey;
+  private final long trailingSiblingKey;
+
+  /** Member-mode statistics for the coordinator: members driven and the last member's node count. */
+  private long membersDriven;
+  private long lastMemberNodeCount;
+
+  BulkJsonTreeAssembler(final BulkRecordSink sink, final PathSummaryWriter<JsonNodeReadOnlyTrx> pathSummaryWriter,
+      final boolean buildPathSummary, final BulkJsonScanner scanner, final long firstKey) {
+    this(sink, pathSummaryWriter, buildPathSummary, scanner, firstKey, false, 0, 0, NULL_KEY, NULL_KEY);
+  }
+
+  BulkJsonTreeAssembler(final BulkRecordSink sink, final PathSummaryWriter<JsonNodeReadOnlyTrx> pathSummaryWriter,
+      final boolean buildPathSummary, final BulkJsonScanner scanner, final long firstKey, final boolean memberMode,
+      final long memberRootKey, final long memberRootPcr, final long memberLeftBoundaryKey,
+      final long trailingSiblingKey) {
+    this.sink = sink;
+    this.pathSummaryWriter = pathSummaryWriter;
+    this.buildPathSummary = buildPathSummary;
+    this.scanner = scanner;
+    this.expectedNextKey = firstKey;
+    this.epochAccountedUpToKey = firstKey;
+    this.memberMode = memberMode;
+    this.memberRootKey = memberRootKey;
+    this.memberRootPcr = memberRootPcr;
+    this.memberLeftBoundaryKey = memberLeftBoundaryKey;
+    this.trailingSiblingKey = trailingSiblingKey;
+  }
+
+  /** Pre-fills the PCR memo (worker mode: every path the chunk uses must already be resolved). */
+  void prefillPcrMemo(final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> resolved) {
+    for (final var entry : resolved.long2ObjectEntrySet()) {
+      final Object2LongOpenHashMap<String> copy = new Object2LongOpenHashMap<>(entry.getValue());
+      copy.defaultReturnValue(-1);
+      pcrMemo.put(entry.getLongKey(), copy);
+    }
+  }
+
+  /** The coordinator's memo, snapshot after a counting run to hand to the chunk's builder. */
+  Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> pcrMemoView() {
+    return pcrMemo;
+  }
+
+  long membersDriven() {
+    return membersDriven;
+  }
+
+  long lastMemberNodeCount() {
+    return lastMemberNodeCount;
+  }
+
+  long nextKey() {
+    return expectedNextKey;
+  }
+
+  /**
+   * Assemble ONE top-level JSON value from {@code input} into the fresh resource behind
+   * {@code wtx}. The caller commits.
+   *
+   * @param wtx a write transaction on a FRESH resource; must be the standard implementation, since
+   *        bulk assembly drives its internal factory/summary/notification machinery
+   * @param input the token source; consumed up to (and including) the top-level value's end
+   */
+  public static void assemble(final JsonNodeTrx wtx, final Reader input) {
+    assemble(wtx, new BulkJsonScanner(input));
+  }
+
+  /** Test seam: inject a scanner (e.g. with a tiny buffer to stress refills inside tokens). */
+  static void assemble(final JsonNodeTrx wtx, final BulkJsonScanner scanner) {
+    if (!(wtx instanceof final JsonNodeTrxImpl impl)) {
+      throw new IllegalArgumentException(
+          "bulk assembly requires the standard JsonNodeTrx implementation, got " + wtx.getClass().getName());
+    }
+    refuseUnsupportedShape(impl);
+    try {
+      new BulkJsonTreeAssembler(new WtxBulkRecordSink(impl), impl.bulkPathSummaryWriter(),
+          impl.bulkBuildPathSummary(), scanner, impl.getMaxNodeKey() + 1).run();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** Refusal BEFORE any write: nothing may silently mix builders or half-load. */
+  private static void refuseUnsupportedShape(final JsonNodeTrxImpl wtx) {
+    final ResourceConfiguration config = wtx.getResourceSession().getResourceConfig();
+    if (config.hashType != HashType.NONE) {
+      throw new IllegalStateException("bulk assembly v0.1 supports hashType=NONE only, got " + config.hashType);
+    }
+    if (config.areDeweyIDsStored) {
+      throw new IllegalStateException("bulk assembly v0.1 does not support DeweyIDs");
+    }
+    if (config.storeNodeHistory()) {
+      throw new IllegalStateException("bulk assembly v0.1 does not support node history");
+    }
+    final PathSummaryWriter<JsonNodeReadOnlyTrx> summary = wtx.bulkPathSummaryWriter();
+    if (summary != null && summary.isPathStatisticsEnabled()) {
+      throw new IllegalStateException("bulk assembly v0.1 does not support path statistics");
+    }
+    if (!wtx.moveToDocumentRoot() || wtx.hasFirstChild()) {
+      throw new IllegalStateException("bulk assembly requires a FRESH resource (empty document root)");
+    }
+  }
+
+  void run() throws IOException {
+    expectedNextKeyAtRunStart = expectedNextKey;
+    memberStartKey = expectedNextKey;
+    if (memberMode) {
+      // Frame 0: the pre-existing top-level array. The previous chunk's last member is the left
+      // sibling of this chunk's first member; child bookkeeping here is chunk-local (the
+      // coordinator fixes the array once at the very end with GLOBAL counts).
+      levelKind[0] = LEVEL_ARRAY;
+      levelContainerKey[0] = memberRootKey;
+      levelContentPcr[0] = memberRootPcr;
+      levelFirstChild[0] = NULL_KEY;
+      levelLastChild[0] = memberLeftBoundaryKey;
+      levelChildCount[0] = 0;
+    } else {
+      // Frame 0: the document. Its content PCR is 0, matching what the cursor path reports for
+      // JSON_DOCUMENT context (getPathNodeKey(StructNode) returns 0 there).
+      levelKind[0] = LEVEL_DOCUMENT;
+      levelContainerKey[0] = Fixed.DOCUMENT_NODE_KEY.getStandardProperty();
+      levelContentPcr[0] = 0;
+      levelFirstChild[0] = NULL_KEY;
+      levelLastChild[0] = NULL_KEY;
+      levelChildCount[0] = 0;
+    }
+    depth = 0;
+
+    loop: while (true) {
+      final int event = scanner.next();
+      switch (event) {
+        case BulkJsonScanner.EVENT_BEGIN_OBJECT -> openContainer(true);
+        case BulkJsonScanner.EVENT_BEGIN_ARRAY -> openContainer(false);
+        case BulkJsonScanner.EVENT_NAME -> pendingName = scanner.name();
+        case BulkJsonScanner.EVENT_STRING -> leafString(scanner.stringUtf8(), scanner.stringUtf8Length());
+        case BulkJsonScanner.EVENT_NUMBER -> leafNumber(scanner.number());
+        case BulkJsonScanner.EVENT_TRUE -> leafBoolean(true);
+        case BulkJsonScanner.EVENT_FALSE -> leafBoolean(false);
+        case BulkJsonScanner.EVENT_NULL -> leafNull();
+        case BulkJsonScanner.EVENT_END_OBJECT, BulkJsonScanner.EVENT_END_ARRAY -> closeContainer();
+        case BulkJsonScanner.EVENT_END_DOCUMENT -> {
+          break loop;
+        }
+        default -> throw new IllegalStateException("unknown scanner event " + event);
+      }
+      if (!memberMode && depth == 0 && levelChildCount[0] > 0) {
+        // One top-level value per assemble; a second is an input-shape refusal.
+        break;
+      }
+    }
+
+    if (depth != 0) {
+      throw new IllegalStateException("bulk assembly ended with " + depth + " unclosed container(s)");
+    }
+    flushPendingPathReferences();
+    if (!memberMode) {
+      fixupDocument();
+    }
+  }
+
+  // ==== containers ============================================================================
+
+  private void openContainer(final boolean isObject) throws IOException {
+    final byte parentLevelKind = levelKind[depth];
+    final long parentKey = levelContainerKey[depth];
+    final long leftSibKey = levelLastChild[depth];
+    final long containerKey;
+    final long contentPcr;
+
+    if (parentLevelKind == LEVEL_OBJECT) {
+      // Named structural: the fused OBJECT_NAMED_OBJECT / OBJECT_NAMED_ARRAY record.
+      final String name = takePendingName();
+      final long fieldPcr = resolveFieldPcr(name);
+      if (isObject) {
+        containerKey = assertMinted(sink.createObjectNamedObjectNode(parentKey, leftSibKey, fieldPcr, name));
+        contentPcr = fieldPcr;
+      } else {
+        // The fused named array stores the __array__-layer PCR (see the cursor path's
+        // insertObjectRecordStructuralAsFirstChild); its notification carries the SAME key.
+        final long arrayPcr;
+        if (!buildPathSummary) {
+          arrayPcr = 0;
+        } else {
+          final long memoized = memoizedPcr(fieldPcr, "__array__");
+          if (memoized >= 0) {
+            arrayPcr = memoized;
+          } else if (pathSummaryWriter == null) {
+            throw new IllegalStateException(
+                "array path under (" + fieldPcr + ") was not pre-resolved for this build chunk");
+          } else {
+            arrayPcr = pathSummaryWriter.getArrayChildPathNodeKey(fieldPcr);
+            rememberPcr(fieldPcr, "__array__", arrayPcr);
+          }
+        }
+        containerKey = assertMinted(sink.createObjectNamedArrayNode(parentKey, leftSibKey, arrayPcr, name));
+        contentPcr = arrayPcr;
+      }
+      pushLevel(isObject
+          ? LEVEL_OBJECT
+          : LEVEL_ARRAY, containerKey, contentPcr);
+      return;
+    }
+
+    // Unnamed structural under document or an array.
+    if (isObject) {
+      // Plain OBJECT is TRANSPARENT for path anchoring: its fields resolve under the parent
+      // context, exactly like the cursor's stop-kind walk that passes straight through OBJECT.
+      contentPcr = levelContentPcr[depth];
+      containerKey = assertMinted(sink.createObjectNode(parentKey, leftSibKey, contentPcr));
+      pushLevel(LEVEL_OBJECT, containerKey, contentPcr);
+    } else {
+      // One __array__ path step regardless of insert position (user-ruled unification, applied to
+      // the cursor path in the same change): an array's path class depends on where it sits, so
+      // [[1],[2]] puts both inner arrays in ONE class.
+      final long arrayPcr;
+      if (!buildPathSummary) {
+        arrayPcr = 0;
+      } else {
+        final long parentPcr = levelContentPcr[depth];
+        final long memoized = memoizedPcr(parentPcr, "__array__");
+        if (memoized >= 0) {
+          arrayPcr = memoized;
+        } else if (pathSummaryWriter == null) {
+          throw new IllegalStateException(
+              "array path under (" + parentPcr + ") was not pre-resolved for this build chunk");
+        } else {
+          arrayPcr = pathSummaryWriter.getPathNodeKey(parentPcr, ARRAY_PATH_QNM, NodeKind.ARRAY);
+          rememberPcr(parentPcr, "__array__", arrayPcr);
+        }
+      }
+      containerKey = assertMinted(sink.createArrayNode(parentKey, leftSibKey, arrayPcr));
+      pushLevel(LEVEL_ARRAY, containerKey, arrayPcr);
+    }
+  }
+
+  private void closeContainer() throws IOException {
+    final long containerKey = levelContainerKey[depth];
+    final long firstChild = levelFirstChild[depth];
+    final long lastChild = levelLastChild[depth];
+    final long childCount = levelChildCount[depth];
+    depth--;
+    recordChildInParent(containerKey);
+
+    // The container's rightSib is knowable exactly now: every descendant has minted, so the next
+    // mint IS the following sibling (or nothing follows — where in member mode a TOP-LEVEL
+    // member's successor is the next chunk's first key, supplied from outside).
+    final long rightSibKey = peekSiblingFollows()
+        ? expectedNextKey
+        : (memberMode && depth == 0
+            ? trailingSiblingKey
+            : NULL_KEY);
+
+    if (childCount == 0 && rightSibKey == NULL_KEY) {
+      return; // the sink already wrote NULL child pointers and NULL rightSib — nothing changed
+    }
+    sink.fixupContainer(containerKey, firstChild, lastChild, childCount, rightSibKey);
+  }
+
+  private void fixupDocument() {
+    if (levelChildCount[0] == 0) {
+      return;
+    }
+    sink.fixupDocument(levelContainerKey[0], levelFirstChild[0], levelLastChild[0], levelChildCount[0]);
+  }
+
+  // ==== leaves ================================================================================
+
+  private void leafString(final byte[] utf8, final int utf8Length) throws IOException {
+    if (levelKind[depth] == LEVEL_OBJECT) {
+      final String name = takePendingName();
+      final long fieldPcr = resolveFieldPcr(name);
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createObjectNamedStringNode(levelContainerKey[depth],
+          levelLastChild[depth], rightSibKey, fieldPcr, name, utf8, utf8Length)));
+    } else {
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createStringNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, utf8, utf8Length, levelContentPcr[depth])));
+    }
+  }
+
+  private void leafNumber(final Number value) throws IOException {
+    if (levelKind[depth] == LEVEL_OBJECT) {
+      final String name = takePendingName();
+      final long fieldPcr = resolveFieldPcr(name);
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createObjectNamedNumberNode(levelContainerKey[depth],
+          levelLastChild[depth], rightSibKey, fieldPcr, name, value)));
+    } else {
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createNumberNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, value, levelContentPcr[depth])));
+    }
+  }
+
+  private void leafBoolean(final boolean value) throws IOException {
+    if (levelKind[depth] == LEVEL_OBJECT) {
+      final String name = takePendingName();
+      final long fieldPcr = resolveFieldPcr(name);
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createObjectNamedBooleanNode(levelContainerKey[depth],
+          levelLastChild[depth], rightSibKey, fieldPcr, name, value)));
+    } else {
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createBooleanNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, value, levelContentPcr[depth])));
+    }
+  }
+
+  private void leafNull() throws IOException {
+    if (levelKind[depth] == LEVEL_OBJECT) {
+      final String name = takePendingName();
+      final long fieldPcr = resolveFieldPcr(name);
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(sink.createObjectNamedNullNode(levelContainerKey[depth], levelLastChild[depth],
+          rightSibKey, fieldPcr, name)));
+    } else {
+      final long rightSibKey = predictedLeafRightSibling();
+      recordChildInParent(assertMinted(
+          sink.createNullNode(levelContainerKey[depth], levelLastChild[depth], rightSibKey, levelContentPcr[depth])));
+    }
+  }
+
+  // ==== shared mechanics ======================================================================
+
+  /**
+   * A leaf occupies exactly one key, so if the lookahead shows another sibling, that sibling's key
+   * is the one AFTER this leaf's. The prediction is verified when the sibling actually mints.
+   */
+  private long predictedLeafRightSibling() throws IOException {
+    if (peekSiblingFollows()) {
+      return expectedNextKey + 1;
+    }
+    return memberMode && depth == 0
+        ? trailingSiblingKey
+        : NULL_KEY;
+  }
+
+  /** After the current value is consumed: does another sibling follow in the open container? */
+  private boolean peekSiblingFollows() throws IOException {
+    final int next = scanner.peek();
+    return next != BulkJsonScanner.EVENT_END_OBJECT && next != BulkJsonScanner.EVENT_END_ARRAY
+        && next != BulkJsonScanner.EVENT_END_DOCUMENT;
+  }
+
+  private long resolveFieldPcr(final String name) {
+    if (!buildPathSummary) {
+      return 0;
+    }
+    final long parentPcr = levelContentPcr[depth];
+    final long memoized = memoizedPcr(parentPcr, name);
+    if (memoized >= 0) {
+      return memoized;
+    }
+    if (pathSummaryWriter == null) {
+      // Worker mode runs on a PRE-FILLED memo; a miss means the counting pass and this build saw
+      // different paths — refuse loudly rather than resolve out of order.
+      throw new IllegalStateException(
+          "path (" + parentPcr + ", '" + name + "') was not pre-resolved for this build chunk");
+    }
+    // Same literal path kind the cursor passes for EVERY named step (fields of all value types).
+    final long pcr = pathSummaryWriter.getPathNodeKey(parentPcr, new QNm(name), NodeKind.OBJECT_NAMED_OBJECT);
+    rememberPcr(parentPcr, name, pcr);
+    return pcr;
+  }
+
+  /** Memo hit: count the repeat locally and return the PCR; miss: {@code -1}. */
+  private long memoizedPcr(final long parentPcr, final String name) {
+    final Object2LongOpenHashMap<String> byName = pcrMemo.get(parentPcr);
+    if (byName == null) {
+      return -1;
+    }
+    final long pcr = byName.getLong(name);
+    if (pcr >= 0) {
+      pendingPathReferences.addTo(pcr, 1);
+    }
+    return pcr;
+  }
+
+  private void rememberPcr(final long parentPcr, final String name, final long pcr) {
+    Object2LongOpenHashMap<String> byName = pcrMemo.get(parentPcr);
+    if (byName == null) {
+      byName = new Object2LongOpenHashMap<>();
+      byName.defaultReturnValue(-1);
+      pcrMemo.put(parentPcr, byName);
+    }
+    byName.put(name, pcr);
+  }
+
+  private void flushPendingPathReferences() {
+    if (pendingPathReferences.isEmpty()) {
+      return;
+    }
+    if (pathSummaryWriter == null) {
+      // Worker mode: Stage A's counting pass over the same chars already counted every
+      // occurrence; the worker's tallies are a byproduct and must not double-count.
+      pendingPathReferences.clear();
+      return;
+    }
+    for (final var iterator = pendingPathReferences.long2IntEntrySet().fastIterator(); iterator.hasNext();) {
+      final var entry = iterator.next();
+      pathSummaryWriter.addReferences(entry.getLongKey(), entry.getIntValue());
+    }
+    pendingPathReferences.clear();
+  }
+
+  private String takePendingName() {
+    final String name = pendingName;
+    if (name == null) {
+      throw new IllegalStateException("value inside an object without a preceding field name");
+    }
+    pendingName = null;
+    return name;
+  }
+
+  private long assertMinted(final long mintedKey) {
+    if (mintedKey != expectedNextKey) {
+      throw new IllegalStateException(
+          "bulk key prediction violated: expected " + expectedNextKey + " but the sink minted " + mintedKey);
+    }
+    expectedNextKey++;
+    return mintedKey;
+  }
+
+  private void recordChildInParent(final long childKey) {
+    if (levelFirstChild[depth] == NULL_KEY) {
+      levelFirstChild[depth] = childKey;
+    }
+    levelLastChild[depth] = childKey;
+    levelChildCount[depth]++;
+    if (memberMode && depth == 0) {
+      membersDriven++;
+      lastMemberNodeCount = expectedNextKey - lastMemberStartKey();
+      memberStartKey = expectedNextKey;
+    }
+    if (depth == 1) {
+      // A child of the TOP-LEVEL container completed — for an array-of-records import this is
+      // exactly one record. Account its node count and let the sink rotate the intermediate
+      // epoch under the SAME predicate the cursor path uses (count threshold OR TIL page-work
+      // boundary). Safe point by construction: no leaf serialization is ever deferred, and the
+      // only pending state is open containers' close-fixups — the same shape the cursor path
+      // flushes under all the time. Forward-pointer predictions written before the flush refer to
+      // keys this load WILL mint next (asserted at the mint), which is sound for uncommitted
+      // pages only this transaction can read.
+      final long mutations = expectedNextKey - epochAccountedUpToKey;
+      if (mutations > 0 && mutations <= Integer.MAX_VALUE) {
+        // Deferred path-reference deltas must land BEFORE the rotation that may flush the summary
+        // pages, so every epoch's durable image carries counts the delta scheme has caught up on.
+        flushPendingPathReferences();
+        sink.accountRecords((int) mutations);
+        epochAccountedUpToKey = expectedNextKey;
+      }
+    }
+  }
+
+  private void pushLevel(final byte kind, final long containerKey, final long contentPcr) {
+    depth++;
+    if (depth == levelKind.length) {
+      final int grown = levelKind.length << 1;
+      levelKind = Arrays.copyOf(levelKind, grown);
+      levelContainerKey = Arrays.copyOf(levelContainerKey, grown);
+      levelContentPcr = Arrays.copyOf(levelContentPcr, grown);
+      levelFirstChild = Arrays.copyOf(levelFirstChild, grown);
+      levelLastChild = Arrays.copyOf(levelLastChild, grown);
+      levelChildCount = Arrays.copyOf(levelChildCount, grown);
+    }
+    levelKind[depth] = kind;
+    levelContainerKey[depth] = containerKey;
+    levelContentPcr[depth] = contentPcr;
+    levelFirstChild[depth] = NULL_KEY;
+    levelLastChild[depth] = NULL_KEY;
+    levelChildCount[depth] = 0;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkRecordSink.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkRecordSink.java
@@ -6,21 +6,21 @@ package io.sirix.access.trx.node.json;
 /**
  * The record-emission backend of {@link BulkJsonTreeAssembler}: everything the assembler's
  * prediction/container machinery needs from the storage layer, and nothing else. Three
- * implementations are planned — the transaction-backed sink (the original sequential behavior),
- * a counting sink (the parallel importer's Stage-A node counter, so count and build share ONE
- * code path), and a worker page builder emitting standalone {@code KeyValueLeafPage}s.
+ * implementations are planned — the transaction-backed sink (the original sequential behavior), a
+ * counting sink (the parallel importer's Stage-A node counter, so count and build share ONE code
+ * path), and a worker page builder emitting standalone {@code KeyValueLeafPage}s.
  *
  * <p>
  * CONTRACT — written for the hottest call path in a bulk load (~one call per node):
  * <ul>
- * <li>Primitives only: {@code long} keys/PCRs, {@code byte[]+length} string values. The lone
- * object parameters are the field-name {@link String} (canonical instance from the scanner's
- * intern table) and the heterogeneous {@link Number} a JSON number decodes to — both exactly what
- * the underlying encoders take.</li>
- * <li>Every creation returns the key the record MINTED AT; the assembler asserts it against its
- * own prediction, so a sink that mints out of sequence fails loudly, never silently.</li>
- * <li>A sink may bind returned state to reusable flyweights internally, so callers must not
- * retain anything a creation call produced beyond the NEXT sink call.</li>
+ * <li>Primitives only: {@code long} keys/PCRs, {@code byte[]+length} string values. The lone object
+ * parameters are the field-name {@link String} (canonical instance from the scanner's intern table)
+ * and the heterogeneous {@link Number} a JSON number decodes to — both exactly what the underlying
+ * encoders take.</li>
+ * <li>Every creation returns the key the record MINTED AT; the assembler asserts it against its own
+ * prediction, so a sink that mints out of sequence fails loudly, never silently.</li>
+ * <li>A sink may bind returned state to reusable flyweights internally, so callers must not retain
+ * anything a creation call produced beyond the NEXT sink call.</li>
  * <li>Notification PCRs ride the creation calls; a sink that does not notify ignores them.</li>
  * </ul>
  */
@@ -38,8 +38,7 @@ interface BulkRecordSink {
 
   // ==== leaves (created with FINAL pointers) ===================================================
 
-  long createStringNode(long parentKey, long leftSibKey, long rightSibKey, byte[] utf8, int utf8Length,
-      long notifyPcr);
+  long createStringNode(long parentKey, long leftSibKey, long rightSibKey, byte[] utf8, int utf8Length, long notifyPcr);
 
   long createObjectNamedStringNode(long parentKey, long leftSibKey, long rightSibKey, long pathNodeKey, String name,
       byte[] utf8, int utf8Length);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkRecordSink.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/BulkRecordSink.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+/**
+ * The record-emission backend of {@link BulkJsonTreeAssembler}: everything the assembler's
+ * prediction/container machinery needs from the storage layer, and nothing else. Three
+ * implementations are planned — the transaction-backed sink (the original sequential behavior),
+ * a counting sink (the parallel importer's Stage-A node counter, so count and build share ONE
+ * code path), and a worker page builder emitting standalone {@code KeyValueLeafPage}s.
+ *
+ * <p>
+ * CONTRACT — written for the hottest call path in a bulk load (~one call per node):
+ * <ul>
+ * <li>Primitives only: {@code long} keys/PCRs, {@code byte[]+length} string values. The lone
+ * object parameters are the field-name {@link String} (canonical instance from the scanner's
+ * intern table) and the heterogeneous {@link Number} a JSON number decodes to — both exactly what
+ * the underlying encoders take.</li>
+ * <li>Every creation returns the key the record MINTED AT; the assembler asserts it against its
+ * own prediction, so a sink that mints out of sequence fails loudly, never silently.</li>
+ * <li>A sink may bind returned state to reusable flyweights internally, so callers must not
+ * retain anything a creation call produced beyond the NEXT sink call.</li>
+ * <li>Notification PCRs ride the creation calls; a sink that does not notify ignores them.</li>
+ * </ul>
+ */
+interface BulkRecordSink {
+
+  // ==== containers (created with NULL child/right-sibling pointers; fixed once at close) =======
+
+  long createObjectNode(long parentKey, long leftSibKey, long notifyPcr);
+
+  long createArrayNode(long parentKey, long leftSibKey, long arrayPcr);
+
+  long createObjectNamedObjectNode(long parentKey, long leftSibKey, long pathNodeKey, String name);
+
+  long createObjectNamedArrayNode(long parentKey, long leftSibKey, long pathNodeKey, String name);
+
+  // ==== leaves (created with FINAL pointers) ===================================================
+
+  long createStringNode(long parentKey, long leftSibKey, long rightSibKey, byte[] utf8, int utf8Length,
+      long notifyPcr);
+
+  long createObjectNamedStringNode(long parentKey, long leftSibKey, long rightSibKey, long pathNodeKey, String name,
+      byte[] utf8, int utf8Length);
+
+  long createNumberNode(long parentKey, long leftSibKey, long rightSibKey, Number value, long notifyPcr);
+
+  long createObjectNamedNumberNode(long parentKey, long leftSibKey, long rightSibKey, long pathNodeKey, String name,
+      Number value);
+
+  long createBooleanNode(long parentKey, long leftSibKey, long rightSibKey, boolean value, long notifyPcr);
+
+  long createObjectNamedBooleanNode(long parentKey, long leftSibKey, long rightSibKey, long pathNodeKey, String name,
+      boolean value);
+
+  long createNullNode(long parentKey, long leftSibKey, long rightSibKey, long notifyPcr);
+
+  long createObjectNamedNullNode(long parentKey, long leftSibKey, long rightSibKey, long pathNodeKey, String name);
+
+  // ==== one-shot fixups ========================================================================
+
+  /** Applies a container's close-time pointers in one touch; {@code rightSibKey} may be null-key. */
+  void fixupContainer(long containerKey, long firstChildKey, long lastChildKey, long childCount, long rightSibKey);
+
+  /** Applies the document node's pointers once, at the end of the run. */
+  void fixupDocument(long documentKey, long firstChildKey, long lastChildKey, long childCount);
+
+  // ==== epoch accounting =======================================================================
+
+  /** Accounts {@code mutations} records at a safe boundary; the sink may rotate a flush epoch. */
+  void accountRecords(int mutations);
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ChunkIndexTupleBatch.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ChunkIndexTupleBatch.java
@@ -22,10 +22,10 @@ import java.util.Arrays;
  * the union of every PATH/CAS definition's resolved path classes and of every NAME definition's
  * included dictionary name keys ({@code null} union = a definition indexes everything, collect
  * all). The exact per-definition filter, include/exclude semantics and CAS type conversion run at
- * drain, inside the builders themselves — the one place those semantics already live. The
- * snapshots are exact for their chunk by the importer's standing argument: a chunk's paths and
- * names are resolved into the summary and the dictionary BEFORE the chunk is dispatched, so a
- * class first occurring in this chunk is in this chunk's snapshot.
+ * drain, inside the builders themselves — the one place those semantics already live. The snapshots
+ * are exact for their chunk by the importer's standing argument: a chunk's paths and names are
+ * resolved into the summary and the dictionary BEFORE the chunk is dispatched, so a class first
+ * occurring in this chunk is in this chunk's snapshot.
  *
  * <h2>Memory discipline</h2> Primitive parallel lists grown amortized, one UTF-8 arena for CAS
  * string values, {@code Number} references reused from the parser's own boxes — no per-record
@@ -70,8 +70,8 @@ final class ChunkIndexTupleBatch {
   private byte[] casStringArena = new byte[1024];
   private int casStringArenaUsed;
 
-  ChunkIndexTupleBatch(final boolean pathActive, final @Nullable LongOpenHashSet pathPcrUnion,
-      final boolean casActive, final @Nullable LongOpenHashSet casPcrUnion, final boolean nameActive,
+  ChunkIndexTupleBatch(final boolean pathActive, final @Nullable LongOpenHashSet pathPcrUnion, final boolean casActive,
+      final @Nullable LongOpenHashSet casPcrUnion, final boolean nameActive,
       final @Nullable IntOpenHashSet nameKeyUnion) {
     this.pathActive = pathActive;
     this.pathPcrUnion = pathPcrUnion;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ChunkIndexTupleBatch.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ChunkIndexTupleBatch.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import it.unimi.dsi.fastutil.bytes.ByteArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Arrays;
+
+/**
+ * One chunk's PATH/CAS/NAME index tuples, collected in the parallel importer's build worker from
+ * the same primitives the worker writes into page bytes, and drained by the coordinator into the
+ * families' {@code add(...)} entry points in chunk order.
+ *
+ * <h2>Filtering split</h2> The worker pre-prunes with UNION filters snapshot at chunk dispatch —
+ * the union of every PATH/CAS definition's resolved path classes and of every NAME definition's
+ * included dictionary name keys ({@code null} union = a definition indexes everything, collect
+ * all). The exact per-definition filter, include/exclude semantics and CAS type conversion run at
+ * drain, inside the builders themselves — the one place those semantics already live. The
+ * snapshots are exact for their chunk by the importer's standing argument: a chunk's paths and
+ * names are resolved into the summary and the dictionary BEFORE the chunk is dispatched, so a
+ * class first occurring in this chunk is in this chunk's snapshot.
+ *
+ * <h2>Memory discipline</h2> Primitive parallel lists grown amortized, one UTF-8 arena for CAS
+ * string values, {@code Number} references reused from the parser's own boxes — no per-record
+ * allocation beyond the amortized growth. The batch dies once the coordinator drains it.
+ */
+final class ChunkIndexTupleBatch {
+
+  static final byte CAS_KIND_STRING = 0;
+  static final byte CAS_KIND_NUMBER = 1;
+  static final byte CAS_KIND_BOOLEAN_TRUE = 2;
+  static final byte CAS_KIND_BOOLEAN_FALSE = 3;
+
+  private final @Nullable LongOpenHashSet pathPcrUnion;
+  private final @Nullable LongOpenHashSet casPcrUnion;
+  private final @Nullable IntOpenHashSet nameKeyUnion;
+  private final boolean pathActive;
+  private final boolean casActive;
+  private final boolean nameActive;
+
+  // PATH: (pathNodeKey, nodeKey) for ARRAY and every OBJECT_NAMED_* create.
+  private final LongArrayList pathPcrs = new LongArrayList(64);
+  private final LongArrayList pathNodeKeys = new LongArrayList(64);
+
+  // OBJECT_NAMED_ARRAY mirror candidates: the OBJECT_KEY-layer entry lives under the PARENT path
+  // class of the array-layer one, which only the coordinator's path summary can resolve — so these
+  // carry the array-layer class and are re-keyed (and union-filtered) at drain.
+  private final LongArrayList mirrorArrayPcrs = new LongArrayList(8);
+  private final LongArrayList mirrorNodeKeys = new LongArrayList(8);
+
+  // NAME: (dictionary name key, nodeKey) for every OBJECT_NAMED_* create.
+  private final IntArrayList nameKeys = new IntArrayList(64);
+  private final LongArrayList nameNodeKeys = new LongArrayList(64);
+
+  // CAS: (pathNodeKey, nodeKey, kind, value) for the six value kinds. String payloads live in the
+  // arena in tuple order; Number payloads are the parser's own boxes in tuple order.
+  private final LongArrayList casPcrs = new LongArrayList(64);
+  private final LongArrayList casNodeKeys = new LongArrayList(64);
+  private final ByteArrayList casKinds = new ByteArrayList(64);
+  private final IntArrayList casStringOffsets = new IntArrayList(32);
+  private final IntArrayList casStringLengths = new IntArrayList(32);
+  private final ObjectArrayList<Number> casNumbers = new ObjectArrayList<>(32);
+  private byte[] casStringArena = new byte[1024];
+  private int casStringArenaUsed;
+
+  ChunkIndexTupleBatch(final boolean pathActive, final @Nullable LongOpenHashSet pathPcrUnion,
+      final boolean casActive, final @Nullable LongOpenHashSet casPcrUnion, final boolean nameActive,
+      final @Nullable IntOpenHashSet nameKeyUnion) {
+    this.pathActive = pathActive;
+    this.pathPcrUnion = pathPcrUnion;
+    this.casActive = casActive;
+    this.casPcrUnion = casPcrUnion;
+    this.nameActive = nameActive;
+    this.nameKeyUnion = nameKeyUnion;
+  }
+
+  // ==== worker feed ============================================================================
+
+  /** An ARRAY or OBJECT_NAMED_* create — the kinds the PATH family indexes. */
+  void onPathEntry(final long pathNodeKey, final long nodeKey) {
+    if (pathActive && (pathPcrUnion == null || pathPcrUnion.contains(pathNodeKey))) {
+      pathPcrs.add(pathNodeKey);
+      pathNodeKeys.add(nodeKey);
+    }
+  }
+
+  /** An OBJECT_NAMED_ARRAY create — carries a second, OBJECT_KEY-layer PATH entry after re-keying. */
+  void onNamedArrayMirrorCandidate(final long arrayLayerPathNodeKey, final long nodeKey) {
+    if (pathActive) {
+      mirrorArrayPcrs.add(arrayLayerPathNodeKey);
+      mirrorNodeKeys.add(nodeKey);
+    }
+  }
+
+  /** Any OBJECT_NAMED_* create — the kinds the NAME family indexes, keyed by dictionary name key. */
+  void onNameEntry(final int nameKey, final long nodeKey) {
+    if (nameActive && (nameKeyUnion == null || nameKeyUnion.contains(nameKey))) {
+      nameKeys.add(nameKey);
+      nameNodeKeys.add(nodeKey);
+    }
+  }
+
+  void onCasString(final long pathNodeKey, final long nodeKey, final byte[] utf8, final int length) {
+    if (!casActive || (casPcrUnion != null && !casPcrUnion.contains(pathNodeKey))) {
+      return;
+    }
+    if (casStringArenaUsed + length > casStringArena.length) {
+      int grown = casStringArena.length;
+      while (grown < casStringArenaUsed + length) {
+        grown = Math.multiplyExact(grown, 2);
+      }
+      casStringArena = Arrays.copyOf(casStringArena, grown);
+    }
+    System.arraycopy(utf8, 0, casStringArena, casStringArenaUsed, length);
+    casStringOffsets.add(casStringArenaUsed);
+    casStringLengths.add(length);
+    casStringArenaUsed += length;
+    casPcrs.add(pathNodeKey);
+    casNodeKeys.add(nodeKey);
+    casKinds.add(CAS_KIND_STRING);
+  }
+
+  void onCasNumber(final long pathNodeKey, final long nodeKey, final Number value) {
+    if (!casActive || (casPcrUnion != null && !casPcrUnion.contains(pathNodeKey))) {
+      return;
+    }
+    casNumbers.add(value);
+    casPcrs.add(pathNodeKey);
+    casNodeKeys.add(nodeKey);
+    casKinds.add(CAS_KIND_NUMBER);
+  }
+
+  void onCasBoolean(final long pathNodeKey, final long nodeKey, final boolean value) {
+    if (!casActive || (casPcrUnion != null && !casPcrUnion.contains(pathNodeKey))) {
+      return;
+    }
+    casPcrs.add(pathNodeKey);
+    casNodeKeys.add(nodeKey);
+    casKinds.add(value
+        ? CAS_KIND_BOOLEAN_TRUE
+        : CAS_KIND_BOOLEAN_FALSE);
+  }
+
+  // ==== coordinator drain ======================================================================
+
+  int pathEntryCount() {
+    return pathPcrs.size();
+  }
+
+  long pathPcrAt(final int index) {
+    return pathPcrs.getLong(index);
+  }
+
+  long pathNodeKeyAt(final int index) {
+    return pathNodeKeys.getLong(index);
+  }
+
+  int mirrorCandidateCount() {
+    return mirrorArrayPcrs.size();
+  }
+
+  long mirrorArrayPcrAt(final int index) {
+    return mirrorArrayPcrs.getLong(index);
+  }
+
+  long mirrorNodeKeyAt(final int index) {
+    return mirrorNodeKeys.getLong(index);
+  }
+
+  int nameEntryCount() {
+    return nameKeys.size();
+  }
+
+  int nameKeyAt(final int index) {
+    return nameKeys.getInt(index);
+  }
+
+  long nameNodeKeyAt(final int index) {
+    return nameNodeKeys.getLong(index);
+  }
+
+  int casEntryCount() {
+    return casPcrs.size();
+  }
+
+  long casPcrAt(final int index) {
+    return casPcrs.getLong(index);
+  }
+
+  long casNodeKeyAt(final int index) {
+    return casNodeKeys.getLong(index);
+  }
+
+  byte casKindAt(final int index) {
+    return casKinds.getByte(index);
+  }
+
+  byte[] casStringArena() {
+    return casStringArena;
+  }
+
+  /** Offset of the {@code stringOrdinal}-th CAS string tuple's payload in {@link #casStringArena}. */
+  int casStringOffsetAt(final int stringOrdinal) {
+    return casStringOffsets.getInt(stringOrdinal);
+  }
+
+  int casStringLengthAt(final int stringOrdinal) {
+    return casStringLengths.getInt(stringOrdinal);
+  }
+
+  Number casNumberAt(final int numberOrdinal) {
+    return casNumbers.get(numberOrdinal);
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The parallel importer's fused Stage-A: ONE pass over the raw UTF-8 stream that simultaneously
@@ -85,10 +87,16 @@ final class FusedSliceAndScan {
 
   }
 
-  /** One member-aligned chunk plus everything the coordinator must resolve before its build. */
+  /**
+   * One member-aligned chunk plus everything the coordinator must resolve before its build.
+   *
+   * @param memberNodes the node count of each member in document order, or {@code null} when the
+   *        coordinator did not ask for them. Only a load that must name every record — a one-pass
+   *        projection build — needs them; an ordinary import pays neither the array nor the stores.
+   */
   record Chunk(byte[] bytes, int length, boolean isFinal, long nodes, long members, long lastMemberNodes,
       List<PathStep> newSteps, List<PathStep> touchedSteps, int[] stepOccurrences, List<String> newNames,
-      List<int[]> nameTallies) {
+      List<int[]> nameTallies, long @Nullable [] memberNodes) {
   }
 
   private static final int READ_BUFFER_BYTES = 1 << 20;
@@ -133,6 +141,13 @@ final class FusedSliceAndScan {
   private long lastMemberNodes;
   private long memberStartNodes;
 
+  /**
+   * Per-member node counts for the CURRENT chunk, or {@code null} when the coordinator does not
+   * need them. Reserved once at the requested capacity and reused for every chunk, so a load that
+   * does need them still allocates no per-chunk array beyond the handed-off copy.
+   */
+  private final @Nullable LongArrayList memberNodes;
+
   // ==== open-addressed byte-hash name table (slots map to STABLE dense ids) ===================
   private byte[][] nameBytes = new byte[NAME_TABLE_CAPACITY][];
   private int[] nameIdBySlot = new int[NAME_TABLE_CAPACITY];
@@ -169,9 +184,20 @@ final class FusedSliceAndScan {
   }
 
   FusedSliceAndScan(final InputStream in, final int chunkByteBudget) {
+    this(in, chunkByteBudget, false);
+  }
+
+  /**
+   * @param trackMemberNodes whether each chunk should carry its members' node counts — the only way
+   *        a coordinator can name every record's root key by range arithmetic
+   */
+  FusedSliceAndScan(final InputStream in, final int chunkByteBudget, final boolean trackMemberNodes) {
     this.in = in;
     this.chunkByteBudget = Math.max(1024, chunkByteBudget);
     this.chunkBuffer = new byte[this.chunkByteBudget + (this.chunkByteBudget >> 2)];
+    this.memberNodes = trackMemberNodes
+        ? new LongArrayList(1024)
+        : null;
   }
 
   PathStep rootStep() {
@@ -209,6 +235,9 @@ final class FusedSliceAndScan {
     members = 0;
     lastMemberNodes = 0;
     memberStartNodes = 0;
+    if (memberNodes != null) {
+      memberNodes.clear();
+    }
     depth = 0;
     contextStep[0] = rootStep;
     contextIsObject[0] = false;
@@ -377,6 +406,9 @@ final class FusedSliceAndScan {
     members++;
     lastMemberNodes = nodes - memberStartNodes;
     memberStartNodes = nodes;
+    if (memberNodes != null) {
+      memberNodes.add(lastMemberNodes);
+    }
   }
 
   /** Closes the chunk at this member boundary when the budget is met. */
@@ -522,8 +554,11 @@ final class FusedSliceAndScan {
     }
     final byte[] out = acquireChunkBuffer(chunkLength);
     System.arraycopy(chunkBuffer, 0, out, 0, chunkLength);
+    final long[] memberNodeCounts = memberNodes == null
+        ? null
+        : memberNodes.toLongArray();
     return new Chunk(out, chunkLength, isFinal, nodes, members, lastMemberNodes, List.copyOf(newSteps),
-        List.copyOf(touchedSteps), stepOccurrences, List.copyOf(newNames), tallies);
+        List.copyOf(touchedSteps), stepOccurrences, List.copyOf(newNames), tallies, memberNodeCounts);
   }
 
   private boolean matches(final byte[] existing, final int start, final int len) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ArrayBlockingQueue;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -27,10 +28,10 @@ import org.jspecify.annotations.Nullable;
  * distinct name for the whole load.</li>
  * <li>Each name entry carries its own tiny {@code parentPCR → fieldPCR} map, so the per-occurrence
  * path cost is one long-hash probe instead of a String-keyed memo lookup; misses resolve through
- * the REAL summary writer on the coordinator (global first-occurrence order preserved:
- * path-resolve before name-intern, the sequential path's exact dictionary call order).</li>
- * <li>Reference-count deltas accumulate per path node and flush per chunk (before any rotation
- * can flush summary pages cold).</li>
+ * the REAL summary writer on the coordinator (global first-occurrence order preserved: path-resolve
+ * before name-intern, the sequential path's exact dictionary call order).</li>
+ * <li>Reference-count deltas accumulate per path node and flush per chunk (before any rotation can
+ * flush summary pages cold).</li>
  * </ul>
  *
  * <p>
@@ -40,12 +41,12 @@ import org.jspecify.annotations.Nullable;
 final class FusedSliceAndScan {
 
   /**
-   * One node of the feeder-owned PATH TRIE: scan context is tracked by trie-node IDENTITY, never
-   * by PCR values, so the feeder needs no access to the path summary at all. The coordinator
-   * resolves {@link #pcr} for NEW nodes at chunk handoff, in first-occurrence order — the exact
-   * order a sequential load inserts paths. Field ownership is disjoint across the two threads:
-   * the feeder mutates the children maps and tallies, the coordinator writes {@code pcr}; the
-   * handoff queue's put/take pair is the fence that publishes each chunk's new nodes.
+   * One node of the feeder-owned PATH TRIE: scan context is tracked by trie-node IDENTITY, never by
+   * PCR values, so the feeder needs no access to the path summary at all. The coordinator resolves
+   * {@link #pcr} for NEW nodes at chunk handoff, in first-occurrence order — the exact order a
+   * sequential load inserts paths. Field ownership is disjoint across the two threads: the feeder
+   * mutates the children maps and tallies, the coordinator writes {@code pcr}; the handoff queue's
+   * put/take pair is the fence that publishes each chunk's new nodes.
    */
   static final class PathStep {
     final PathStep parent;
@@ -142,9 +143,9 @@ final class FusedSliceAndScan {
   private long memberStartNodes;
 
   /**
-   * Per-member node counts for the CURRENT chunk, or {@code null} when the coordinator does not
-   * need them. Reserved once at the requested capacity and reused for every chunk, so a load that
-   * does need them still allocates no per-chunk array beyond the handed-off copy.
+   * Per-member node counts for the CURRENT chunk, or {@code null} when the coordinator does not need
+   * them. Reserved once at the requested capacity and reused for every chunk, so a load that does
+   * need them still allocates no per-chunk array beyond the handed-off copy.
    */
   private final @Nullable LongArrayList memberNodes;
 
@@ -164,9 +165,9 @@ final class FusedSliceAndScan {
   private final PathStep rootStep = new PathStep(null, -1, null);
 
   /**
-   * Recycled chunk buffers: a fresh multi-MB {@code byte[]} per chunk is a G1 humongous
-   * allocation — measured at ~2.8 GB of churn every 1.7 s on a 1M import, driving 10 of 12
-   * collections. Receivers return buffers via {@link #releaseChunkBuffer} once the build is done.
+   * Recycled chunk buffers: a fresh multi-MB {@code byte[]} per chunk is a G1 humongous allocation —
+   * measured at ~2.8 GB of churn every 1.7 s on a 1M import, driving 10 of 12 collections. Receivers
+   * return buffers via {@link #releaseChunkBuffer} once the build is done.
    */
   private final ArrayBlockingQueue<byte[]> chunkBufferPool = new ArrayBlockingQueue<>(16);
 
@@ -188,8 +189,8 @@ final class FusedSliceAndScan {
   }
 
   /**
-   * @param trackMemberNodes whether each chunk should carry its members' node counts — the only way
-   *        a coordinator can name every record's root key by range arithmetic
+   * @param trackMemberNodes whether each chunk should carry its members' node counts — the only way a
+   *        coordinator can name every record's root key by range arithmetic
    */
   FusedSliceAndScan(final InputStream in, final int chunkByteBudget, final boolean trackMemberNodes) {
     this.in = in;
@@ -541,7 +542,7 @@ final class FusedSliceAndScan {
     final List<int[]> tallies = new ArrayList<>(touchedNameCount);
     for (int i = 0; i < touchedNameCount; i++) {
       final int nameId = touchedNameSlots[i];
-      tallies.add(new int[] { nameId, nameChunkOccurrencesById[nameId] });
+      tallies.add(new int[] {nameId, nameChunkOccurrencesById[nameId]});
       nameChunkOccurrencesById[nameId] = 0;
     }
     touchedNameCount = 0;
@@ -629,7 +630,7 @@ final class FusedSliceAndScan {
   }
 
   private static String decodeName(final byte[] raw) {
-    final String utf8 = new String(raw, java.nio.charset.StandardCharsets.UTF_8);
+    final String utf8 = new String(raw, StandardCharsets.UTF_8);
     if (utf8.indexOf('\\') < 0) {
       return utf8;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/FusedSliceAndScan.java
@@ -1,0 +1,626 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+/**
+ * The parallel importer's fused Stage-A: ONE pass over the raw UTF-8 stream that simultaneously
+ * SLICES member-aligned chunks (bulk segment copies, never per-byte appends) and produces every
+ * piece of coordinator metadata — exact node count, member count, last-member node count, name
+ * occurrences and path resolution — without decoding a single value byte and, in steady state,
+ * without allocating per name occurrence:
+ *
+ * <ul>
+ * <li>Names resolve through an open-addressed BYTE-hash table (FNV-1a over the raw name bytes,
+ * verified by byte comparison): decode-to-String happens only on a table miss, i.e. once per
+ * distinct name for the whole load.</li>
+ * <li>Each name entry carries its own tiny {@code parentPCR → fieldPCR} map, so the per-occurrence
+ * path cost is one long-hash probe instead of a String-keyed memo lookup; misses resolve through
+ * the REAL summary writer on the coordinator (global first-occurrence order preserved:
+ * path-resolve before name-intern, the sequential path's exact dictionary call order).</li>
+ * <li>Reference-count deltas accumulate per path node and flush per chunk (before any rotation
+ * can flush summary pages cold).</li>
+ * </ul>
+ *
+ * <p>
+ * The build that follows verifies the count exactly (final minted key == range end AND populated
+ * slots == n), so a divergence between this pass and the full tokenizer refuses loudly per chunk.
+ */
+final class FusedSliceAndScan {
+
+  /**
+   * One node of the feeder-owned PATH TRIE: scan context is tracked by trie-node IDENTITY, never
+   * by PCR values, so the feeder needs no access to the path summary at all. The coordinator
+   * resolves {@link #pcr} for NEW nodes at chunk handoff, in first-occurrence order — the exact
+   * order a sequential load inserts paths. Field ownership is disjoint across the two threads:
+   * the feeder mutates the children maps and tallies, the coordinator writes {@code pcr}; the
+   * handoff queue's put/take pair is the fence that publishes each chunk's new nodes.
+   */
+  static final class PathStep {
+    final PathStep parent;
+    /** The STABLE dense name id of this step, or {@code -1} for an {@code __array__} step. */
+    final int nameSlot;
+    /** The decoded field name (null for {@code __array__} steps); immutable pre-publication. */
+    final String name;
+    long pcr = -1;
+    private Int2ObjectOpenHashMap<PathStep> childrenByNameSlot;
+    private PathStep arrayChild;
+    /** Occurrences THIS chunk (drained at handoff into reference-count deltas). */
+    int chunkOccurrences;
+    boolean touchedThisChunk;
+
+    PathStep(final PathStep parent, final int nameSlot, final String name) {
+      this.parent = parent;
+      this.nameSlot = nameSlot;
+      this.name = name;
+    }
+
+    Int2ObjectOpenHashMap<PathStep> childrenByNameSlot() {
+      if (childrenByNameSlot == null) {
+        childrenByNameSlot = new Int2ObjectOpenHashMap<>(4);
+      }
+      return childrenByNameSlot;
+    }
+
+    Int2ObjectOpenHashMap<PathStep> childrenRaw() {
+      return childrenByNameSlot;
+    }
+
+    PathStep arrayChild() {
+      return arrayChild;
+    }
+
+    void setArrayChild(final PathStep child) {
+      this.arrayChild = child;
+    }
+
+  }
+
+  /** One member-aligned chunk plus everything the coordinator must resolve before its build. */
+  record Chunk(byte[] bytes, int length, boolean isFinal, long nodes, long members, long lastMemberNodes,
+      List<PathStep> newSteps, List<PathStep> touchedSteps, int[] stepOccurrences, List<String> newNames,
+      List<int[]> nameTallies) {
+  }
+
+  private static final int READ_BUFFER_BYTES = 1 << 20;
+  private static final int INITIAL_DEPTH_CAPACITY = 64;
+  private static final int NAME_TABLE_CAPACITY = 1 << 10;
+
+  private final InputStream in;
+  private final int chunkByteBudget;
+
+  private final byte[] readBuffer = new byte[READ_BUFFER_BYTES];
+  private int position;
+  private int limit;
+  /** Start of the not-yet-copied segment of the read buffer (bulk chunk copies). */
+  private int segmentStart;
+
+  private byte[] chunkBuffer;
+  private int chunkLength;
+
+  private boolean inString;
+  private boolean escaped;
+  private boolean stringIsName;
+  private int nameStartInChunk = -1;
+  private boolean arrayClosed;
+
+  // Container context: the current PATH STEP + object flag, mirroring the assembler's rules
+  // (plain OBJECT is transparent; arrays add one __array__ step; named containers anchor theirs).
+  private PathStep[] contextStep = new PathStep[INITIAL_DEPTH_CAPACITY];
+  private boolean[] contextIsObject = new boolean[INITIAL_DEPTH_CAPACITY];
+  private int depth;
+
+  /** A name string just closed; the NEXT value token binds to it (its path step precomputed). */
+  private PathStep pendingFieldStep;
+  private boolean namePending;
+
+  /** The document-ordered handoff lists for the CURRENT chunk. */
+  private final ArrayList<PathStep> newSteps = new ArrayList<>();
+  private final ArrayList<PathStep> touchedSteps = new ArrayList<>();
+  private final ArrayList<String> newNames = new ArrayList<>();
+
+  private long nodes;
+  private long members;
+  private long lastMemberNodes;
+  private long memberStartNodes;
+
+  // ==== open-addressed byte-hash name table (slots map to STABLE dense ids) ===================
+  private byte[][] nameBytes = new byte[NAME_TABLE_CAPACITY][];
+  private int[] nameIdBySlot = new int[NAME_TABLE_CAPACITY];
+  private String[] nameStringById = new String[64];
+  private int[] nameChunkOccurrencesById = new int[64];
+  private int nameCount;
+  private int nameMask = NAME_TABLE_CAPACITY - 1;
+
+  /** Distinct-name slots touched THIS chunk, for occurrence-delta emission + reset. */
+  private int[] touchedNameSlots = new int[256];
+  private int touchedNameCount;
+
+  /** The trie root = the top-level array's own step; the coordinator sets its PCR up front. */
+  private final PathStep rootStep = new PathStep(null, -1, null);
+
+  /**
+   * Recycled chunk buffers: a fresh multi-MB {@code byte[]} per chunk is a G1 humongous
+   * allocation — measured at ~2.8 GB of churn every 1.7 s on a 1M import, driving 10 of 12
+   * collections. Receivers return buffers via {@link #releaseChunkBuffer} once the build is done.
+   */
+  private final ArrayBlockingQueue<byte[]> chunkBufferPool = new ArrayBlockingQueue<>(16);
+
+  private byte[] acquireChunkBuffer(final int needed) {
+    final byte[] pooled = chunkBufferPool.poll();
+    if (pooled != null && pooled.length >= needed) {
+      return pooled;
+    }
+    return new byte[Math.max(needed, chunkByteBudget + (chunkByteBudget >> 2))];
+  }
+
+  /** Thread-safe; called by the importer (any thread) when a chunk's bytes are no longer read. */
+  void releaseChunkBuffer(final byte[] buffer) {
+    chunkBufferPool.offer(buffer);
+  }
+
+  FusedSliceAndScan(final InputStream in, final int chunkByteBudget) {
+    this.in = in;
+    this.chunkByteBudget = Math.max(1024, chunkByteBudget);
+    this.chunkBuffer = new byte[this.chunkByteBudget + (this.chunkByteBudget >> 2)];
+  }
+
+  PathStep rootStep() {
+    return rootStep;
+  }
+
+  /** Consumes leading whitespace and the top-level {@code '['}. */
+  void consumeArrayOpen() throws IOException {
+    while (true) {
+      if (position == limit && !fill()) {
+        throw new IllegalStateException("input ended before the top-level array opened");
+      }
+      final byte c = readBuffer[position];
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+        position++;
+        segmentStart = position;
+        continue;
+      }
+      if (c != '[') {
+        throw new IllegalStateException("parallel import requires a top-level array, got byte " + c);
+      }
+      position++;
+      segmentStart = position;
+      return;
+    }
+  }
+
+  /** The next member-aligned chunk with its metadata, or {@code null} at the array's end. */
+  Chunk nextChunk() throws IOException {
+    if (arrayClosed) {
+      return null;
+    }
+    chunkLength = 0;
+    nodes = 0;
+    members = 0;
+    lastMemberNodes = 0;
+    memberStartNodes = 0;
+    depth = 0;
+    contextStep[0] = rootStep;
+    contextIsObject[0] = false;
+    namePending = false;
+    newSteps.clear();
+    touchedSteps.clear();
+    newNames.clear();
+
+    while (true) {
+      if (position == limit && !refillPreservingChunk()) {
+        throw new IllegalStateException("input ended inside the top-level array (depth " + depth + ")");
+      }
+      final byte c = readBuffer[position];
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          position++;
+          continue;
+        }
+        // Tight skip: race through the string body to the next quote or backslash — the bulk of
+        // real-world bytes live inside string values, and this loop is the whole cost of passing
+        // them (no decode, no copy beyond the segment flush).
+        final byte[] buffer = readBuffer;
+        int scanPosition = position;
+        final int scanLimit = limit;
+        while (scanPosition < scanLimit) {
+          final byte b = buffer[scanPosition];
+          if (b == '"' || b == '\\') {
+            break;
+          }
+          scanPosition++;
+        }
+        position = scanPosition;
+        if (position == limit) {
+          continue; // refill via the loop head
+        }
+        if (buffer[position] == '\\') {
+          escaped = true;
+          position++;
+          continue;
+        }
+        // Closing quote.
+        inString = false;
+        position++;
+        if (stringIsName) {
+          stringIsName = false;
+          // The name's bytes sit in the CHUNK buffer (flushed below) or the current segment;
+          // close the segment so the name is contiguous in chunkBuffer, then resolve it.
+          flushSegment();
+          resolveName(nameStartInChunk, chunkLength - 1);
+          nameStartInChunk = -1;
+        } else {
+          nodes++;
+          valueCompleted();
+        }
+        continue;
+      }
+
+      switch (c) {
+        case ' ', '\t', '\n', '\r', ',', ':' -> position++;
+        case '"' -> {
+          inString = true;
+          // Name iff directly inside an object and no name is pending yet.
+          stringIsName = contextIsObject[depth] && !namePending;
+          if (stringIsName) {
+            flushSegmentUpTo(position);
+            nameStartInChunk = chunkLength + 1;
+          }
+          position++;
+        }
+        case '{' -> {
+          nodes++;
+          if (namePending) {
+            namePending = false;
+            push(pendingFieldStep, true);
+          } else {
+            // Plain OBJECT is transparent for path anchoring.
+            push(contextStep[depth], true);
+          }
+          position++;
+        }
+        case '[' -> {
+          nodes++;
+          if (namePending) {
+            namePending = false;
+            push(arrayStepUnder(pendingFieldStep), false);
+          } else {
+            push(arrayStepUnder(contextStep[depth]), false);
+          }
+          position++;
+        }
+        case '}' -> {
+          if (depth == 0) {
+            throw new IllegalStateException("unbalanced '}' at the top level");
+          }
+          depth--;
+          position++;
+          if (depth == 0) {
+            memberCompleted();
+            final Chunk chunk = maybeCloseChunk();
+            if (chunk != null) {
+              return chunk;
+            }
+          }
+        }
+        case ']' -> {
+          if (depth == 0) {
+            arrayClosed = true;
+            flushSegmentUpTo(position);
+            position++;
+            segmentStart = position;
+            return nodes > 0
+                ? finishChunk(true)
+                : null;
+          }
+          depth--;
+          position++;
+          if (depth == 0) {
+            memberCompleted();
+            final Chunk chunk = maybeCloseChunk();
+            if (chunk != null) {
+              return chunk;
+            }
+          }
+        }
+        default -> {
+          // Number or literal: skip to its structural end.
+          nodes++;
+          if (namePending) {
+            namePending = false;
+          }
+          position++;
+          while (true) {
+            if (position == limit && !refillPreservingChunk()) {
+              throw new IllegalStateException("input ended inside a literal");
+            }
+            final byte v = readBuffer[position];
+            if (v == ',' || v == '}' || v == ']' || v == ' ' || v == '\t' || v == '\n' || v == '\r') {
+              break;
+            }
+            position++;
+          }
+          if (depth == 0) {
+            memberCompleted();
+            final Chunk chunk = maybeCloseChunk();
+            if (chunk != null) {
+              return chunk;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private void valueCompleted() {
+    if (namePending) {
+      namePending = false;
+    }
+    if (depth == 0) {
+      memberCompleted();
+    }
+  }
+
+  private void memberCompleted() {
+    members++;
+    lastMemberNodes = nodes - memberStartNodes;
+    memberStartNodes = nodes;
+  }
+
+  /** Closes the chunk at this member boundary when the budget is met. */
+  private Chunk maybeCloseChunk() throws IOException {
+    flushSegmentUpTo(position);
+    if (chunkLength < chunkByteBudget) {
+      return null;
+    }
+    final boolean isFinal = peekArrayCloses();
+    return finishChunk(isFinal);
+  }
+
+  private boolean peekArrayCloses() throws IOException {
+    while (true) {
+      if (position == limit && !fill()) {
+        throw new IllegalStateException("input ended inside the top-level array");
+      }
+      final byte c = readBuffer[position];
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',') {
+        position++;
+        segmentStart = position;
+        continue;
+      }
+      if (c == ']') {
+        arrayClosed = true;
+        position++;
+        segmentStart = position;
+        return true;
+      }
+      return false;
+    }
+  }
+
+  // ==== chunk buffer (bulk segment copies) =====================================================
+
+  private void flushSegment() {
+    flushSegmentUpTo(position);
+  }
+
+  private void flushSegmentUpTo(final int end) {
+    final int len = end - segmentStart;
+    if (len > 0) {
+      ensureChunkCapacity(len);
+      System.arraycopy(readBuffer, segmentStart, chunkBuffer, chunkLength, len);
+      chunkLength += len;
+    }
+    segmentStart = end;
+  }
+
+  private void ensureChunkCapacity(final int extra) {
+    if (chunkLength + extra > chunkBuffer.length) {
+      chunkBuffer = Arrays.copyOf(chunkBuffer, Math.max(chunkBuffer.length << 1, chunkLength + extra));
+    }
+  }
+
+  private boolean fill() throws IOException {
+    flushSegmentUpTo(limit);
+    limit = in.read(readBuffer, 0, readBuffer.length);
+    position = 0;
+    segmentStart = 0;
+    return limit > 0;
+  }
+
+  private boolean refillPreservingChunk() throws IOException {
+    return fill();
+  }
+
+  // ==== name resolution ========================================================================
+
+  /** Name bytes live at {@code chunkBuffer[start .. endExclusive)} (closing quote excluded). */
+  private void resolveName(final int start, final int endExclusive) {
+    final int len = endExclusive - start;
+    long hash = 0xcbf29ce484222325L;
+    for (int i = start; i < endExclusive; i++) {
+      hash = (hash ^ chunkBuffer[i]) * 0x100000001b3L;
+    }
+    int slot = (int) hash & nameMask;
+    while (true) {
+      final byte[] existing = nameBytes[slot];
+      if (existing == null) {
+        insertName(slot, start, len);
+        break;
+      }
+      if (matches(existing, start, len)) {
+        break;
+      }
+      slot = (slot + 1) & nameMask;
+    }
+    final int nameId = nameIdBySlot[slot];
+    if (nameChunkOccurrencesById[nameId]++ == 0) {
+      rememberTouched(nameId);
+    }
+    pendingFieldStep = fieldStepUnder(contextStep[depth], nameId);
+    namePending = true;
+  }
+
+  /** Get-or-create the named child step; occurrences tally per step for reference deltas. */
+  private PathStep fieldStepUnder(final PathStep parent, final int nameId) {
+    final Int2ObjectOpenHashMap<PathStep> children = parent.childrenByNameSlot();
+    PathStep step = children.get(nameId);
+    if (step == null) {
+      step = new PathStep(parent, nameId, nameStringById[nameId]);
+      children.put(nameId, step);
+      newSteps.add(step);
+    }
+    tallyStep(step);
+    return step;
+  }
+
+  private PathStep arrayStepUnder(final PathStep parent) {
+    PathStep step = parent.arrayChild();
+    if (step == null) {
+      step = new PathStep(parent, -1, null);
+      parent.setArrayChild(step);
+      newSteps.add(step);
+    }
+    tallyStep(step);
+    return step;
+  }
+
+  private void tallyStep(final PathStep step) {
+    if (!step.touchedThisChunk) {
+      step.touchedThisChunk = true;
+      touchedSteps.add(step);
+    }
+    step.chunkOccurrences++;
+  }
+
+  private Chunk finishChunk(final boolean isFinal) {
+    final List<int[]> tallies = new ArrayList<>(touchedNameCount);
+    for (int i = 0; i < touchedNameCount; i++) {
+      final int nameId = touchedNameSlots[i];
+      tallies.add(new int[] { nameId, nameChunkOccurrencesById[nameId] });
+      nameChunkOccurrencesById[nameId] = 0;
+    }
+    touchedNameCount = 0;
+    final int[] stepOccurrences = new int[touchedSteps.size()];
+    for (int i = 0; i < touchedSteps.size(); i++) {
+      final PathStep step = touchedSteps.get(i);
+      stepOccurrences[i] = step.chunkOccurrences;
+      step.chunkOccurrences = 0;
+      step.touchedThisChunk = false;
+    }
+    final byte[] out = acquireChunkBuffer(chunkLength);
+    System.arraycopy(chunkBuffer, 0, out, 0, chunkLength);
+    return new Chunk(out, chunkLength, isFinal, nodes, members, lastMemberNodes, List.copyOf(newSteps),
+        List.copyOf(touchedSteps), stepOccurrences, List.copyOf(newNames), tallies);
+  }
+
+  private boolean matches(final byte[] existing, final int start, final int len) {
+    if (existing.length != len) {
+      return false;
+    }
+    return Arrays.mismatch(existing, 0, len, chunkBuffer, start, start + len) < 0;
+  }
+
+  private void insertName(final int slot, final int start, final int len) {
+    final byte[] copy = new byte[len];
+    System.arraycopy(chunkBuffer, start, copy, 0, len);
+    final String decoded = decodeName(copy);
+    final int nameId = nameCount++;
+    nameBytes[slot] = copy;
+    nameIdBySlot[slot] = nameId;
+    if (nameId == nameStringById.length) {
+      nameStringById = Arrays.copyOf(nameStringById, nameStringById.length << 1);
+      nameChunkOccurrencesById = Arrays.copyOf(nameChunkOccurrencesById, nameChunkOccurrencesById.length << 1);
+    }
+    nameStringById[nameId] = decoded;
+    newNames.add(decoded);
+    if (nameCount * 2 > nameMask) {
+      growNameTable();
+    }
+  }
+
+  private void rememberTouched(final int slot) {
+    if (touchedNameCount == touchedNameSlots.length) {
+      touchedNameSlots = Arrays.copyOf(touchedNameSlots, touchedNameSlots.length << 1);
+    }
+    touchedNameSlots[touchedNameCount++] = slot;
+  }
+
+  private void growNameTable() {
+    final int newCapacity = (nameMask + 1) << 1;
+    final byte[][] oldBytes = nameBytes;
+    final int[] oldIds = nameIdBySlot;
+    nameBytes = new byte[newCapacity][];
+    nameIdBySlot = new int[newCapacity];
+    nameMask = newCapacity - 1;
+    for (int i = 0; i < oldBytes.length; i++) {
+      final byte[] name = oldBytes[i];
+      if (name == null) {
+        continue;
+      }
+      long hash = 0xcbf29ce484222325L;
+      for (final byte b : name) {
+        hash = (hash ^ b) * 0x100000001b3L;
+      }
+      int slot = (int) hash & nameMask;
+      while (nameBytes[slot] != null) {
+        slot = (slot + 1) & nameMask;
+      }
+      nameBytes[slot] = name;
+      nameIdBySlot[slot] = oldIds[i];
+    }
+  }
+
+  private void push(final PathStep step, final boolean isObject) {
+    depth++;
+    if (depth == contextStep.length) {
+      contextStep = Arrays.copyOf(contextStep, contextStep.length << 1);
+      contextIsObject = Arrays.copyOf(contextIsObject, contextIsObject.length << 1);
+    }
+    contextStep[depth] = step;
+    contextIsObject[depth] = isObject;
+  }
+
+  private static String decodeName(final byte[] raw) {
+    final String utf8 = new String(raw, java.nio.charset.StandardCharsets.UTF_8);
+    if (utf8.indexOf('\\') < 0) {
+      return utf8;
+    }
+    final StringBuilder out = new StringBuilder(utf8.length());
+    for (int i = 0; i < utf8.length(); i++) {
+      char c = utf8.charAt(i);
+      if (c == '\\') {
+        i++;
+        c = utf8.charAt(i);
+        switch (c) {
+          case '"', '\\', '/' -> out.append(c);
+          case 'b' -> out.append('\b');
+          case 'f' -> out.append('\f');
+          case 'n' -> out.append('\n');
+          case 'r' -> out.append('\r');
+          case 't' -> out.append('\t');
+          case 'u' -> {
+            out.append((char) Integer.parseInt(utf8.substring(i + 1, i + 5), 16));
+            i += 4;
+          }
+          default -> throw new IllegalStateException("invalid escape \\" + c + " in field name");
+        }
+      } else {
+        out.append(c);
+      }
+    }
+    return out.toString();
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -200,7 +200,11 @@ final class JsonNodeTrxImpl extends
       "Insert is not allowed if parent node is not an array node!";
 
   private static final QNm ARRAY_PATH_QNM = new QNm("__array__");
-  private static final QNm ARRAY_SIBLING_PATH_QNM = new QNm("array");
+  // A sibling array resolves the SAME __array__ path step as a first-child array: an array's
+  // path class is a property of WHERE it sits, not of which insert position created it —
+  // [[1],[2]] must put both inner arrays in ONE path class or every path-addressed consumer
+  // (summary counts, projections, CAS indexes) silently sees only the first element.
+
   private static final long UNKNOWN_NOTIFICATION_PATH_NODE_KEY = Long.MIN_VALUE;
   private static final Str STR_TRUE = new Str("true");
   private static final Str STR_FALSE = new Str("false");
@@ -1167,6 +1171,46 @@ final class JsonNodeTrxImpl extends
     }
   }
 
+  // ==== bulk-assembly seam (package-private) ==================================================
+  // The BulkJsonTreeAssembler drives the SAME factory / path-summary / notification machinery as
+  // the cursor inserts, but computes every structural pointer from its own stack before a record
+  // is first written — so it needs the collaborators, not the cursor choreography. Nothing here
+  // widens the public API, and nothing here may be called while ordinary cursor edits are in
+  // flight on this transaction.
+
+  JsonNodeFactory bulkNodeFactory() {
+    return nodeFactory;
+  }
+
+  @Nullable
+  PathSummaryWriter<JsonNodeReadOnlyTrx> bulkPathSummaryWriter() {
+    return pathSummaryWriter;
+  }
+
+  boolean bulkBuildPathSummary() {
+    return buildPathSummary;
+  }
+
+  boolean bulkStoreChildCount() {
+    return storeChildCount;
+  }
+
+  boolean bulkUseTextCompression() {
+    return useTextCompression;
+  }
+
+  boolean bulkHasPrimitiveIndexes() {
+    return indexController.hasAnyPrimitiveIndex();
+  }
+
+  void bulkNotifyInsert(final ImmutableNode node, final long pathNodeKey) {
+    notifyPrimitiveIndexChange(IndexController.ChangeType.INSERT, node, pathNodeKey);
+  }
+
+  void bulkAccountRecord(final int mutations) {
+    bulkAccountMutations(mutations);
+  }
+
   @Override
   public JsonNodeTrx insertObjectRecordAsLeftSibling(final String key, final ObjectRecordValue<?> value) {
     requireNonNull(key);
@@ -1994,7 +2038,7 @@ final class JsonNodeTrxImpl extends
       final long rightSibKey = currentNode.getNodeKey();
 
       moveToParent();
-      final long pathNodeKey = getPathNodeKey(rightSibKey, ARRAY_SIBLING_PATH_QNM, NodeKind.ARRAY);
+      final long pathNodeKey = getPathNodeKey(rightSibKey, ARRAY_PATH_QNM, NodeKind.ARRAY);
       moveTo(rightSibKey);
 
       final SirixDeweyID id = deweyIDManager.newLeftSiblingID();
@@ -2041,7 +2085,7 @@ final class JsonNodeTrxImpl extends
       final long rightSibKey = currentNode.getRightSiblingKey();
 
       moveToParent();
-      final long pathNodeKey = getPathNodeKey(leftSibKey, ARRAY_SIBLING_PATH_QNM, NodeKind.ARRAY);
+      final long pathNodeKey = getPathNodeKey(leftSibKey, ARRAY_PATH_QNM, NodeKind.ARRAY);
       moveTo(leftSibKey);
 
       final SirixDeweyID id = deweyIDManager.newRightSiblingID();

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/JsonNodeTrxImpl.java
@@ -59,6 +59,7 @@ import io.sirix.diff.JsonDiffSerializer;
 import io.sirix.exception.SirixException;
 import io.sirix.exception.SirixIOException;
 import io.sirix.exception.SirixUsageException;
+import io.sirix.index.IndexDef;
 import io.sirix.index.IndexType;
 import io.sirix.index.path.summary.PathSummaryWriter;
 import io.sirix.index.path.summary.PathSummaryWriter.OPType;
@@ -105,6 +106,8 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.locks.Lock;
@@ -1201,6 +1204,41 @@ final class JsonNodeTrxImpl extends
 
   boolean bulkHasPrimitiveIndexes() {
     return indexController.hasAnyPrimitiveIndex();
+  }
+
+  /**
+   * The one index family the parallel importer cannot maintain: valid-time intervals are resolved by
+   * a configured-path visitor over whole records, which has no chunk-local equivalent yet. PATH, CAS
+   * and NAME are fed by the importer's own worker-collected tuples, and PROJECTION by the
+   * coordinator's record attribution.
+   */
+  boolean bulkHasValidTimeIndex() {
+    // Def-based rather than the controller's cached listener flag: the flag is set when listeners
+    // bind, but a VALIDTIME definition catalogued WITHOUT its listener would serialize on commit as
+    // an index nothing maintained — exactly the silent outcome the refusal exists to prevent.
+    return indexController.hasValidTimeIndex() || !bulkIndexDefsOfType(IndexType.VALIDTIME).isEmpty();
+  }
+
+  /** Catalogued definitions of {@code indexType}, for the parallel importer's index maintenance. */
+  Set<IndexDef> bulkIndexDefsOfType(final IndexType indexType) {
+    final Set<IndexDef> defs = new HashSet<>();
+    for (final IndexDef indexDef : indexController.getIndexes().getIndexDefs()) {
+      if (indexDef.getType() == indexType) {
+        defs.add(indexDef);
+      }
+    }
+    return defs;
+  }
+
+  /** Catalogued PROJECTION definitions, for the parallel importer's arm check. */
+  Set<IndexDef> bulkProjectionIndexDefs() {
+    final Set<IndexDef> projectionDefs = new HashSet<>();
+    for (final IndexDef indexDef : indexController.getIndexes().getIndexDefs()) {
+      if (indexDef.isProjectionIndex()) {
+        projectionDefs.add(indexDef);
+      }
+    }
+    return projectionDefs;
   }
 
   void bulkNotifyInsert(final ImmutableNode node, final long pathNodeKey) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/NdjsonAsArrayInputStream.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/NdjsonAsArrayInputStream.java
@@ -7,16 +7,16 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Presents an NDJSON stream (one JSON value per line) as a single top-level JSON ARRAY — the
- * shape the parallel bulk importer parallelizes. The transform is exact and 1:1 in the body:
- * JSON forbids raw control characters inside strings, so a literal {@code '\n'} can only separate
- * records and maps to {@code ','}; the only insertions are the opening {@code '['} and the
- * closing {@code ']'}. A trailing newline yields a trailing comma, which the importer's slicer
- * treats as separator noise.
+ * Presents an NDJSON stream (one JSON value per line) as a single top-level JSON ARRAY — the shape
+ * the parallel bulk importer parallelizes. The transform is exact and 1:1 in the body: JSON forbids
+ * raw control characters inside strings, so a literal {@code '\n'} can only separate records and
+ * maps to {@code ','}; the only insertions are the opening {@code '['} and the closing {@code ']'}.
+ * A trailing newline yields a trailing comma, which the importer's slicer treats as separator
+ * noise.
  *
  * <p>
- * An optional record limit truncates the stream after N records — for bounded imports of a
- * prefix of a large corpus (the array closes cleanly at the cut).
+ * An optional record limit truncates the stream after N records — for bounded imports of a prefix
+ * of a large corpus (the array closes cleanly at the cut).
  */
 public final class NdjsonAsArrayInputStream extends InputStream {
 

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/NdjsonAsArrayInputStream.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/NdjsonAsArrayInputStream.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Presents an NDJSON stream (one JSON value per line) as a single top-level JSON ARRAY — the
+ * shape the parallel bulk importer parallelizes. The transform is exact and 1:1 in the body:
+ * JSON forbids raw control characters inside strings, so a literal {@code '\n'} can only separate
+ * records and maps to {@code ','}; the only insertions are the opening {@code '['} and the
+ * closing {@code ']'}. A trailing newline yields a trailing comma, which the importer's slicer
+ * treats as separator noise.
+ *
+ * <p>
+ * An optional record limit truncates the stream after N records — for bounded imports of a
+ * prefix of a large corpus (the array closes cleanly at the cut).
+ */
+public final class NdjsonAsArrayInputStream extends InputStream {
+
+  private static final int STATE_PREFIX = 0;
+  private static final int STATE_BODY = 1;
+  private static final int STATE_SUFFIX = 2;
+  private static final int STATE_DONE = 3;
+
+  private final InputStream in;
+  private final long recordLimit;
+  private long records;
+  private int state = STATE_PREFIX;
+
+  public NdjsonAsArrayInputStream(final InputStream in) {
+    this(in, Long.MAX_VALUE);
+  }
+
+  public NdjsonAsArrayInputStream(final InputStream in, final long recordLimit) {
+    this.in = in;
+    this.recordLimit = recordLimit;
+  }
+
+  @Override
+  public int read() throws IOException {
+    final byte[] one = new byte[1];
+    final int n = read(one, 0, 1);
+    return n < 0
+        ? -1
+        : one[0] & 0xFF;
+  }
+
+  @Override
+  public int read(final byte[] target, final int off, final int len) throws IOException {
+    if (len == 0) {
+      return 0;
+    }
+    switch (state) {
+      case STATE_PREFIX -> {
+        target[off] = '[';
+        state = STATE_BODY;
+        return 1;
+      }
+      case STATE_BODY -> {
+        final int n = in.read(target, off, len);
+        if (n < 0) {
+          state = STATE_SUFFIX;
+          return read(target, off, len);
+        }
+        for (int i = off; i < off + n; i++) {
+          if (target[i] == '\n') {
+            if (++records >= recordLimit) {
+              // Close the array at this record boundary and drop the rest of the block.
+              target[i] = ']';
+              state = STATE_DONE;
+              return i - off + 1;
+            }
+            target[i] = ',';
+          }
+        }
+        return n;
+      }
+      case STATE_SUFFIX -> {
+        target[off] = ']';
+        state = STATE_DONE;
+        return 1;
+      }
+      default -> {
+        return -1;
+      }
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
@@ -1,0 +1,637 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.index.path.summary.PathSummaryWriter;
+import io.sirix.node.NodeKind;
+import io.sirix.page.KeyValueLeafPage;
+import io.sirix.page.RevisionRootPage;
+import io.sirix.settings.Fixed;
+import io.brackit.query.atomic.QNm;
+
+import java.io.CharArrayReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+
+/**
+ * GENERAL parallel bulk import of a JSON document whose top level is a large array — the shape
+ * every bulk corpus has (NDJSON rides a trivial adapter) and the only shape that parallelizes:
+ * members are independent subtrees under one array, so chunks of members can be BUILT off-thread
+ * while a single coordinator owns everything shared.
+ *
+ * <p>
+ * Pipeline (see the campaign plan for the full invariant audit):
+ * <ol>
+ * <li><b>Slice</b>: a lightweight structural scanner cuts the stream into member-aligned char
+ * chunks (strings/escapes tracked; no tokenization).</li>
+ * <li><b>Count + resolve (coordinator)</b>: the fused pass produces exact node counts, member
+ * boundaries, names (the only decoded text) and path resolution in the SAME byte sweep that
+ * slices — reference deltas flush per chunk, before any rotation can flush summary pages
+ * cold.</li>
+ * <li><b>Reserve</b>: the chunk's exact contiguous key range via
+ * {@link RevisionRootPage#reserveKeyRangeInDocumentIndex(long)} — dense keys, so the result is
+ * record-identical to a sequential load.</li>
+ * <li><b>Build (worker)</b>: the same assembler core with a {@link WorkerPageBuilder} emits
+ * FINAL record bytes into standalone pages; pre-resolved names/PCRs; range/slot verification
+ * always on.</li>
+ * <li><b>Stitch + adopt (coordinator)</b>: pages sharing a page key with already-live territory
+ * (page 0's prologue records, the previous chunk's held tail) are merged record-by-record through
+ * the CoW-checked blit seam; whole pages are adopted via
+ * {@link StorageEngineWriter#adoptDocumentLeafPage}; the chunk's TAIL partial page is HELD out of
+ * the intent log until its successor's head is merged into it (the flusher-race amendment).</li>
+ * </ol>
+ *
+ * <p>
+ * v1 scope: fresh resource, same refusals as {@link BulkJsonTreeAssembler}; index notifications
+ * refused (no primitive indexes during import); the caller commits. This entry point is
+ * single-builder (the M2 pipeline); the M3 executor fan-out layers on top of the same chunk
+ * protocol.
+ */
+public final class ParallelBulkJsonImporter {
+
+  private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
+  private static final QNm ARRAY_PATH_QNM = new QNm("__array__");
+  private static final int DEFAULT_CHUNK_CHAR_BUDGET =
+      Integer.getInteger("sirix.parallelImport.chunkBytes", 4 << 20);
+  private static final int ADOPT_BURST_PAGES = 16;
+
+  private final JsonNodeTrxImpl wtx;
+  private final StorageEngineWriter storageEngineWriter;
+  private final PathSummaryWriter<JsonNodeReadOnlyTrx> pathSummaryWriter;
+  private final boolean buildPathSummary;
+  private final WtxBulkRecordSink wtxSink;
+  private final RevisionRootPage revisionRootPage;
+  private final ResourceConfiguration resourceConfig;
+  private final int chunkCharBudget;
+
+  /** Interned dictionary keys by the feeder's STABLE dense name id, in first-occurrence order. */
+  private final ArrayList<String> nameById = new ArrayList<>(64);
+  private final it.unimi.dsi.fastutil.ints.IntArrayList nameKeyById = new it.unimi.dsi.fastutil.ints.IntArrayList(64);
+
+  /** The coordinator's growing (parentPCR, name) → PCR view, snapshot per chunk for the builder. */
+  private Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> masterPcrMemo = new Long2ObjectOpenHashMap<>();
+
+  private KeyValueLeafPage heldTailPage;
+  private long heldTailPageKey = -1;
+
+  /** Recycled decode scratch: chars ≤ bytes for UTF-8, so one budget-sized array fits a chunk. */
+  private final ArrayBlockingQueue<char[]> charScratchPool = new ArrayBlockingQueue<>(16);
+
+  private char[] acquireCharScratch(final int neededChars) {
+    final char[] pooled = charScratchPool.poll();
+    if (pooled != null && pooled.length >= neededChars) {
+      return pooled;
+    }
+    return new char[Math.max(neededChars, chunkCharBudget + (chunkCharBudget >> 2))];
+  }
+
+  private ParallelBulkJsonImporter(final JsonNodeTrxImpl wtx, final int chunkCharBudget) {
+    this.wtx = wtx;
+    this.storageEngineWriter = wtx.getStorageEngineWriter();
+    this.pathSummaryWriter = wtx.bulkPathSummaryWriter();
+    this.buildPathSummary = wtx.bulkBuildPathSummary();
+    this.wtxSink = new WtxBulkRecordSink(wtx);
+    this.revisionRootPage = storageEngineWriter.getActualRevisionRootPage();
+    this.resourceConfig = wtx.getResourceSession().getResourceConfig();
+    this.chunkCharBudget = chunkCharBudget;
+  }
+
+  /** As {@link #assemble(JsonNodeTrx, Reader, int)} with the default chunk budget. */
+  public static void assemble(final JsonNodeTrx wtx, final Reader input) {
+    assemble(wtx, input, DEFAULT_CHUNK_CHAR_BUDGET, defaultParallelism());
+  }
+
+  /** Byte-stream entry — the primary path: the coordinator never decodes value bytes. */
+  public static void assemble(final JsonNodeTrx wtx, final InputStream input) {
+    assembleBytes(wtx, input, DEFAULT_CHUNK_CHAR_BUDGET, defaultParallelism());
+  }
+
+  /** Builder threads: builds are cheap relative to the flush pipeline's parallel serialization,
+   * so the default leaves MOST cores to the snapshot flush pool — measured: an oversized build
+   * pool starves serialization (serializeJoinWait dominated the flush worker at builders=16). */
+  private static int defaultParallelism() {
+    final int configured = Integer.getInteger("sirix.parallelImport.builders", -1);
+    if (configured > 0) {
+      return configured;
+    }
+    return Math.max(2, Runtime.getRuntime().availableProcessors() / 4);
+  }
+
+  /**
+   * Imports ONE top-level JSON value from {@code input} into the fresh resource behind
+   * {@code wtx}, building member chunks through the parallel page pipeline when the top level is
+   * an array and falling back to the sequential assembler otherwise. The caller commits.
+   *
+   * @param wtx a write transaction on a FRESH resource (standard implementation)
+   * @param input the character source
+   * @param chunkCharBudget approximate chars per build chunk (test seam; small values force many
+   *        chunks and page-sharing boundaries)
+   */
+  public static void assemble(final JsonNodeTrx wtx, final Reader input, final int chunkCharBudget) {
+    assemble(wtx, input, chunkCharBudget, defaultParallelism());
+  }
+
+  /**
+   * As {@link #assemble(JsonNodeTrx, Reader, int)} with explicit builder parallelism; {@code 1}
+   * builds inline on the coordinator.
+   */
+  public static void assemble(final JsonNodeTrx wtx, final Reader input, final int chunkCharBudget,
+      final int parallelism) {
+    assembleBytes(wtx, new ReaderUtf8InputStream(input), chunkCharBudget, parallelism);
+  }
+
+  /**
+   * The pipeline proper, over raw UTF-8 bytes: the coordinator slices and scans BYTES (structural
+   * JSON is ASCII; multi-byte sequences never contain ASCII bytes), and each build worker decodes
+   * only its own chunk — the corpus-wide decode runs in parallel instead of on the spine.
+   */
+  public static void assembleBytes(final JsonNodeTrx wtx, final InputStream input, final int chunkCharBudget,
+      final int parallelism) {
+    if (!(wtx instanceof final JsonNodeTrxImpl impl)) {
+      throw new IllegalArgumentException(
+          "parallel bulk import requires the standard JsonNodeTrx implementation, got " + wtx.getClass().getName());
+    }
+    refuseUnsupportedShape(impl);
+    try {
+      final PushbackInputStream stream = new PushbackInputStream(input, 1);
+      if (!nextIsArray(stream)) {
+        // Not a top-level array: nothing to parallelize — the sequential assembler is the
+        // general path for every other shape.
+        BulkJsonTreeAssembler.assemble(wtx, new InputStreamReader(stream, StandardCharsets.UTF_8));
+        return;
+      }
+      new ParallelBulkJsonImporter(impl, chunkCharBudget).run(stream, Math.max(1, parallelism));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** The assembler's refusals plus the importer's own: no primitive indexes during import. */
+  private static void refuseUnsupportedShape(final JsonNodeTrxImpl wtx) {
+    final ResourceConfiguration config = wtx.getResourceSession().getResourceConfig();
+    if (config.hashType != HashType.NONE) {
+      throw new IllegalStateException("parallel bulk import supports hashType=NONE only, got " + config.hashType);
+    }
+    if (config.areDeweyIDsStored) {
+      throw new IllegalStateException("parallel bulk import does not support DeweyIDs");
+    }
+    if (config.storeNodeHistory()) {
+      throw new IllegalStateException("parallel bulk import does not support node history");
+    }
+    final PathSummaryWriter<JsonNodeReadOnlyTrx> summary = wtx.bulkPathSummaryWriter();
+    if (summary != null && summary.isPathStatisticsEnabled()) {
+      throw new IllegalStateException("parallel bulk import does not support path statistics");
+    }
+    if (wtx.bulkHasPrimitiveIndexes()) {
+      throw new IllegalStateException(
+          "parallel bulk import does not support primitive-index maintenance during the load");
+    }
+    if (!wtx.moveToDocumentRoot() || wtx.hasFirstChild()) {
+      throw new IllegalStateException("parallel bulk import requires a FRESH resource (empty document root)");
+    }
+  }
+
+  /** Peeks past leading whitespace; pushes the decisive byte back either way. */
+  private static boolean nextIsArray(final PushbackInputStream stream) throws IOException {
+    while (true) {
+      final int c = stream.read();
+      if (c < 0) {
+        return false;
+      }
+      if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+        continue;
+      }
+      stream.unread(c);
+      return c == '[';
+    }
+  }
+
+  // ==== the pipeline ===========================================================================
+
+  /** One dispatched chunk build in flight; adoption strictly in chunk order (tail-hold chain). */
+  private record PendingBuild(Future<List<KeyValueLeafPage>> pages, WorkerPageBuilder builder, long lastKey,
+      long chunkLastMemberKey, long chunkMembers) {
+  }
+
+  private void run(final InputStream input, final int parallelism) throws IOException {
+
+    // Prologue: the root array through the ordinary transaction path — page 0 enters the intent
+    // log here and is stitched via the CoW-checked blit seam, never held.
+    final long rootArrayPcr = buildPathSummary
+        ? pathSummaryWriter.getPathNodeKey(0, ARRAY_PATH_QNM, NodeKind.ARRAY)
+        : 0;
+    final long rootArrayKey =
+        wtxSink.createArrayNode(Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), NULL_KEY, rootArrayPcr);
+    rememberRootArrayPcr(rootArrayPcr);
+
+    final FusedSliceAndScan fused = new FusedSliceAndScan(input, chunkCharBudget);
+    fused.consumeArrayOpen();
+    fused.rootStep().pcr = rootArrayPcr;
+
+    // The FEEDER: scans + slices ahead on its own thread, fully writer-free — all shared-state
+    // resolution (paths, names, reservation) happens HERE on the coordinator at chunk handoff.
+    final BlockingQueue<Object> handoff = new ArrayBlockingQueue<>(4);
+    final Thread feeder = new Thread(() -> {
+      try {
+        FusedSliceAndScan.Chunk next;
+        while ((next = fused.nextChunk()) != null) {
+          handoff.put(next);
+        }
+        handoff.put(FEEDER_DONE);
+      } catch (final Throwable t) {
+        try {
+          handoff.put(t);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }, "sirix-bulk-import-feeder");
+    feeder.setDaemon(true);
+    feeder.start();
+
+    final ExecutorService buildPool = parallelism > 1
+        ? Executors.newFixedThreadPool(parallelism)
+        : null;
+    final ArrayDeque<PendingBuild> inFlight = new ArrayDeque<>(parallelism + 2);
+    final int maxInFlight = parallelism + 2;
+
+    long totalMembers = 0;
+    long lastMemberKey = NULL_KEY;
+    long expectedNextReservation = rootArrayKey + 1;
+
+    try {
+    while (true) {
+      final Object taken;
+      try {
+        taken = handoff.take();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted awaiting the feeder", e);
+      }
+      if (taken == FEEDER_DONE) {
+        break;
+      }
+      if (taken instanceof Throwable failure) {
+        if (failure instanceof RuntimeException runtime) {
+          throw runtime;
+        }
+        if (failure instanceof IOException io) {
+          throw io;
+        }
+        throw new IllegalStateException("feeder failed", failure);
+      }
+      final FusedSliceAndScan.Chunk chunk = (FusedSliceAndScan.Chunk) taken;
+
+      final long chunkNodes = chunk.nodes();
+      final long chunkMembers = chunk.members();
+      if (chunkNodes == 0) {
+        continue;
+      }
+      // --- Resolve this chunk's metadata on the coordinator, in document order ------------------
+      final Object2IntOpenHashMap<String> chunkNames = resolveChunkMetadata(chunk);
+
+      // --- Reserve the exact dense range ---------------------------------------------------
+      final long firstKey = revisionRootPage.reserveKeyRangeInDocumentIndex(chunkNodes);
+      if (firstKey != expectedNextReservation) {
+        throw new IllegalStateException(
+            "reserved range starts at " + firstKey + " but the pipeline expected " + expectedNextReservation);
+      }
+      final long lastKey = firstKey + chunkNodes - 1;
+      final long chunkLastMemberKey = firstKey + chunkNodes - chunk.lastMemberNodes();
+      final long trailingSiblingKey = chunk.isFinal()
+          ? NULL_KEY
+          : lastKey + 1;
+
+      // --- Stage B: build — off-thread when a pool exists, inline otherwise ---------------------
+      final WorkerPageBuilder builder =
+          new WorkerPageBuilder(resourceConfig, storageEngineWriter.getRevisionNumber(),
+              resourceConfig.nodeHashFunction, wtx.bulkStoreChildCount(), chunkNames, firstKey, lastKey);
+      final byte[] chunkBytes = chunk.bytes();
+      final int chunkByteLength = chunk.length();
+      final long buildFirstKey = firstKey;
+      final long buildLastMemberBoundary = lastMemberKey;
+      final long buildTrailing = trailingSiblingKey;
+      final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> memoSnapshot = copyMemo(masterPcrMemo);
+
+      if (buildPool == null) {
+        stitchAndAdopt(buildChunk(fused, builder, chunkBytes, chunkByteLength, buildFirstKey, lastKey, rootArrayKey,
+            rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot), lastKey);
+      } else {
+        final long submittedLastKey = lastKey;
+        inFlight.addLast(new PendingBuild(buildPool.submit(() -> {
+          // The chunk's own UTF-8 decode happens HERE, on the pool thread — the whole corpus
+          // decode parallelizes across builders, into POOLED scratch (no per-chunk large arrays).
+          return buildChunk(fused, builder, chunkBytes, chunkByteLength, buildFirstKey, submittedLastKey, rootArrayKey,
+              rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
+        }), builder, lastKey, chunkLastMemberKey, chunkMembers));
+        // Admission control: never more than P+2 chunks of frames in flight; adoption is strictly
+        // in chunk order, which the tail-hold stitch chain requires anyway.
+        while (inFlight.size() >= maxInFlight) {
+          adoptNext(inFlight);
+        }
+      }
+
+      totalMembers += chunkMembers;
+      lastMemberKey = chunkLastMemberKey;
+      expectedNextReservation = lastKey + 1;
+    }
+
+    while (!inFlight.isEmpty()) {
+      adoptNext(inFlight);
+    }
+    } finally {
+      if (buildPool != null) {
+        buildPool.shutdownNow();
+      }
+    }
+
+    if (heldTailPage != null) {
+      adoptBurst(new KeyValueLeafPage[] { heldTailPage }, 1);
+      heldTailPage = null;
+      heldTailPageKey = -1;
+    }
+
+    // Root array + document fixups, once, with GLOBAL counts.
+    if (totalMembers > 0) {
+      wtxSink.fixupContainer(rootArrayKey, rootArrayKey + 1, lastMemberKey, totalMembers, NULL_KEY);
+    }
+    wtxSink.fixupDocument(Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), rootArrayKey, rootArrayKey, 1);
+
+    if (revisionRootPage.getMaxNodeKeyInDocumentIndex() != expectedNextReservation - 1) {
+      throw new IllegalStateException("document max node key " + revisionRootPage.getMaxNodeKeyInDocumentIndex()
+          + " does not match the last reserved key " + (expectedNextReservation - 1));
+    }
+  }
+
+  /** Runs one chunk build on the calling thread: pooled decode, run, verify, release buffers. */
+  private List<KeyValueLeafPage> buildChunk(final FusedSliceAndScan fused, final WorkerPageBuilder builder,
+      final byte[] chunkBytes, final int chunkByteLength, final long firstKey, final long lastKey,
+      final long rootArrayKey, final long rootArrayPcr, final long leftBoundaryKey, final long trailingSiblingKey,
+      final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> memoSnapshot) throws IOException {
+    final char[] scratch = acquireCharScratch(chunkByteLength);
+    try {
+      // Decode straight into the pooled scratch — no String detour, no second copy.
+      final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                                                           .onMalformedInput(CodingErrorAction.REPLACE)
+                                                           .onUnmappableCharacter(CodingErrorAction.REPLACE);
+      final CharBuffer out = CharBuffer.wrap(scratch);
+      decoder.decode(ByteBuffer.wrap(chunkBytes, 0, chunkByteLength), out, true);
+      final int chars = out.position();
+      fused.releaseChunkBuffer(chunkBytes);
+      final BulkJsonTreeAssembler building = new BulkJsonTreeAssembler(builder, null, buildPathSummary,
+          new BulkJsonScanner(new CharArrayReader(scratch, 0, chars)), firstKey, true, rootArrayKey, rootArrayPcr,
+          leftBoundaryKey, trailingSiblingKey);
+      building.prefillPcrMemo(memoSnapshot);
+      building.run();
+      return builder.finish(lastKey);
+    } finally {
+      charScratchPool.offer(scratch);
+    }
+  }
+
+  private void adoptNext(final ArrayDeque<PendingBuild> inFlight) {
+    final PendingBuild next = inFlight.pollFirst();
+    try {
+      stitchAndAdopt(next.pages().get(), next.lastKey());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted while awaiting a chunk build", e);
+    } catch (final java.util.concurrent.ExecutionException e) {
+      throw new IllegalStateException("chunk build failed", e.getCause());
+    }
+  }
+
+  // ==== name interning + counting ==============================================================
+
+  /** Marker object closing the feeder handoff. */
+  private static final Object FEEDER_DONE = new Object();
+
+  /**
+   * Resolves a chunk's deferred metadata IN DOCUMENT ORDER on the coordinator — the sequential
+   * path's exact dictionary/summary call sequence, batched: new paths resolve through the real
+   * summary writer (each miss counts its first occurrence), new names intern via createNameKey,
+   * repeat occurrences land as reference/count deltas, and the master memo gains every new
+   * (parentPCR, name) → PCR pair for the build worker's snapshot.
+   *
+   * @return the chunk's name → dictionary-key table for the build worker
+   */
+  private Object2IntOpenHashMap<String> resolveChunkMetadata(final FusedSliceAndScan.Chunk chunk) {
+    // Names first-occurring in this chunk, in document order (interleaved order vs paths is
+    // preserved by the sequential path only per-record; the dictionary probe sequences that
+    // matter are name-vs-name and path-vs-path order, both exact here).
+    for (final String name : chunk.newNames()) {
+      nameById.add(name);
+      nameKeyById.add(storageEngineWriter.createNameKey(name, NodeKind.OBJECT_NAMED_OBJECT));
+    }
+    // New path steps, in document order; resolution counts each step's first occurrence.
+    for (final FusedSliceAndScan.PathStep step : chunk.newSteps()) {
+      if (!buildPathSummary) {
+        step.pcr = 0;
+        continue;
+      }
+      final long parentPcr = step.parent.pcr;
+      if (parentPcr < 0) {
+        throw new IllegalStateException("path step resolved before its parent — feeder order broken");
+      }
+      step.pcr = step.name == null
+          ? pathSummaryWriter.getPathNodeKey(parentPcr, ARRAY_PATH_QNM, NodeKind.ARRAY)
+          : pathSummaryWriter.getPathNodeKey(parentPcr, new QNm(step.name), NodeKind.OBJECT_NAMED_OBJECT);
+      recordInMasterMemo(parentPcr, step.name == null
+          ? "__array__"
+          : step.name, step.pcr);
+    }
+    // Reference-count deltas: a step created THIS chunk had its first occurrence counted by the
+    // resolution above, so its delta is occurrences - 1.
+    if (buildPathSummary) {
+      final List<FusedSliceAndScan.PathStep> touched = chunk.touchedSteps();
+      final int[] occurrences = chunk.stepOccurrences();
+      for (int i = 0; i < touched.size(); i++) {
+        final FusedSliceAndScan.PathStep step = touched.get(i);
+        final int delta = chunk.newSteps().contains(step)
+            ? occurrences[i] - 1
+            : occurrences[i];
+        if (delta > 0) {
+          pathSummaryWriter.addReferences(step.pcr, delta);
+        }
+      }
+    }
+    // Name occurrence deltas + the worker's name table.
+    final Object2IntOpenHashMap<String> table = new Object2IntOpenHashMap<>(chunk.nameTallies().size());
+    table.defaultReturnValue(Integer.MIN_VALUE);
+    final int newNamesStart = nameById.size() - chunk.newNames().size();
+    for (final int[] tally : chunk.nameTallies()) {
+      final int nameId = tally[0];
+      final int count = tally[1];
+      final int nameKey = nameKeyById.getInt(nameId);
+      table.put(nameById.get(nameId), nameKey);
+      final int delta = nameId >= newNamesStart
+          ? count - 1
+          : count;
+      if (delta > 0) {
+        storageEngineWriter.addNameCount(nameKey, delta, NodeKind.OBJECT_NAMED_OBJECT);
+      }
+    }
+    return table;
+  }
+
+  private void recordInMasterMemo(final long parentPcr, final String name, final long pcr) {
+    Object2LongOpenHashMap<String> byName = masterPcrMemo.get(parentPcr);
+    if (byName == null) {
+      byName = new Object2LongOpenHashMap<>();
+      byName.defaultReturnValue(-1);
+      masterPcrMemo.put(parentPcr, byName);
+    }
+    byName.put(name, pcr);
+  }
+
+
+  private void rememberRootArrayPcr(final long rootArrayPcr) {
+    if (!buildPathSummary) {
+      return;
+    }
+    final Object2LongOpenHashMap<String> underDocument = new Object2LongOpenHashMap<>();
+    underDocument.defaultReturnValue(-1);
+    underDocument.put("__array__", rootArrayPcr);
+    masterPcrMemo.put(0L, underDocument);
+  }
+
+  private static Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> copyMemo(
+      final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> source) {
+    final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> copy = new Long2ObjectOpenHashMap<>(source.size());
+    for (final var entry : source.long2ObjectEntrySet()) {
+      final Object2LongOpenHashMap<String> byName = new Object2LongOpenHashMap<>(entry.getValue());
+      byName.defaultReturnValue(-1);
+      copy.put(entry.getLongKey(), byName);
+    }
+    return copy;
+  }
+
+  // ==== stitch + adopt =========================================================================
+
+  private void stitchAndAdopt(final List<KeyValueLeafPage> pages, final long lastKey) {
+    final KeyValueLeafPage[] burst = new KeyValueLeafPage[ADOPT_BURST_PAGES];
+    int burstSize = 0;
+    final boolean tailPartial = ((lastKey + 1) & 1023) != 0;
+
+    for (int i = 0; i < pages.size(); i++) {
+      final KeyValueLeafPage page = pages.get(i);
+      final boolean isTail = i == pages.size() - 1;
+      final long pageKey = page.getPageKey();
+
+      if (pageKey == heldTailPageKey) {
+        // Shares the previous chunk's held tail: merge into the coordinator-owned page object.
+        mergeInto(heldTailPage, page);
+        if (isTail && tailPartial) {
+          // Whole chunk inside the held page; keep holding.
+          continue;
+        }
+        // The held page is now complete territory-wise up to this chunk's coverage.
+        if (!isTail || !tailPartial) {
+          burstSize = enqueue(burst, burstSize, heldTailPage);
+          heldTailPage = null;
+          heldTailPageKey = -1;
+        }
+        continue;
+      }
+
+      if (pageKey == 0) {
+        // Page 0 is TIL-live (document root + root array prologue): CoW-checked blit.
+        mergeInto(storageEngineWriter.prepareDocumentLeafForBlit(0), page);
+        page.retire();
+        continue;
+      }
+
+      if (isTail && tailPartial) {
+        heldTailPage = page;
+        heldTailPageKey = pageKey;
+        continue;
+      }
+
+      burstSize = enqueue(burst, burstSize, page);
+    }
+    flushBurst(burst, burstSize);
+  }
+
+  private int enqueue(final KeyValueLeafPage[] burst, final int burstSize, final KeyValueLeafPage page) {
+    burst[burstSize] = page;
+    if (burstSize + 1 == burst.length) {
+      flushBurst(burst, burst.length);
+      return 0;
+    }
+    return burstSize + 1;
+  }
+
+  private void flushBurst(final KeyValueLeafPage[] burst, final int burstSize) {
+    adoptBurst(burst, burstSize);
+  }
+
+  private void adoptBurst(final KeyValueLeafPage[] burst, final int burstSize) {
+    if (burstSize == 0) {
+      return;
+    }
+    int records = 0;
+    for (int i = 0; i < burstSize; i++) {
+      storageEngineWriter.adoptDocumentLeafPage(burst[i]);
+      records += burst[i].populatedSlots().length;
+      burst[i] = null;
+    }
+    // Accounting after the burst lets the ordinary predicate rotate the flush epoch — the same
+    // cadence machinery the sequential path drives per top-level record.
+    wtx.bulkAccountRecord(records);
+  }
+
+  /** Replays every record of {@code source} into {@code target} (same page key, disjoint slots). */
+  private static void mergeInto(final KeyValueLeafPage target, final KeyValueLeafPage source) {
+    final long pageBase = source.getPageKey() << 10;
+    for (final int slot : source.populatedSlots()) {
+      final MemorySegment record = source.getSlot(slot);
+      final int kindId = source.getSlotNodeKindId(slot);
+      final long absOffset = target.prepareHeapForDirectWriteOrOverflow((int) record.byteSize(), 0);
+      if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+        throw new IllegalStateException(
+            "boundary merge overflowed page " + target.getPageKey() + " at slot " + slot);
+      }
+      MemorySegment.copy(record, 0, target.getSlottedPage(), absOffset, record.byteSize());
+      target.completeDirectWrite((byte) kindId, pageBase | slot, slot, (int) record.byteSize(), null);
+    }
+    // Overflow-sized values live as heap records, not slots — carry them across as objects.
+    // Direct-write records never enter records[] (write singletons skip it), so every non-null
+    // entry here IS an overflow node.
+    for (int slot = 0; slot < 1024; slot++) {
+      final var heapRecord = source.getRecord(slot);
+      if (heapRecord != null) {
+        target.setRecord(heapRecord);
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
@@ -821,7 +821,10 @@ public final class ParallelBulkJsonImporter {
 
       if (pageKey == heldTailPageKey) {
         // Shares the previous chunk's held tail: merge into the coordinator-owned page object.
+        // The worker page owns an allocator frame and nothing reads it after the merge, so it is
+        // retired here exactly as the page-0 blit below retires its source.
         mergeInto(heldTailPage, page);
+        page.retire();
         if (isTail && tailPartial) {
           // Whole chunk inside the held page; keep holding.
           continue;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
@@ -3,17 +3,29 @@
  */
 package io.sirix.access.trx.node.json;
 
+import io.sirix.access.DatabaseType;
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.api.StorageEngineWriter;
 import io.sirix.api.json.JsonNodeReadOnlyTrx;
 import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexType;
+import io.sirix.index.cas.CASIndexBuilder;
+import io.sirix.index.cas.CASIndexBuilderFactory;
+import io.sirix.index.name.NameIndexBuilder;
+import io.sirix.index.name.NameIndexBuilderFactory;
+import io.sirix.index.path.PathIndexBuilder;
+import io.sirix.index.path.PathIndexBuilderFactory;
 import io.sirix.index.path.summary.PathSummaryWriter;
+import io.sirix.index.projection.ProjectionBulkLoad;
+import io.sirix.index.projection.ProjectionChunkRowBatch;
 import io.sirix.node.NodeKind;
 import io.sirix.page.KeyValueLeafPage;
 import io.sirix.page.RevisionRootPage;
 import io.sirix.settings.Fixed;
 import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
 
 import java.io.CharArrayReader;
 import java.io.IOException;
@@ -26,7 +38,9 @@ import java.nio.charset.StandardCharsets;
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
@@ -37,11 +51,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import org.jspecify.annotations.Nullable;
 
 /**
  * GENERAL parallel bulk import of a JSON document whose top level is a large array — the shape
@@ -72,8 +92,14 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
  * </ol>
  *
  * <p>
- * v1 scope: fresh resource, same refusals as {@link BulkJsonTreeAssembler}; index notifications
- * refused (no primitive indexes during import); the caller commits. This entry point is
+ * Scope: fresh resource, same refusals as {@link BulkJsonTreeAssembler}. PATH, CAS and NAME index
+ * definitions are maintained BY the load: workers collect each family's tuples from the primitives
+ * they hold, the coordinator drains them into the families' ordinary builders, and one flush per
+ * family materialises each trie before the caller's commit. A PROJECTION index armed for this
+ * transaction is likewise maintained in the same single pass, fed by the coordinator's record
+ * attribution over the workers' row batches. Only valid-time interval maintenance is refused — it
+ * is resolved by a configured-path visitor over whole records, with no chunk-local equivalent yet.
+ * The caller commits, and that final commit is what closes the builds. This entry point is
  * single-builder (the M2 pipeline); the M3 executor fan-out layers on top of the same chunk
  * protocol.
  */
@@ -84,6 +110,7 @@ public final class ParallelBulkJsonImporter {
   private static final int DEFAULT_CHUNK_CHAR_BUDGET =
       Integer.getInteger("sirix.parallelImport.chunkBytes", 4 << 20);
   private static final int ADOPT_BURST_PAGES = 16;
+  private static final ProjectionBulkLoad[] NO_PROJECTION_LOADS = new ProjectionBulkLoad[0];
 
   private final JsonNodeTrxImpl wtx;
   private final StorageEngineWriter storageEngineWriter;
@@ -104,6 +131,66 @@ public final class ParallelBulkJsonImporter {
   private KeyValueLeafPage heldTailPage;
   private long heldTailPageKey = -1;
 
+  /**
+   * Load-time projection builds this import feeds, empty when none is armed. Non-empty switches on
+   * the feeder's per-member node counts and the record attribution below; empty leaves every code
+   * path exactly as it was.
+   */
+  private final ProjectionBulkLoad[] projectionLoads;
+
+  /**
+   * Record roots and their last node keys, in document order, awaiting their row feed. A record's
+   * row is handed to the builds only once its WHOLE subtree has entered the intent log — the same
+   * watermark discipline the old key-attribution queue drained against — so the feed's document
+   * order and the storage epoch a row's dictionary interns land in stay exactly where they were.
+   * Only the row's SOURCE changed: the worker's batch, extracted during the build, instead of a
+   * coordinator re-read through the transaction.
+   */
+  private final @Nullable LongArrayList pendingRecordRoots;
+  private final @Nullable LongArrayList pendingRecordEnds;
+
+  /** Index of the oldest record in the two queues above whose row has not been fed yet. */
+  private int pendingRecordHead;
+
+  /** Worker-extracted row batches, in chunk order — one array (one batch per armed load) per chunk. */
+  private final @Nullable ArrayDeque<ProjectionChunkRowBatch[]> pendingFeedBatches;
+
+  /** Next unfed row of the head entry of {@link #pendingFeedBatches}. */
+  private int feedRowInHeadBatch;
+
+  /** The record-set container (the root array) every fed record is a child of. */
+  private long feedRecordSetKey = -1;
+
+  // ==== PATH/CAS/NAME maintenance riding the load ==============================================
+
+  private final IndexDef[] pathIndexDefs;
+  private final IndexDef[] casIndexDefs;
+  private final IndexDef[] nameIndexDefs;
+  private final PathIndexBuilder[] pathIndexBuilders;
+  private final CASIndexBuilder[] casIndexBuilders;
+  private final NameIndexBuilder[] nameIndexBuilders;
+  private final boolean indexTuplesActive;
+  private final boolean pathIndexesEverything;
+  private final boolean casIndexesEverything;
+  private final boolean collectAllNames;
+  private final Set<String> includedNameStrings;
+  private final IntOpenHashSet includedNameKeys;
+  private final @Nullable Int2ObjectOpenHashMap<QNm> qnmByNameKey;
+  private final @Nullable Long2LongOpenHashMap mirrorParentPcrMemo;
+
+  private static final Str STR_TRUE = new Str("true");
+  private static final Str STR_FALSE = new Str("false");
+
+  /** Highest node key that is live in the intent log, i.e. readable back through the wtx. */
+  private long adoptedWatermark = -1;
+
+  /**
+   * Last key of the chunk being adopted. A page is adopted whole, but the chunk that produced it may
+   * stop part-way through the page's slot range (page 0's prologue chunk does), so the watermark a
+   * page can justify is capped by what the chunk actually built.
+   */
+  private long currentChunkLastKey = -1;
+
   /** Recycled decode scratch: chars ≤ bytes for UTF-8, so one budget-sized array fits a chunk. */
   private final ArrayBlockingQueue<char[]> charScratchPool = new ArrayBlockingQueue<>(16);
 
@@ -115,15 +202,102 @@ public final class ParallelBulkJsonImporter {
     return new char[Math.max(neededChars, chunkCharBudget + (chunkCharBudget >> 2))];
   }
 
-  private ParallelBulkJsonImporter(final JsonNodeTrxImpl wtx, final int chunkCharBudget) {
+  private ParallelBulkJsonImporter(final JsonNodeTrxImpl wtx, final int chunkCharBudget,
+      final ProjectionBulkLoad[] projectionLoads) {
     this.wtx = wtx;
     this.storageEngineWriter = wtx.getStorageEngineWriter();
     this.pathSummaryWriter = wtx.bulkPathSummaryWriter();
     this.buildPathSummary = wtx.bulkBuildPathSummary();
-    this.wtxSink = new WtxBulkRecordSink(wtx);
+    // The coordinator attributes records to the armed builds itself; the spine's own handful of
+    // nodes must not additionally arrive as notifications, or the same record set would be
+    // announced twice through two different mechanisms.
+    this.wtxSink = new WtxBulkRecordSink(wtx, false);
     this.revisionRootPage = storageEngineWriter.getActualRevisionRootPage();
     this.resourceConfig = wtx.getResourceSession().getResourceConfig();
     this.chunkCharBudget = chunkCharBudget;
+    this.projectionLoads = projectionLoads;
+    this.pendingRecordRoots = projectionLoads.length == 0
+        ? null
+        : new LongArrayList(1024);
+    this.pendingRecordEnds = projectionLoads.length == 0
+        ? null
+        : new LongArrayList(1024);
+    this.pendingFeedBatches = projectionLoads.length == 0
+        ? null
+        : new ArrayDeque<>(8);
+
+    // PATH/CAS/NAME maintenance riding the load: the catalogued definitions get their ordinary
+    // builders, whose empty-tree bulk-loader arms this import feeds through the workers' tuple
+    // batches. The refusal above already rejected the one family this cannot serve (valid-time).
+    final Set<IndexDef> pathDefs = wtx.bulkIndexDefsOfType(IndexType.PATH);
+    final Set<IndexDef> casDefs = wtx.bulkIndexDefsOfType(IndexType.CAS);
+    final Set<IndexDef> nameDefs = wtx.bulkIndexDefsOfType(IndexType.NAME);
+    this.pathIndexDefs = pathDefs.toArray(IndexDef[]::new);
+    this.casIndexDefs = casDefs.toArray(IndexDef[]::new);
+    this.nameIndexDefs = nameDefs.toArray(IndexDef[]::new);
+    this.pathIndexBuilders = new PathIndexBuilder[pathIndexDefs.length];
+    final PathIndexBuilderFactory pathFactory = new PathIndexBuilderFactory(DatabaseType.JSON);
+    for (int i = 0; i < pathIndexDefs.length; i++) {
+      pathIndexBuilders[i] = pathFactory.create(storageEngineWriter, wtx.getPathSummary(), pathIndexDefs[i]);
+    }
+    this.casIndexBuilders = new CASIndexBuilder[casIndexDefs.length];
+    final CASIndexBuilderFactory casFactory = new CASIndexBuilderFactory(DatabaseType.JSON);
+    for (int i = 0; i < casIndexDefs.length; i++) {
+      casIndexBuilders[i] = casFactory.create(storageEngineWriter, wtx.getPathSummary(), casIndexDefs[i]);
+    }
+    this.nameIndexBuilders = new NameIndexBuilder[nameIndexDefs.length];
+    final NameIndexBuilderFactory nameFactory = new NameIndexBuilderFactory(DatabaseType.JSON);
+    for (int i = 0; i < nameIndexDefs.length; i++) {
+      nameIndexBuilders[i] = nameFactory.create(storageEngineWriter, nameIndexDefs[i]);
+    }
+    this.indexTuplesActive = pathIndexBuilders.length > 0 || casIndexBuilders.length > 0
+        || nameIndexBuilders.length > 0;
+
+    // NAME-family worker pre-filter: dictionary keys of the names any definition INCLUDES,
+    // maintained as names intern (a name first occurring in chunk N is interned before chunk N
+    // dispatches, so per-chunk snapshots are exact). A definition with an empty include set — or
+    // an include the JSON name space cannot express — indexes every name, so the pre-filter
+    // degrades to collect-all and the builders' own include/exclude filter decides at drain.
+    boolean collectAllNames = false;
+    final Set<String> includedNames = new HashSet<>();
+    for (final IndexDef nameDef : nameIndexDefs) {
+      if (nameDef.getIncluded().isEmpty()) {
+        collectAllNames = true;
+        break;
+      }
+      for (final QNm included : nameDef.getIncluded()) {
+        if ((included.getPrefix() != null && !included.getPrefix().isEmpty())
+            || (included.getNamespaceURI() != null && !included.getNamespaceURI().isEmpty())) {
+          collectAllNames = true;
+          break;
+        }
+        includedNames.add(included.getLocalName());
+      }
+    }
+    this.collectAllNames = collectAllNames;
+    this.includedNameStrings = includedNames;
+    this.includedNameKeys = new IntOpenHashSet(Math.max(4, includedNames.size() * 2));
+    this.qnmByNameKey = nameIndexBuilders.length > 0
+        ? new Int2ObjectOpenHashMap<>(64)
+        : null;
+    // Whether any definition of the family indexes EVERY path — then the worker collects every
+    // eligible node and each builder's own filter decides at drain.
+    boolean pathAll = false;
+    for (final IndexDef def : pathIndexDefs) {
+      pathAll |= def.getPaths().isEmpty();
+    }
+    this.pathIndexesEverything = pathAll;
+    boolean casAll = false;
+    for (final IndexDef def : casIndexDefs) {
+      casAll |= def.getPaths().isEmpty();
+    }
+    this.casIndexesEverything = casAll;
+    this.mirrorParentPcrMemo = pathIndexBuilders.length > 0
+        ? new Long2LongOpenHashMap(16)
+        : null;
+    if (mirrorParentPcrMemo != null) {
+      mirrorParentPcrMemo.defaultReturnValue(Long.MIN_VALUE);
+    }
   }
 
   /** As {@link #assemble(JsonNodeTrx, Reader, int)} with the default chunk budget. */
@@ -181,23 +355,39 @@ public final class ParallelBulkJsonImporter {
       throw new IllegalArgumentException(
           "parallel bulk import requires the standard JsonNodeTrx implementation, got " + wtx.getClass().getName());
     }
-    refuseUnsupportedShape(impl);
+    final ProjectionBulkLoad[] projectionLoads = refuseUnsupportedShape(impl);
     try {
       final PushbackInputStream stream = new PushbackInputStream(input, 1);
       if (!nextIsArray(stream)) {
         // Not a top-level array: nothing to parallelize — the sequential assembler is the
-        // general path for every other shape.
+        // general path for every other shape. Its own record sink notifies the projection
+        // listener, which feeds any armed load exactly as it does for a sequential import.
         BulkJsonTreeAssembler.assemble(wtx, new InputStreamReader(stream, StandardCharsets.UTF_8));
         return;
       }
-      new ParallelBulkJsonImporter(impl, chunkCharBudget).run(stream, Math.max(1, parallelism));
+      new ParallelBulkJsonImporter(impl, chunkCharBudget, projectionLoads).run(stream, Math.max(1, parallelism));
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  /** The assembler's refusals plus the importer's own: no primitive indexes during import. */
-  private static void refuseUnsupportedShape(final JsonNodeTrxImpl wtx) {
+  /**
+   * The assembler's refusals plus the importer's own.
+   *
+   * <p>
+   * Index maintenance splits three ways here. PATH, CAS and NAME definitions are MAINTAINED by the
+   * import itself: the workers collect each family's (key, nodeKey) tuples from the primitives they
+   * already hold, and the coordinator drains them into the families' ordinary builders — the same
+   * entries the sequential path's per-node change notifications produce. A PROJECTION index is
+   * accepted when, and only when, a LOAD-TIME build is armed for it on THIS transaction
+   * ({@code createProjectionIndexAtLoadStart}), because that build is fed by the coordinator's own
+   * record attribution; a catalogued projection with no armed load would be silently left
+   * unmaintained, so it refuses. Valid-time interval maintenance remains refused — it is resolved by
+   * a configured-path visitor over whole records, which has no chunk-local equivalent yet.
+   *
+   * @return the armed loads this import must feed, empty when none
+   */
+  private static ProjectionBulkLoad[] refuseUnsupportedShape(final JsonNodeTrxImpl wtx) {
     final ResourceConfiguration config = wtx.getResourceSession().getResourceConfig();
     if (config.hashType != HashType.NONE) {
       throw new IllegalStateException("parallel bulk import supports hashType=NONE only, got " + config.hashType);
@@ -212,13 +402,39 @@ public final class ParallelBulkJsonImporter {
     if (summary != null && summary.isPathStatisticsEnabled()) {
       throw new IllegalStateException("parallel bulk import does not support path statistics");
     }
-    if (wtx.bulkHasPrimitiveIndexes()) {
+    if (wtx.bulkHasValidTimeIndex()) {
       throw new IllegalStateException(
-          "parallel bulk import does not support primitive-index maintenance during the load");
+          "parallel bulk import does not support valid-time index maintenance during the load — load with no "
+              + "valid-time index configured and build it afterwards");
     }
     if (!wtx.moveToDocumentRoot() || wtx.hasFirstChild()) {
       throw new IllegalStateException("parallel bulk import requires a FRESH resource (empty document root)");
     }
+    // Resolved LAST: every prior refusal throws before any armed load is looked up, so a refused
+    // import never leaves an armed load resolved-but-unfed behind.
+    return resolveArmedProjectionLoads(wtx);
+  }
+
+  private static ProjectionBulkLoad[] resolveArmedProjectionLoads(final JsonNodeTrxImpl wtx) {
+    final Set<IndexDef> projectionDefs = wtx.bulkProjectionIndexDefs();
+    if (projectionDefs.isEmpty()) {
+      return NO_PROJECTION_LOADS;
+    }
+    final String resourceKey = wtx.getResourceSession().getResourceConfig().getResource().toString();
+    final ProjectionBulkLoad[] loads = new ProjectionBulkLoad[projectionDefs.size()];
+    int count = 0;
+    for (final IndexDef indexDef : projectionDefs) {
+      final ProjectionBulkLoad load = ProjectionBulkLoad.active(resourceKey, indexDef.getID(), wtx);
+      if (load == null) {
+        throw new IllegalStateException("Projection index " + indexDef.getID()
+            + " is catalogued on this resource but has no load-time build armed for this transaction. The parallel "
+            + "importer feeds a projection by attributing the records IT writes, which requires the definition to be "
+            + "declared before the data through createProjectionIndexAtLoadStart. Either arm it there, or load with "
+            + "no declared projection and build the index afterwards with jn:create-projection-index.");
+      }
+      loads[count++] = load;
+    }
+    return loads;
   }
 
   /** Peeks past leading whitespace; pushes the decisive byte back either way. */
@@ -253,8 +469,21 @@ public final class ParallelBulkJsonImporter {
     final long rootArrayKey =
         wtxSink.createArrayNode(Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), NULL_KEY, rootArrayPcr);
     rememberRootArrayPcr(rootArrayPcr);
+    // Page 0 carries the document root and this array; it enters the intent log through the ordinary
+    // transaction path above, so everything up to here is already readable back.
+    adoptedWatermark = rootArrayKey;
+    currentChunkLastKey = rootArrayKey;
+    feedRecordSetKey = rootArrayKey;
+    for (final ProjectionBulkLoad load : projectionLoads) {
+      load.noteArrayRootInstance(rootArrayKey, wtx);
+    }
+    // The root array is created by the coordinator's own sink, so no worker batch ever carries it —
+    // but the sequential leg's PATH listener indexes every ARRAY node, this one included.
+    for (final PathIndexBuilder pathIndexBuilder : pathIndexBuilders) {
+      pathIndexBuilder.add(rootArrayPcr, rootArrayKey);
+    }
 
-    final FusedSliceAndScan fused = new FusedSliceAndScan(input, chunkCharBudget);
+    final FusedSliceAndScan fused = new FusedSliceAndScan(input, chunkCharBudget, projectionLoads.length > 0);
     fused.consumeArrayOpen();
     fused.rootStep().pcr = rootArrayPcr;
 
@@ -328,14 +557,25 @@ public final class ParallelBulkJsonImporter {
       }
       final long lastKey = firstKey + chunkNodes - 1;
       final long chunkLastMemberKey = firstKey + chunkNodes - chunk.lastMemberNodes();
+      enqueueRecordRoots(chunk, firstKey, chunkLastMemberKey, lastKey);
       final long trailingSiblingKey = chunk.isFinal()
           ? NULL_KEY
           : lastKey + 1;
 
       // --- Stage B: build — off-thread when a pool exists, inline otherwise ---------------------
+      // With a projection armed, the chunk carries a row batch per armed build: the worker extracts
+      // the rows AS IT BUILDS, from the primitives it already holds, and the coordinator replays
+      // them at adoption. The batch snapshot is taken HERE, after resolveChunkMetadata, so a field
+      // whose first occurrence is in this chunk has already acquired its path class.
+      final ProjectionChunkRowBatch[] chunkBatches = newChunkBatches((int) chunkMembers);
+      final ChunkIndexTupleBatch chunkIndexBatch = newChunkIndexBatch();
       final WorkerPageBuilder builder =
           new WorkerPageBuilder(resourceConfig, storageEngineWriter.getRevisionNumber(),
-              resourceConfig.nodeHashFunction, wtx.bulkStoreChildCount(), chunkNames, firstKey, lastKey);
+              resourceConfig.nodeHashFunction, wtx.bulkStoreChildCount(), chunkNames, firstKey, lastKey,
+              chunkBatches, feedRecordSetKey, chunkIndexBatch);
+      if (chunkBatches != null) {
+        pendingFeedBatches.addLast(chunkBatches);
+      }
       final byte[] chunkBytes = chunk.bytes();
       final int chunkByteLength = chunk.length();
       final long buildFirstKey = firstKey;
@@ -344,8 +584,10 @@ public final class ParallelBulkJsonImporter {
       final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> memoSnapshot = copyMemo(masterPcrMemo);
 
       if (buildPool == null) {
-        stitchAndAdopt(buildChunk(fused, builder, chunkBytes, chunkByteLength, buildFirstKey, lastKey, rootArrayKey,
-            rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot), lastKey);
+        final List<KeyValueLeafPage> builtPages = buildChunk(fused, builder, chunkBytes, chunkByteLength,
+            buildFirstKey, lastKey, rootArrayKey, rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
+        drainIndexTuples(builder.indexTuples());
+        stitchAndAdopt(builtPages, lastKey);
       } else {
         final long submittedLastKey = lastKey;
         inFlight.addLast(new PendingBuild(buildPool.submit(() -> {
@@ -379,6 +621,30 @@ public final class ParallelBulkJsonImporter {
       adoptBurst(new KeyValueLeafPage[] { heldTailPage }, 1);
       heldTailPage = null;
       heldTailPageKey = -1;
+    }
+
+    // Everything built is now in the intent log, so the remaining rows — the records that were
+    // still inside a held tail page — can be fed. Nothing must be left pending: the builds' own
+    // end-of-load row count would come up short and refuse.
+    if (projectionLoads.length > 0) {
+      adoptedWatermark = expectedNextReservation - 1;
+      feedReadableRows();
+      if (pendingRecordCount() != 0) {
+        throw new IllegalStateException(
+            "the import finished with " + pendingRecordCount() + " records never handed to the projection build");
+      }
+    }
+
+    // Materialise the PATH/CAS/NAME indexes: every chunk's tuples are drained, so one flush per
+    // family builds each trie in a single pass, before the caller's commit persists it.
+    for (final PathIndexBuilder pathIndexBuilder : pathIndexBuilders) {
+      pathIndexBuilder.finish();
+    }
+    for (final CASIndexBuilder casIndexBuilder : casIndexBuilders) {
+      casIndexBuilder.finish();
+    }
+    for (final NameIndexBuilder nameIndexBuilder : nameIndexBuilders) {
+      nameIndexBuilder.finish();
     }
 
     // Root array + document fixups, once, with GLOBAL counts.
@@ -422,7 +688,9 @@ public final class ParallelBulkJsonImporter {
   private void adoptNext(final ArrayDeque<PendingBuild> inFlight) {
     final PendingBuild next = inFlight.pollFirst();
     try {
-      stitchAndAdopt(next.pages().get(), next.lastKey());
+      final List<KeyValueLeafPage> builtPages = next.pages().get();
+      drainIndexTuples(next.builder().indexTuples());
+      stitchAndAdopt(builtPages, next.lastKey());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("interrupted while awaiting a chunk build", e);
@@ -451,7 +719,9 @@ public final class ParallelBulkJsonImporter {
     // matter are name-vs-name and path-vs-path order, both exact here).
     for (final String name : chunk.newNames()) {
       nameById.add(name);
-      nameKeyById.add(storageEngineWriter.createNameKey(name, NodeKind.OBJECT_NAMED_OBJECT));
+      final int nameKey = storageEngineWriter.createNameKey(name, NodeKind.OBJECT_NAMED_OBJECT);
+      nameKeyById.add(nameKey);
+      noteInternedName(name, nameKey);
     }
     // New path steps, in document order; resolution counts each step's first occurrence.
     for (final FusedSliceAndScan.PathStep step : chunk.newSteps()) {
@@ -539,6 +809,7 @@ public final class ParallelBulkJsonImporter {
   // ==== stitch + adopt =========================================================================
 
   private void stitchAndAdopt(final List<KeyValueLeafPage> pages, final long lastKey) {
+    currentChunkLastKey = lastKey;
     final KeyValueLeafPage[] burst = new KeyValueLeafPage[ADOPT_BURST_PAGES];
     int burstSize = 0;
     final boolean tailPartial = ((lastKey + 1) & 1023) != 0;
@@ -568,6 +839,7 @@ public final class ParallelBulkJsonImporter {
         // Page 0 is TIL-live (document root + root array prologue): CoW-checked blit.
         mergeInto(storageEngineWriter.prepareDocumentLeafForBlit(0), page);
         page.retire();
+        noteAdoptedPage(0);
         continue;
       }
 
@@ -580,6 +852,249 @@ public final class ParallelBulkJsonImporter {
       burstSize = enqueue(burst, burstSize, page);
     }
     flushBurst(burst, burstSize);
+  }
+
+  /**
+   * Queue this chunk's record roots with the last node key of each, derived from the feeder's
+   * per-member node counts over the chunk's contiguous reserved range.
+   */
+  private void enqueueRecordRoots(final FusedSliceAndScan.Chunk chunk, final long firstKey,
+      final long chunkLastMemberKey, final long lastKey) {
+    if (projectionLoads.length == 0) {
+      return;
+    }
+    final long[] memberNodes = chunk.memberNodes();
+    if (memberNodes == null || memberNodes.length != chunk.members()) {
+      throw new IllegalStateException("the feeder handed " + (memberNodes == null
+          ? "no"
+          : String.valueOf(memberNodes.length)) + " member node counts for a chunk of " + chunk.members()
+          + " members; a load-time projection build cannot name its records without them");
+    }
+    long recordKey = firstKey;
+    for (final long memberNodeCount : memberNodes) {
+      pendingRecordRoots.add(recordKey);
+      recordKey += memberNodeCount;
+      pendingRecordEnds.add(recordKey - 1);
+    }
+    // The two independently-derived boundaries of the same chunk must agree, or the record roots
+    // this queue names are not the ones the build produced.
+    if (recordKey - 1 != lastKey) {
+      throw new IllegalStateException("member node counts cover keys up to " + (recordKey - 1)
+          + " but the chunk's reserved range ends at " + lastKey);
+    }
+    if (chunk.members() > 0 && pendingRecordRoots.getLong(pendingRecordRoots.size() - 1) != chunkLastMemberKey) {
+      throw new IllegalStateException("the last member root derived from node counts is "
+          + pendingRecordRoots.getLong(pendingRecordRoots.size() - 1) + " but range arithmetic says "
+          + chunkLastMemberKey);
+    }
+  }
+
+  /** Per-chunk row batches for the armed builds, snapshot after the chunk's paths resolved. */
+  private ProjectionChunkRowBatch @Nullable [] newChunkBatches(final int members) {
+    if (projectionLoads.length == 0) {
+      return null;
+    }
+    final ProjectionChunkRowBatch[] batches = new ProjectionChunkRowBatch[projectionLoads.length];
+    for (int i = 0; i < projectionLoads.length; i++) {
+      batches[i] = projectionLoads[i].newChunkBatch(wtx.getPathSummary(), members, feedRecordSetKey);
+    }
+    return batches;
+  }
+
+  /**
+   * Feed every queued record whose WHOLE subtree has been adopted to the armed builds, oldest
+   * first, from the worker-extracted batches. The batch row and the queue entry describe the same
+   * record through two independent derivations — the worker's parent-key detection and the feeder's
+   * member node counts — so their root keys are cross-checked per row before the row is appended.
+   */
+  private void feedReadableRows() {
+    final int pending = pendingRecordRoots.size();
+    int head = pendingRecordHead;
+    while (head < pending && pendingRecordEnds.getLong(head) <= adoptedWatermark) {
+      ProjectionChunkRowBatch[] batches = pendingFeedBatches.peekFirst();
+      while (batches != null && feedRowInHeadBatch >= batches[0].rowCount()) {
+        pendingFeedBatches.pollFirst();
+        feedRowInHeadBatch = 0;
+        batches = pendingFeedBatches.peekFirst();
+      }
+      if (batches == null) {
+        throw new IllegalStateException("record root " + pendingRecordRoots.getLong(head)
+            + " is adopted but no chunk batch holds its row");
+      }
+      final long recordKey = pendingRecordRoots.getLong(head);
+      final int row = feedRowInHeadBatch;
+      if (batches[0].recordRootAt(row) != recordKey) {
+        throw new IllegalStateException("the worker attributed batch row " + row + " to record root "
+            + batches[0].recordRootAt(row) + " but the feeder's member counts derived root " + recordKey);
+      }
+      for (int i = 0; i < projectionLoads.length; i++) {
+        projectionLoads[i].appendCoordinatorRow(storageEngineWriter, batches[i], row, recordKey, feedRecordSetKey,
+            Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
+      }
+      feedRowInHeadBatch = row + 1;
+      head++;
+    }
+    if (head == pendingRecordHead) {
+      return;
+    }
+    pendingRecordHead = head;
+    // Compact only once the consumed prefix dominates, so a chunk's worth of members costs one
+    // amortized shift rather than one per adoption burst.
+    if (pendingRecordHead > (pending >> 1)) {
+      pendingRecordRoots.removeElements(0, pendingRecordHead);
+      pendingRecordEnds.removeElements(0, pendingRecordHead);
+      pendingRecordHead = 0;
+    }
+  }
+
+  /** Records still awaiting attribution — the queue minus its already-consumed prefix. */
+  private int pendingRecordCount() {
+    return pendingRecordRoots.size() - pendingRecordHead;
+  }
+
+  // ==== PATH/CAS/NAME tuple flow ===============================================================
+
+  /** Book-keeping for a freshly interned field name: its drain-time QNm and the NAME pre-filter. */
+  private void noteInternedName(final String name, final int nameKey) {
+    if (qnmByNameKey == null) {
+      return;
+    }
+    qnmByNameKey.put(nameKey, new QNm(name));
+    if (!collectAllNames && includedNameStrings.contains(name)) {
+      includedNameKeys.add(nameKey);
+    }
+  }
+
+  /**
+   * A tuple batch for the next chunk, with the per-family union filters resolved against the LIVE
+   * path summary and name dictionary — after this chunk's Stage-A resolution, so a path class or
+   * name first occurring in this chunk is in this chunk's snapshot. The union sets are fresh (or
+   * copied) objects per chunk because the workers read them off-thread while later chunks grow the
+   * coordinator's originals.
+   */
+  private @Nullable ChunkIndexTupleBatch newChunkIndexBatch() {
+    if (!indexTuplesActive) {
+      return null;
+    }
+    final boolean pathActive = pathIndexBuilders.length > 0;
+    final boolean casActive = casIndexBuilders.length > 0;
+    final boolean nameActive = nameIndexBuilders.length > 0;
+    LongOpenHashSet pathUnion = null;
+    if (pathActive && !pathIndexesEverything) {
+      pathUnion = new LongOpenHashSet();
+      for (final IndexDef pathDef : pathIndexDefs) {
+        pathUnion.addAll(wtx.getPathSummary().getPCRsForPaths(pathDef.getPaths()));
+      }
+    }
+    LongOpenHashSet casUnion = null;
+    if (casActive && !casIndexesEverything) {
+      casUnion = new LongOpenHashSet();
+      for (final IndexDef casDef : casIndexDefs) {
+        casUnion.addAll(wtx.getPathSummary().getPCRsForPaths(casDef.getPaths()));
+      }
+    }
+    IntOpenHashSet nameUnion = null;
+    if (nameActive && !collectAllNames) {
+      nameUnion = new IntOpenHashSet(includedNameKeys);
+    }
+    return new ChunkIndexTupleBatch(pathActive, pathUnion, casActive, casUnion, nameActive, nameUnion);
+  }
+
+  /**
+   * Drain one chunk's collected tuples into every family builder, in chunk (document) order. The
+   * builders re-apply their own per-definition filters and the CAS type conversion — exactly the
+   * semantics the sequential import's listeners run per notification.
+   */
+  private void drainIndexTuples(final @Nullable ChunkIndexTupleBatch batch) {
+    if (batch == null) {
+      return;
+    }
+    // The builders cache their resolved path classes for a FROZEN summary; this feeder's summary
+    // grows between drains, so a class first minted since the previous drain (or after the
+    // prologue's root-array entry) would stay invisible behind the stale set.
+    for (final PathIndexBuilder pathIndexBuilder : pathIndexBuilders) {
+      pathIndexBuilder.refreshIndexedPaths();
+    }
+    for (final CASIndexBuilder casIndexBuilder : casIndexBuilders) {
+      casIndexBuilder.refreshIndexedPaths();
+    }
+    final int pathEntries = batch.pathEntryCount();
+    for (int i = 0; i < pathEntries; i++) {
+      final long pcr = batch.pathPcrAt(i);
+      final long nodeKey = batch.pathNodeKeyAt(i);
+      for (final PathIndexBuilder pathIndexBuilder : pathIndexBuilders) {
+        pathIndexBuilder.add(pcr, nodeKey);
+      }
+    }
+    // OBJECT_NAMED_ARRAY plays BOTH the ARRAY and the OBJECT_KEY structural roles: mirror each
+    // entry under the parent (OBJECT_KEY-layer) path class, exactly as the sequential listener
+    // does. The parent resolution is memoised per distinct array-layer class.
+    final int mirrorEntries = batch.mirrorCandidateCount();
+    for (int i = 0; i < mirrorEntries; i++) {
+      final long objectKeyLayerPcr = mirrorObjectKeyLayerPcr(batch.mirrorArrayPcrAt(i));
+      if (objectKeyLayerPcr < 0) {
+        continue;
+      }
+      final long nodeKey = batch.mirrorNodeKeyAt(i);
+      for (final PathIndexBuilder pathIndexBuilder : pathIndexBuilders) {
+        pathIndexBuilder.add(objectKeyLayerPcr, nodeKey);
+      }
+    }
+    final int nameEntries = batch.nameEntryCount();
+    for (int i = 0; i < nameEntries; i++) {
+      final QNm name = qnmByNameKey.get(batch.nameKeyAt(i));
+      if (name == null) {
+        throw new IllegalStateException(
+            "name key " + batch.nameKeyAt(i) + " was collected for the NAME index but never interned");
+      }
+      final long nodeKey = batch.nameNodeKeyAt(i);
+      for (final NameIndexBuilder nameIndexBuilder : nameIndexBuilders) {
+        nameIndexBuilder.add(name, nodeKey);
+      }
+    }
+    final int casEntries = batch.casEntryCount();
+    int stringOrdinal = 0;
+    int numberOrdinal = 0;
+    for (int i = 0; i < casEntries; i++) {
+      final Str value;
+      switch (batch.casKindAt(i)) {
+        case ChunkIndexTupleBatch.CAS_KIND_STRING -> {
+          final int offset = batch.casStringOffsetAt(stringOrdinal);
+          final int length = batch.casStringLengthAt(stringOrdinal);
+          stringOrdinal++;
+          value = new Str(new String(batch.casStringArena(), offset, length, StandardCharsets.UTF_8));
+        }
+        case ChunkIndexTupleBatch.CAS_KIND_NUMBER -> {
+          value = new Str(String.valueOf(batch.casNumberAt(numberOrdinal)));
+          numberOrdinal++;
+        }
+        case ChunkIndexTupleBatch.CAS_KIND_BOOLEAN_TRUE -> value = STR_TRUE;
+        case ChunkIndexTupleBatch.CAS_KIND_BOOLEAN_FALSE -> value = STR_FALSE;
+        default -> throw new IllegalStateException("unknown CAS tuple kind " + batch.casKindAt(i));
+      }
+      final long pcr = batch.casPcrAt(i);
+      final long nodeKey = batch.casNodeKeyAt(i);
+      for (final CASIndexBuilder casIndexBuilder : casIndexBuilders) {
+        casIndexBuilder.add(value, pcr, nodeKey);
+      }
+    }
+  }
+
+  /**
+   * The OBJECT_KEY-layer path class above an OBJECT_NAMED_ARRAY's array-layer class, or {@code -1}
+   * when the summary holds no parent for it. Memoised: distinct array-layer classes are few.
+   */
+  private long mirrorObjectKeyLayerPcr(final long arrayLayerPcr) {
+    final long memoised = mirrorParentPcrMemo.get(arrayLayerPcr);
+    if (memoised != Long.MIN_VALUE) {
+      return memoised;
+    }
+    final var arrayPathNode = wtx.getPathSummary().getPathNodeForPathNodeKey(arrayLayerPcr);
+    final long parent = arrayPathNode == null
+        ? -1L
+        : arrayPathNode.getParentKey();
+    mirrorParentPcrMemo.put(arrayLayerPcr, parent);
+    return parent;
   }
 
   private int enqueue(final KeyValueLeafPage[] burst, final int burstSize, final KeyValueLeafPage page) {
@@ -603,11 +1118,38 @@ public final class ParallelBulkJsonImporter {
     for (int i = 0; i < burstSize; i++) {
       storageEngineWriter.adoptDocumentLeafPage(burst[i]);
       records += burst[i].populatedSlots().length;
+      noteAdoptedPage(burst[i].getPageKey());
       burst[i] = null;
     }
     // Accounting after the burst lets the ordinary predicate rotate the flush epoch — the same
     // cadence machinery the sequential path drives per top-level record.
+    if (projectionLoads.length == 0) {
+      wtx.bulkAccountRecord(records);
+      return;
+    }
+    // Feed every now-readable row to the armed builds BEFORE accounting, because accounting is
+    // what rotates the flush epoch: the rotation drain closes the builds' current dictionary
+    // generation, so feeding first keeps each row's interns in the epoch its record was adopted
+    // in. The rows themselves come from the worker batches and read nothing back, so — unlike the
+    // key-attribution design this replaced — a record straddling the held tail page no longer
+    // forces the accounting (and with it the whole flush epoch) to wait for the next chunk.
+    feedReadableRows();
     wtx.bulkAccountRecord(records);
+  }
+
+  /**
+   * Advance the readable-key watermark for a page that just entered the intent log. A page covers
+   * its whole 1024-slot range, but never past what the chunk that produced it actually built — the
+   * prologue chunk stops inside page 0.
+   */
+  private void noteAdoptedPage(final long pageKey) {
+    if (projectionLoads.length == 0) {
+      return;
+    }
+    final long covered = Math.min(((pageKey + 1) << 10) - 1, currentChunkLastKey);
+    if (covered > adoptedWatermark) {
+      adoptedWatermark = covered;
+    }
   }
 
   /** Replays every record of {@code source} into {@code target} (same page key, disjoint slots). */

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ParallelBulkJsonImporter.java
@@ -47,11 +47,13 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
@@ -75,15 +77,14 @@ import org.jspecify.annotations.Nullable;
  * <li><b>Slice</b>: a lightweight structural scanner cuts the stream into member-aligned char
  * chunks (strings/escapes tracked; no tokenization).</li>
  * <li><b>Count + resolve (coordinator)</b>: the fused pass produces exact node counts, member
- * boundaries, names (the only decoded text) and path resolution in the SAME byte sweep that
- * slices — reference deltas flush per chunk, before any rotation can flush summary pages
- * cold.</li>
+ * boundaries, names (the only decoded text) and path resolution in the SAME byte sweep that slices
+ * — reference deltas flush per chunk, before any rotation can flush summary pages cold.</li>
  * <li><b>Reserve</b>: the chunk's exact contiguous key range via
  * {@link RevisionRootPage#reserveKeyRangeInDocumentIndex(long)} — dense keys, so the result is
  * record-identical to a sequential load.</li>
- * <li><b>Build (worker)</b>: the same assembler core with a {@link WorkerPageBuilder} emits
- * FINAL record bytes into standalone pages; pre-resolved names/PCRs; range/slot verification
- * always on.</li>
+ * <li><b>Build (worker)</b>: the same assembler core with a {@link WorkerPageBuilder} emits FINAL
+ * record bytes into standalone pages; pre-resolved names/PCRs; range/slot verification always
+ * on.</li>
  * <li><b>Stitch + adopt (coordinator)</b>: pages sharing a page key with already-live territory
  * (page 0's prologue records, the previous chunk's held tail) are merged record-by-record through
  * the CoW-checked blit seam; whole pages are adopted via
@@ -107,8 +108,7 @@ public final class ParallelBulkJsonImporter {
 
   private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
   private static final QNm ARRAY_PATH_QNM = new QNm("__array__");
-  private static final int DEFAULT_CHUNK_CHAR_BUDGET =
-      Integer.getInteger("sirix.parallelImport.chunkBytes", 4 << 20);
+  private static final int DEFAULT_CHUNK_CHAR_BUDGET = Integer.getInteger("sirix.parallelImport.chunkBytes", 4 << 20);
   private static final int ADOPT_BURST_PAGES = 16;
   private static final ProjectionBulkLoad[] NO_PROJECTION_LOADS = new ProjectionBulkLoad[0];
 
@@ -123,7 +123,7 @@ public final class ParallelBulkJsonImporter {
 
   /** Interned dictionary keys by the feeder's STABLE dense name id, in first-occurrence order. */
   private final ArrayList<String> nameById = new ArrayList<>(64);
-  private final it.unimi.dsi.fastutil.ints.IntArrayList nameKeyById = new it.unimi.dsi.fastutil.ints.IntArrayList(64);
+  private final IntArrayList nameKeyById = new IntArrayList(64);
 
   /** The coordinator's growing (parentPCR, name) → PCR view, snapshot per chunk for the builder. */
   private Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> masterPcrMemo = new Long2ObjectOpenHashMap<>();
@@ -139,12 +139,12 @@ public final class ParallelBulkJsonImporter {
   private final ProjectionBulkLoad[] projectionLoads;
 
   /**
-   * Record roots and their last node keys, in document order, awaiting their row feed. A record's
-   * row is handed to the builds only once its WHOLE subtree has entered the intent log — the same
-   * watermark discipline the old key-attribution queue drained against — so the feed's document
-   * order and the storage epoch a row's dictionary interns land in stay exactly where they were.
-   * Only the row's SOURCE changed: the worker's batch, extracted during the build, instead of a
-   * coordinator re-read through the transaction.
+   * Record roots and their last node keys, in document order, awaiting their row feed. A record's row
+   * is handed to the builds only once its WHOLE subtree has entered the intent log — the same
+   * watermark discipline the old key-attribution queue drained against — so the feed's document order
+   * and the storage epoch a row's dictionary interns land in stay exactly where they were. Only the
+   * row's SOURCE changed: the worker's batch, extracted during the build, instead of a coordinator
+   * re-read through the transaction.
    */
   private final @Nullable LongArrayList pendingRecordRoots;
   private final @Nullable LongArrayList pendingRecordEnds;
@@ -152,7 +152,9 @@ public final class ParallelBulkJsonImporter {
   /** Index of the oldest record in the two queues above whose row has not been fed yet. */
   private int pendingRecordHead;
 
-  /** Worker-extracted row batches, in chunk order — one array (one batch per armed load) per chunk. */
+  /**
+   * Worker-extracted row batches, in chunk order — one array (one batch per armed load) per chunk.
+   */
   private final @Nullable ArrayDeque<ProjectionChunkRowBatch[]> pendingFeedBatches;
 
   /** Next unfed row of the head entry of {@link #pendingFeedBatches}. */
@@ -250,8 +252,8 @@ public final class ParallelBulkJsonImporter {
     for (int i = 0; i < nameIndexDefs.length; i++) {
       nameIndexBuilders[i] = nameFactory.create(storageEngineWriter, nameIndexDefs[i]);
     }
-    this.indexTuplesActive = pathIndexBuilders.length > 0 || casIndexBuilders.length > 0
-        || nameIndexBuilders.length > 0;
+    this.indexTuplesActive =
+        pathIndexBuilders.length > 0 || casIndexBuilders.length > 0 || nameIndexBuilders.length > 0;
 
     // NAME-family worker pre-filter: dictionary keys of the names any definition INCLUDES,
     // maintained as names intern (a name first occurring in chunk N is interned before chunk N
@@ -310,9 +312,11 @@ public final class ParallelBulkJsonImporter {
     assembleBytes(wtx, input, DEFAULT_CHUNK_CHAR_BUDGET, defaultParallelism());
   }
 
-  /** Builder threads: builds are cheap relative to the flush pipeline's parallel serialization,
-   * so the default leaves MOST cores to the snapshot flush pool — measured: an oversized build
-   * pool starves serialization (serializeJoinWait dominated the flush worker at builders=16). */
+  /**
+   * Builder threads: builds are cheap relative to the flush pipeline's parallel serialization, so the
+   * default leaves MOST cores to the snapshot flush pool — measured: an oversized build pool starves
+   * serialization (serializeJoinWait dominated the flush worker at builders=16).
+   */
   private static int defaultParallelism() {
     final int configured = Integer.getInteger("sirix.parallelImport.builders", -1);
     if (configured > 0) {
@@ -322,9 +326,9 @@ public final class ParallelBulkJsonImporter {
   }
 
   /**
-   * Imports ONE top-level JSON value from {@code input} into the fresh resource behind
-   * {@code wtx}, building member chunks through the parallel page pipeline when the top level is
-   * an array and falling back to the sequential assembler otherwise. The caller commits.
+   * Imports ONE top-level JSON value from {@code input} into the fresh resource behind {@code wtx},
+   * building member chunks through the parallel page pipeline when the top level is an array and
+   * falling back to the sequential assembler otherwise. The caller commits.
    *
    * @param wtx a write transaction on a FRESH resource (standard implementation)
    * @param input the character source
@@ -519,98 +523,97 @@ public final class ParallelBulkJsonImporter {
     long expectedNextReservation = rootArrayKey + 1;
 
     try {
-    while (true) {
-      final Object taken;
-      try {
-        taken = handoff.take();
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new IllegalStateException("interrupted awaiting the feeder", e);
-      }
-      if (taken == FEEDER_DONE) {
-        break;
-      }
-      if (taken instanceof Throwable failure) {
-        if (failure instanceof RuntimeException runtime) {
-          throw runtime;
+      while (true) {
+        final Object taken;
+        try {
+          taken = handoff.take();
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IllegalStateException("interrupted awaiting the feeder", e);
         }
-        if (failure instanceof IOException io) {
-          throw io;
+        if (taken == FEEDER_DONE) {
+          break;
         }
-        throw new IllegalStateException("feeder failed", failure);
-      }
-      final FusedSliceAndScan.Chunk chunk = (FusedSliceAndScan.Chunk) taken;
-
-      final long chunkNodes = chunk.nodes();
-      final long chunkMembers = chunk.members();
-      if (chunkNodes == 0) {
-        continue;
-      }
-      // --- Resolve this chunk's metadata on the coordinator, in document order ------------------
-      final Object2IntOpenHashMap<String> chunkNames = resolveChunkMetadata(chunk);
-
-      // --- Reserve the exact dense range ---------------------------------------------------
-      final long firstKey = revisionRootPage.reserveKeyRangeInDocumentIndex(chunkNodes);
-      if (firstKey != expectedNextReservation) {
-        throw new IllegalStateException(
-            "reserved range starts at " + firstKey + " but the pipeline expected " + expectedNextReservation);
-      }
-      final long lastKey = firstKey + chunkNodes - 1;
-      final long chunkLastMemberKey = firstKey + chunkNodes - chunk.lastMemberNodes();
-      enqueueRecordRoots(chunk, firstKey, chunkLastMemberKey, lastKey);
-      final long trailingSiblingKey = chunk.isFinal()
-          ? NULL_KEY
-          : lastKey + 1;
-
-      // --- Stage B: build — off-thread when a pool exists, inline otherwise ---------------------
-      // With a projection armed, the chunk carries a row batch per armed build: the worker extracts
-      // the rows AS IT BUILDS, from the primitives it already holds, and the coordinator replays
-      // them at adoption. The batch snapshot is taken HERE, after resolveChunkMetadata, so a field
-      // whose first occurrence is in this chunk has already acquired its path class.
-      final ProjectionChunkRowBatch[] chunkBatches = newChunkBatches((int) chunkMembers);
-      final ChunkIndexTupleBatch chunkIndexBatch = newChunkIndexBatch();
-      final WorkerPageBuilder builder =
-          new WorkerPageBuilder(resourceConfig, storageEngineWriter.getRevisionNumber(),
-              resourceConfig.nodeHashFunction, wtx.bulkStoreChildCount(), chunkNames, firstKey, lastKey,
-              chunkBatches, feedRecordSetKey, chunkIndexBatch);
-      if (chunkBatches != null) {
-        pendingFeedBatches.addLast(chunkBatches);
-      }
-      final byte[] chunkBytes = chunk.bytes();
-      final int chunkByteLength = chunk.length();
-      final long buildFirstKey = firstKey;
-      final long buildLastMemberBoundary = lastMemberKey;
-      final long buildTrailing = trailingSiblingKey;
-      final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> memoSnapshot = copyMemo(masterPcrMemo);
-
-      if (buildPool == null) {
-        final List<KeyValueLeafPage> builtPages = buildChunk(fused, builder, chunkBytes, chunkByteLength,
-            buildFirstKey, lastKey, rootArrayKey, rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
-        drainIndexTuples(builder.indexTuples());
-        stitchAndAdopt(builtPages, lastKey);
-      } else {
-        final long submittedLastKey = lastKey;
-        inFlight.addLast(new PendingBuild(buildPool.submit(() -> {
-          // The chunk's own UTF-8 decode happens HERE, on the pool thread — the whole corpus
-          // decode parallelizes across builders, into POOLED scratch (no per-chunk large arrays).
-          return buildChunk(fused, builder, chunkBytes, chunkByteLength, buildFirstKey, submittedLastKey, rootArrayKey,
-              rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
-        }), builder, lastKey, chunkLastMemberKey, chunkMembers));
-        // Admission control: never more than P+2 chunks of frames in flight; adoption is strictly
-        // in chunk order, which the tail-hold stitch chain requires anyway.
-        while (inFlight.size() >= maxInFlight) {
-          adoptNext(inFlight);
+        if (taken instanceof Throwable failure) {
+          if (failure instanceof RuntimeException runtime) {
+            throw runtime;
+          }
+          if (failure instanceof IOException io) {
+            throw io;
+          }
+          throw new IllegalStateException("feeder failed", failure);
         }
+        final FusedSliceAndScan.Chunk chunk = (FusedSliceAndScan.Chunk) taken;
+
+        final long chunkNodes = chunk.nodes();
+        final long chunkMembers = chunk.members();
+        if (chunkNodes == 0) {
+          continue;
+        }
+        // --- Resolve this chunk's metadata on the coordinator, in document order ------------------
+        final Object2IntOpenHashMap<String> chunkNames = resolveChunkMetadata(chunk);
+
+        // --- Reserve the exact dense range ---------------------------------------------------
+        final long firstKey = revisionRootPage.reserveKeyRangeInDocumentIndex(chunkNodes);
+        if (firstKey != expectedNextReservation) {
+          throw new IllegalStateException(
+              "reserved range starts at " + firstKey + " but the pipeline expected " + expectedNextReservation);
+        }
+        final long lastKey = firstKey + chunkNodes - 1;
+        final long chunkLastMemberKey = firstKey + chunkNodes - chunk.lastMemberNodes();
+        enqueueRecordRoots(chunk, firstKey, chunkLastMemberKey, lastKey);
+        final long trailingSiblingKey = chunk.isFinal()
+            ? NULL_KEY
+            : lastKey + 1;
+
+        // --- Stage B: build — off-thread when a pool exists, inline otherwise ---------------------
+        // With a projection armed, the chunk carries a row batch per armed build: the worker extracts
+        // the rows AS IT BUILDS, from the primitives it already holds, and the coordinator replays
+        // them at adoption. The batch snapshot is taken HERE, after resolveChunkMetadata, so a field
+        // whose first occurrence is in this chunk has already acquired its path class.
+        final ProjectionChunkRowBatch[] chunkBatches = newChunkBatches((int) chunkMembers);
+        final ChunkIndexTupleBatch chunkIndexBatch = newChunkIndexBatch();
+        final WorkerPageBuilder builder = new WorkerPageBuilder(resourceConfig, storageEngineWriter.getRevisionNumber(),
+            resourceConfig.nodeHashFunction, wtx.bulkStoreChildCount(), chunkNames, firstKey, lastKey, chunkBatches,
+            feedRecordSetKey, chunkIndexBatch);
+        if (chunkBatches != null) {
+          pendingFeedBatches.addLast(chunkBatches);
+        }
+        final byte[] chunkBytes = chunk.bytes();
+        final int chunkByteLength = chunk.length();
+        final long buildFirstKey = firstKey;
+        final long buildLastMemberBoundary = lastMemberKey;
+        final long buildTrailing = trailingSiblingKey;
+        final Long2ObjectOpenHashMap<Object2LongOpenHashMap<String>> memoSnapshot = copyMemo(masterPcrMemo);
+
+        if (buildPool == null) {
+          final List<KeyValueLeafPage> builtPages = buildChunk(fused, builder, chunkBytes, chunkByteLength,
+              buildFirstKey, lastKey, rootArrayKey, rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
+          drainIndexTuples(builder.indexTuples());
+          stitchAndAdopt(builtPages, lastKey);
+        } else {
+          final long submittedLastKey = lastKey;
+          inFlight.addLast(new PendingBuild(buildPool.submit(() -> {
+            // The chunk's own UTF-8 decode happens HERE, on the pool thread — the whole corpus
+            // decode parallelizes across builders, into POOLED scratch (no per-chunk large arrays).
+            return buildChunk(fused, builder, chunkBytes, chunkByteLength, buildFirstKey, submittedLastKey,
+                rootArrayKey, rootArrayPcr, buildLastMemberBoundary, buildTrailing, memoSnapshot);
+          }), builder, lastKey, chunkLastMemberKey, chunkMembers));
+          // Admission control: never more than P+2 chunks of frames in flight; adoption is strictly
+          // in chunk order, which the tail-hold stitch chain requires anyway.
+          while (inFlight.size() >= maxInFlight) {
+            adoptNext(inFlight);
+          }
+        }
+
+        totalMembers += chunkMembers;
+        lastMemberKey = chunkLastMemberKey;
+        expectedNextReservation = lastKey + 1;
       }
 
-      totalMembers += chunkMembers;
-      lastMemberKey = chunkLastMemberKey;
-      expectedNextReservation = lastKey + 1;
-    }
-
-    while (!inFlight.isEmpty()) {
-      adoptNext(inFlight);
-    }
+      while (!inFlight.isEmpty()) {
+        adoptNext(inFlight);
+      }
     } finally {
       if (buildPool != null) {
         buildPool.shutdownNow();
@@ -618,7 +621,7 @@ public final class ParallelBulkJsonImporter {
     }
 
     if (heldTailPage != null) {
-      adoptBurst(new KeyValueLeafPage[] { heldTailPage }, 1);
+      adoptBurst(new KeyValueLeafPage[] {heldTailPage}, 1);
       heldTailPage = null;
       heldTailPageKey = -1;
     }
@@ -694,7 +697,7 @@ public final class ParallelBulkJsonImporter {
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IllegalStateException("interrupted while awaiting a chunk build", e);
-    } catch (final java.util.concurrent.ExecutionException e) {
+    } catch (final ExecutionException e) {
       throw new IllegalStateException("chunk build failed", e.getCause());
     }
   }
@@ -705,11 +708,11 @@ public final class ParallelBulkJsonImporter {
   private static final Object FEEDER_DONE = new Object();
 
   /**
-   * Resolves a chunk's deferred metadata IN DOCUMENT ORDER on the coordinator — the sequential
-   * path's exact dictionary/summary call sequence, batched: new paths resolve through the real
-   * summary writer (each miss counts its first occurrence), new names intern via createNameKey,
-   * repeat occurrences land as reference/count deltas, and the master memo gains every new
-   * (parentPCR, name) → PCR pair for the build worker's snapshot.
+   * Resolves a chunk's deferred metadata IN DOCUMENT ORDER on the coordinator — the sequential path's
+   * exact dictionary/summary call sequence, batched: new paths resolve through the real summary
+   * writer (each miss counts its first occurrence), new names intern via createNameKey, repeat
+   * occurrences land as reference/count deltas, and the master memo gains every new (parentPCR, name)
+   * → PCR pair for the build worker's snapshot.
    *
    * @return the chunk's name → dictionary-key table for the build worker
    */
@@ -905,10 +908,10 @@ public final class ParallelBulkJsonImporter {
   }
 
   /**
-   * Feed every queued record whose WHOLE subtree has been adopted to the armed builds, oldest
-   * first, from the worker-extracted batches. The batch row and the queue entry describe the same
-   * record through two independent derivations — the worker's parent-key detection and the feeder's
-   * member node counts — so their root keys are cross-checked per row before the row is appended.
+   * Feed every queued record whose WHOLE subtree has been adopted to the armed builds, oldest first,
+   * from the worker-extracted batches. The batch row and the queue entry describe the same record
+   * through two independent derivations — the worker's parent-key detection and the feeder's member
+   * node counts — so their root keys are cross-checked per row before the row is appended.
    */
   private void feedReadableRows() {
     final int pending = pendingRecordRoots.size();
@@ -921,8 +924,8 @@ public final class ParallelBulkJsonImporter {
         batches = pendingFeedBatches.peekFirst();
       }
       if (batches == null) {
-        throw new IllegalStateException("record root " + pendingRecordRoots.getLong(head)
-            + " is adopted but no chunk batch holds its row");
+        throw new IllegalStateException(
+            "record root " + pendingRecordRoots.getLong(head) + " is adopted but no chunk batch holds its row");
       }
       final long recordKey = pendingRecordRoots.getLong(head);
       final int row = feedRowInHeadBatch;
@@ -970,9 +973,9 @@ public final class ParallelBulkJsonImporter {
 
   /**
    * A tuple batch for the next chunk, with the per-family union filters resolved against the LIVE
-   * path summary and name dictionary — after this chunk's Stage-A resolution, so a path class or
-   * name first occurring in this chunk is in this chunk's snapshot. The union sets are fresh (or
-   * copied) objects per chunk because the workers read them off-thread while later chunks grow the
+   * path summary and name dictionary — after this chunk's Stage-A resolution, so a path class or name
+   * first occurring in this chunk is in this chunk's snapshot. The union sets are fresh (or copied)
+   * objects per chunk because the workers read them off-thread while later chunks grow the
    * coordinator's originals.
    */
   private @Nullable ChunkIndexTupleBatch newChunkIndexBatch() {
@@ -1141,8 +1144,8 @@ public final class ParallelBulkJsonImporter {
   }
 
   /**
-   * Advance the readable-key watermark for a page that just entered the intent log. A page covers
-   * its whole 1024-slot range, but never past what the chunk that produced it actually built — the
+   * Advance the readable-key watermark for a page that just entered the intent log. A page covers its
+   * whole 1024-slot range, but never past what the chunk that produced it actually built — the
    * prologue chunk stops inside page 0.
    */
   private void noteAdoptedPage(final long pageKey) {
@@ -1163,8 +1166,7 @@ public final class ParallelBulkJsonImporter {
       final int kindId = source.getSlotNodeKindId(slot);
       final long absOffset = target.prepareHeapForDirectWriteOrOverflow((int) record.byteSize(), 0);
       if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
-        throw new IllegalStateException(
-            "boundary merge overflowed page " + target.getPageKey() + " at slot " + slot);
+        throw new IllegalStateException("boundary merge overflowed page " + target.getPageKey() + " at slot " + slot);
       }
       MemorySegment.copy(record, 0, target.getSlottedPage(), absOffset, record.byteSize());
       target.completeDirectWrite((byte) kindId, pageBase | slot, slot, (int) record.byteSize(), null);

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ReaderUtf8InputStream.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ReaderUtf8InputStream.java
@@ -21,9 +21,9 @@ import java.nio.charset.StandardCharsets;
 final class ReaderUtf8InputStream extends InputStream {
 
   private final Reader in;
-  private final CharsetEncoder encoder =
-      StandardCharsets.UTF_8.newEncoder().onMalformedInput(CodingErrorAction.REPLACE)
-                            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+  private final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder()
+                                                               .onMalformedInput(CodingErrorAction.REPLACE)
+                                                               .onUnmappableCharacter(CodingErrorAction.REPLACE);
   private final CharBuffer chars = CharBuffer.allocate(1 << 13);
   private final ByteBuffer bytes = ByteBuffer.allocate(1 << 14);
   private boolean endOfInput;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ReaderUtf8InputStream.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/ReaderUtf8InputStream.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Streams a {@link Reader}'s characters as UTF-8 bytes — the bridge that lets character-based
+ * callers (tests, in-process generators) use the byte-based parallel import pipeline. File and
+ * network callers should hand the raw {@link InputStream} directly and skip the round trip.
+ */
+final class ReaderUtf8InputStream extends InputStream {
+
+  private final Reader in;
+  private final CharsetEncoder encoder =
+      StandardCharsets.UTF_8.newEncoder().onMalformedInput(CodingErrorAction.REPLACE)
+                            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+  private final CharBuffer chars = CharBuffer.allocate(1 << 13);
+  private final ByteBuffer bytes = ByteBuffer.allocate(1 << 14);
+  private boolean endOfInput;
+
+  ReaderUtf8InputStream(final Reader in) {
+    this.in = in;
+    chars.limit(0);
+    bytes.limit(0);
+  }
+
+  @Override
+  public int read() throws IOException {
+    return refill()
+        ? bytes.get() & 0xFF
+        : -1;
+  }
+
+  @Override
+  public int read(final byte[] target, final int off, final int len) throws IOException {
+    if (!refill()) {
+      return -1;
+    }
+    final int n = Math.min(len, bytes.remaining());
+    bytes.get(target, off, n);
+    return n;
+  }
+
+  private boolean refill() throws IOException {
+    while (!bytes.hasRemaining()) {
+      if (!chars.hasRemaining() && !endOfInput) {
+        chars.clear();
+        final int read = in.read(chars);
+        if (read < 0) {
+          endOfInput = true;
+          chars.limit(0);
+        } else {
+          chars.flip();
+        }
+      }
+      bytes.clear();
+      final CoderResult result = encoder.encode(chars, bytes, endOfInput);
+      bytes.flip();
+      if (endOfInput && !bytes.hasRemaining() && result.isUnderflow()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void close() throws IOException {
+    in.close();
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
@@ -37,19 +37,19 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 /**
  * Stage-B worker sink of the parallel bulk importer: builds records with FINAL bytes into
- * STANDALONE {@link KeyValueLeafPage}s for a pre-reserved contiguous key range, entirely
- * off-thread — no transaction, no intent log, no shared dictionaries. It replicates the
- * transaction factory's direct-write skeleton per node kind (estimate → heap reserve →
- * {@code writeNewRecord} → {@code completeDirectWrite}), with three deliberate differences:
+ * STANDALONE {@link KeyValueLeafPage}s for a pre-reserved contiguous key range, entirely off-thread
+ * — no transaction, no intent log, no shared dictionaries. It replicates the transaction factory's
+ * direct-write skeleton per node kind (estimate → heap reserve → {@code writeNewRecord} →
+ * {@code completeDirectWrite}), with three deliberate differences:
  * <ul>
- * <li>Keys mint from the worker's own counter over the reserved range — the assembler's
- * prediction asserts every mint, and {@link #finish(long)} additionally verifies the final key
- * and the populated-slot total, so a count/build divergence refuses loudly (critic C2).</li>
+ * <li>Keys mint from the worker's own counter over the reserved range — the assembler's prediction
+ * asserts every mint, and {@link #finish(long)} additionally verifies the final key and the
+ * populated-slot total, so a count/build divergence refuses loudly (critic C2).</li>
  * <li>Field names arrive as PRE-RESOLVED dictionary keys through the chunk's name table — the
  * coordinator interned every name in first-occurrence order during the counting pass.</li>
- * <li>Insert-time FSST never engages: v1 imports into a FRESH resource, where the sequential
- * path's encode is a no-op too (no prior revision, no table) — the flags written are identical
- * by construction.</li>
+ * <li>Insert-time FSST never engages: v1 imports into a FRESH resource, where the sequential path's
+ * encode is a no-op too (no prior revision, no table) — the flags written are identical by
+ * construction.</li>
  * </ul>
  *
  * <p>
@@ -107,17 +107,16 @@ final class WorkerPageBuilder implements BulkRecordSink {
   private final ObjectNamedArrayNode scratchNamedArrayNode;
 
   WorkerPageBuilder(final ResourceConfiguration resourceConfig, final int revisionNumber,
-      final LongHashFunction hashFunction, final boolean storeChildCount,
-      final Object2IntOpenHashMap<String> nameKeys, final long firstKey, final long lastKey) {
-    this(resourceConfig, revisionNumber, hashFunction, storeChildCount, nameKeys, firstKey, lastKey, null,
-        NULL_KEY, null);
+      final LongHashFunction hashFunction, final boolean storeChildCount, final Object2IntOpenHashMap<String> nameKeys,
+      final long firstKey, final long lastKey) {
+    this(resourceConfig, revisionNumber, hashFunction, storeChildCount, nameKeys, firstKey, lastKey, null, NULL_KEY,
+        null);
   }
 
   WorkerPageBuilder(final ResourceConfiguration resourceConfig, final int revisionNumber,
-      final LongHashFunction hashFunction, final boolean storeChildCount,
-      final Object2IntOpenHashMap<String> nameKeys, final long firstKey, final long lastKey,
-      final ProjectionChunkRowBatch @Nullable [] projectionBatches, final long projectionRecordSetKey,
-      final @Nullable ChunkIndexTupleBatch indexTuples) {
+      final LongHashFunction hashFunction, final boolean storeChildCount, final Object2IntOpenHashMap<String> nameKeys,
+      final long firstKey, final long lastKey, final ProjectionChunkRowBatch @Nullable [] projectionBatches,
+      final long projectionRecordSetKey, final @Nullable ChunkIndexTupleBatch indexTuples) {
     this.resourceConfig = resourceConfig;
     this.revisionNumber = revisionNumber;
     this.hashFunction = hashFunction;
@@ -137,18 +136,16 @@ final class WorkerPageBuilder implements BulkRecordSink {
     this.projectionTrackChildValues = trackChildValues;
     this.indexTuples = indexTuples;
 
-    this.scratchObjectNode =
-        new ObjectNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, NULL_KEY, NULL_KEY, 0,
-            0, 0, hashFunction, (SirixDeweyID) null);
+    this.scratchObjectNode = new ObjectNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY,
+        NULL_KEY, NULL_KEY, 0, 0, 0, hashFunction, (SirixDeweyID) null);
     this.scratchArrayNode = new ArrayNode(0, 0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY,
         NULL_KEY, NULL_KEY, 0, 0, 0, hashFunction, (SirixDeweyID) null);
-    this.scratchNullNode =
-        new NullNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0, hashFunction, (SirixDeweyID) null);
+    this.scratchNullNode = new NullNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0,
+        hashFunction, (SirixDeweyID) null);
     this.scratchBooleanNode = new BooleanNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY,
         0, false, hashFunction, (SirixDeweyID) null);
-    this.scratchNumberNode =
-        new NumberNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0, 0, hashFunction,
-            (SirixDeweyID) null);
+    this.scratchNumberNode = new NumberNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0,
+        0, hashFunction, (SirixDeweyID) null);
     this.scratchStringNode = new StringNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0,
         new byte[0], hashFunction, (SirixDeweyID) null, false, null);
     this.scratchNamedBooleanNode = new ObjectNamedBooleanNode(0, hashFunction);
@@ -189,7 +186,9 @@ final class WorkerPageBuilder implements BulkRecordSink {
 
   // ==== projection extraction hooks (no-ops when nothing is armed) =============================
 
-  /** A structured, unnamed node: a record root when its parent is the record set, else a plain child. */
+  /**
+   * A structured, unnamed node: a record root when its parent is the record set, else a plain child.
+   */
   private void noteUnnamedStructured(final long nodeKey, final long parentKey) {
     if (parentKey == projectionRecordSetKey) {
       for (final ProjectionChunkRowBatch batch : projectionBatches) {
@@ -224,7 +223,8 @@ final class WorkerPageBuilder implements BulkRecordSink {
   }
 
   /** The chunk's PATH/CAS/NAME tuples, for the coordinator's drain; {@code null} when unarmed. */
-  @Nullable ChunkIndexTupleBatch indexTuples() {
+  @Nullable
+  ChunkIndexTupleBatch indexTuples() {
     return indexTuples;
   }
 
@@ -240,8 +240,8 @@ final class WorkerPageBuilder implements BulkRecordSink {
       if (currentPage != null) {
         pages.add(currentPage);
       }
-      currentPage = new KeyValueLeafPage(pageKey, IndexType.DOCUMENT, resourceConfig, revisionNumber, null, null,
-          false);
+      currentPage =
+          new KeyValueLeafPage(pageKey, IndexType.DOCUMENT, resourceConfig, revisionNumber, null, null, false);
       currentPageKey = pageKey;
     }
     populatedSlots++;
@@ -284,10 +284,9 @@ final class WorkerPageBuilder implements BulkRecordSink {
     }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchArrayNode.estimateSerializedSize(), 0);
-    final int recordBytes =
-        ArrayNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchArrayNode.getHeapOffsets(), nodeKey, parentKey,
-            NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY, arrayPcr, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, 0,
-            0);
+    final int recordBytes = ArrayNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchArrayNode.getHeapOffsets(),
+        nodeKey, parentKey, NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY, arrayPcr, Constants.NULL_REVISION_NUMBER,
+        revisionNumber, 0, 0, 0);
     kvl.completeDirectWrite(NodeKind.ARRAY.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
     return nodeKey;
   }
@@ -355,10 +354,9 @@ final class WorkerPageBuilder implements BulkRecordSink {
       kvl.setRecord(node);
       return nodeKey;
     }
-    final int recordBytes =
-        StringNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchStringNode.getHeapOffsets(), nodeKey,
-            parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER, revisionNumber, utf8, 0, utf8Length,
-            false);
+    final int recordBytes = StringNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchStringNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER,
+        revisionNumber, utf8, 0, utf8Length, false);
     kvl.completeDirectWrite(NodeKind.STRING_VALUE.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
     return nodeKey;
   }
@@ -381,9 +379,9 @@ final class WorkerPageBuilder implements BulkRecordSink {
     if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
       final byte[] valueCopy = new byte[utf8Length];
       System.arraycopy(utf8, 0, valueCopy, 0, utf8Length);
-      final ObjectNamedStringNode node =
-          new ObjectNamedStringNode(nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
-              Constants.NULL_REVISION_NUMBER, revisionNumber, 0, valueCopy, hashFunction, (SirixDeweyID) null, false, null);
+      final ObjectNamedStringNode node = new ObjectNamedStringNode(nodeKey, parentKey, rightSibKey, leftSibKey, nameKey,
+          pathNodeKey, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, valueCopy, hashFunction, (SirixDeweyID) null,
+          false, null);
       kvl.setRecord(node);
       return nodeKey;
     }
@@ -536,9 +534,9 @@ final class WorkerPageBuilder implements BulkRecordSink {
   }
 
   /**
-   * Binds a scratch flyweight to a container record in the worker's OWN un-adopted pages — the
-   * same dir-entry mechanics as the transaction binder, safe here because nothing else can see
-   * these pages yet.
+   * Binds a scratch flyweight to a container record in the worker's OWN un-adopted pages — the same
+   * dir-entry mechanics as the transaction binder, safe here because nothing else can see these pages
+   * yet.
    */
   private StructNode bindOwnContainer(final long containerKey) {
     if (containerKey < firstKey || containerKey >= nextKey) {

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
@@ -5,6 +5,7 @@ package io.sirix.access.trx.node.json;
 
 import io.sirix.access.ResourceConfiguration;
 import io.sirix.index.IndexType;
+import io.sirix.index.projection.ProjectionChunkRowBatch;
 import io.sirix.node.NodeKind;
 import io.sirix.node.json.ArrayNode;
 import io.sirix.node.json.BooleanNode;
@@ -26,6 +27,7 @@ import io.sirix.settings.Constants;
 import io.sirix.settings.Fixed;
 
 import net.openhft.hashing.LongHashFunction;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
@@ -57,6 +59,7 @@ import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 final class WorkerPageBuilder implements BulkRecordSink {
 
   private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
+  private static final ProjectionChunkRowBatch[] NO_PROJECTION_BATCHES = new ProjectionChunkRowBatch[0];
 
   private final ResourceConfiguration resourceConfig;
   private final int revisionNumber;
@@ -65,6 +68,22 @@ final class WorkerPageBuilder implements BulkRecordSink {
   private final Object2IntOpenHashMap<String> nameKeys;
   private final long firstKey;
   private final long lastKey;
+
+  /**
+   * Armed projection batches this build feeds AS IT BUILDS — one per armed definition, empty when
+   * none is armed. The worker holds every record's primitives in hand exactly once, here, so
+   * extraction costs one hook per node instead of a per-record re-read through the transaction.
+   */
+  private final ProjectionChunkRowBatch[] projectionBatches;
+  private final long projectionRecordSetKey;
+  private final boolean projectionTrackChildValues;
+
+  /**
+   * PATH/CAS/NAME tuples this build collects AS IT BUILDS, or {@code null} when none of those
+   * families is armed. Same rationale as the projection batches: the worker holds every node's
+   * (pathNodeKey, nameKey, value) exactly once, here.
+   */
+  private final @Nullable ChunkIndexTupleBatch indexTuples;
 
   private final List<KeyValueLeafPage> pages = new ArrayList<>();
   private KeyValueLeafPage currentPage;
@@ -90,6 +109,15 @@ final class WorkerPageBuilder implements BulkRecordSink {
   WorkerPageBuilder(final ResourceConfiguration resourceConfig, final int revisionNumber,
       final LongHashFunction hashFunction, final boolean storeChildCount,
       final Object2IntOpenHashMap<String> nameKeys, final long firstKey, final long lastKey) {
+    this(resourceConfig, revisionNumber, hashFunction, storeChildCount, nameKeys, firstKey, lastKey, null,
+        NULL_KEY, null);
+  }
+
+  WorkerPageBuilder(final ResourceConfiguration resourceConfig, final int revisionNumber,
+      final LongHashFunction hashFunction, final boolean storeChildCount,
+      final Object2IntOpenHashMap<String> nameKeys, final long firstKey, final long lastKey,
+      final ProjectionChunkRowBatch @Nullable [] projectionBatches, final long projectionRecordSetKey,
+      final @Nullable ChunkIndexTupleBatch indexTuples) {
     this.resourceConfig = resourceConfig;
     this.revisionNumber = revisionNumber;
     this.hashFunction = hashFunction;
@@ -98,6 +126,16 @@ final class WorkerPageBuilder implements BulkRecordSink {
     this.firstKey = firstKey;
     this.lastKey = lastKey;
     this.nextKey = firstKey;
+    this.projectionBatches = projectionBatches == null
+        ? NO_PROJECTION_BATCHES
+        : projectionBatches;
+    this.projectionRecordSetKey = projectionRecordSetKey;
+    boolean trackChildValues = false;
+    for (final ProjectionChunkRowBatch batch : this.projectionBatches) {
+      trackChildValues |= batch.trackChildValues();
+    }
+    this.projectionTrackChildValues = trackChildValues;
+    this.indexTuples = indexTuples;
 
     this.scratchObjectNode =
         new ObjectNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, NULL_KEY, NULL_KEY, 0,
@@ -143,11 +181,51 @@ final class WorkerPageBuilder implements BulkRecordSink {
       pages.add(currentPage);
       currentPage = null;
     }
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.finishBuild();
+    }
     return pages;
+  }
+
+  // ==== projection extraction hooks (no-ops when nothing is armed) =============================
+
+  /** A structured, unnamed node: a record root when its parent is the record set, else a plain child. */
+  private void noteUnnamedStructured(final long nodeKey, final long parentKey) {
+    if (parentKey == projectionRecordSetKey) {
+      for (final ProjectionChunkRowBatch batch : projectionBatches) {
+        batch.beginRecord(nodeKey);
+      }
+    } else if (projectionTrackChildValues) {
+      for (final ProjectionChunkRowBatch batch : projectionBatches) {
+        batch.onChildNonString(parentKey);
+      }
+    }
+  }
+
+  /** An unnamed non-string leaf: a scalar record root, or a set-poisoning child. */
+  private void noteUnnamedNonString(final long nodeKey, final long parentKey) {
+    noteUnnamedStructured(nodeKey, parentKey);
+  }
+
+  private void noteUnnamedString(final long nodeKey, final long parentKey, final byte[] utf8, final int utf8Length) {
+    if (parentKey == projectionRecordSetKey) {
+      for (final ProjectionChunkRowBatch batch : projectionBatches) {
+        batch.beginRecord(nodeKey);
+      }
+    } else if (projectionTrackChildValues) {
+      for (final ProjectionChunkRowBatch batch : projectionBatches) {
+        batch.onChildValueString(parentKey, utf8, utf8Length);
+      }
+    }
   }
 
   long firstKey() {
     return firstKey;
+  }
+
+  /** The chunk's PATH/CAS/NAME tuples, for the coordinator's drain; {@code null} when unarmed. */
+  @Nullable ChunkIndexTupleBatch indexTuples() {
+    return indexTuples;
   }
 
   // ==== minting + page roll ====================================================================
@@ -187,6 +265,7 @@ final class WorkerPageBuilder implements BulkRecordSink {
   @Override
   public long createObjectNode(final long parentKey, final long leftSibKey, final long notifyPcr) {
     final long nodeKey = mint();
+    noteUnnamedStructured(nodeKey, parentKey);
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchObjectNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
@@ -199,6 +278,10 @@ final class WorkerPageBuilder implements BulkRecordSink {
   @Override
   public long createArrayNode(final long parentKey, final long leftSibKey, final long arrayPcr) {
     final long nodeKey = mint();
+    noteUnnamedStructured(nodeKey, parentKey);
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(arrayPcr, nodeKey);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchArrayNode.estimateSerializedSize(), 0);
     final int recordBytes =
@@ -214,6 +297,13 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final String name) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedObject(pathNodeKey);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedObjectNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNamedObjectNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
@@ -228,6 +318,14 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final String name) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedArray(pathNodeKey, nodeKey);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNamedArrayMirrorCandidate(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedArrayNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNamedArrayNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
@@ -243,6 +341,10 @@ final class WorkerPageBuilder implements BulkRecordSink {
   public long createStringNode(final long parentKey, final long leftSibKey, final long rightSibKey, final byte[] utf8,
       final int utf8Length, final long notifyPcr) {
     final long nodeKey = mint();
+    noteUnnamedString(nodeKey, parentKey, utf8, utf8Length);
+    if (indexTuples != null) {
+      indexTuples.onCasString(notifyPcr, nodeKey, utf8, utf8Length);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(55 + utf8Length, 0);
     if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
@@ -266,6 +368,14 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final long pathNodeKey, final String name, final byte[] utf8, final int utf8Length) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedString(pathNodeKey, utf8, utf8Length);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+      indexTuples.onCasString(pathNodeKey, nodeKey, utf8, utf8Length);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(64 + utf8Length, 0);
     if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
@@ -288,6 +398,10 @@ final class WorkerPageBuilder implements BulkRecordSink {
   public long createNumberNode(final long parentKey, final long leftSibKey, final long rightSibKey, final Number value,
       final long notifyPcr) {
     final long nodeKey = mint();
+    noteUnnamedNonString(nodeKey, parentKey);
+    if (indexTuples != null) {
+      indexTuples.onCasNumber(notifyPcr, nodeKey, value);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNumberNode.estimateSerializedSize(), 0);
     final int recordBytes =
@@ -302,6 +416,14 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final long pathNodeKey, final String name, final Number value) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedNumber(pathNodeKey, value);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+      indexTuples.onCasNumber(pathNodeKey, nodeKey, value);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedNumberNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNamedNumberNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
@@ -315,6 +437,10 @@ final class WorkerPageBuilder implements BulkRecordSink {
   public long createBooleanNode(final long parentKey, final long leftSibKey, final long rightSibKey,
       final boolean value, final long notifyPcr) {
     final long nodeKey = mint();
+    noteUnnamedNonString(nodeKey, parentKey);
+    if (indexTuples != null) {
+      indexTuples.onCasBoolean(notifyPcr, nodeKey, value);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchBooleanNode.estimateSerializedSize(), 0);
     final int recordBytes =
@@ -329,6 +455,14 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final long pathNodeKey, final String name, final boolean value) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedBoolean(pathNodeKey, value);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+      indexTuples.onCasBoolean(pathNodeKey, nodeKey, value);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedBooleanNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNamedBooleanNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
@@ -342,6 +476,7 @@ final class WorkerPageBuilder implements BulkRecordSink {
   public long createNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
       final long notifyPcr) {
     final long nodeKey = mint();
+    noteUnnamedNonString(nodeKey, parentKey);
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNullNode.estimateSerializedSize(), 0);
     final int recordBytes = NullNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchNullNode.getHeapOffsets(),
@@ -355,6 +490,13 @@ final class WorkerPageBuilder implements BulkRecordSink {
       final long pathNodeKey, final String name) {
     final int nameKey = resolvedNameKey(name);
     final long nodeKey = mint();
+    for (final ProjectionChunkRowBatch batch : projectionBatches) {
+      batch.onNamedNull(pathNodeKey);
+    }
+    if (indexTuples != null) {
+      indexTuples.onPathEntry(pathNodeKey, nodeKey);
+      indexTuples.onNameEntry(nameKey, nodeKey);
+    }
     final KeyValueLeafPage kvl = currentPage;
     final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedNullNode.estimateSerializedSize(), 0);
     final int recordBytes = ObjectNamedNullNode.writeNewRecord(kvl.getSlottedPage(), absOffset,

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WorkerPageBuilder.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.index.IndexType;
+import io.sirix.node.NodeKind;
+import io.sirix.node.json.ArrayNode;
+import io.sirix.node.json.BooleanNode;
+import io.sirix.node.json.NullNode;
+import io.sirix.node.json.NumberNode;
+import io.sirix.node.json.ObjectNamedArrayNode;
+import io.sirix.node.json.ObjectNamedBooleanNode;
+import io.sirix.node.json.ObjectNamedNullNode;
+import io.sirix.node.json.ObjectNamedNumberNode;
+import io.sirix.node.json.ObjectNamedObjectNode;
+import io.sirix.node.json.ObjectNamedStringNode;
+import io.sirix.node.json.ObjectNode;
+import io.sirix.node.json.StringNode;
+import io.sirix.node.SirixDeweyID;
+import io.sirix.node.interfaces.StructNode;
+import io.sirix.page.KeyValueLeafPage;
+import io.sirix.page.PageLayout;
+import io.sirix.settings.Constants;
+import io.sirix.settings.Fixed;
+
+import net.openhft.hashing.LongHashFunction;
+
+import java.lang.foreign.MemorySegment;
+import java.util.ArrayList;
+import java.util.List;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+/**
+ * Stage-B worker sink of the parallel bulk importer: builds records with FINAL bytes into
+ * STANDALONE {@link KeyValueLeafPage}s for a pre-reserved contiguous key range, entirely
+ * off-thread — no transaction, no intent log, no shared dictionaries. It replicates the
+ * transaction factory's direct-write skeleton per node kind (estimate → heap reserve →
+ * {@code writeNewRecord} → {@code completeDirectWrite}), with three deliberate differences:
+ * <ul>
+ * <li>Keys mint from the worker's own counter over the reserved range — the assembler's
+ * prediction asserts every mint, and {@link #finish(long)} additionally verifies the final key
+ * and the populated-slot total, so a count/build divergence refuses loudly (critic C2).</li>
+ * <li>Field names arrive as PRE-RESOLVED dictionary keys through the chunk's name table — the
+ * coordinator interned every name in first-occurrence order during the counting pass.</li>
+ * <li>Insert-time FSST never engages: v1 imports into a FRESH resource, where the sequential
+ * path's encode is a no-op too (no prior revision, no table) — the flags written are identical
+ * by construction.</li>
+ * </ul>
+ *
+ * <p>
+ * Oversized string values take the same overflow route as the factory: a heap record via
+ * {@link KeyValueLeafPage#setRecord}, diverted to an overflow page at commit.
+ */
+final class WorkerPageBuilder implements BulkRecordSink {
+
+  private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
+
+  private final ResourceConfiguration resourceConfig;
+  private final int revisionNumber;
+  private final LongHashFunction hashFunction;
+  private final boolean storeChildCount;
+  private final Object2IntOpenHashMap<String> nameKeys;
+  private final long firstKey;
+  private final long lastKey;
+
+  private final List<KeyValueLeafPage> pages = new ArrayList<>();
+  private KeyValueLeafPage currentPage;
+  private long currentPageKey = -1;
+  private long nextKey;
+  private long populatedSlots;
+
+  // Worker-local flyweight scratch: estimateSerializedSize()/getHeapOffsets() plus the container
+  // fixup binds. Same construction recipes as the transaction factory's singletons.
+  private final ObjectNode scratchObjectNode;
+  private final ArrayNode scratchArrayNode;
+  private final NullNode scratchNullNode;
+  private final BooleanNode scratchBooleanNode;
+  private final NumberNode scratchNumberNode;
+  private final StringNode scratchStringNode;
+  private final ObjectNamedBooleanNode scratchNamedBooleanNode;
+  private final ObjectNamedNumberNode scratchNamedNumberNode;
+  private final ObjectNamedStringNode scratchNamedStringNode;
+  private final ObjectNamedNullNode scratchNamedNullNode;
+  private final ObjectNamedObjectNode scratchNamedObjectNode;
+  private final ObjectNamedArrayNode scratchNamedArrayNode;
+
+  WorkerPageBuilder(final ResourceConfiguration resourceConfig, final int revisionNumber,
+      final LongHashFunction hashFunction, final boolean storeChildCount,
+      final Object2IntOpenHashMap<String> nameKeys, final long firstKey, final long lastKey) {
+    this.resourceConfig = resourceConfig;
+    this.revisionNumber = revisionNumber;
+    this.hashFunction = hashFunction;
+    this.storeChildCount = storeChildCount;
+    this.nameKeys = nameKeys;
+    this.firstKey = firstKey;
+    this.lastKey = lastKey;
+    this.nextKey = firstKey;
+
+    this.scratchObjectNode =
+        new ObjectNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, NULL_KEY, NULL_KEY, 0,
+            0, 0, hashFunction, (SirixDeweyID) null);
+    this.scratchArrayNode = new ArrayNode(0, 0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY,
+        NULL_KEY, NULL_KEY, 0, 0, 0, hashFunction, (SirixDeweyID) null);
+    this.scratchNullNode =
+        new NullNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0, hashFunction, (SirixDeweyID) null);
+    this.scratchBooleanNode = new BooleanNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY,
+        0, false, hashFunction, (SirixDeweyID) null);
+    this.scratchNumberNode =
+        new NumberNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0, 0, hashFunction,
+            (SirixDeweyID) null);
+    this.scratchStringNode = new StringNode(0, 0, Constants.NULL_REVISION_NUMBER, revisionNumber, NULL_KEY, NULL_KEY, 0,
+        new byte[0], hashFunction, (SirixDeweyID) null, false, null);
+    this.scratchNamedBooleanNode = new ObjectNamedBooleanNode(0, hashFunction);
+    this.scratchNamedNumberNode = new ObjectNamedNumberNode(0, hashFunction);
+    this.scratchNamedStringNode = new ObjectNamedStringNode(0, hashFunction);
+    this.scratchNamedNullNode = new ObjectNamedNullNode(0, hashFunction);
+    this.scratchNamedObjectNode = new ObjectNamedObjectNode(0, hashFunction);
+    this.scratchNamedArrayNode = new ObjectNamedArrayNode(0, hashFunction);
+  }
+
+  // ==== output =================================================================================
+
+  /**
+   * Verifies the build filled the reserved range EXACTLY and returns the pages in page-key order.
+   * Always on — this replaces the shared-mint safety net for off-thread builds.
+   *
+   * @param expectedLastKey the range's last reserved key
+   */
+  List<KeyValueLeafPage> finish(final long expectedLastKey) {
+    if (nextKey - 1 != expectedLastKey) {
+      throw new IllegalStateException(
+          "chunk build minted up to " + (nextKey - 1) + " but the reserved range ends at " + expectedLastKey);
+    }
+    final long expectedRecords = expectedLastKey - firstKey + 1;
+    if (populatedSlots != expectedRecords) {
+      throw new IllegalStateException(
+          "chunk build populated " + populatedSlots + " slots for " + expectedRecords + " reserved keys");
+    }
+    if (currentPage != null) {
+      pages.add(currentPage);
+      currentPage = null;
+    }
+    return pages;
+  }
+
+  long firstKey() {
+    return firstKey;
+  }
+
+  // ==== minting + page roll ====================================================================
+
+  private long mint() {
+    final long key = nextKey++;
+    if (key > lastKey) {
+      throw new IllegalStateException("chunk build overran its reserved range at key " + key);
+    }
+    final long pageKey = key >>> 10;
+    if (pageKey != currentPageKey) {
+      if (currentPage != null) {
+        pages.add(currentPage);
+      }
+      currentPage = new KeyValueLeafPage(pageKey, IndexType.DOCUMENT, resourceConfig, revisionNumber, null, null,
+          false);
+      currentPageKey = pageKey;
+    }
+    populatedSlots++;
+    return key;
+  }
+
+  private static int slotOf(final long key) {
+    return (int) (key & (Constants.NDP_NODE_COUNT - 1));
+  }
+
+  private int resolvedNameKey(final String name) {
+    final int key = nameKeys.getInt(name);
+    if (key == Integer.MIN_VALUE) {
+      throw new IllegalStateException("name '" + name + "' was not pre-interned for this build chunk");
+    }
+    return key;
+  }
+
+  // ==== containers =============================================================================
+
+  @Override
+  public long createObjectNode(final long parentKey, final long leftSibKey, final long notifyPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchObjectNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchObjectNode.getHeapOffsets(), nodeKey, parentKey, NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY,
+        Constants.NULL_REVISION_NUMBER, revisionNumber, 0, 0, 0);
+    kvl.completeDirectWrite(NodeKind.OBJECT.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createArrayNode(final long parentKey, final long leftSibKey, final long arrayPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchArrayNode.estimateSerializedSize(), 0);
+    final int recordBytes =
+        ArrayNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchArrayNode.getHeapOffsets(), nodeKey, parentKey,
+            NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY, arrayPcr, Constants.NULL_REVISION_NUMBER, revisionNumber, 0, 0,
+            0);
+    kvl.completeDirectWrite(NodeKind.ARRAY.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedObjectNode(final long parentKey, final long leftSibKey, final long pathNodeKey,
+      final String name) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedObjectNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNamedObjectNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedObjectNode.getHeapOffsets(), nodeKey, parentKey, NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY, nameKey,
+        pathNodeKey, Constants.NULL_REVISION_NUMBER, revisionNumber, 0L, 0L, 0L);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_OBJECT.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedArrayNode(final long parentKey, final long leftSibKey, final long pathNodeKey,
+      final String name) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedArrayNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNamedArrayNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedArrayNode.getHeapOffsets(), nodeKey, parentKey, NULL_KEY, leftSibKey, NULL_KEY, NULL_KEY, nameKey,
+        pathNodeKey, Constants.NULL_REVISION_NUMBER, revisionNumber, 0L, 0L, 0L);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_ARRAY.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  // ==== leaves =================================================================================
+
+  @Override
+  public long createStringNode(final long parentKey, final long leftSibKey, final long rightSibKey, final byte[] utf8,
+      final int utf8Length, final long notifyPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(55 + utf8Length, 0);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      final byte[] valueCopy = new byte[utf8Length];
+      System.arraycopy(utf8, 0, valueCopy, 0, utf8Length);
+      final StringNode node = new StringNode(nodeKey, parentKey, Constants.NULL_REVISION_NUMBER, revisionNumber,
+          rightSibKey, leftSibKey, 0, valueCopy, hashFunction, (SirixDeweyID) null, false, null);
+      kvl.setRecord(node);
+      return nodeKey;
+    }
+    final int recordBytes =
+        StringNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchStringNode.getHeapOffsets(), nodeKey,
+            parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER, revisionNumber, utf8, 0, utf8Length,
+            false);
+    kvl.completeDirectWrite(NodeKind.STRING_VALUE.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedStringNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final byte[] utf8, final int utf8Length) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWriteOrOverflow(64 + utf8Length, 0);
+    if (absOffset == KeyValueLeafPage.DIRECT_WRITE_OVERFLOW) {
+      final byte[] valueCopy = new byte[utf8Length];
+      System.arraycopy(utf8, 0, valueCopy, 0, utf8Length);
+      final ObjectNamedStringNode node =
+          new ObjectNamedStringNode(nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
+              Constants.NULL_REVISION_NUMBER, revisionNumber, 0, valueCopy, hashFunction, (SirixDeweyID) null, false, null);
+      kvl.setRecord(node);
+      return nodeKey;
+    }
+    final int recordBytes = ObjectNamedStringNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedStringNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
+        Constants.NULL_REVISION_NUMBER, revisionNumber, 0, utf8, 0, utf8Length, false);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_STRING.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createNumberNode(final long parentKey, final long leftSibKey, final long rightSibKey, final Number value,
+      final long notifyPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNumberNode.estimateSerializedSize(), 0);
+    final int recordBytes =
+        NumberNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchNumberNode.getHeapOffsets(), nodeKey,
+            parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER, revisionNumber, value);
+    kvl.completeDirectWrite(NodeKind.NUMBER_VALUE.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedNumberNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final Number value) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedNumberNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNamedNumberNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedNumberNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
+        Constants.NULL_REVISION_NUMBER, revisionNumber, 0, value);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_NUMBER.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createBooleanNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final boolean value, final long notifyPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchBooleanNode.estimateSerializedSize(), 0);
+    final int recordBytes =
+        BooleanNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchBooleanNode.getHeapOffsets(), nodeKey,
+            parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER, revisionNumber, value);
+    kvl.completeDirectWrite(NodeKind.BOOLEAN_VALUE.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedBooleanNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final boolean value) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedBooleanNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNamedBooleanNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedBooleanNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
+        Constants.NULL_REVISION_NUMBER, revisionNumber, 0, value);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_BOOLEAN.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long notifyPcr) {
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNullNode.estimateSerializedSize(), 0);
+    final int recordBytes = NullNode.writeNewRecord(kvl.getSlottedPage(), absOffset, scratchNullNode.getHeapOffsets(),
+        nodeKey, parentKey, rightSibKey, leftSibKey, Constants.NULL_REVISION_NUMBER, revisionNumber);
+    kvl.completeDirectWrite(NodeKind.NULL_VALUE.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  @Override
+  public long createObjectNamedNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name) {
+    final int nameKey = resolvedNameKey(name);
+    final long nodeKey = mint();
+    final KeyValueLeafPage kvl = currentPage;
+    final long absOffset = kvl.prepareHeapForDirectWrite(scratchNamedNullNode.estimateSerializedSize(), 0);
+    final int recordBytes = ObjectNamedNullNode.writeNewRecord(kvl.getSlottedPage(), absOffset,
+        scratchNamedNullNode.getHeapOffsets(), nodeKey, parentKey, rightSibKey, leftSibKey, nameKey, pathNodeKey,
+        Constants.NULL_REVISION_NUMBER, revisionNumber, 0);
+    kvl.completeDirectWrite(NodeKind.OBJECT_NAMED_NULL.getId(), nodeKey, slotOf(nodeKey), recordBytes, null);
+    return nodeKey;
+  }
+
+  // ==== fixups =================================================================================
+
+  @Override
+  public void fixupContainer(final long containerKey, final long firstChildKey, final long lastChildKey,
+      final long childCount, final long rightSibKey) {
+    final StructNode container = bindOwnContainer(containerKey);
+    if (childCount > 0) {
+      container.setFirstChildKey(firstChildKey);
+      container.setLastChildKey(lastChildKey);
+      if (storeChildCount) {
+        container.setChildCount(childCount);
+      }
+    }
+    if (rightSibKey != NULL_KEY) {
+      container.setRightSiblingKey(rightSibKey);
+    }
+  }
+
+  @Override
+  public void fixupDocument(final long documentKey, final long firstChildKey, final long lastChildKey,
+      final long childCount) {
+    throw new IllegalStateException("a worker chunk never owns the document node");
+  }
+
+  @Override
+  public void accountRecords(final int mutations) {
+    // Workers have no epoch machinery; the coordinator accounts at adoption time.
+  }
+
+  /**
+   * Binds a scratch flyweight to a container record in the worker's OWN un-adopted pages — the
+   * same dir-entry mechanics as the transaction binder, safe here because nothing else can see
+   * these pages yet.
+   */
+  private StructNode bindOwnContainer(final long containerKey) {
+    if (containerKey < firstKey || containerKey >= nextKey) {
+      throw new IllegalStateException(
+          "container " + containerKey + " is outside this chunk's built range [" + firstKey + ", " + nextKey + ")");
+    }
+    final int pageIndex = (int) ((containerKey >>> 10) - (firstKey >>> 10));
+    final KeyValueLeafPage page = pageIndex == pages.size()
+        ? currentPage
+        : pages.get(pageIndex);
+    final MemorySegment slottedPage = page.getSlottedPage();
+    final int slot = slotOf(containerKey);
+    final int nodeKindId = PageLayout.getDirNodeKindId(slottedPage, slot);
+    final long recordBase = PageLayout.heapAbsoluteOffset(PageLayout.getDirHeapOffset(slottedPage, slot));
+    return switch (nodeKindId) {
+      case 24 -> { // OBJECT
+        scratchObjectNode.bind(slottedPage, recordBase, containerKey, slot);
+        scratchObjectNode.setOwnerPage(page);
+        yield scratchObjectNode;
+      }
+      case 25 -> { // ARRAY
+        scratchArrayNode.bind(slottedPage, recordBase, containerKey, slot);
+        scratchArrayNode.setOwnerPage(page);
+        yield scratchArrayNode;
+      }
+      case 52 -> { // OBJECT_NAMED_OBJECT
+        scratchNamedObjectNode.bind(slottedPage, recordBase, containerKey, slot);
+        scratchNamedObjectNode.setOwnerPage(page);
+        yield scratchNamedObjectNode;
+      }
+      case 53 -> { // OBJECT_NAMED_ARRAY
+        scratchNamedArrayNode.bind(slottedPage, recordBase, containerKey, slot);
+        scratchNamedArrayNode.setOwnerPage(page);
+        yield scratchNamedArrayNode;
+      }
+      default -> throw new IllegalStateException("unexpected container kind id " + nodeKindId + " at " + containerKey);
+    };
+  }
+
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.node.interfaces.StructNode;
+import io.sirix.node.interfaces.immutable.ImmutableNode;
+import io.sirix.settings.Fixed;
+
+/**
+ * The transaction-backed {@link BulkRecordSink}: records mint through the write transaction's
+ * bulk node factory exactly as the sequential assembler always did, index notifications ride each
+ * creation, and the one-shot fixups go through the CoW-checked
+ * {@code prepareRecordForModificationDocument} path.
+ *
+ * <p>
+ * The fixups apply child counts with a single {@link StructNode#setChildCount(long)} instead of
+ * the historical one-increment-per-child loop — at 100M top-level records that loop was 100M
+ * decode-modify-encode round trips (each able to trigger a varint-width resize) to reach a value
+ * one write expresses.
+ */
+final class WtxBulkRecordSink implements BulkRecordSink {
+
+  private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
+
+  private final JsonNodeTrxImpl wtx;
+  private final JsonNodeFactory factory;
+  private final StorageEngineWriter storageEngineWriter;
+  private final boolean storeChildCount;
+  private final boolean useTextCompression;
+  private final boolean notifyIndexes;
+
+  WtxBulkRecordSink(final JsonNodeTrxImpl wtx) {
+    this.wtx = wtx;
+    this.factory = wtx.bulkNodeFactory();
+    this.storageEngineWriter = wtx.getStorageEngineWriter();
+    this.storeChildCount = wtx.bulkStoreChildCount();
+    this.useTextCompression = wtx.bulkUseTextCompression();
+    this.notifyIndexes = wtx.bulkHasPrimitiveIndexes();
+  }
+
+  @Override
+  public long createObjectNode(final long parentKey, final long leftSibKey, final long notifyPcr) {
+    final var node = factory.createJsonObjectNode(parentKey, leftSibKey, NULL_KEY, null);
+    notifyInsert(node, notifyPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createArrayNode(final long parentKey, final long leftSibKey, final long arrayPcr) {
+    final var node = factory.createJsonArrayNode(parentKey, leftSibKey, NULL_KEY, arrayPcr, null);
+    notifyInsert(node, arrayPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedObjectNode(final long parentKey, final long leftSibKey, final long pathNodeKey,
+      final String name) {
+    final var node = factory.createJsonObjectNamedObjectNode(parentKey, leftSibKey, NULL_KEY, pathNodeKey, name, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedArrayNode(final long parentKey, final long leftSibKey, final long pathNodeKey,
+      final String name) {
+    final var node = factory.createJsonObjectNamedArrayNode(parentKey, leftSibKey, NULL_KEY, pathNodeKey, name, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createStringNode(final long parentKey, final long leftSibKey, final long rightSibKey, final byte[] utf8,
+      final int utf8Length, final long notifyPcr) {
+    final var node =
+        factory.createJsonStringNode(parentKey, leftSibKey, rightSibKey, utf8, 0, utf8Length, useTextCompression, null);
+    notifyInsert(node, notifyPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedStringNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final byte[] utf8, final int utf8Length) {
+    final var node = factory.createJsonObjectNamedStringNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name,
+        utf8, 0, utf8Length, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createNumberNode(final long parentKey, final long leftSibKey, final long rightSibKey, final Number value,
+      final long notifyPcr) {
+    final var node = factory.createJsonNumberNode(parentKey, leftSibKey, rightSibKey, value, null);
+    notifyInsert(node, notifyPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedNumberNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final Number value) {
+    final var node =
+        factory.createJsonObjectNamedNumberNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name, value, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createBooleanNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final boolean value, final long notifyPcr) {
+    final var node = factory.createJsonBooleanNode(parentKey, leftSibKey, rightSibKey, value, null);
+    notifyInsert(node, notifyPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedBooleanNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name, final boolean value) {
+    final var node =
+        factory.createJsonObjectNamedBooleanNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name, value, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long notifyPcr) {
+    final var node = factory.createJsonNullNode(parentKey, leftSibKey, rightSibKey, null);
+    notifyInsert(node, notifyPcr);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public long createObjectNamedNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
+      final long pathNodeKey, final String name) {
+    final var node =
+        factory.createJsonObjectNamedNullNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name, null);
+    notifyInsert(node, pathNodeKey);
+    return node.getNodeKey();
+  }
+
+  @Override
+  public void fixupContainer(final long containerKey, final long firstChildKey, final long lastChildKey,
+      final long childCount, final long rightSibKey) {
+    final StructNode container = storageEngineWriter.prepareRecordForModificationDocument(containerKey);
+    if (childCount > 0) {
+      container.setFirstChildKey(firstChildKey);
+      container.setLastChildKey(lastChildKey);
+      if (storeChildCount) {
+        container.setChildCount(childCount);
+      }
+    }
+    if (rightSibKey != NULL_KEY) {
+      container.setRightSiblingKey(rightSibKey);
+    }
+  }
+
+  @Override
+  public void fixupDocument(final long documentKey, final long firstChildKey, final long lastChildKey,
+      final long childCount) {
+    final StructNode document = storageEngineWriter.prepareRecordForModificationDocument(documentKey);
+    document.setFirstChildKey(firstChildKey);
+    document.setLastChildKey(lastChildKey);
+    if (storeChildCount) {
+      document.setChildCount(childCount);
+    }
+  }
+
+  @Override
+  public void accountRecords(final int mutations) {
+    wtx.bulkAccountRecord(mutations);
+  }
+
+  private void notifyInsert(final ImmutableNode node, final long pathNodeKey) {
+    if (notifyIndexes) {
+      wtx.bulkNotifyInsert(node, pathNodeKey);
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
@@ -32,12 +32,23 @@ final class WtxBulkRecordSink implements BulkRecordSink {
   private final boolean notifyIndexes;
 
   WtxBulkRecordSink(final JsonNodeTrxImpl wtx) {
+    this(wtx, wtx.bulkHasPrimitiveIndexes());
+  }
+
+  /**
+   * @param notifyIndexes whether each creation fires a primitive-index notification. The parallel
+   *        importer passes {@code false} even with a projection armed: its workers mint records off
+   *        the transaction and never notify at all, so the coordinator attributes records to the
+   *        load directly rather than through a notification stream only the spine's own handful of
+   *        nodes would reach.
+   */
+  WtxBulkRecordSink(final JsonNodeTrxImpl wtx, final boolean notifyIndexes) {
     this.wtx = wtx;
     this.factory = wtx.bulkNodeFactory();
     this.storageEngineWriter = wtx.getStorageEngineWriter();
     this.storeChildCount = wtx.bulkStoreChildCount();
     this.useTextCompression = wtx.bulkUseTextCompression();
-    this.notifyIndexes = wtx.bulkHasPrimitiveIndexes();
+    this.notifyIndexes = notifyIndexes;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/node/json/WtxBulkRecordSink.java
@@ -9,14 +9,14 @@ import io.sirix.node.interfaces.immutable.ImmutableNode;
 import io.sirix.settings.Fixed;
 
 /**
- * The transaction-backed {@link BulkRecordSink}: records mint through the write transaction's
- * bulk node factory exactly as the sequential assembler always did, index notifications ride each
+ * The transaction-backed {@link BulkRecordSink}: records mint through the write transaction's bulk
+ * node factory exactly as the sequential assembler always did, index notifications ride each
  * creation, and the one-shot fixups go through the CoW-checked
  * {@code prepareRecordForModificationDocument} path.
  *
  * <p>
- * The fixups apply child counts with a single {@link StructNode#setChildCount(long)} instead of
- * the historical one-increment-per-child loop — at 100M top-level records that loop was 100M
+ * The fixups apply child counts with a single {@link StructNode#setChildCount(long)} instead of the
+ * historical one-increment-per-child loop — at 100M top-level records that loop was 100M
  * decode-modify-encode round trips (each able to trigger a varint-width resize) to reach a value
  * one write expresses.
  */
@@ -38,9 +38,9 @@ final class WtxBulkRecordSink implements BulkRecordSink {
   /**
    * @param notifyIndexes whether each creation fires a primitive-index notification. The parallel
    *        importer passes {@code false} even with a projection armed: its workers mint records off
-   *        the transaction and never notify at all, so the coordinator attributes records to the
-   *        load directly rather than through a notification stream only the spine's own handful of
-   *        nodes would reach.
+   *        the transaction and never notify at all, so the coordinator attributes records to the load
+   *        directly rather than through a notification stream only the spine's own handful of nodes
+   *        would reach.
    */
   WtxBulkRecordSink(final JsonNodeTrxImpl wtx, final boolean notifyIndexes) {
     this.wtx = wtx;
@@ -144,8 +144,7 @@ final class WtxBulkRecordSink implements BulkRecordSink {
   @Override
   public long createObjectNamedNullNode(final long parentKey, final long leftSibKey, final long rightSibKey,
       final long pathNodeKey, final String name) {
-    final var node =
-        factory.createJsonObjectNamedNullNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name, null);
+    final var node = factory.createJsonObjectNamedNullNode(parentKey, leftSibKey, rightSibKey, pathNodeKey, name, null);
     notifyInsert(node, pathNodeKey);
     return node.getNodeKey();
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
@@ -93,10 +93,10 @@ import java.util.Objects;
 public final class HOTTrieWriter {
 
   /**
-   * In-place leaf splits performed — the task #57 split path, where the left half keeps its
-   * original {@link PageReference} and therefore its pre-split fragment chain. Observability only;
-   * a test that claims to exercise that path must prove it reached THIS split and not one of the
-   * two immune implementations that allocate fresh references.
+   * In-place leaf splits performed — the task #57 split path, where the left half keeps its original
+   * {@link PageReference} and therefore its pre-split fragment chain. Observability only; a test that
+   * claims to exercise that path must prove it reached THIS split and not one of the two immune
+   * implementations that allocate fresh references.
    *
    * <p>
    * OFF unless {@code -Dsirix.hot.mergeDiag=true} — the same switch that gates the fragment-merge

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/HOTTrieWriter.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.LongSupplier;
 import io.sirix.page.HOTIndirectPage;
@@ -90,6 +91,34 @@ import java.util.Objects;
  * @see HOTIndirectPage
  */
 public final class HOTTrieWriter {
+
+  /**
+   * In-place leaf splits performed — the task #57 split path, where the left half keeps its
+   * original {@link PageReference} and therefore its pre-split fragment chain. Observability only;
+   * a test that claims to exercise that path must prove it reached THIS split and not one of the
+   * two immune implementations that allocate fresh references.
+   *
+   * <p>
+   * OFF unless {@code -Dsirix.hot.mergeDiag=true} — the same switch that gates the fragment-merge
+   * counters in {@code VersioningType}, so one flag turns the whole HOT diagnostic family on. The
+   * split runs on the write path, and a shared counter there is exactly the kind of always-on
+   * debugging apparatus the performance rules forbid; gated on a {@code static final} the branch
+   * folds away entirely.
+   * </p>
+   */
+  private static final boolean HOT_MERGE_DIAG = Boolean.getBoolean("sirix.hot.mergeDiag");
+
+  private static final LongAdder IN_PLACE_LEAF_SPLITS = new LongAdder();
+
+  /** In-place leaf splits counted since the last reset; always {@code 0} when diagnostics are off. */
+  public static long inPlaceLeafSplits() {
+    return IN_PLACE_LEAF_SPLITS.sum();
+  }
+
+  /** Zero the split counter — a counter that cannot be reset cannot witness a specific operation. */
+  public static void resetInPlaceLeafSplits() {
+    IN_PLACE_LEAF_SPLITS.reset();
+  }
 
   /** Maximum tree height - increased to handle unbalanced trees during inserts. */
   private static final int MAX_TREE_HEIGHT = 64;
@@ -1201,6 +1230,14 @@ public final class HOTTrieWriter {
       rightRef.setPage(rightPage);
       log.put(rightRef, PageContainer.getInstance(rightPage, rightPage));
       rightPageOwnershipTransferred = true;
+
+      // TASK #57 WITNESS. This is the IN-PLACE split: the non-root branch below reuses leafRef for
+      // the left half, so the pre-split fragment chain stays attached to it. The other two split
+      // implementations allocate fresh references and are immune. Counted so a test can prove it
+      // reached THIS split rather than one of the immune ones.
+      if (HOT_MERGE_DIAG) {
+        IN_PLACE_LEAF_SPLITS.increment();
+      }
 
       // Both halves are complete dumps after split — release the stale completePageRef
       // so the orphaned original page can be reclaimed by TIL.put() and GC.

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -592,6 +592,23 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
   private long hftCompletedEpochDataGrowNanos;
   private boolean hftCompletedEpochDataGrowExact;
 
+  /**
+   * Phase breakdown summed over every worker run.
+   *
+   * <p>
+   * The per-epoch tuples above retain only the slowest and the most-blocking epoch, and on a bulk
+   * import both are the very first one — the epoch that pays JIT warm-up. Attributing the pipeline
+   * from those alone therefore describes warm-up rather than steady state. These totals answer what
+   * the flush actually spends its time on across the whole transaction, which is what decides
+   * whether widening the pipeline can pay: only the append phase is strictly serialized per writer,
+   * so the overlap a deeper pipeline can win is bounded by it.
+   * </p>
+   */
+  private long hftSerializeJoinWaitNanosTotal;
+  private long hftKvlAppendNanosTotal;
+  private long hftSideNanosTotal;
+  private long hftFinalFlushNanosTotal;
+
   /** Phase breakdown retained for the slowest worker. */
   private long hftMaxWorkerEpochId;
   private long hftMaxWorkerEpochQueueWaitNanos;
@@ -836,7 +853,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
             + "nativeReservoirCount=%d nativeReservoirBytes=%d kvlFrameCachePages=%d "
             + "kvlFrameCacheBytes=%d kvlCacheFallbackPages=%d kvlCacheFallbackBytes=%d "
             + "pinnedTrieSpillEpochs=%d pinnedTrieSpillPages=%d pinnedTrieSpillBatchMax=%d "
-            + "pinnedTrieLiveMax=%d pinnedTrieHighWater=%d%n",
+            + "pinnedTrieLiveMax=%d pinnedTrieHighWater=%d "
+            + "serializeJoinWaitTotalNs=%d kvlAppendTotalNs=%d sideTotalNs=%d finalFlushTotalNs=%d%n",
         hftCombinedEpochs, hftSideOnlyEpochs, hftSnapshotKvlPages, hftSnapshotKvlAttemptedPages,
         hftSnapshotKvlPromotedPages, hftMaxSnapshotKvlAttemptedPages, hftStagedSidePages, hftStagedSideBytes,
         hftPeakActiveSideBytes, hftPermitAcquires, hftPermitWaitNanos, hftMaxPermitWaitNanos, hftRotationPermitAcquires,
@@ -847,7 +865,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         hftFinalDrainCount, hftFinalDrainNanos, hftMaxFinalDrainNanos, hftNativeReservoirCount, hftNativeReservoirBytes,
         hftKvlFrameCachePages, hftKvlFrameCacheBytes, hftKvlCacheFallbackPages, hftKvlCacheFallbackBytes,
         hftPinnedTrieSpillEpochs, hftPinnedTrieSpillPages, hftPinnedTrieSpillBatchMax, hftPinnedTrieLiveMax,
-        hftPinnedTrieHighWater);
+        hftPinnedTrieHighWater, hftSerializeJoinWaitNanosTotal, hftKvlAppendNanosTotal, hftSideNanosTotal,
+        hftFinalFlushNanosTotal);
     if (hftMaxWorkerEpochId != 0L) {
       System.out.printf(
           "# HFT_ASYNC_MAX_WORKER epoch=%d queueWaitNs=%d workerNs=%d sideNs=%d "
@@ -2254,10 +2273,33 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * pre-serialized in parallel before the sequential append pass writes and closes them. Two windows
    * are in flight at once (double buffering), so the transient draw on the shared segment-allocator
    * budget is bounded by {@code 2 × WINDOW} copies, each holding a pooled slotted segment
-   * (64&nbsp;KiB typical, up to 256&nbsp;KiB) plus its cached encoded form. At the current 16-page
-   * window this permits at most 32 pooled copies plus their encodings. The double buffering keeps the
-   * flush pool's workers serializing while this thread appends; widening the window past the pool's
-   * appetite only inflates the footprint.
+   * (64&nbsp;KiB typical, up to 256&nbsp;KiB) plus its cached encoded form. The double buffering keeps
+   * the flush pool's workers serializing while this thread appends; widening the window past the
+   * pool's appetite only inflates the footprint.
+   *
+   * <p>
+   * <b>Equal to the epoch on purpose, and measured that way.</b> Defining the width as the epoch size
+   * makes an epoch exactly one window, so the loop below joins its only serialization, appends it, and
+   * finds no successor started — the double buffering never actually overlaps anything. That reads
+   * like a defect, and the obvious repair is to size the window independently so several windows per
+   * epoch pipeline against each other. It was tried, on a 1M-row ClickBench bulk import at
+   * {@code maxLogEntries=256} (395 epochs, 264 KVL pages each). The overlap is real and visible in the
+   * phase telemetry — a 64-page window cut the serialization-join stall from 8.1 s to 6.8 s and total
+   * worker time from 10.6 s to 9.7 s — and it bought nothing: interleaved min-of-3 wall time was
+   * 12.047 s at one window per epoch against 12.412 s at four, and a 16-page window (17 windows per
+   * epoch) regressed to 13.8 s as per-window fork/join overhead took over.
+   * </p>
+   *
+   * <p>
+   * The reason is that the append pass this would overlap is the small phase: the flush spends ~77% of
+   * its time waiting on the parallel serialize pool and ~23% appending, and the pool is the throughput
+   * limit for the whole load. Recovering the append window hands the freed capacity straight back to
+   * contention with the insert threads, which is the same effect that makes oversizing
+   * {@code sirix.asyncFlush.parallelism} lose (14 serializers measured slower end to end than 9,
+   * despite a strictly lower worker time). Anyone reaching for a deeper flush pipeline — a wider
+   * window here, or a multi-generation intent log so consecutive epochs overlap — is aiming at the
+   * 23%, and should first check what the serialize stage costs.
+   * </p>
    */
   private static final int SNAPSHOT_FLUSH_WINDOW = MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT;
 
@@ -2595,6 +2637,10 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
 
         hftWorkerRuns++;
         hftWorkerNanos += workerNanos;
+        hftSerializeJoinWaitNanosTotal += serializeJoinWaitNanos;
+        hftKvlAppendNanosTotal += kvlAppendNanos;
+        hftSideNanosTotal += sideNanos;
+        hftFinalFlushNanosTotal += finalFlushNanos;
         hftMaxSnapshotKvlAttemptedPages = Math.max(hftMaxSnapshotKvlAttemptedPages, attemptedKvlPagesInEpoch);
         if (workerNanos > hftMaxWorkerNanos) {
           hftMaxWorkerNanos = workerNanos;

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -52,6 +52,7 @@ import io.sirix.node.delegates.NodeDelegate;
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.node.interfaces.FlyweightNode;
 import io.sirix.node.interfaces.Node;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import io.sirix.page.CASPage;
 import io.sirix.page.DeweyIDPage;
 import io.sirix.page.HOTIndirectPage;
@@ -143,7 +144,8 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * upper bound on attempted KVL pages and matches one serializer window.
    * </p>
    */
-  static final int MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT = 16;
+  static final int MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT =
+      Integer.getInteger("sirix.asyncFlush.maxLogEntries", 16);
 
   /**
    * Buffered output for page writes.
@@ -1281,6 +1283,51 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
         storageEngineReader.getRevisionNumber(), (SirixDeweyID) null));
     cont.getModifiedAsKeyValuePage().setRecord(delNode);
     cont.getCompleteAsKeyValuePage().setRecord(delNode);
+  }
+
+  /**
+   * Writer-scoped memo for projection value-dictionary records, keyed by node key. See the interface
+   * javadoc on {@code StorageEngineReader#cachedProjectionDictionaryRecord} for why this is sound:
+   * the dictionary sub-trie is copy-on-write with freshly minted keys, the one stable-key rewrite
+   * (the generation header) is evicted by the put hook, and this writer is single-threaded. Records
+   * memoized here are heap-materialized (bound flyweights are refused), so entries stay valid after
+   * the async flush releases the pages they were decoded from — which is exactly the moment the
+   * uncached path starts paying a full page decode per record and this memo starts earning its keep
+   * (measured: ~16% of a bulk load's CPU was radix re-reads through that path).
+   */
+  private @Nullable Long2ObjectOpenHashMap<DataRecord> projectionDictionaryRecordMemo;
+
+  @Override
+  public @Nullable DataRecord cachedProjectionDictionaryRecord(final long key) {
+    final Long2ObjectOpenHashMap<DataRecord> memo = projectionDictionaryRecordMemo;
+    return memo == null
+        ? null
+        : memo.get(key);
+  }
+
+  @Override
+  public void cacheProjectionDictionaryRecord(final long key, final DataRecord record) {
+    if (record instanceof final FlyweightNode flyweight && flyweight.isBound()) {
+      // A bound flyweight reads through its page's memory segment, which the flush lifecycle may
+      // release — memoizing it would be a use-after-free. Dictionary node classes are plain heap
+      // records, so this guard is expected to never fire; it exists so a future flyweight
+      // conversion fails safe (the read stays correct, merely unmemoized) instead of dangling.
+      return;
+    }
+    Long2ObjectOpenHashMap<DataRecord> memo = projectionDictionaryRecordMemo;
+    if (memo == null) {
+      memo = new Long2ObjectOpenHashMap<>(1 << 12);
+      projectionDictionaryRecordMemo = memo;
+    }
+    memo.put(key, record);
+  }
+
+  @Override
+  public void evictProjectionDictionaryRecord(final long key) {
+    final Long2ObjectOpenHashMap<DataRecord> memo = projectionDictionaryRecordMemo;
+    if (memo != null) {
+      memo.remove(key);
+    }
   }
 
   @Override
@@ -2444,9 +2491,12 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
                 } finally {
                   // Null the slot only once the copy is closed — a write failure must leave
                   // nothing open, and a slot nulled before the write would hide the copy from
-                  // closeWindowLeftovers.
+                  // closeWindowLeftovers. In-place (adopted) pages are NOT copies: the snapshot
+                  // cleanup is their single closer.
                   currentWindow[i - base] = null;
-                  serializationCopy.close();
+                  if (!serializationCopy.isAdoptedImmutableForFlush()) {
+                    serializationCopy.close();
+                  }
                 }
                 log.setSnapshotDiskOffset(i, shadowRef.getKey());
                 log.setSnapshotHash(i, shadowRef.getHashAsLong(), shadowRef.hasHash());
@@ -2844,9 +2894,20 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * of 32767 — an oversized value must degrade, not turn every write transaction into an
    * ExceptionInInitializerError).
    */
+  /**
+   * The snapshot serialize pool is shared by EVERY writer in the JVM, and its size is the hard
+   * ceiling on concurrent flush serialization. The old default of {@code min(2, cores-1)} was sized
+   * for one writer — two serializers keep pace with one insert thread's rotation cadence — but it
+   * silently capped PARTITIONED parallel ingest at ~2× one writer no matter how many partitions ran:
+   * 16 writers spent ~65% of a 1M-row load parked while exactly two threads serialized every page in
+   * the process (26.6 s). Sizing the pool to about half the machine restored scaling (18.0 s, 55.7k
+   * rows/s, within 19% of the zero-flush bound) and leaves the single-writer full load unchanged
+   * (within noise), since idle work-stealing workers cost nothing. Oversubscribing to cores (16
+   * serializers + 16 writers on 20 cores) measured WORSE than 8 — hence half, not all.
+   */
   private static final ForkJoinPool SNAPSHOT_FLUSH_POOL =
       new ForkJoinPool(Math.min(32767, Math.max(1, Integer.getInteger("sirix.asyncFlush.parallelism",
-          Math.min(2, Runtime.getRuntime().availableProcessors() - 1)))));
+          Math.max(2, Runtime.getRuntime().availableProcessors() / 2 - 1)))));
 
   /**
    * Kick off the parallel deep-copy + pre-serialize pass for the snapshot window starting at
@@ -2981,7 +3042,14 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
           if (!(modified instanceof KeyValueLeafPage kvl)) {
             return;
           }
-          final KeyValueLeafPage serializationCopy = kvl.deepCopy();
+          // Bulk-import ADOPTED pages are immutable post-adoption: serialize IN PLACE, skipping
+          // the defensive copy (1.4 GB of memcpy per 1M rows on the flush lane). Every refusal
+          // exit in the disposable serializer precedes the frame overwrite, so the promote path
+          // still sees an untouched page.
+          final boolean inPlace = kvl.isAdoptedImmutableForFlush();
+          final KeyValueLeafPage serializationCopy = inPlace
+              ? kvl
+              : kvl.deepCopy();
           try {
             if (!serializeDisposableSnapshotKeyValuePage(config, serializationCopy)) {
               // Overlong records still carrying NULL disk keys and identity encodings larger than
@@ -2989,14 +3057,18 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
               // cleanupSnapshot() promotes the ORIGINAL page into the live TIL, where recursive
               // final commit either resolves the overflow or serializes with an ordinary owned
               // cache. No borrowed pooled alias is ever published on this path.
-              serializationCopy.close();
+              if (!inPlace) {
+                serializationCopy.close();
+              }
               log.setSnapshotDiskOffset(i, TransactionIntentLog.SNAPSHOT_PROMOTE_TO_TIL);
               return;
             }
           } catch (final Throwable t) {
             // A copy that never reached the window would be invisible to
             // closeWindowLeftovers — release its pooled segments before recording.
-            serializationCopy.close();
+            if (!inPlace) {
+              serializationCopy.close();
+            }
             throw t;
           }
           window[i - base] = serializationCopy;
@@ -3037,7 +3109,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
       final KeyValueLeafPage leftover = window[i];
       if (leftover != null) {
         window[i] = null;
-        leftover.close();
+        if (!leftover.isAdoptedImmutableForFlush()) {
+          leftover.close();
+        }
       }
     }
   }
@@ -4033,6 +4107,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     if (isClosed) {
       return;
     }
+    projectionDictionaryRecordMemo = null;
 
     Throwable asyncFailure = null;
     try {
@@ -4769,6 +4844,52 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
     if (secondPage != null && !secondPage.isClosed()) {
       secondPage.retire();
     }
+  }
+
+  @Override
+  public void addNameCount(final int key, final int delta, final NodeKind nodeKind) {
+    storageEngineReader.assertNotClosed();
+    getNamePage(newRevisionRootPage).addCount(key, delta, nodeKind, this);
+  }
+
+  @Override
+  public void adoptDocumentLeafPage(final KeyValueLeafPage page) {
+    storageEngineReader.assertNotClosed();
+    final long recordPageKey = page.getPageKey();
+    final PageReference indexReference =
+        storageEngineReader.getPageReference(newRevisionRootPage, IndexType.DOCUMENT, -1);
+    // Walking the trie CoWs the indirect spine into the log exactly as an ordinary insert would.
+    final PageReference reference =
+        keyedTrieWriter.prepareLeafOfTree(this, log, getUberPage().getPageCountExp(IndexType.DOCUMENT), indexReference,
+            recordPageKey, -1, IndexType.DOCUMENT, newRevisionRootPage);
+    if (reference.getKey() != Constants.NULL_ID_LONG || log.get(reference) != null) {
+      throw new IllegalStateException(
+          "bulk adoption requires unwritten territory, but document page " + recordPageKey + " already exists");
+    }
+    // Mirror createFreshRecordPage's container shape: empty COMPLETE twin + the built MODIFIED
+    // page — read-back, flush eligibility and commit all key off that structure.
+    final KeyValueLeafPage completeTwin = new KeyValueLeafPage(recordPageKey, IndexType.DOCUMENT,
+        getResourceSession().getResourceConfig(), storageEngineReader.getRevisionNumber(), null, null, false);
+    appendLogRecord(reference, PageContainer.getInstance(completeTwin, page));
+    storageEngineReader.invalidateMostRecentlyReadRecordPage(IndexType.DOCUMENT, -1);
+    // In-place flush eligibility: no heap records (overflow values need the copy+promote route).
+    boolean hasHeapRecords = false;
+    for (int slot = 0; slot < Constants.NDP_NODE_COUNT; slot++) {
+      if (page.getRecord(slot) != null) {
+        hasHeapRecords = true;
+        break;
+      }
+    }
+    if (!hasHeapRecords) {
+      page.markAdoptedImmutableForFlush();
+    }
+  }
+
+  @Override
+  public KeyValueLeafPage prepareDocumentLeafForBlit(final long recordPageKey) {
+    storageEngineReader.assertNotClosed();
+    final PageContainer container = prepareRecordPage(recordPageKey, -1, IndexType.DOCUMENT);
+    return (KeyValueLeafPage) container.getModifiedAsKeyValuePage();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/access/trx/page/NodeStorageEngineWriter.java
@@ -144,8 +144,7 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * upper bound on attempted KVL pages and matches one serializer window.
    * </p>
    */
-  static final int MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT =
-      Integer.getInteger("sirix.asyncFlush.maxLogEntries", 16);
+  static final int MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT = Integer.getInteger("sirix.asyncFlush.maxLogEntries", 16);
 
   /**
    * Buffered output for page writes.
@@ -599,9 +598,9 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * The per-epoch tuples above retain only the slowest and the most-blocking epoch, and on a bulk
    * import both are the very first one — the epoch that pays JIT warm-up. Attributing the pipeline
    * from those alone therefore describes warm-up rather than steady state. These totals answer what
-   * the flush actually spends its time on across the whole transaction, which is what decides
-   * whether widening the pipeline can pay: only the append phase is strictly serialized per writer,
-   * so the overlap a deeper pipeline can win is bounded by it.
+   * the flush actually spends its time on across the whole transaction, which is what decides whether
+   * widening the pipeline can pay: only the append phase is strictly serialized per writer, so the
+   * overlap a deeper pipeline can win is bounded by it.
    * </p>
    */
   private long hftSerializeJoinWaitNanosTotal;
@@ -2273,32 +2272,32 @@ final class NodeStorageEngineWriter extends AbstractForwardingStorageEngineReade
    * pre-serialized in parallel before the sequential append pass writes and closes them. Two windows
    * are in flight at once (double buffering), so the transient draw on the shared segment-allocator
    * budget is bounded by {@code 2 × WINDOW} copies, each holding a pooled slotted segment
-   * (64&nbsp;KiB typical, up to 256&nbsp;KiB) plus its cached encoded form. The double buffering keeps
-   * the flush pool's workers serializing while this thread appends; widening the window past the
-   * pool's appetite only inflates the footprint.
+   * (64&nbsp;KiB typical, up to 256&nbsp;KiB) plus its cached encoded form. The double buffering
+   * keeps the flush pool's workers serializing while this thread appends; widening the window past
+   * the pool's appetite only inflates the footprint.
    *
    * <p>
    * <b>Equal to the epoch on purpose, and measured that way.</b> Defining the width as the epoch size
-   * makes an epoch exactly one window, so the loop below joins its only serialization, appends it, and
-   * finds no successor started — the double buffering never actually overlaps anything. That reads
-   * like a defect, and the obvious repair is to size the window independently so several windows per
-   * epoch pipeline against each other. It was tried, on a 1M-row ClickBench bulk import at
-   * {@code maxLogEntries=256} (395 epochs, 264 KVL pages each). The overlap is real and visible in the
-   * phase telemetry — a 64-page window cut the serialization-join stall from 8.1 s to 6.8 s and total
-   * worker time from 10.6 s to 9.7 s — and it bought nothing: interleaved min-of-3 wall time was
-   * 12.047 s at one window per epoch against 12.412 s at four, and a 16-page window (17 windows per
-   * epoch) regressed to 13.8 s as per-window fork/join overhead took over.
+   * makes an epoch exactly one window, so the loop below joins its only serialization, appends it,
+   * and finds no successor started — the double buffering never actually overlaps anything. That
+   * reads like a defect, and the obvious repair is to size the window independently so several
+   * windows per epoch pipeline against each other. It was tried, on a 1M-row ClickBench bulk import
+   * at {@code maxLogEntries=256} (395 epochs, 264 KVL pages each). The overlap is real and visible in
+   * the phase telemetry — a 64-page window cut the serialization-join stall from 8.1 s to 6.8 s and
+   * total worker time from 10.6 s to 9.7 s — and it bought nothing: interleaved min-of-3 wall time
+   * was 12.047 s at one window per epoch against 12.412 s at four, and a 16-page window (17 windows
+   * per epoch) regressed to 13.8 s as per-window fork/join overhead took over.
    * </p>
    *
    * <p>
-   * The reason is that the append pass this would overlap is the small phase: the flush spends ~77% of
-   * its time waiting on the parallel serialize pool and ~23% appending, and the pool is the throughput
-   * limit for the whole load. Recovering the append window hands the freed capacity straight back to
-   * contention with the insert threads, which is the same effect that makes oversizing
-   * {@code sirix.asyncFlush.parallelism} lose (14 serializers measured slower end to end than 9,
-   * despite a strictly lower worker time). Anyone reaching for a deeper flush pipeline — a wider
-   * window here, or a multi-generation intent log so consecutive epochs overlap — is aiming at the
-   * 23%, and should first check what the serialize stage costs.
+   * The reason is that the append pass this would overlap is the small phase: the flush spends ~77%
+   * of its time waiting on the parallel serialize pool and ~23% appending, and the pool is the
+   * throughput limit for the whole load. Recovering the append window hands the freed capacity
+   * straight back to contention with the insert threads, which is the same effect that makes
+   * oversizing {@code sirix.asyncFlush.parallelism} lose (14 serializers measured slower end to end
+   * than 9, despite a strictly lower worker time). Anyone reaching for a deeper flush pipeline — a
+   * wider window here, or a multi-generation intent log so consecutive epochs overlap — is aiming at
+   * the 23%, and should first check what the serialize stage costs.
    * </p>
    */
   private static final int SNAPSHOT_FLUSH_WINDOW = MAX_ASYNC_FLUSH_LOG_ENTRY_COUNT;

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineReader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineReader.java
@@ -51,8 +51,47 @@ import io.sirix.page.RegionsOnlyPage;
 public interface StorageEngineReader extends AutoCloseable {
 
   /**
+   * Writer-side memo hooks for the projection value dictionary's record reads.
+   *
+   * <p>
+   * The dictionary radix resolves every node it touches through
+   * {@code NamePage#getProjectionValueDictionaryRecord}, and in a WRITER whose intent log no longer
+   * holds the page (async flush released it) each such read decodes a whole durable page — IO,
+   * checksum verify, LZ77 decode, version combine — to detach one record. The radix walks revisit the
+   * same few upper-level nodes constantly (a generation append re-reads the shared path per new
+   * entry), which measured as ~16% of a bulk load's CPU. These hooks let the writer memoize the
+   * DETACHED records by node key, which is sound because the dictionary sub-trie is copy-on-write
+   * with freshly minted keys — the ONE record rewritten under a stable key (the generation header) is
+   * evicted by the put hook. Default no-ops keep read-only transactions — which may share pages and
+   * threads — entirely out of it.
+   *
+   * @param key the dictionary record's node key
+   * @return the memoized record, or {@code null} when absent or unsupported
+   */
+  default @Nullable DataRecord cachedProjectionDictionaryRecord(final long key) {
+    return null;
+  }
+
+  /**
+   * Memoize a projection-dictionary record just read for {@code key}. No-op by default; the writer
+   * override skips records that are still bound to a page segment.
+   *
+   * @param key the dictionary record's node key
+   * @param record the record read for that key
+   */
+  default void cacheProjectionDictionaryRecord(final long key, final DataRecord record) {}
+
+  /**
+   * Drop the memo entry for {@code key}, called by the dictionary put path BEFORE persisting so a
+   * record rewritten under a stable key (the generation header) can never be served stale.
+   *
+   * @param key the node key being (re)written
+   */
+  default void evictProjectionDictionaryRecord(final long key) {}
+
+  /**
    * Get the buffer manager.
-   * 
+   *
    * @return the buffer manager
    */
   BufferManager getBufferManager();

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
@@ -130,6 +130,47 @@ public interface StorageEngineWriter extends StorageEngineReader {
    * @param len length of the value
    * @return the encoded bytes to store with the compressed flag, or {@code null} to store raw
    */
+  /**
+   * Adds {@code delta} occurrences to an EXISTING interned name's count in one record touch — the
+   * batched sibling of the per-occurrence counting in {@code createNameKey}; the parallel bulk
+   * importer applies per-chunk occurrence deltas through it before any flush epoch can rotate.
+   *
+   * @param key the interned name key
+   * @param delta additional occurrences; must be positive
+   * @param nodeKind the kind selecting the dictionary
+   */
+  default void addNameCount(int key, int delta, NodeKind nodeKind) {
+    throw new UnsupportedOperationException("batched name counting is not supported by this writer");
+  }
+
+  /**
+   * Adopts an externally BUILT document leaf page into this writer's transaction intent log — the
+   * parallel bulk importer's installation seam. The page must cover unwritten territory: its
+   * record page key must resolve to a reference with no persisted predecessor and no log entry.
+   * The adopted page becomes the container's MODIFIED half (an empty complete twin is created),
+   * mirroring exactly what the ordinary fresh-page path produces, so read-back, async flush and
+   * commit treat it like any other freshly written page.
+   *
+   * @param page a fully built page for a contiguous pre-reserved key range
+   */
+  default void adoptDocumentLeafPage(KeyValueLeafPage page) {
+    throw new UnsupportedOperationException("bulk page adoption is not supported by this writer");
+  }
+
+  /**
+   * Resolves the LIVE (CoW-checked) modified half of a document leaf page for direct record
+   * blitting — the parallel bulk importer's stitch seam for pages that are already in the intent
+   * log (the page-0 prologue and chunk-boundary pages). Goes through the ordinary
+   * prepare-record-page machinery, so a frozen-snapshot instance is deep-copied first and caches
+   * stay coherent.
+   *
+   * @param recordPageKey the document record page key
+   * @return the modified page, safe for direct writes on the writer thread
+   */
+  default KeyValueLeafPage prepareDocumentLeafForBlit(long recordPageKey) {
+    throw new UnsupportedOperationException("bulk page blitting is not supported by this writer");
+  }
+
   default byte[] encodeStringValueForInsert(KeyValueLeafPage page, byte[] value, int off, int len) {
     return null;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
@@ -130,6 +130,10 @@ public interface StorageEngineWriter extends StorageEngineReader {
    * @param len length of the value
    * @return the encoded bytes to store with the compressed flag, or {@code null} to store raw
    */
+  default byte[] encodeStringValueForInsert(KeyValueLeafPage page, byte[] value, int off, int len) {
+    return null;
+  }
+
   /**
    * Adds {@code delta} occurrences to an EXISTING interned name's count in one record touch — the
    * batched sibling of the per-occurrence counting in {@code createNameKey}; the parallel bulk
@@ -169,10 +173,6 @@ public interface StorageEngineWriter extends StorageEngineReader {
    */
   default KeyValueLeafPage prepareDocumentLeafForBlit(long recordPageKey) {
     throw new UnsupportedOperationException("bulk page blitting is not supported by this writer");
-  }
-
-  default byte[] encodeStringValueForInsert(KeyValueLeafPage page, byte[] value, int off, int len) {
-    return null;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/api/StorageEngineWriter.java
@@ -149,11 +149,11 @@ public interface StorageEngineWriter extends StorageEngineReader {
 
   /**
    * Adopts an externally BUILT document leaf page into this writer's transaction intent log — the
-   * parallel bulk importer's installation seam. The page must cover unwritten territory: its
-   * record page key must resolve to a reference with no persisted predecessor and no log entry.
-   * The adopted page becomes the container's MODIFIED half (an empty complete twin is created),
-   * mirroring exactly what the ordinary fresh-page path produces, so read-back, async flush and
-   * commit treat it like any other freshly written page.
+   * parallel bulk importer's installation seam. The page must cover unwritten territory: its record
+   * page key must resolve to a reference with no persisted predecessor and no log entry. The adopted
+   * page becomes the container's MODIFIED half (an empty complete twin is created), mirroring exactly
+   * what the ordinary fresh-page path produces, so read-back, async flush and commit treat it like
+   * any other freshly written page.
    *
    * @param page a fully built page for a contiguous pre-reserved key range
    */
@@ -162,11 +162,10 @@ public interface StorageEngineWriter extends StorageEngineReader {
   }
 
   /**
-   * Resolves the LIVE (CoW-checked) modified half of a document leaf page for direct record
-   * blitting — the parallel bulk importer's stitch seam for pages that are already in the intent
-   * log (the page-0 prologue and chunk-boundary pages). Goes through the ordinary
-   * prepare-record-page machinery, so a frozen-snapshot instance is deep-copied first and caches
-   * stay coherent.
+   * Resolves the LIVE (CoW-checked) modified half of a document leaf page for direct record blitting
+   * — the parallel bulk importer's stitch seam for pages that are already in the intent log (the
+   * page-0 prologue and chunk-boundary pages). Goes through the ordinary prepare-record-page
+   * machinery, so a frozen-snapshot instance is deep-copied first and caches stay coherent.
    *
    * @param recordPageKey the document record page key
    * @return the modified page, safe for direct writes on the writer thread

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -268,6 +268,9 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   private volatile SizeClass[] classes;
   private volatile long budgetBytes;
 
+  /** Budget share only oversized allocations may commit — see {@link #initInternal}. */
+  private volatile long oversizedHeadroomBytes;
+
   /**
    * Physical/touchable capacity retained by committed frame slots plus live oversized arenas. A frame
    * slot remains committed across recycle cycles, so its bytes leave this counter only when the whole
@@ -397,6 +400,19 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
           "budgetBytes must be >= largest size class (" + SIZE_CLASSES[SIZE_CLASSES.length - 1] + ")");
     }
     this.budgetBytes = budgetBytes;
+    final long configuredHeadroom = Long.getLong("sirix.allocator.oversizedHeadroomBytes", -1L);
+    // Slab-region commitments never release before shutdown (no portable way to decommit pages of
+    // a live mmap'd region), so an unchecked slab peak would permanently starve the oversized path
+    // — the large-value (de)compression buffers a post-ingest query still needs. Fresh-slot
+    // commitment stops short of the full budget; only oversized allocations (whose bytes DO
+    // return on release) may use the headroom. Default: 1/16th of the budget, capped at 1 GiB —
+    // zero for tiny test budgets, so their exhaustion semantics are unchanged.
+    // Only budgets comfortably above embedded/test scale reserve headroom by default: an
+    // allocator budgeted EXACTLY for its slabs (focused tests, tiny embedded configs) must keep
+    // its full slab capacity.
+    this.oversizedHeadroomBytes = configuredHeadroom >= 0
+        ? Math.min(configuredHeadroom, budgetBytes)
+        : (budgetBytes >= 64L * 1024 * 1024 ? Math.min(budgetBytes / 16, 1L << 30) : 0L);
     final SizeClass[] cls = new SizeClass[SIZE_CLASSES.length];
     // Per-class virtual reservation is workload-independent; MAP_NORESERVE means physical pages
     // only commit when touched. Cap the number of slots to bound version metadata; its fixed-size
@@ -504,7 +520,7 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
         // A fresh slot adds retained commitment. Recycled slots do not: their pages deliberately
         // remain committed, and charging them again would eventually consume the budget with the
         // same physical slot over and over.
-        if (!reserveCommittedBytes(c.slotSize)) {
+        if (!reserveSlabCommittedBytes(c.slotSize)) {
           return -1;
         }
         slotIdx = popFreshSlot(c);
@@ -554,13 +570,30 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
     }
   }
 
-  private boolean reserveCommittedBytes(final long bytes) {
+  boolean reserveCommittedBytes(final long bytes) {
+    return reserveCommittedBytesUpTo(bytes, budgetBytes);
+  }
+
+  /**
+   * Fresh-slot (slab) commitment is permanent until shutdown, so it may never consume the
+   * oversized headroom — the slice that keeps large-value buffers allocatable after a slab peak.
+   * Package-private so the witness test can drive the decision table directly.
+   */
+  boolean reserveSlabCommittedBytes(final long bytes) {
+    return reserveCommittedBytesUpTo(bytes, budgetBytes - oversizedHeadroomBytes);
+  }
+
+  long oversizedHeadroomBytes() {
+    return oversizedHeadroomBytes;
+  }
+
+  private boolean reserveCommittedBytesUpTo(final long bytes, final long limit) {
     if (bytes <= 0) {
       throw new IllegalArgumentException("allocation size must be positive: " + bytes);
     }
     long current = committedBytes.getAcquire();
     while (true) {
-      if (current > budgetBytes || bytes > budgetBytes - current) {
+      if (current > limit || bytes > limit - current) {
         return false;
       }
       if (committedBytes.compareAndSet(current, current + bytes)) {

--- a/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/cache/FrameSlotAllocator.java
@@ -412,7 +412,9 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
     // its full slab capacity.
     this.oversizedHeadroomBytes = configuredHeadroom >= 0
         ? Math.min(configuredHeadroom, budgetBytes)
-        : (budgetBytes >= 64L * 1024 * 1024 ? Math.min(budgetBytes / 16, 1L << 30) : 0L);
+        : (budgetBytes >= 64L * 1024 * 1024
+            ? Math.min(budgetBytes / 16, 1L << 30)
+            : 0L);
     final SizeClass[] cls = new SizeClass[SIZE_CLASSES.length];
     // Per-class virtual reservation is workload-independent; MAP_NORESERVE means physical pages
     // only commit when touched. Cap the number of slots to bound version metadata; its fixed-size
@@ -575,8 +577,8 @@ public final class FrameSlotAllocator implements MemorySegmentAllocator {
   }
 
   /**
-   * Fresh-slot (slab) commitment is permanent until shutdown, so it may never consume the
-   * oversized headroom — the slice that keeps large-value buffers allocatable after a slab peak.
+   * Fresh-slot (slab) commitment is permanent until shutdown, so it may never consume the oversized
+   * headroom — the slice that keeps large-value buffers allocatable after a slab peak.
    * Package-private so the witness test can drive the decision table directly.
    */
   boolean reserveSlabCommittedBytes(final long bytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
@@ -146,6 +146,54 @@ public final class CASIndexBuilder {
   }
 
   /**
+   * Invalidate the resolved path-class cache. Sound for this builder's own frozen-summary
+   * traversal, stale for an import-time feeder whose summary grows between drains — a class first
+   * minted after the previous drain would stay invisible. Called once per drained chunk.
+   */
+  public void refreshIndexedPaths() {
+    resolvedPCRs = null;
+  }
+
+  /**
+   * Primitive entry for feeders that hold no node object — the parallel bulk importer's coordinator
+   * drain, which stringifies each value from the same primitives the write path carried. Same path
+   * filter, the same KEEP-the-conversion typing discipline and skip-on-conversion-failure as
+   * {@link #process}, and the same bulk-vs-incremental arm.
+   */
+  public void add(final Str strValue, final long pathNodeKey, final long nodeKey) {
+    try {
+      if (!matchesIndexedPath(pathNodeKey)) {
+        return;
+      }
+      Atomic typedValue = strValue;
+      try {
+        if (type != Type.STR) {
+          typedValue = AtomicUtil.toType(strValue, type);
+        }
+      } catch (final SirixRuntimeException e) {
+        LOGGER.debug("Value '{}' is not of type {}, skipping CAS index entry for node {}", strValue, type, nodeKey, e);
+        return;
+      }
+      final CASValue value = new CASValue(typedValue, type, pathNodeKey);
+      if (useHOT) {
+        assert hotWriter != null;
+        if (bulkLoader != null) {
+          bulkLoader.add(value, nodeKey);
+        } else {
+          hotWriter.indexNodeKey(value, nodeKey);
+        }
+      } else {
+        assert rbTreeWriter != null;
+        final Optional<NodeReferences> references = rbTreeWriter.get(value, SearchMode.EQUAL);
+        rbTreeWriter.index(value, references.orElseGet(NodeReferences::new).addNodeKey(nodeKey),
+            RBTreeReader.MoveCursor.NO_MOVE);
+      }
+    } catch (final PathException | SirixIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+  }
+
+  /**
    * Whether {@code pathNodeKey} is one of the path-class records this index covers. An empty path
    * configuration means "index every path".
    *

--- a/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/cas/CASIndexBuilder.java
@@ -146,9 +146,9 @@ public final class CASIndexBuilder {
   }
 
   /**
-   * Invalidate the resolved path-class cache. Sound for this builder's own frozen-summary
-   * traversal, stale for an import-time feeder whose summary grows between drains — a class first
-   * minted after the previous drain would stay invisible. Called once per drained chunk.
+   * Invalidate the resolved path-class cache. Sound for this builder's own frozen-summary traversal,
+   * stale for an import-time feeder whose summary grows between drains — a class first minted after
+   * the previous drain would stay invisible. Called once per drained chunk.
    */
   public void refreshIndexedPaths() {
     resolvedPCRs = null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
@@ -285,6 +285,38 @@ public final class HOTBulkBuilder {
     }
 
     /**
+     * Expansion predicate for a frontier node: only a branch whose key group does NOT fit a
+     * single leaf page may be split further. A fitting group is left whole so {@link #bulk}
+     * cuts it as one page — the "highest fitting {@code R(S)} subtree" policy.
+     */
+    private boolean isExpandable(final RNode r) {
+      return r instanceof RBranch && !fitsLeafPage(r.lo(), r.hi());
+    }
+
+    /**
+     * Conservative page-fit test for {@code keys[lo..hi]}: entry count within
+     * {@link HOTLeafPage#MAX_ENTRIES} and the worst-case slot-heap footprint within
+     * {@link HOTLeafPage#DEFAULT_SIZE}. The footprint upper bound charges the FULL key per
+     * entry ({@code 2 + keyLen + 2 + valueLen}); the page stores only the post-prefix suffix
+     * ({@code suffixLen ≤ keyLen}), so a group that passes here can never overflow the real
+     * page and {@code tryBuildLeaf} cannot fail on it. The sum exits early once over budget,
+     * bounding the walk at {@code O(capacity / entrySize)} regardless of group size.
+     */
+    private boolean fitsLeafPage(final int lo, final int hi) {
+      if (hi - lo + 1 > MAX_LEAF_ENTRIES) {
+        return false;
+      }
+      long bytes = 0;
+      for (int i = lo; i <= hi; i++) {
+        bytes += 4 + keys[i].length + values[i].length;
+        if (bytes > HOTLeafPage.DEFAULT_SIZE) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    /**
      * Speculatively build a leaf page holding {@code keys[lo..hi]}. Returns {@code null} if the
      * entries do not fit a page (entry-count or byte-capacity overflow signalled by
      * {@link HOTLeafPage#put} returning {@code false} on a genuine — non-duplicate — insert).
@@ -315,27 +347,40 @@ public final class HOTBulkBuilder {
      * largest still-expandable frontier node) until the block has {@code MAX_FANOUT} children
      * or no frontier node can be split; then derive the discriminative-bit set, the
      * sparse-path partials, and recurse into each child.
+     *
+     * <p><b>Leaf-boundary stop.</b> A frontier node whose whole key group fits one leaf page is
+     * never expanded: expanding it would split a page-fitting {@code R(S)} subtree across several
+     * frontier slots, each of which then compresses into its own (fragmented, under-filled)
+     * page — measured at 7× the leaf count on dense/strided key sets. Stopping there realizes
+     * the documented cut policy ("the highest {@code R(S)} subtree whose key group fits a
+     * page"). Any frontier is invariant-correct (Theorem 1), so only packing changes; height
+     * can only shrink (a would-be sub-indirect becomes a height-0 leaf child).
      */
     private HOTIndirectPage buildIndirect(final RBranch root) {
       // Frontier: the block's exit points, each with the block-internal path that reaches it.
-      // A path step is {beta, side} with side 0 = left, 1 = right.
+      // A path step is {beta, side} with side 0 = left, 1 = right. fexpandable[i] caches the
+      // expansion predicate (branch AND does not fit a leaf page), computed once per entry —
+      // the byte-fit walk is O(min(group, capacity/entry)) and must not rerun per pick loop.
       final RNode[] fnodes = new RNode[MAX_FANOUT];
       final int[][][] fpaths = new int[MAX_FANOUT][][];
+      final boolean[] fexpandable = new boolean[MAX_FANOUT];
       int fcount = 0;
       fnodes[fcount] = root.left();
       fpaths[fcount] = new int[][] {{root.beta(), 0}};
+      fexpandable[fcount] = isExpandable(root.left());
       fcount++;
       fnodes[fcount] = root.right();
       fpaths[fcount] = new int[][] {{root.beta(), 1}};
+      fexpandable[fcount] = isExpandable(root.right());
       fcount++;
 
       while (fcount < MAX_FANOUT) {
-        // Pick the largest expandable (RBranch) frontier node.
+        // Pick the largest expandable frontier node.
         int idx = -1;
         int best = -1;
         for (int i = 0; i < fcount; i++) {
-          if (fnodes[i] instanceof RBranch rb) {
-            final int s = rSize(rb);
+          if (fexpandable[i]) {
+            final int s = rSize(fnodes[i]);
             if (s > best) {
               best = s;
               idx = i;
@@ -352,10 +397,13 @@ public final class HOTBulkBuilder {
         // Replace fnodes[idx] by rb.left(); insert rb.right() at idx+1, shifting the tail.
         System.arraycopy(fnodes, idx + 1, fnodes, idx + 2, fcount - (idx + 1));
         System.arraycopy(fpaths, idx + 1, fpaths, idx + 2, fcount - (idx + 1));
+        System.arraycopy(fexpandable, idx + 1, fexpandable, idx + 2, fcount - (idx + 1));
         fnodes[idx] = rb.left();
         fpaths[idx] = leftPath;
+        fexpandable[idx] = isExpandable(rb.left());
         fnodes[idx + 1] = rb.right();
         fpaths[idx + 1] = rightPath;
+        fexpandable[idx + 1] = isExpandable(rb.right());
         fcount++;
       }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
@@ -17,49 +17,53 @@ import java.util.function.LongSupplier;
 /**
  * Pure bulk-build / rebuild primitive for HOT (Height-Optimized Trie) secondary indexes.
  *
- * <p>Given a list of {@code (key, value)} entries sorted ascending by unsigned big-endian
+ * <p>
+ * Given a list of {@code (key, value)} entries sorted ascending by unsigned big-endian
  * (lexicographic) key, {@link #build} materializes a correct HOT subtree out of real
- * {@link HOTLeafPage} and {@link HOTIndirectPage} objects and returns its root. The function is
- * a faithful port of the formally-verified model in {@code HOTFormalModelTest} (the
- * {@code buildR} / {@code bulk} / sparse-path encoding triple) — see
- * {@code docs/HOT_FORMAL_FOUNDATION.md} (Theorem 1). It is property-test-verified there over
- * thousands of adversarial key sets.
+ * {@link HOTLeafPage} and {@link HOTIndirectPage} objects and returns its root. The function is a
+ * faithful port of the formally-verified model in {@code HOTFormalModelTest} (the {@code buildR} /
+ * {@code bulk} / sparse-path encoding triple) — see {@code docs/HOT_FORMAL_FOUNDATION.md} (Theorem
+ * 1). It is property-test-verified there over thousands of adversarial key sets.
  *
- * <p><b>Purity.</b> {@code build} allocates exclusively new pages and never mutates any page
- * passed in or referenced elsewhere. It performs no I/O. Page keys are drawn from the supplied
+ * <p>
+ * <b>Purity.</b> {@code build} allocates exclusively new pages and never mutates any page passed in
+ * or referenced elsewhere. It performs no I/O. Page keys are drawn from the supplied
  * {@link LongSupplier} — the caller controls allocation so the result can be spliced in via
  * copy-on-write with full path-copy to the root (Sirix's persistent-page discipline).
  *
- * <p><b>Algorithm.</b> Two deterministic phases (foundation §3.2):
+ * <p>
+ * <b>Algorithm.</b> Two deterministic phases (foundation §3.2):
  * <ol>
- *   <li>Build {@code R(S)}, Binna's binary Patricia trie of the key set, by the standard MSDB
- *       recursion. The most-significant differing bit (MSDB) between two variable-length keys
- *       compared as unsigned big-endian is the first differing byte, then the most significant
- *       differing bit within that byte.</li>
- *   <li>Compress {@code R(S)}: cut a {@link HOTLeafPage} at the highest {@code R(S)} subtree
- *       whose key group fits a page (&le; {@link HOTLeafPage#MAX_ENTRIES} entries <em>and</em>
- *       &le; page byte capacity); SMHP-partition the remaining upper structure into
- *       {@link HOTIndirectPage} compound nodes of &le; {@link HOTIndirectPage#MAX_NODE_ENTRIES}
- *       children; sparse-path-encode the stored partial keys.</li>
+ * <li>Build {@code R(S)}, Binna's binary Patricia trie of the key set, by the standard MSDB
+ * recursion. The most-significant differing bit (MSDB) between two variable-length keys compared as
+ * unsigned big-endian is the first differing byte, then the most significant differing bit within
+ * that byte.</li>
+ * <li>Compress {@code R(S)}: cut a {@link HOTLeafPage} at the highest {@code R(S)} subtree whose
+ * key group fits a page (&le; {@link HOTLeafPage#MAX_ENTRIES} entries <em>and</em> &le; page byte
+ * capacity); SMHP-partition the remaining upper structure into {@link HOTIndirectPage} compound
+ * nodes of &le; {@link HOTIndirectPage#MAX_NODE_ENTRIES} children; sparse-path-encode the stored
+ * partial keys.</li>
  * </ol>
  * Because a leaf page stores a <em>complete</em> {@code R(S)} subtree, every ancestor
- * discriminative bit is constant across the leaf's keys (Fact R1), so invariant I5 holds
- * regardless of leaf cardinality.
+ * discriminative bit is constant across the leaf's keys (Fact R1), so invariant I5 holds regardless
+ * of leaf cardinality.
  *
- * <p><b>Tombstones.</b> A tombstone (a {@code NodeReferences} value tagged {@code 0xFE}) is a
- * key and is included like any other entry — it occupies a leaf slot and participates in
- * {@code R(S)} construction.
+ * <p>
+ * <b>Tombstones.</b> A tombstone (a {@code NodeReferences} value tagged {@code 0xFE}) is a key and
+ * is included like any other entry — it occupies a leaf slot and participates in {@code R(S)}
+ * construction.
  *
- * <p><b>MultiMask encoding consistency.</b> The stored partial of child {@code i} is the
- * sparse-path encoding: bit {@code j} is set iff the block BiNode {@code discBits[j]} lies on
- * the path to child {@code i} <em>and</em> that path takes the 1-side. Discriminative bits are
- * packed MSB-first by absolute bit position — {@code discBits[0]} (smallest absolute position,
- * most significant) gets weight {@code 1 << (m-1)}. This is exactly the bit order
- * {@link HOTIndirectPage}'s routing produces from {@code Long.compress} (SingleMask) and from
- * the chunked {@code computeMultiMaskPartialKey} (MultiMask): the lowest long-bit / lowest
- * result-bit corresponds to the least-significant captured key bit. The builder chooses the
- * SingleMask layout when every discriminative bit fits an 8-byte window and the MultiMask
- * layout otherwise; both decode the partials identically.
+ * <p>
+ * <b>MultiMask encoding consistency.</b> The stored partial of child {@code i} is the sparse-path
+ * encoding: bit {@code j} is set iff the block BiNode {@code discBits[j]} lies on the path to child
+ * {@code i} <em>and</em> that path takes the 1-side. Discriminative bits are packed MSB-first by
+ * absolute bit position — {@code discBits[0]} (smallest absolute position, most significant) gets
+ * weight {@code 1 << (m-1)}. This is exactly the bit order {@link HOTIndirectPage}'s routing
+ * produces from {@code Long.compress} (SingleMask) and from the chunked
+ * {@code computeMultiMaskPartialKey} (MultiMask): the lowest long-bit / lowest result-bit
+ * corresponds to the least-significant captured key bit. The builder chooses the SingleMask layout
+ * when every discriminative bit fits an 8-byte window and the MultiMask layout otherwise; both
+ * decode the partials identically.
  *
  * @author Johannes Lichtenberger
  * @see HOTLeafPage
@@ -78,11 +82,11 @@ public final class HOTBulkBuilder {
   }
 
   /**
-   * A single {@code (key, value)} entry. Both arrays are treated as immutable; the builder
-   * never modifies them and never retains references beyond the {@link #build} call other than
-   * by copying their bytes into freshly allocated leaf pages.
+   * A single {@code (key, value)} entry. Both arrays are treated as immutable; the builder never
+   * modifies them and never retains references beyond the {@link #build} call other than by copying
+   * their bytes into freshly allocated leaf pages.
    *
-   * @param key   the full index key (variable-length, compared unsigned big-endian)
+   * @param key the full index key (variable-length, compared unsigned big-endian)
    * @param value the value payload (a tombstone is a 1-byte {@code 0xFE})
    */
   public record Entry(byte[] key, byte[] value) {
@@ -93,33 +97,32 @@ public final class HOTBulkBuilder {
   }
 
   /**
-   * The result of a bulk build: the root page and a {@link PageReference} that already has the
-   * root swizzled in via {@link PageReference#setPage}. Every page in the subtree is reachable
-   * from {@code rootReference} and has a page key drawn from the caller's allocator.
+   * The result of a bulk build: the root page and a {@link PageReference} that already has the root
+   * swizzled in via {@link PageReference#setPage}. Every page in the subtree is reachable from
+   * {@code rootReference} and has a page key drawn from the caller's allocator.
    *
    * @param rootReference a reference whose in-memory page is {@link #rootPage}
-   * @param rootPage      the root of the built HOT subtree (a {@link HOTLeafPage} when the key
-   *                      set fits a single page, otherwise a {@link HOTIndirectPage})
-   * @param leafCount     number of leaf pages created
+   * @param rootPage the root of the built HOT subtree (a {@link HOTLeafPage} when the key set fits a
+   *        single page, otherwise a {@link HOTIndirectPage})
+   * @param leafCount number of leaf pages created
    * @param indirectCount number of indirect pages created
    */
-  public record BuildResult(PageReference rootReference, Page rootPage, int leafCount,
-                             int indirectCount) {}
+  public record BuildResult(PageReference rootReference, Page rootPage, int leafCount, int indirectCount) {
+  }
 
   /**
    * Build a HOT subtree from sorted, distinct entries.
    *
-   * @param sortedEntries     entries sorted strictly ascending by unsigned big-endian key; must
-   *                          contain no duplicate keys
-   * @param revision          the revision number stamped onto every created page
-   * @param indexType         the index type ({@code PATH} / {@code CAS} / {@code NAME})
-   * @param pageKeyAllocator  supplier of fresh persistent page keys; called once per created
-   *                          page (leaf and indirect)
+   * @param sortedEntries entries sorted strictly ascending by unsigned big-endian key; must contain
+   *        no duplicate keys
+   * @param revision the revision number stamped onto every created page
+   * @param indexType the index type ({@code PATH} / {@code CAS} / {@code NAME})
+   * @param pageKeyAllocator supplier of fresh persistent page keys; called once per created page
+   *        (leaf and indirect)
    * @return the build result; {@code rootPage} is {@code null}-free
-   * @throws NullPointerException     if any argument is {@code null}
+   * @throws NullPointerException if any argument is {@code null}
    * @throws IllegalArgumentException if {@code sortedEntries} is empty, not strictly ascending,
-   *                                  contains a duplicate key, or contains a single entry whose
-   *                                  bytes cannot fit a leaf page
+   *         contains a duplicate key, or contains a single entry whose bytes cannot fit a leaf page
    */
   public static BuildResult build(final java.util.List<Entry> sortedEntries, final int revision,
       final IndexType indexType, final LongSupplier pageKeyAllocator) {
@@ -141,12 +144,11 @@ public final class HOTBulkBuilder {
       if (i > 0) {
         final int cmp = Arrays.compareUnsigned(keys[i - 1], keys[i]);
         if (cmp == 0) {
-          throw new IllegalArgumentException(
-              "duplicate key at index " + i + ": " + hex(keys[i]));
+          throw new IllegalArgumentException("duplicate key at index " + i + ": " + hex(keys[i]));
         }
         if (cmp > 0) {
-          throw new IllegalArgumentException("entries not sorted ascending at index " + i
-              + ": " + hex(keys[i - 1]) + " > " + hex(keys[i]));
+          throw new IllegalArgumentException(
+              "entries not sorted ascending at index " + i + ": " + hex(keys[i - 1]) + " > " + hex(keys[i]));
         }
       }
     }
@@ -170,23 +172,25 @@ public final class HOTBulkBuilder {
   }
 
   /** A leaf of {@code R(S)}: the contiguous key group {@code keys[lo..hi]}. */
-  private record RLeaf(int lo, int hi) implements RNode {}
+  private record RLeaf(int lo, int hi) implements RNode {
+  }
 
   /**
-   * A branch of {@code R(S)}: splits {@code keys[lo..hi]} on the discriminative bit
-   * {@code beta} (an absolute MSB-first bit position). All keys under {@code left} have
-   * {@code key[beta] == 0}, all under {@code right} have {@code key[beta] == 1}.
+   * A branch of {@code R(S)}: splits {@code keys[lo..hi]} on the discriminative bit {@code beta} (an
+   * absolute MSB-first bit position). All keys under {@code left} have {@code key[beta] == 0}, all
+   * under {@code right} have {@code key[beta] == 1}.
    */
-  private record RBranch(int lo, int hi, int beta, RNode left, RNode right) implements RNode {}
+  private record RBranch(int lo, int hi, int beta, RNode left, RNode right) implements RNode {
+  }
 
   private static int rSize(final RNode r) {
     return r.hi() - r.lo() + 1;
   }
 
   /**
-   * Build {@code R(keys[lo..hi])} by the MSDB recursion. {@code keys} is sorted strictly
-   * ascending unsigned; both halves of every branch are non-empty because {@code beta} is a
-   * genuinely differing bit.
+   * Build {@code R(keys[lo..hi])} by the MSDB recursion. {@code keys} is sorted strictly ascending
+   * unsigned; both halves of every branch are non-empty because {@code beta} is a genuinely differing
+   * bit.
    */
   private static RNode buildR(final byte[][] keys, final int lo, final int hi) {
     if (lo == hi) {
@@ -203,15 +207,19 @@ public final class HOTBulkBuilder {
 
   /**
    * Most significant differing bit position (absolute, MSB-first; bit 0 = MSB of byte 0) of two
-   * distinct variable-length keys compared as unsigned big-endian. Missing trailing bytes are
-   * treated as {@code 0x00}, so {@code "AB"} and {@code "AB\0..."} would be equal — the caller
-   * guarantees distinct keys, so a differing bit always exists.
+   * distinct variable-length keys compared as unsigned big-endian. Missing trailing bytes are treated
+   * as {@code 0x00}, so {@code "AB"} and {@code "AB\0..."} would be equal — the caller guarantees
+   * distinct keys, so a differing bit always exists.
    */
   static int msdb(final byte[] a, final byte[] b) {
     final int max = Math.max(a.length, b.length);
     for (int i = 0; i < max; i++) {
-      final int av = i < a.length ? (a[i] & 0xFF) : 0;
-      final int bv = i < b.length ? (b[i] & 0xFF) : 0;
+      final int av = i < a.length
+          ? (a[i] & 0xFF)
+          : 0;
+      final int bv = i < b.length
+          ? (b[i] & 0xFF)
+          : 0;
       final int x = av ^ bv;
       if (x != 0) {
         // Most significant differing bit within the byte: 0 = MSB ... 7 = LSB.
@@ -251,8 +259,8 @@ public final class HOTBulkBuilder {
     private int leafCount;
     private int indirectCount;
 
-    BulkContext(final byte[][] keys, final byte[][] values, final int revision,
-        final IndexType indexType, final LongSupplier pageKeyAllocator) {
+    BulkContext(final byte[][] keys, final byte[][] values, final int revision, final IndexType indexType,
+        final LongSupplier pageKeyAllocator) {
       this.keys = keys;
       this.values = values;
       this.revision = revision;
@@ -261,9 +269,9 @@ public final class HOTBulkBuilder {
     }
 
     /**
-     * Compress the {@code R(S)} node {@code r} into a HOT page. A node becomes a leaf page when
-     * its key group fits a page; otherwise it becomes an indirect page whose block is grown
-     * greedily to {@code MAX_FANOUT} children (any frontier is invariant-correct by Theorem 1).
+     * Compress the {@code R(S)} node {@code r} into a HOT page. A node becomes a leaf page when its key
+     * group fits a page; otherwise it becomes an indirect page whose block is grown greedily to
+     * {@code MAX_FANOUT} children (any frontier is invariant-correct by Theorem 1).
      */
     Page bulk(final RNode r) {
       final int size = rSize(r);
@@ -276,8 +284,7 @@ public final class HOTBulkBuilder {
           return leaf;
         }
         if (r instanceof RLeaf) {
-          throw new IllegalArgumentException(
-              "single entry exceeds leaf page capacity: key " + hex(keys[r.lo()]));
+          throw new IllegalArgumentException("single entry exceeds leaf page capacity: key " + hex(keys[r.lo()]));
         }
       }
       // r has > MAX_LEAF_ENTRIES keys, or its group did not fit a page: it is an RBranch.
@@ -285,9 +292,9 @@ public final class HOTBulkBuilder {
     }
 
     /**
-     * Expansion predicate for a frontier node: only a branch whose key group does NOT fit a
-     * single leaf page may be split further. A fitting group is left whole so {@link #bulk}
-     * cuts it as one page — the "highest fitting {@code R(S)} subtree" policy.
+     * Expansion predicate for a frontier node: only a branch whose key group does NOT fit a single leaf
+     * page may be split further. A fitting group is left whole so {@link #bulk} cuts it as one page —
+     * the "highest fitting {@code R(S)} subtree" policy.
      */
     private boolean isExpandable(final RNode r) {
       return r instanceof RBranch && !fitsLeafPage(r.lo(), r.hi());
@@ -296,11 +303,11 @@ public final class HOTBulkBuilder {
     /**
      * Conservative page-fit test for {@code keys[lo..hi]}: entry count within
      * {@link HOTLeafPage#MAX_ENTRIES} and the worst-case slot-heap footprint within
-     * {@link HOTLeafPage#DEFAULT_SIZE}. The footprint upper bound charges the FULL key per
-     * entry ({@code 2 + keyLen + 2 + valueLen}); the page stores only the post-prefix suffix
-     * ({@code suffixLen ≤ keyLen}), so a group that passes here can never overflow the real
-     * page and {@code tryBuildLeaf} cannot fail on it. The sum exits early once over budget,
-     * bounding the walk at {@code O(capacity / entrySize)} regardless of group size.
+     * {@link HOTLeafPage#DEFAULT_SIZE}. The footprint upper bound charges the FULL key per entry
+     * ({@code 2 + keyLen + 2 + valueLen}); the page stores only the post-prefix suffix
+     * ({@code suffixLen ≤ keyLen}), so a group that passes here can never overflow the real page and
+     * {@code tryBuildLeaf} cannot fail on it. The sum exits early once over budget, bounding the walk
+     * at {@code O(capacity / entrySize)} regardless of group size.
      */
     private boolean fitsLeafPage(final int lo, final int hi) {
       if (hi - lo + 1 > MAX_LEAF_ENTRIES) {
@@ -317,11 +324,11 @@ public final class HOTBulkBuilder {
     }
 
     /**
-     * Speculatively build a leaf page holding {@code keys[lo..hi]}. Returns {@code null} if the
-     * entries do not fit a page (entry-count or byte-capacity overflow signalled by
-     * {@link HOTLeafPage#put} returning {@code false} on a genuine — non-duplicate — insert).
-     * The keys are distinct, so a {@code false} return is unambiguously overflow. A discarded
-     * speculative page is {@link HOTLeafPage#close closed} so its off-heap segment is released.
+     * Speculatively build a leaf page holding {@code keys[lo..hi]}. Returns {@code null} if the entries
+     * do not fit a page (entry-count or byte-capacity overflow signalled by {@link HOTLeafPage#put}
+     * returning {@code false} on a genuine — non-duplicate — insert). The keys are distinct, so a
+     * {@code false} return is unambiguously overflow. A discarded speculative page is
+     * {@link HOTLeafPage#close closed} so its off-heap segment is released.
      */
     private HOTLeafPage tryBuildLeaf(final int lo, final int hi) {
       final int count = hi - lo + 1;
@@ -343,18 +350,19 @@ public final class HOTBulkBuilder {
 
     /**
      * Compress one {@code R(S)} branch into a HOT indirect compound node. Mirrors
-     * {@code HOTFormalModelTest.bulk}: greedily expand the block frontier (always splitting the
-     * largest still-expandable frontier node) until the block has {@code MAX_FANOUT} children
-     * or no frontier node can be split; then derive the discriminative-bit set, the
-     * sparse-path partials, and recurse into each child.
+     * {@code HOTFormalModelTest.bulk}: greedily expand the block frontier (always splitting the largest
+     * still-expandable frontier node) until the block has {@code MAX_FANOUT} children or no frontier
+     * node can be split; then derive the discriminative-bit set, the sparse-path partials, and recurse
+     * into each child.
      *
-     * <p><b>Leaf-boundary stop.</b> A frontier node whose whole key group fits one leaf page is
-     * never expanded: expanding it would split a page-fitting {@code R(S)} subtree across several
-     * frontier slots, each of which then compresses into its own (fragmented, under-filled)
-     * page — measured at 7× the leaf count on dense/strided key sets. Stopping there realizes
-     * the documented cut policy ("the highest {@code R(S)} subtree whose key group fits a
-     * page"). Any frontier is invariant-correct (Theorem 1), so only packing changes; height
-     * can only shrink (a would-be sub-indirect becomes a height-0 leaf child).
+     * <p>
+     * <b>Leaf-boundary stop.</b> A frontier node whose whole key group fits one leaf page is never
+     * expanded: expanding it would split a page-fitting {@code R(S)} subtree across several frontier
+     * slots, each of which then compresses into its own (fragmented, under-filled) page — measured at
+     * 7× the leaf count on dense/strided key sets. Stopping there realizes the documented cut policy
+     * ("the highest {@code R(S)} subtree whose key group fits a page"). Any frontier is
+     * invariant-correct (Theorem 1), so only packing changes; height can only shrink (a would-be
+     * sub-indirect becomes a height-0 leaf child).
      */
     private HOTIndirectPage buildIndirect(final RBranch root) {
       // Frontier: the block's exit points, each with the block-internal path that reaches it.
@@ -445,14 +453,15 @@ public final class HOTBulkBuilder {
       int maxChildHeight = 0;
       for (final PageReference child : children) {
         final Page cp = child.getPage();
-        final int h = cp instanceof HOTIndirectPage hi ? hi.getHeight() : 0;
+        final int h = cp instanceof HOTIndirectPage hi
+            ? hi.getHeight()
+            : 0;
         if (h > maxChildHeight) {
           maxChildHeight = h;
         }
       }
       indirectCount++;
-      return assembleIndirect(discBits, partials, children, maxChildHeight + 1, revision,
-          pageKeyAllocator);
+      return assembleIndirect(discBits, partials, children, maxChildHeight + 1, revision, pageKeyAllocator);
     }
   }
 
@@ -464,29 +473,29 @@ public final class HOTBulkBuilder {
   }
 
   /**
-   * Assemble a {@link HOTIndirectPage} from the discriminative-bit set, the sparse-path
-   * partials, and the child references. Children must already be in strictly ascending
-   * partial-key order (foundation §4, I7) — {@code R(S)} left-to-right order for a bulk build,
-   * a contiguous re-encoded sub-block for an incremental split — so no re-sort is needed. Picks
-   * the SingleMask layout when the bits fit an 8-byte window and the MultiMask layout otherwise;
-   * both decode {@code partials} identically.
+   * Assemble a {@link HOTIndirectPage} from the discriminative-bit set, the sparse-path partials, and
+   * the child references. Children must already be in strictly ascending partial-key order
+   * (foundation §4, I7) — {@code R(S)} left-to-right order for a bulk build, a contiguous re-encoded
+   * sub-block for an incremental split — so no re-sort is needed. Picks the SingleMask layout when
+   * the bits fit an 8-byte window and the MultiMask layout otherwise; both decode {@code partials}
+   * identically.
    *
-   * <p>Package-private: shared with {@link HOTIncrementalInsert}'s {@code splitIndirect} and
+   * <p>
+   * Package-private: shared with {@link HOTIncrementalInsert}'s {@code splitIndirect} and
    * {@code addEntry}, which re-encode a node's sub-block exactly as a bulk build encodes an
    * {@code R(S)} branch.
    *
-   * @param discBits         discriminative bits as sorted ascending absolute (MSB-first)
-   *                         positions; {@code discBits[0]} is the assembled node's MSB
-   * @param partials         per-child sparse-path partial keys, parallel to {@code children}
-   * @param children         child references in ascending partial-key order
-   * @param height           the assembled node's height ({@code 1 + max child height})
-   * @param revision         the revision stamped onto the created page
+   * @param discBits discriminative bits as sorted ascending absolute (MSB-first) positions;
+   *        {@code discBits[0]} is the assembled node's MSB
+   * @param partials per-child sparse-path partial keys, parallel to {@code children}
+   * @param children child references in ascending partial-key order
+   * @param height the assembled node's height ({@code 1 + max child height})
+   * @param revision the revision stamped onto the created page
    * @param pageKeyAllocator supplier of a fresh persistent page key
    * @return a freshly allocated compound node
    */
-  static HOTIndirectPage assembleIndirect(final int[] discBits, final int[] partials,
-      final PageReference[] children, final int height, final int revision,
-      final LongSupplier pageKeyAllocator) {
+  static HOTIndirectPage assembleIndirect(final int[] discBits, final int[] partials, final PageReference[] children,
+      final int height, final int revision, final LongSupplier pageKeyAllocator) {
     final int numChildren = children.length;
     final int firstByte = discBits[0] >>> 3;
     final int lastByte = discBits[discBits.length - 1] >>> 3;
@@ -502,10 +511,8 @@ public final class HOTBulkBuilder {
         bitMask |= 1L << (63 - absBitInWindow);
       }
       return numChildren <= 16
-          ? HOTIndirectPage.createSpanNode(pageKey, revision, firstByte, bitMask, partials,
-              children, height)
-          : HOTIndirectPage.createMultiNode(pageKey, revision, firstByte, bitMask, partials,
-              children, height);
+          ? HOTIndirectPage.createSpanNode(pageKey, revision, firstByte, bitMask, partials, children, height)
+          : HOTIndirectPage.createMultiNode(pageKey, revision, firstByte, bitMask, partials, children, height);
     }
 
     // MultiMask: discriminative bits span more than 8 bytes. Group them by key byte.
@@ -534,13 +541,15 @@ public final class HOTBulkBuilder {
       idx++;
     }
     return numChildren <= 16
-        ? HOTIndirectPage.createSpanNodeMultiMask(pageKey, revision, extractionPositions,
-            extractionMasks, numExtractionBytes, partials, children, height, msbIndex)
-        : HOTIndirectPage.createMultiNodeMultiMask(pageKey, revision, extractionPositions,
-            extractionMasks, numExtractionBytes, partials, children, height, msbIndex);
+        ? HOTIndirectPage.createSpanNodeMultiMask(pageKey, revision, extractionPositions, extractionMasks,
+            numExtractionBytes, partials, children, height, msbIndex)
+        : HOTIndirectPage.createMultiNodeMultiMask(pageKey, revision, extractionPositions, extractionMasks,
+            numExtractionBytes, partials, children, height, msbIndex);
   }
 
   private static String hex(final byte[] b) {
-    return b == null ? "null" : java.util.HexFormat.of().formatHex(b);
+    return b == null
+        ? "null"
+        : java.util.HexFormat.of().formatHex(b);
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkBuilder.java
@@ -358,11 +358,15 @@ public final class HOTBulkBuilder {
      * <p>
      * <b>Leaf-boundary stop.</b> A frontier node whose whole key group fits one leaf page is never
      * expanded: expanding it would split a page-fitting {@code R(S)} subtree across several frontier
-     * slots, each of which then compresses into its own (fragmented, under-filled) page — measured at
-     * 7× the leaf count on dense/strided key sets. Stopping there realizes the documented cut policy
-     * ("the highest {@code R(S)} subtree whose key group fits a page"). Any frontier is
-     * invariant-correct (Theorem 1), so only packing changes; height can only shrink (a would-be
-     * sub-indirect becomes a height-0 leaf child).
+     * slots, each of which then compresses into its own (fragmented, under-filled) page. Stopping there
+     * realizes the documented cut policy ("the highest {@code R(S)} subtree whose key group fits a
+     * page"). Any frontier is invariant-correct (Theorem 1), so only packing changes; height can only
+     * shrink (a would-be sub-indirect becomes a height-0 leaf child).
+     *
+     * <p>
+     * Guarded by {@code HOTBulkBuilderTest} V6, which asserts the built leaf count equals the number of
+     * maximal page-fitting {@code R(S)} subtrees — an oracle derived from {@code R(S)} alone, so it is
+     * independent of this frontier logic. Dropping the {@link #fitsLeafPage} term below makes it fail.
      */
     private HOTIndirectPage buildIndirect(final RBranch root) {
       // Frontier: the block's exit points, each with the block-internal path that reaches it.

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntComparator;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Accumulating bulk loader for HOT <b>slot stores</b> — writers whose entries are opaque
+ * {@code byte[]} payloads under 8-byte keys with REPLACE (last-writer-wins) semantics, such as the
+ * projection index's {@code ProjectionIndexHOTStorage} (order-label directory, column-segment
+ * slots, fence/Bloom/metadata blobs).
+ *
+ * <p>
+ * Shares the {@link AbstractHOTBulkIndexLoader} pattern — block-arena accumulation, one
+ * permutation sort, an exactly-sized entry list, one {@code spliceBulkBuiltRoot} — but is a
+ * separate class in the same family because that loader is postings-shaped (it carries a
+ * {@code nodeKey} per entry and its fold OR-merges chunked {@code NodeReferences} runs), it is
+ * {@code sealed}, and slot semantics need a different fold: keep the LAST payload written per key.
+ * Measured against the per-entry {@code writeSlotValue} path this construction is 9–14× faster at
+ * 1 M–10 M entries ({@code docs/HOT_BULK_BUILD.md} §Seam 2a).
+ *
+ * <h2>Read-through</h2>
+ * <p>
+ * While a loader is active its owner serves point reads of accumulated keys from
+ * {@link #lastPayload}: the owner engages the loader only on a VIRGIN tree and routes every write
+ * through {@link #tryAdd}, so the accumulator and the (empty) tree partition the key space — a key
+ * is in the map or it was never written. {@link #containsKey} lets the owner detect the one
+ * operation that genuinely needs physical pages (a side-reference attach) and splice first.
+ * </p>
+ *
+ * <h2>Capacity</h2>
+ * <p>
+ * Bounded by entry count and arena bytes ({@code docs/HOT_BULK_BUILD.md} §Seam 2a arithmetic: the
+ * built pages cost ≈64 KiB per 512 entries ON TOP of the arena, and none of them are
+ * spill-eligible until the splice registers them). {@link #tryAdd} returns {@code false} at
+ * capacity; the owner splices the accumulated prefix and continues per-entry.
+ * </p>
+ *
+ * <h2>Threading</h2>
+ * <p>
+ * Not thread-safe; a loader belongs to the single writer that owns its index tree.
+ * </p>
+ *
+ * @author Johannes Lichtenberger
+ */
+public final class HOTBulkSlotLoader {
+
+  /** Size of one payload block. A power of two so the packed position splits with shift/mask. */
+  private static final int BLOCK_BYTES = 1 << 20;
+
+  private static final int BLOCK_SHIFT = 20;
+
+  private static final int BLOCK_MASK = BLOCK_BYTES - 1;
+
+  private static final int INITIAL_ENTRIES = 1024;
+
+  /** Largest payload a HOT leaf slot can hold ({@code HOTLeafPage} value-length limit). */
+  private static final int MAX_PAYLOAD_BYTES = 65_535;
+
+  /** Hard entry-count cap. */
+  private final int maxEntries;
+
+  /** Hard arena-byte cap (payload bytes; the fixed per-entry index is amortized on top). */
+  private final long maxArenaBytes;
+
+  /** Payload blocks; a payload never straddles two of them. */
+  private byte[][] blocks = new byte[8][];
+
+  private int blockCount;
+
+  private byte[] currentBlock;
+
+  private int currentBlockIndex;
+
+  private int currentBlockOffset;
+
+  /** The slot key of entry {@code i}. */
+  private long[] keys = new long[INITIAL_ENTRIES];
+
+  /** Packed {@code (blockIndex << BLOCK_SHIFT) | offset} of entry {@code i}'s payload. */
+  private long[] payloadPos = new long[INITIAL_ENTRIES];
+
+  /** Length of entry {@code i}'s payload. */
+  private int[] payloadLen = new int[INITIAL_ENTRIES];
+
+  /** Number of accumulated entries (re-puts of one key append — the fold keeps the last). */
+  private int count;
+
+  /** Total payload bytes accumulated. */
+  private long arenaBytes;
+
+  /** slot key → ordinal of the LAST write of that key; also the membership set. */
+  private final Long2IntOpenHashMap lastOrdinalByKey = new Long2IntOpenHashMap();
+
+  public HOTBulkSlotLoader(final int maxEntries, final long maxArenaBytes) {
+    if (maxEntries <= 0) {
+      throw new IllegalArgumentException("maxEntries must be positive, got " + maxEntries);
+    }
+    if (maxArenaBytes <= 0) {
+      throw new IllegalArgumentException("maxArenaBytes must be positive, got " + maxArenaBytes);
+    }
+    this.maxEntries = maxEntries;
+    this.maxArenaBytes = maxArenaBytes;
+    this.lastOrdinalByKey.defaultReturnValue(-1);
+    this.currentBlock = new byte[BLOCK_BYTES];
+    this.blocks[blockCount++] = currentBlock;
+  }
+
+  /**
+   * Accumulate one slot write. A zero-length payload is a tombstone value and is kept like any
+   * other (the projection's slot stores treat zero-length as "tombstoned").
+   *
+   * @param slotKey the slot key
+   * @param payload the payload; copied, never retained
+   * @return {@code true} when accumulated; {@code false} when the write does not fit this
+   *         loader's contract (capacity reached, or an over-long payload) — the caller must
+   *         splice and fall through to its per-entry path
+   */
+  public boolean tryAdd(final long slotKey, final byte[] payload) {
+    requireNonNull(payload, "payload");
+    if (count >= maxEntries || payload.length > MAX_PAYLOAD_BYTES
+        || arenaBytes + payload.length > maxArenaBytes) {
+      return false;
+    }
+    if (currentBlockOffset + payload.length > BLOCK_BYTES) {
+      if (blockCount == blocks.length) {
+        blocks = Arrays.copyOf(blocks, blocks.length << 1);
+      }
+      currentBlock = new byte[BLOCK_BYTES];
+      currentBlockIndex = blockCount;
+      blocks[blockCount++] = currentBlock;
+      currentBlockOffset = 0;
+    }
+    if (count == keys.length) {
+      final int newCapacity = keys.length << 1;
+      keys = Arrays.copyOf(keys, newCapacity);
+      payloadPos = Arrays.copyOf(payloadPos, newCapacity);
+      payloadLen = Arrays.copyOf(payloadLen, newCapacity);
+    }
+    System.arraycopy(payload, 0, currentBlock, currentBlockOffset, payload.length);
+    keys[count] = slotKey;
+    payloadPos[count] = ((long) currentBlockIndex << BLOCK_SHIFT) | currentBlockOffset;
+    payloadLen[count] = payload.length;
+    lastOrdinalByKey.put(slotKey, count);
+    currentBlockOffset += payload.length;
+    arenaBytes += payload.length;
+    count++;
+    return true;
+  }
+
+  /** Whether {@code slotKey} has been written since this loader was engaged. */
+  public boolean containsKey(final long slotKey) {
+    return lastOrdinalByKey.containsKey(slotKey);
+  }
+
+  /**
+   * The LAST payload written for {@code slotKey}, as a fresh array, or {@code null} when the key
+   * was never written into this loader. A zero-length result is a tombstoned slot — exactly what
+   * the per-entry read path returns for one.
+   */
+  public byte @Nullable [] lastPayload(final long slotKey) {
+    final int ordinal = lastOrdinalByKey.get(slotKey);
+    if (ordinal < 0) {
+      return null;
+    }
+    final long pos = payloadPos[ordinal];
+    final byte[] block = blocks[(int) (pos >>> BLOCK_SHIFT)];
+    final int offset = (int) (pos & BLOCK_MASK);
+    return Arrays.copyOfRange(block, offset, offset + payloadLen[ordinal]);
+  }
+
+  /** Number of accumulated writes (not distinct keys). */
+  public int size() {
+    return count;
+  }
+
+  /** Whether nothing has been accumulated. */
+  public boolean isEmpty() {
+    return count == 0;
+  }
+
+  /**
+   * Fold to last-writer-wins, sort by key, build the canonical tree and splice it as
+   * {@code writer}'s root — the production {@code spliceBulkBuiltRoot} path (empty-tree guard,
+   * {@link HOTBulkBuilder}, fresh-subtree TIL registration). The loader is spent afterwards.
+   *
+   * @param writer the owning writer; its tree must still be empty
+   * @return the number of DISTINCT entries spliced (0 for an empty loader)
+   */
+  public int spliceInto(final AbstractHOTIndexWriter<?> writer) {
+    requireNonNull(writer, "writer");
+    final int distinct = lastOrdinalByKey.size();
+    if (distinct == 0) {
+      releaseBuffers();
+      return 0;
+    }
+
+    // The winning ordinals, sorted by slot key. Keys are sorted SIGNED: PathKeySerializer's
+    // sign-flipped big-endian encoding makes unsigned byte order equal signed long order.
+    final int[] winners = new int[distinct];
+    int w = 0;
+    for (final int ordinal : lastOrdinalByKey.values()) {
+      winners[w++] = ordinal;
+    }
+    final IntComparator byKey = (a, b) -> Long.compare(keys[a], keys[b]);
+    IntArrays.parallelQuickSort(winners, byKey);
+
+    final List<HOTBulkBuilder.Entry> entries = new ArrayList<>(distinct);
+    for (int i = 0; i < distinct; i++) {
+      final int ordinal = winners[i];
+      final byte[] keyBytes = new byte[8];
+      PathKeySerializer.INSTANCE.serialize(keys[ordinal], keyBytes, 0);
+      final long pos = payloadPos[ordinal];
+      final byte[] block = blocks[(int) (pos >>> BLOCK_SHIFT)];
+      final int offset = (int) (pos & BLOCK_MASK);
+      entries.add(new HOTBulkBuilder.Entry(keyBytes,
+          Arrays.copyOfRange(block, offset, offset + payloadLen[ordinal])));
+    }
+    writer.spliceBulkBuiltRoot(entries);
+    releaseBuffers();
+    return distinct;
+  }
+
+  /** Discard everything — used when the owning tree is reset mid-accumulation. */
+  public void clear() {
+    releaseBuffers();
+  }
+
+  private void releaseBuffers() {
+    blocks = new byte[0][];
+    blockCount = 0;
+    currentBlock = null;
+    currentBlockIndex = 0;
+    currentBlockOffset = 0;
+    keys = new long[0];
+    payloadPos = new long[0];
+    payloadLen = new int[0];
+    count = 0;
+    arenaBytes = 0;
+    lastOrdinalByKey.clear();
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
@@ -22,13 +22,13 @@ import static java.util.Objects.requireNonNull;
  * slots, fence/Bloom/metadata blobs).
  *
  * <p>
- * Shares the {@link AbstractHOTBulkIndexLoader} pattern — block-arena accumulation, one
- * permutation sort, an exactly-sized entry list, one {@code spliceBulkBuiltRoot} — but is a
- * separate class in the same family because that loader is postings-shaped (it carries a
- * {@code nodeKey} per entry and its fold OR-merges chunked {@code NodeReferences} runs), it is
- * {@code sealed}, and slot semantics need a different fold: keep the LAST payload written per key.
- * Measured against the per-entry {@code writeSlotValue} path this construction is 9–14× faster at
- * 1 M–10 M entries ({@code docs/HOT_BULK_BUILD.md} §Seam 2a).
+ * Shares the {@link AbstractHOTBulkIndexLoader} pattern — block-arena accumulation, one permutation
+ * sort, an exactly-sized entry list, one {@code spliceBulkBuiltRoot} — but is a separate class in
+ * the same family because that loader is postings-shaped (it carries a {@code nodeKey} per entry
+ * and its fold OR-merges chunked {@code NodeReferences} runs), it is {@code sealed}, and slot
+ * semantics need a different fold: keep the LAST payload written per key. Measured against the
+ * per-entry {@code writeSlotValue} path this construction is 9–14× faster at 1 M–10 M entries
+ * ({@code docs/HOT_BULK_BUILD.md} §Seam 2a).
  *
  * <h2>Read-through</h2>
  * <p>
@@ -42,9 +42,9 @@ import static java.util.Objects.requireNonNull;
  * <h2>Capacity</h2>
  * <p>
  * Bounded by entry count and arena bytes ({@code docs/HOT_BULK_BUILD.md} §Seam 2a arithmetic: the
- * built pages cost ≈64 KiB per 512 entries ON TOP of the arena, and none of them are
- * spill-eligible until the splice registers them). {@link #tryAdd} returns {@code false} at
- * capacity; the owner splices the accumulated prefix and continues per-entry.
+ * built pages cost ≈64 KiB per 512 entries ON TOP of the arena, and none of them are spill-eligible
+ * until the splice registers them). {@link #tryAdd} returns {@code false} at capacity; the owner
+ * splices the accumulated prefix and continues per-entry.
  * </p>
  *
  * <h2>Threading</h2>
@@ -118,19 +118,18 @@ public final class HOTBulkSlotLoader {
   }
 
   /**
-   * Accumulate one slot write. A zero-length payload is a tombstone value and is kept like any
-   * other (the projection's slot stores treat zero-length as "tombstoned").
+   * Accumulate one slot write. A zero-length payload is a tombstone value and is kept like any other
+   * (the projection's slot stores treat zero-length as "tombstoned").
    *
    * @param slotKey the slot key
    * @param payload the payload; copied, never retained
-   * @return {@code true} when accumulated; {@code false} when the write does not fit this
-   *         loader's contract (capacity reached, or an over-long payload) — the caller must
-   *         splice and fall through to its per-entry path
+   * @return {@code true} when accumulated; {@code false} when the write does not fit this loader's
+   *         contract (capacity reached, or an over-long payload) — the caller must splice and fall
+   *         through to its per-entry path
    */
   public boolean tryAdd(final long slotKey, final byte[] payload) {
     requireNonNull(payload, "payload");
-    if (count >= maxEntries || payload.length > MAX_PAYLOAD_BYTES
-        || arenaBytes + payload.length > maxArenaBytes) {
+    if (count >= maxEntries || payload.length > MAX_PAYLOAD_BYTES || arenaBytes + payload.length > maxArenaBytes) {
       return false;
     }
     if (currentBlockOffset >= BLOCK_BYTES || currentBlockOffset + payload.length > BLOCK_BYTES) {
@@ -165,9 +164,9 @@ public final class HOTBulkSlotLoader {
   }
 
   /**
-   * The LAST payload written for {@code slotKey}, as a fresh array, or {@code null} when the key
-   * was never written into this loader. A zero-length result is a tombstoned slot — exactly what
-   * the per-entry read path returns for one.
+   * The LAST payload written for {@code slotKey}, as a fresh array, or {@code null} when the key was
+   * never written into this loader. A zero-length result is a tombstoned slot — exactly what the
+   * per-entry read path returns for one.
    */
   public byte @Nullable [] lastPayload(final long slotKey) {
     final int ordinal = lastOrdinalByKey.get(slotKey);
@@ -191,9 +190,9 @@ public final class HOTBulkSlotLoader {
   }
 
   /**
-   * Fold to last-writer-wins, sort by key, build the canonical tree and splice it as
-   * {@code writer}'s root — the production {@code spliceBulkBuiltRoot} path (empty-tree guard,
-   * {@link HOTBulkBuilder}, fresh-subtree TIL registration). The loader is spent afterwards.
+   * Fold to last-writer-wins, sort by key, build the canonical tree and splice it as {@code writer}'s
+   * root — the production {@code spliceBulkBuiltRoot} path (empty-tree guard, {@link HOTBulkBuilder},
+   * fresh-subtree TIL registration). The loader is spent afterwards.
    *
    * @param writer the owning writer; its tree must still be empty
    * @return the number of DISTINCT entries spliced (0 for an empty loader)
@@ -210,7 +209,7 @@ public final class HOTBulkSlotLoader {
     // sign-flipped big-endian encoding makes unsigned byte order equal signed long order.
     final int[] winners = new int[distinct];
     int w = 0;
-    for (final IntIterator ordinals = lastOrdinalByKey.values().iterator(); ordinals.hasNext(); ) {
+    for (final IntIterator ordinals = lastOrdinalByKey.values().iterator(); ordinals.hasNext();) {
       winners[w++] = ordinals.nextInt();
     }
     final IntComparator byKey = (a, b) -> Long.compare(keys[a], keys[b]);
@@ -224,8 +223,7 @@ public final class HOTBulkSlotLoader {
       final long pos = payloadPos[ordinal];
       final byte[] block = blocks[(int) (pos >>> BLOCK_SHIFT)];
       final int offset = (int) (pos & BLOCK_MASK);
-      entries.add(new HOTBulkBuilder.Entry(keyBytes,
-          Arrays.copyOfRange(block, offset, offset + payloadLen[ordinal])));
+      entries.add(new HOTBulkBuilder.Entry(keyBytes, Arrays.copyOfRange(block, offset, offset + payloadLen[ordinal])));
     }
     releaseBuffers();
     writer.spliceBulkBuiltRoot(entries);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
@@ -5,6 +5,7 @@ package io.sirix.index.hot;
 
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
 import org.jspecify.annotations.Nullable;
 
@@ -132,7 +133,7 @@ public final class HOTBulkSlotLoader {
         || arenaBytes + payload.length > maxArenaBytes) {
       return false;
     }
-    if (currentBlockOffset + payload.length > BLOCK_BYTES) {
+    if (currentBlockOffset >= BLOCK_BYTES || currentBlockOffset + payload.length > BLOCK_BYTES) {
       if (blockCount == blocks.length) {
         blocks = Arrays.copyOf(blocks, blocks.length << 1);
       }
@@ -209,8 +210,8 @@ public final class HOTBulkSlotLoader {
     // sign-flipped big-endian encoding makes unsigned byte order equal signed long order.
     final int[] winners = new int[distinct];
     int w = 0;
-    for (final int ordinal : lastOrdinalByKey.values()) {
-      winners[w++] = ordinal;
+    for (final IntIterator ordinals = lastOrdinalByKey.values().iterator(); ordinals.hasNext(); ) {
+      winners[w++] = ordinals.nextInt();
     }
     final IntComparator byKey = (a, b) -> Long.compare(keys[a], keys[b]);
     IntArrays.parallelQuickSort(winners, byKey);
@@ -226,8 +227,8 @@ public final class HOTBulkSlotLoader {
       entries.add(new HOTBulkBuilder.Entry(keyBytes,
           Arrays.copyOfRange(block, offset, offset + payloadLen[ordinal])));
     }
-    writer.spliceBulkBuiltRoot(entries);
     releaseBuffers();
+    writer.spliceBulkBuiltRoot(entries);
     return distinct;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/hot/HOTBulkSlotLoader.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
  * and its fold OR-merges chunked {@code NodeReferences} runs), it is {@code sealed}, and slot
  * semantics need a different fold: keep the LAST payload written per key. Measured against the
  * per-entry {@code writeSlotValue} path this construction is 9–14× faster at 1 M–10 M entries
- * ({@code docs/HOT_BULK_BUILD.md} §Seam 2a).
+ * ({@code docs/HOT_BULK_BUILD.md} §2).
  *
  * <h2>Read-through</h2>
  * <p>
@@ -41,10 +41,10 @@ import static java.util.Objects.requireNonNull;
  *
  * <h2>Capacity</h2>
  * <p>
- * Bounded by entry count and arena bytes ({@code docs/HOT_BULK_BUILD.md} §Seam 2a arithmetic: the
- * built pages cost ≈64 KiB per 512 entries ON TOP of the arena, and none of them are spill-eligible
- * until the splice registers them). {@link #tryAdd} returns {@code false} at capacity; the owner
- * splices the accumulated prefix and continues per-entry.
+ * Bounded by entry count and arena bytes ({@code docs/HOT_BULK_BUILD.md} §2 arithmetic: the built
+ * pages cost ≈64 KiB per 512 entries ON TOP of the arena, and none of them are spill-eligible until
+ * the splice registers them). {@link #tryAdd} returns {@code false} at capacity; the owner splices
+ * the accumulated prefix and continues per-entry.
  * </p>
  *
  * <h2>Threading</h2>

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/NameIndexBuilder.java
@@ -95,6 +95,35 @@ public final class NameIndexBuilder {
     return VisitResultType.CONTINUE;
   }
 
+  /**
+   * Primitive entry for feeders that hold no node object — the parallel bulk importer's coordinator
+   * drain. Same include/exclude filter and the same bulk-vs-incremental arm as {@link #build}.
+   */
+  public void add(final QNm name, final long nodeKey) {
+    final boolean included = (includes.isEmpty() || includes.contains(name));
+    final boolean excluded = (!excludes.isEmpty() && excludes.contains(name));
+    if (!included || excluded) {
+      return;
+    }
+    try {
+      if (useHOT) {
+        assert hotWriter != null;
+        if (bulkLoader != null) {
+          bulkLoader.add(name, nodeKey);
+        } else {
+          hotWriter.indexNodeKey(name, nodeKey);
+        }
+      } else {
+        assert rbTreeWriter != null;
+        final Optional<NodeReferences> references = rbTreeWriter.get(name, SearchMode.EQUAL);
+        rbTreeWriter.index(name, references.orElseGet(NodeReferences::new).addNodeKey(nodeKey),
+            RBTreeReader.MoveCursor.NO_MOVE);
+      }
+    } catch (final SirixIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+  }
+
   private void buildRBTree(QNm name, ImmutableNode node) {
     assert rbTreeWriter != null;
     final Optional<NodeReferences> textReferences = rbTreeWriter.get(name, SearchMode.EQUAL);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
@@ -315,10 +315,10 @@ public final class Names {
   /**
    * Adds {@code delta} occurrences to an EXISTING interned name's count in one touch — the batched
    * form of the per-occurrence increment in {@link #setName}: one
-   * {@code prepareRecordForModification} on the shared count record instead of {@code delta} of
-   * them. The parallel bulk importer accumulates per-chunk occurrence deltas and applies them at
-   * the pre-rotation flush point (the same point path-reference deltas use), so the count pages
-   * stay hot in the intent log across async flush epochs.
+   * {@code prepareRecordForModification} on the shared count record instead of {@code delta} of them.
+   * The parallel bulk importer accumulates per-chunk occurrence deltas and applies them at the
+   * pre-rotation flush point (the same point path-reference deltas use), so the count pages stay hot
+   * in the intent log across async flush epochs.
    *
    * @param key the name key returned by {@link #setName}/{@link #keyForName}; must be interned
    * @param delta how many additional occurrences to record; must be positive

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
@@ -307,6 +307,32 @@ public final class Names {
    * @param name the name to resolve, never {@code null}
    * @return the key for the name
    */
+  /**
+   * Adds {@code delta} occurrences to an EXISTING interned name's count in one touch — the batched
+   * form of the per-occurrence increment in {@link #setName}: one
+   * {@code prepareRecordForModification} on the shared count record instead of {@code delta} of
+   * them. The parallel bulk importer accumulates per-chunk occurrence deltas and applies them at
+   * the pre-rotation flush point (the same point path-reference deltas use), so the count pages
+   * stay hot in the intent log across async flush epochs.
+   *
+   * @param key the name key returned by {@link #setName}/{@link #keyForName}; must be interned
+   * @param delta how many additional occurrences to record; must be positive
+   * @param storageEngineWriter the writer for the count-record modification
+   */
+  public void addCount(final int key, final int delta, final StorageEngineWriter storageEngineWriter) {
+    if (delta <= 0) {
+      throw new IllegalArgumentException("delta must be positive: " + delta);
+    }
+    if (!countNameMapping.containsKey(key)) {
+      throw new IllegalArgumentException("name key " + key + " is not interned; addCount only batches EXISTING names");
+    }
+    countNameMapping.put(key, countNameMapping.get(key) + delta);
+    final long nodeKey = countNodeMap.get(key);
+    final HashCountEntryNode hashCountEntryNode =
+        storageEngineWriter.prepareRecordForModification(nodeKey, IndexType.NAME, indexNumber);
+    hashCountEntryNode.incrementValueBy(delta);
+  }
+
   public int keyForName(final String name) {
     assert name != null;
     return probe(name, name.hashCode());

--- a/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/name/Names.java
@@ -307,6 +307,11 @@ public final class Names {
    * @param name the name to resolve, never {@code null}
    * @return the key for the name
    */
+  public int keyForName(final String name) {
+    assert name != null;
+    return probe(name, name.hashCode());
+  }
+
   /**
    * Adds {@code delta} occurrences to an EXISTING interned name's count in one touch — the batched
    * form of the per-occurrence increment in {@link #setName}: one
@@ -331,11 +336,6 @@ public final class Names {
     final HashCountEntryNode hashCountEntryNode =
         storageEngineWriter.prepareRecordForModification(nodeKey, IndexType.NAME, indexNumber);
     hashCountEntryNode.incrementValueBy(delta);
-  }
-
-  public int keyForName(final String name) {
-    assert name != null;
-    return probe(name, name.hashCode());
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
@@ -100,6 +100,44 @@ public final class PathIndexBuilder {
   }
 
   /**
+   * Invalidate the resolved path-class cache. The cache is sound for this builder's own use — one
+   * traversal of an already-shredded revision, whose summary cannot grow — but an import-time
+   * feeder resolves paths as it loads, so a class first minted after the previous drain would stay
+   * invisible behind a stale set. Called once per drained chunk; the next {@link #add} re-resolves.
+   */
+  public void refreshIndexedPaths() {
+    resolvedPCRs = null;
+  }
+
+  /**
+   * Primitive entry for feeders that hold no node object — the parallel bulk importer's coordinator
+   * drain. Same path filter, same HOT-vs-RBTree dispatch, same bulk-vs-incremental arm as
+   * {@link #process}; only the {@code ImmutableNode} indirection is gone.
+   */
+  public void add(final long pathNodeKey, final long nodeKey) {
+    try {
+      if (!matchesIndexedPath(pathNodeKey)) {
+        return;
+      }
+      if (useHOT) {
+        assert hotWriter != null;
+        if (bulkLoader != null) {
+          bulkLoader.add(pathNodeKey, nodeKey);
+        } else {
+          hotWriter.indexNodeKey(pathNodeKey, nodeKey);
+        }
+      } else {
+        assert rbTreeWriter != null;
+        final Optional<NodeReferences> references = rbTreeWriter.get(pathNodeKey, SearchMode.EQUAL);
+        rbTreeWriter.index(pathNodeKey, references.orElseGet(NodeReferences::new).addNodeKey(nodeKey),
+            MoveCursor.NO_MOVE);
+      }
+    } catch (final PathException | SirixIOException e) {
+      LOGGER.error(e.getMessage(), e);
+    }
+  }
+
+  /**
    * Returns the {@link PathSummaryReader} backing this builder. Used by JSON-specific dispatch (e.g.
    * fused {@code OBJECT_NAMED_ARRAY} which must index its host record at both the OBJECT_KEY layer
    * and the {@code __array__/ARRAY} layer) to navigate path-summary parents.

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/PathIndexBuilder.java
@@ -101,9 +101,9 @@ public final class PathIndexBuilder {
 
   /**
    * Invalidate the resolved path-class cache. The cache is sound for this builder's own use — one
-   * traversal of an already-shredded revision, whose summary cannot grow — but an import-time
-   * feeder resolves paths as it loads, so a class first minted after the previous drain would stay
-   * invisible behind a stale set. Called once per drained chunk; the next {@link #add} re-resolves.
+   * traversal of an already-shredded revision, whose summary cannot grow — but an import-time feeder
+   * resolves paths as it loads, so a class first minted after the previous drain would stay invisible
+   * behind a stale set. Called once per drained chunk; the next {@link #add} re-resolves.
    */
   public void refreshIndexedPaths() {
     resolvedPCRs = null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathNode.java
@@ -433,6 +433,11 @@ public final class PathNode implements StructNode, NameNode {
   }
 
   @Override
+  public void setChildCount(final long childCount) {
+    this.childCount = childCount;
+  }
+
+  @Override
   public long getDescendantCount() {
     return descendantCount;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
@@ -350,6 +350,27 @@ public final class PathSummaryWriter<R extends NodeCursor & NodeReadOnlyTrx>
    * @param parentPathNodeKey path node key of the OBJECT_KEY parent (must be a valid path node)
    * @return path node key of the {@code __array__/ARRAY} child (existing or freshly inserted)
    */
+  /**
+   * Apply {@code delta} deferred reference-count increments to an existing path node in ONE record
+   * touch. The bulk assembler resolves a path class once (which counts its first occurrence via the
+   * ordinary resolution path) and counts repeats locally; this applies the accumulated repeats at
+   * epoch boundaries, so committed reference counts are EXACTLY what per-occurrence counting
+   * produces while the per-occurrence record modifications disappear. The equivalence oracle's
+   * path-summary dump (references included) pins that equality.
+   *
+   * @param pathNodeKey the existing path node
+   * @param delta how many additional references to record; must be positive
+   */
+  public void addReferences(final long pathNodeKey, final int delta) {
+    if (delta <= 0) {
+      throw new IllegalArgumentException("delta must be positive: " + delta);
+    }
+    final PathNode pathNode = storageEngineWriter.prepareRecordForModification(pathNodeKey, IndexType.PATH_SUMMARY, 0);
+    pathNode.setReferenceCount(pathNode.getReferences() + delta);
+    persistPathSummaryRecord(pathNode);
+    pathSummaryReader.putMapping(pathNode.getNodeKey(), pathNode);
+  }
+
   public long getArrayChildPathNodeKey(final long parentPathNodeKey) {
     if (parentPathNodeKey < 0) {
       throw new IllegalArgumentException("parentPathNodeKey must be a valid path node key");

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
@@ -373,9 +373,9 @@ public final class PathSummaryWriter<R extends NodeCursor & NodeReadOnlyTrx>
    * Apply {@code delta} deferred reference-count increments to an existing path node in ONE record
    * touch. The bulk assembler resolves a path class once (which counts its first occurrence via the
    * ordinary resolution path) and counts repeats locally; this applies the accumulated repeats at
-   * epoch boundaries, so committed reference counts are EXACTLY what per-occurrence counting
-   * produces while the per-occurrence record modifications disappear. The equivalence oracle's
-   * path-summary dump (references included) pins that equality.
+   * epoch boundaries, so committed reference counts are EXACTLY what per-occurrence counting produces
+   * while the per-occurrence record modifications disappear. The equivalence oracle's path-summary
+   * dump (references included) pins that equality.
    *
    * @param pathNodeKey the existing path node
    * @param delta how many additional references to record; must be positive

--- a/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/path/summary/PathSummaryWriter.java
@@ -350,6 +350,25 @@ public final class PathSummaryWriter<R extends NodeCursor & NodeReadOnlyTrx>
    * @param parentPathNodeKey path node key of the OBJECT_KEY parent (must be a valid path node)
    * @return path node key of the {@code __array__/ARRAY} child (existing or freshly inserted)
    */
+  public long getArrayChildPathNodeKey(final long parentPathNodeKey) {
+    if (parentPathNodeKey < 0) {
+      throw new IllegalArgumentException("parentPathNodeKey must be a valid path node key");
+    }
+    final QNm arrayName = ARRAY_PATH_QNM;
+    final long existing = pathSummaryReader.findChild(parentPathNodeKey, arrayName, NodeKind.ARRAY);
+    if (existing >= 0) {
+      final PathNode pathNode = storageEngineWriter.prepareRecordForModification(existing, IndexType.PATH_SUMMARY, 0);
+      pathNode.incrementReferenceCount();
+      persistPathSummaryRecord(pathNode);
+      pathSummaryReader.putMapping(pathNode.getNodeKey(), pathNode);
+      return existing;
+    }
+    pathSummaryReader.moveTo(parentPathNodeKey);
+    final int level = pathSummaryReader.getLevel();
+    insertPathAsFirstChild(arrayName, NodeKind.ARRAY, level + 1);
+    return pathSummaryReader.getNodeKey();
+  }
+
   /**
    * Apply {@code delta} deferred reference-count increments to an existing path node in ONE record
    * touch. The bulk assembler resolves a path class once (which counts its first occurrence via the
@@ -369,25 +388,6 @@ public final class PathSummaryWriter<R extends NodeCursor & NodeReadOnlyTrx>
     pathNode.setReferenceCount(pathNode.getReferences() + delta);
     persistPathSummaryRecord(pathNode);
     pathSummaryReader.putMapping(pathNode.getNodeKey(), pathNode);
-  }
-
-  public long getArrayChildPathNodeKey(final long parentPathNodeKey) {
-    if (parentPathNodeKey < 0) {
-      throw new IllegalArgumentException("parentPathNodeKey must be a valid path node key");
-    }
-    final QNm arrayName = ARRAY_PATH_QNM;
-    final long existing = pathSummaryReader.findChild(parentPathNodeKey, arrayName, NodeKind.ARRAY);
-    if (existing >= 0) {
-      final PathNode pathNode = storageEngineWriter.prepareRecordForModification(existing, IndexType.PATH_SUMMARY, 0);
-      pathNode.incrementReferenceCount();
-      persistPathSummaryRecord(pathNode);
-      pathSummaryReader.putMapping(pathNode.getNodeKey(), pathNode);
-      return existing;
-    }
-    pathSummaryReader.moveTo(parentPathNodeKey);
-    final int level = pathSummaryReader.getLevel();
-    insertPathAsFirstChild(arrayName, NodeKind.ARRAY, level + 1);
-    return pathSummaryReader.getNodeKey();
   }
 
   /** Canonical name of the synthetic {@code __array__/ARRAY} path-summary layer. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalDictionaryBudgetExceededException.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalDictionaryBudgetExceededException.java
@@ -87,13 +87,11 @@ public final class GlobalDictionaryBudgetExceededException extends RuntimeExcept
   static GlobalDictionaryBudgetExceededException structuralDecline(final int column, final long retainedBytes,
       final long budgetBytes, final int entryCount, final String admissionDetail) {
     return new GlobalDictionaryBudgetExceededException(column, retainedBytes, retainedBytes, null, budgetBytes,
-        entryCount,
-        Objects.requireNonNull(admissionDetail, "a structural decline must state which ceiling it hit"));
+        entryCount, Objects.requireNonNull(admissionDetail, "a structural decline must state which ceiling it hit"));
   }
 
-  private GlobalDictionaryBudgetExceededException(final int column, final long retainedBytes,
-      final long breachingBytes, final String breachingTerm, final long budgetBytes, final int entryCount,
-      final String admissionDetail) {
+  private GlobalDictionaryBudgetExceededException(final int column, final long retainedBytes, final long breachingBytes,
+      final String breachingTerm, final long budgetBytes, final int entryCount, final String admissionDetail) {
     super(message(column, retainedBytes, breachingBytes, breachingTerm, budgetBytes, entryCount, admissionDetail));
     this.column = column;
     this.retainedBytes = retainedBytes;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalDictionaryBudgetExceededException.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalDictionaryBudgetExceededException.java
@@ -3,6 +3,8 @@
  */
 package io.sirix.index.projection;
 
+import java.util.Objects;
+
 /**
  * A resource-wide value dictionary declined an aggregate-budget or structural admission while a
  * build was still feeding it.
@@ -21,16 +23,40 @@ package io.sirix.index.projection;
  * recoverable, from a genuine encoding fault, which is not. Same discipline as the projection
  * column store's refusal types — a control-flow signal must never be mistaken for corruption.
  * </p>
+ *
+ * <h2>Why the breaching quantity is carried separately from the retention</h2>
+ *
+ * <p>
+ * Every byte-budget guard compares retention PLUS a reservation — the allocation an insert is about
+ * to make, the workspace a flush needs, the projected flush peak — against the budget, and a
+ * dictionary whose retention ALONE already exceeded the bound would have been refused one admission
+ * earlier. So {@code retainedBytes < budgetBytes} holds on essentially every refusal, and an
+ * operator notice quoting retention against the budget reads as though the guard misfired. The term
+ * that actually tripped the comparison therefore travels with the decline, named
+ * ({@link #breachingTerm()}) and valued ({@link #breachingBytes()}), so the printed arithmetic
+ * explains the breach it announces and the remediation can quote a budget worth raising to.
  */
 public final class GlobalDictionaryBudgetExceededException extends RuntimeException {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   /** The column whose dictionary hit the bound. */
   private final int column;
 
   /** Bytes the dictionary retained when it stopped. */
   private final long retainedBytes;
+
+  /**
+   * The quantity that was actually compared against the budget, in bytes; equal to
+   * {@link #retainedBytes} when no byte comparison took place.
+   */
+  private final long breachingBytes;
+
+  /**
+   * What {@link #breachingBytes} is — {@code "retained+pending"}, {@code "flush-peak"}, … — or
+   * {@code null} when the decline was structural and no byte quantity was weighed at all.
+   */
+  private final String breachingTerm;
 
   /** The bound it was given. */
   private final long budgetBytes;
@@ -41,35 +67,79 @@ public final class GlobalDictionaryBudgetExceededException extends RuntimeExcept
   /** Structural admission reason, or {@code null} for the configured aggregate byte budget. */
   private final String admissionDetail;
 
-  GlobalDictionaryBudgetExceededException(final int column, final long retainedBytes, final long budgetBytes,
-      final int entryCount) {
-    this(column, retainedBytes, budgetBytes, entryCount, null);
+  /**
+   * A byte-budget breach: {@code breachingBytes} is the term the guard weighed, {@code breachingTerm}
+   * names it, and both are reported against {@code budgetBytes}.
+   */
+  static GlobalDictionaryBudgetExceededException budgetBreach(final int column, final long retainedBytes,
+      final long breachingBytes, final String breachingTerm, final long budgetBytes, final int entryCount,
+      final String admissionDetail) {
+    return new GlobalDictionaryBudgetExceededException(column, retainedBytes, breachingBytes,
+        Objects.requireNonNull(breachingTerm, "breachingTerm must name the term that tripped the budget"), budgetBytes,
+        entryCount, admissionDetail);
   }
 
-  GlobalDictionaryBudgetExceededException(final int column, final long retainedBytes, final long budgetBytes,
-      final int entryCount, final String admissionDetail) {
-    super(message(column, retainedBytes, budgetBytes, entryCount, admissionDetail));
+  /**
+   * A structural admission ceiling — a value too long for the V0 layout, an append generation at its
+   * entry limit, a chunk directory at its reference limit. Nothing was weighed against the byte
+   * budget, so nothing may be reported as having exceeded it.
+   */
+  static GlobalDictionaryBudgetExceededException structuralDecline(final int column, final long retainedBytes,
+      final long budgetBytes, final int entryCount, final String admissionDetail) {
+    return new GlobalDictionaryBudgetExceededException(column, retainedBytes, retainedBytes, null, budgetBytes,
+        entryCount,
+        Objects.requireNonNull(admissionDetail, "a structural decline must state which ceiling it hit"));
+  }
+
+  private GlobalDictionaryBudgetExceededException(final int column, final long retainedBytes,
+      final long breachingBytes, final String breachingTerm, final long budgetBytes, final int entryCount,
+      final String admissionDetail) {
+    super(message(column, retainedBytes, breachingBytes, breachingTerm, budgetBytes, entryCount, admissionDetail));
     this.column = column;
     this.retainedBytes = retainedBytes;
+    this.breachingBytes = breachingBytes;
+    this.breachingTerm = breachingTerm;
     this.budgetBytes = budgetBytes;
     this.entryCount = entryCount;
     this.admissionDetail = admissionDetail;
   }
 
-  private static String message(final int column, final long retainedBytes, final long budgetBytes,
-      final int entryCount, final String admissionDetail) {
-    final String reason = admissionDetail == null
-        ? "reached its configured aggregate budget of " + budgetBytes + " B"
-        : "declined an unsafe allocation before mutation: " + admissionDetail;
-    final String remediation = admissionDetail == null
-        ? " Raise the configured byte budget, use per-leaf dictionaries, or split the ingest into"
-            + " bounded append generations."
-        : " Use per-leaf dictionaries or split the ingest into bounded append generations; raising"
-            + " the byte budget cannot override a structural allocation ceiling.";
-    return "Resource-wide value dictionary for column " + column + " " + reason + "; retained " + retainedBytes
-        + " B across " + entryCount
-        + " distinct values. The projection is abandoned for this load (readers fall back to the generic"
-        + " pipeline); the load itself completes." + remediation;
+  private static String message(final int column, final long retainedBytes, final long breachingBytes,
+      final String breachingTerm, final long budgetBytes, final int entryCount, final String admissionDetail) {
+    final StringBuilder message = new StringBuilder(384);
+    message.append("Resource-wide value dictionary for column ").append(column);
+    if (admissionDetail == null) {
+      message.append(" reached its configured aggregate budget of ").append(budgetBytes).append(" B");
+    } else {
+      message.append(" declined an unsafe allocation before mutation: ").append(admissionDetail);
+    }
+    if (breachingTerm != null) {
+      message.append("; its ")
+             .append(breachingTerm)
+             .append(" came to ")
+             .append(breachingBytes)
+             .append(" B, past the ")
+             .append(budgetBytes)
+             .append(" B budget, with ")
+             .append(retainedBytes)
+             .append(" B already retained across ");
+    } else {
+      message.append("; retained ").append(retainedBytes).append(" B across ");
+    }
+    message.append(entryCount)
+           .append(" distinct values. The projection is abandoned for this load (readers fall back to the generic"
+               + " pipeline); the load itself completes.");
+    if (admissionDetail == null) {
+      // The notice's own remedy has to quote a number worth raising to, or it sends the operator
+      // back to guess at the bound the guard already computed for them.
+      message.append(" Raise the configured byte budget to at least ")
+             .append(breachingBytes)
+             .append(" B, use per-leaf dictionaries, or split the ingest into bounded append generations.");
+    } else {
+      message.append(" Use per-leaf dictionaries or split the ingest into bounded append generations; raising"
+          + " the byte budget cannot override a structural allocation ceiling.");
+    }
+    return message.toString();
   }
 
   /** The column whose dictionary hit the bound. */
@@ -80,6 +150,23 @@ public final class GlobalDictionaryBudgetExceededException extends RuntimeExcept
   /** Bytes the dictionary retained when it stopped. */
   public long retainedBytes() {
     return retainedBytes;
+  }
+
+  /**
+   * The quantity the guard actually weighed against {@link #budgetBytes()}, in bytes. Strictly
+   * greater than the budget whenever {@link #breachingTerm()} is non-{@code null}; equal to
+   * {@link #retainedBytes()} for a structural decline, which weighed nothing.
+   */
+  public long breachingBytes() {
+    return breachingBytes;
+  }
+
+  /**
+   * What {@link #breachingBytes()} is, for a message that has to explain its own arithmetic, or
+   * {@code null} when the decline was structural rather than a byte-budget breach.
+   */
+  public String breachingTerm() {
+    return breachingTerm;
   }
 
   /** The bound it was given. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionary.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionary.java
@@ -6,6 +6,7 @@ package io.sirix.index.projection;
 import io.sirix.access.DatabaseType;
 import io.sirix.api.StorageEngineReader;
 import io.sirix.api.json.JsonResourceSession;
+import io.sirix.io.HashAccesses;
 import io.sirix.node.ValueDictionaryHeaderNode;
 import io.sirix.node.interfaces.DataRecord;
 import io.sirix.page.NamePage;
@@ -122,7 +123,9 @@ public final class GlobalValueDictionary {
   }
 
   static long secondaryValueHash(final byte[] utf8, final int off, final int len) {
-    return SECONDARY_HASH.hashBytes(utf8, off, len);
+    // Same xx3 function, Unsafe-free access — identical hash values, minus the per-read
+    // beforeMemoryAccess() deprecation check JDK 25 charges the library's default access.
+    return SECONDARY_HASH.hash(utf8, HashAccesses.BYTES, off, len);
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryProbeFront.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryProbeFront.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import java.util.Arrays;
+
+/**
+ * Resident value→id map fronting one column's streaming global dictionary for the lifetime of a
+ * bulk load.
+ *
+ * <p>
+ * The streaming build rotates bounded {@link GlobalValueDictionaryWriter} generations (each capped
+ * at {@link GlobalValueDictionaryWriter#MAX_DISTINCT_ENTRIES_PER_APPEND} entries by the radix
+ * append's safe-array arithmetic) and releases each one after its flush. Correct for durability —
+ * and catastrophic for interning without this class: once a generation was released, every value
+ * seen before the current epoch had to be re-resolved through the PERSISTENT radix, ~5 record reads
+ * per probe, each a full page decode+checksum through the writer's uncached durable read path.
+ * Measured at ~85% of total load CPU on 150k and 1M ClickBench ingests. This map keeps every
+ * (value, id) pair interned since the load began resident, so a probe is one open-addressing hit
+ * and the persistent radix is never consulted for a value this load has already seen.
+ *
+ * <p>
+ * Deliberately NOT a {@code GlobalValueDictionaryWriter}: the writer enforces the per-append entry
+ * ceiling at intern time (it must stay flushable in one radix append), while this map must hold the
+ * whole load's distinct set — many generations' worth. It holds ids, hashes and value bytes only;
+ * nothing here is ever flushed, so none of the append-planning arithmetic applies. Heap cost is
+ * metered against the same per-column byte budget the election admitted the column under, and
+ * crossing it raises the same typed {@link GlobalDictionaryBudgetExceededException} the abandon
+ * path already understands.
+ *
+ * <p>
+ * Single-threaded by contract, like the builder that owns it. Ids are positive and dense per
+ * column, so id-indexed arrays address the confirm/locate side and {@code 0} doubles as the empty
+ * slot marker in the table.
+ */
+final class GlobalValueDictionaryProbeFront {
+
+  /** Slots, power of two; grown at 50% load so probes stay short. */
+  private static final int INITIAL_TABLE_CAPACITY = 1 << 14;
+
+  private static final int INITIAL_ID_CAPACITY = 1 << 14;
+
+  private static final int INITIAL_ARENA_BYTES = 1 << 20;
+
+  private final int column;
+  private final long budgetBytes;
+
+  /** Primary hash per slot; meaningful only where {@link #tableIds} is non-zero. */
+  private long[] tableHashes = new long[INITIAL_TABLE_CAPACITY];
+
+  /** Id per slot; {@code 0} marks an empty slot (ids start at 1). */
+  private int[] tableIds = new int[INITIAL_TABLE_CAPACITY];
+
+  /** Secondary hash by id, the cheap confirm before the byte compare. */
+  private long[] secondaryHashes = new long[INITIAL_ID_CAPACITY];
+
+  /** Arena offset by id. */
+  private int[] valueOffsets = new int[INITIAL_ID_CAPACITY];
+
+  /** Value length by id. */
+  private int[] valueLengths = new int[INITIAL_ID_CAPACITY];
+
+  /** Value bytes, appended in put order; doubled on demand under the budget. */
+  private byte[] arena = new byte[INITIAL_ARENA_BYTES];
+
+  private int arenaUsed;
+  private int entryCount;
+  private boolean released;
+
+  GlobalValueDictionaryProbeFront(final int column, final long budgetBytes) {
+    if (column < 0) {
+      throw new IllegalArgumentException("column must not be negative: " + column);
+    }
+    if (budgetBytes <= 0) {
+      throw new IllegalArgumentException("budgetBytes must be positive: " + budgetBytes);
+    }
+    this.column = column;
+    this.budgetBytes = budgetBytes;
+  }
+
+  /**
+   * The id this front has recorded for the value, or {@code 0} when the value has not been seen by
+   * this load. Never touches storage.
+   */
+  int findId(final long hash, final long secondaryHash, final byte[] source, final int offset, final int length) {
+    assertLive();
+    final long[] hashes = tableHashes;
+    final int[] ids = tableIds;
+    final int mask = hashes.length - 1;
+    int slot = slotOf(hash, mask);
+    while (true) {
+      final int id = ids[slot];
+      if (id == 0) {
+        return 0;
+      }
+      if (hashes[slot] == hash && secondaryHashes[id] == secondaryHash && valueLengths[id] == length
+          && Arrays.equals(arena, valueOffsets[id], valueOffsets[id] + length, source, offset, offset + length)) {
+        return id;
+      }
+      slot = (slot + 1) & mask;
+    }
+  }
+
+  /**
+   * Record the id minted (or resolved from a durable generation) for a value {@link #findId} just
+   * missed. The caller owns the miss-then-put discipline; a duplicate put would shadow the first
+   * entry harmlessly but waste arena bytes, so it is refused loudly instead.
+   */
+  void put(final long hash, final long secondaryHash, final byte[] source, final int offset, final int length,
+      final int id) {
+    assertLive();
+    if (id <= 0) {
+      throw new IllegalArgumentException("dictionary ids are positive: " + id);
+    }
+    ensureBudgetFor(length);
+    if (entryCount * 2 >= tableIds.length) {
+      growTable();
+    }
+    if (id >= secondaryHashes.length) {
+      final int idCapacity = Integer.highestOneBit(id) << 1;
+      secondaryHashes = Arrays.copyOf(secondaryHashes, idCapacity);
+      valueOffsets = Arrays.copyOf(valueOffsets, idCapacity);
+      valueLengths = Arrays.copyOf(valueLengths, idCapacity);
+    }
+    if (arenaUsed + length > arena.length) {
+      int grown = Math.max(arena.length << 1, arenaUsed + length);
+      arena = Arrays.copyOf(arena, grown);
+    }
+    System.arraycopy(source, offset, arena, arenaUsed, length);
+    secondaryHashes[id] = secondaryHash;
+    valueOffsets[id] = arenaUsed;
+    valueLengths[id] = length;
+    arenaUsed += length;
+
+    final long[] hashes = tableHashes;
+    final int[] ids = tableIds;
+    final int mask = hashes.length - 1;
+    int slot = slotOf(hash, mask);
+    while (ids[slot] != 0) {
+      if (hashes[slot] == hash && ids[slot] == id) {
+        throw new IllegalStateException(
+            "value dictionary probe front already holds id " + id + " for column " + column);
+      }
+      slot = (slot + 1) & mask;
+    }
+    hashes[slot] = hash;
+    ids[slot] = id;
+    entryCount++;
+  }
+
+  int entryCount() {
+    return entryCount;
+  }
+
+  long retainedBytes() {
+    return (long) arena.length + (long) tableHashes.length * Long.BYTES + (long) tableIds.length * Integer.BYTES
+        + (long) secondaryHashes.length * Long.BYTES + (long) valueOffsets.length * Integer.BYTES
+        + (long) valueLengths.length * Integer.BYTES;
+  }
+
+  /** Drop every backing array; the front is unusable afterwards. Idempotent. */
+  void release() {
+    released = true;
+    tableHashes = null;
+    tableIds = null;
+    secondaryHashes = null;
+    valueOffsets = null;
+    valueLengths = null;
+    arena = null;
+  }
+
+  private void assertLive() {
+    if (released) {
+      throw new IllegalStateException("value dictionary probe front for column " + column + " is released");
+    }
+  }
+
+  /**
+   * The growth this put may trigger, checked against the budget BEFORE any allocation so a refusal
+   * leaves the front exactly as it was. The projected figure assumes every growable structure
+   * doubles, which over-reserves slightly at the boundary — a refusal one entry early is a far better
+   * failure than an allocation the budget was supposed to prevent.
+   */
+  private void ensureBudgetFor(final int length) {
+    long projected = retainedBytes();
+    if (arenaUsed + length > arena.length) {
+      projected += Math.max(arena.length, length);
+    }
+    if (entryCount * 2 >= tableIds.length) {
+      projected += (long) tableHashes.length * Long.BYTES + (long) tableIds.length * Integer.BYTES;
+    }
+    if (projected > budgetBytes) {
+      throw new GlobalDictionaryBudgetExceededException(column, projected, budgetBytes, entryCount,
+          "resident probe front for the streaming load cannot grow further; the column's whole-load distinct set "
+              + "no longer fits the per-column budget");
+    }
+  }
+
+  private void growTable() {
+    final long[] oldHashes = tableHashes;
+    final int[] oldIds = tableIds;
+    final int newCapacity = oldHashes.length << 1;
+    final long[] newHashes = new long[newCapacity];
+    final int[] newIds = new int[newCapacity];
+    final int mask = newCapacity - 1;
+    for (int i = 0; i < oldIds.length; i++) {
+      final int id = oldIds[i];
+      if (id == 0) {
+        continue;
+      }
+      int slot = slotOf(oldHashes[i], mask);
+      while (newIds[slot] != 0) {
+        slot = (slot + 1) & mask;
+      }
+      newHashes[slot] = oldHashes[i];
+      newIds[slot] = id;
+    }
+    tableHashes = newHashes;
+    tableIds = newIds;
+  }
+
+  private static int slotOf(final long hash, final int mask) {
+    // Spread the low bits with the high ones; valueHash is already a 64-bit mix, this just folds it.
+    return (int) (hash ^ (hash >>> 32)) & mask;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryProbeFront.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryProbeFront.java
@@ -191,7 +191,8 @@ final class GlobalValueDictionaryProbeFront {
       projected += (long) tableHashes.length * Long.BYTES + (long) tableIds.length * Integer.BYTES;
     }
     if (projected > budgetBytes) {
-      throw new GlobalDictionaryBudgetExceededException(column, projected, budgetBytes, entryCount,
+      throw GlobalDictionaryBudgetExceededException.budgetBreach(column, retainedBytes(), projected,
+          "projected-resident", budgetBytes, entryCount,
           "resident probe front for the streaming load cannot grow further; the column's whole-load distinct set "
               + "no longer fits the per-column budget");
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryWriter.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GlobalValueDictionaryWriter.java
@@ -409,9 +409,15 @@ public final class GlobalValueDictionaryWriter implements GlobalValueDictionaryE
     final long futureRetained = saturatedAdd(retainedBytes(),
         retainedGrowthBytes(requiredChunks, arenaChunkCapacity, idArrayCapacity, tableCapacity));
     final long flushPeak = flushPeakBytes(futureRetained, id, requiredArenaLength, Math.max(maxValueLength, len));
-    if (budgetBytes != Long.MAX_VALUE
-        && Math.max(saturatedAdd(retainedBytes(), allocationBytes), flushPeak) > budgetBytes) {
-      refuseAdmission(null);
+    final long retainedPlusPending = saturatedAdd(retainedBytes(), allocationBytes);
+    if (budgetBytes != Long.MAX_VALUE && Math.max(retainedPlusPending, flushPeak) > budgetBytes) {
+      // Report whichever of the two terms the max() picked, so the notice quotes the number that
+      // actually breached rather than a smaller one the reader cannot reconcile with the budget.
+      if (retainedPlusPending >= flushPeak) {
+        refuseBudget(retainedPlusPending, "retained+pending");
+      } else {
+        refuseBudget(flushPeak, "flush-peak");
+      }
     }
 
     final long[] nextOffsets = idArrayCapacity == offsets.length
@@ -725,8 +731,9 @@ public final class GlobalValueDictionaryWriter implements GlobalValueDictionaryE
   }
 
   private void ensureFlushFitsBudget(final long reservationBytes) {
-    if (budgetBytes != Long.MAX_VALUE && saturatedAdd(retainedBytes(), reservationBytes) > budgetBytes) {
-      refuseAdmission(null);
+    final long retainedPlusReservation = saturatedAdd(retainedBytes(), reservationBytes);
+    if (budgetBytes != Long.MAX_VALUE && retainedPlusReservation > budgetBytes) {
+      refuseBudget(retainedPlusReservation, "retained+flush-reservation");
     }
   }
 
@@ -738,22 +745,47 @@ public final class GlobalValueDictionaryWriter implements GlobalValueDictionaryE
     if (workspaceBytes < 0) {
       throw new IllegalArgumentException("workspaceBytes must be non-negative");
     }
-    if (budgetBytes != Long.MAX_VALUE && saturatedAdd(retainedBytes(), workspaceBytes) > budgetBytes) {
-      refuseAdmission(null);
+    final long retainedPlusWorkspace = saturatedAdd(retainedBytes(), workspaceBytes);
+    if (budgetBytes != Long.MAX_VALUE && retainedPlusWorkspace > budgetBytes) {
+      refuseBudget(retainedPlusWorkspace, "retained+append-workspace");
     }
   }
 
+  /**
+   * Refuse a STRUCTURAL admission — a ceiling that is not weighed in bytes against the budget, so the
+   * decline must not claim any byte quantity exceeded it.
+   */
   private void refuseAdmission(final String detail) {
-    final GlobalDictionaryBudgetExceededException decline =
-        new GlobalDictionaryBudgetExceededException(column, retainedBytes(), budgetBytes, entryCount, detail);
+    throw policyDecline(GlobalDictionaryBudgetExceededException.structuralDecline(column, retainedBytes(), budgetBytes,
+        entryCount, detail), detail);
+  }
+
+  /**
+   * Refuse a BYTE-BUDGET admission, carrying the term the guard actually compared against the budget.
+   *
+   * <p>
+   * Every guard here weighs retention plus a reservation, never retention alone, so the decline has
+   * to carry that sum: quoting {@link #retainedBytes()} instead would report a figure BELOW the
+   * budget it announces as breached — the guard's own arithmetic, contradicted by its own message.
+   * </p>
+   *
+   * @param breachingBytes the quantity that exceeded {@link #budgetBytes}
+   * @param breachingTerm what that quantity is, for a message that explains itself
+   */
+  private void refuseBudget(final long breachingBytes, final String breachingTerm) {
+    throw policyDecline(GlobalDictionaryBudgetExceededException.budgetBreach(column, retainedBytes(), breachingBytes,
+        breachingTerm, budgetBytes, entryCount, null), null);
+  }
+
+  private RuntimeException policyDecline(final GlobalDictionaryBudgetExceededException decline, final String detail) {
     if (admissionPolicy == AdmissionPolicy.FAIL_CLOSED) {
-      throw new IllegalStateException("Forced global value dictionary for column " + column
+      return new IllegalStateException("Forced global value dictionary for column " + column
           + " cannot continue safely: " + (detail == null
               ? "configured aggregate budget exhausted"
               : detail),
           decline);
     }
-    throw decline;
+    return decline;
   }
 
   /**
@@ -779,8 +811,8 @@ public final class GlobalValueDictionaryWriter implements GlobalValueDictionaryE
   static RuntimeException oversizedValueRefusal(final int column, final int length, final long retainedBytes,
       final long budgetBytes, final int entryCount, final AdmissionPolicy admissionPolicy) {
     final String detail = "value length " + length + " exceeds the safe V0 limit of " + MAX_VALUE_BYTES + " bytes";
-    final GlobalDictionaryBudgetExceededException decline =
-        new GlobalDictionaryBudgetExceededException(column, retainedBytes, budgetBytes, entryCount, detail);
+    final GlobalDictionaryBudgetExceededException decline = GlobalDictionaryBudgetExceededException.structuralDecline(
+        column, retainedBytes, budgetBytes, entryCount, detail);
     if (admissionPolicy == AdmissionPolicy.FAIL_CLOSED) {
       return new IllegalStateException(
           "Forced global value dictionary for column " + column + " cannot continue safely: " + detail, decline);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
@@ -425,8 +425,8 @@ public final class ProjectionBulkLoad {
    * state.
    */
   /**
-   * A chunk batch bound to this build's current field resolution — the parallel importer requests
-   * one per chunk, at dispatch, AFTER the chunk's new paths were resolved into the path summary.
+   * A chunk batch bound to this build's current field resolution — the parallel importer requests one
+   * per chunk, at dispatch, AFTER the chunk's new paths were resolved into the path summary.
    */
   public ProjectionChunkRowBatch newChunkBatch(final PathSummaryReader pathSummary, final int expectedRows,
       final long recordSetKey) {
@@ -436,9 +436,9 @@ public final class ProjectionBulkLoad {
   /**
    * Append one worker-extracted row, in document order — the coordinator-fed replacement for the
    * {@link #observeRecord}/{@link #drain} pair: the row's values come from the batch instead of a
-   * record re-read, and its order label from the in-order append lane instead of an ancestry walk,
-   * so nothing here reads the document. Storage and a dictionary generation are bound lazily per
-   * storage epoch; the rotation drain flushes the generation and unbinds, which is what keeps the
+   * record re-read, and its order label from the in-order append lane instead of an ancestry walk, so
+   * nothing here reads the document. Storage and a dictionary generation are bound lazily per storage
+   * epoch; the rotation drain flushes the generation and unbinds, which is what keeps the
    * resource-wide dictionary rotating exactly as it does for the notification-fed load.
    */
   public void appendCoordinatorRow(final StorageEngineWriter storageEngineWriter, final ProjectionChunkRowBatch batch,

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
@@ -149,6 +149,20 @@ public final class ProjectionBulkLoad {
   /** Storage of the CURRENT epoch; set on entry to every method that writes. */
   private @Nullable ProjectionIndexHOTStorage storage;
 
+  /**
+   * COORDINATOR-FED mode: the parallel importer extracts rows in its build workers and appends them
+   * here directly, in document order, so the drain never re-reads a record through the transaction.
+   * Engaged by the first {@link #appendCoordinatorRow}; from then on the notification entry points
+   * refuse, because the same records must not arrive through two mechanisms.
+   */
+  private boolean coordinatorFeed;
+
+  /** Epoch-lived order-label lane of the coordinator feed; bound with {@link #storage}. */
+  private ProjectionStructuralOrderDirectory.@Nullable Accessor feedDirectory;
+
+  /** The previous record's LOCAL order label — the in-order append lane's carry state. */
+  private @Nullable SirixDeweyID feedLastRecordLocal;
+
   private boolean finished;
 
   /**
@@ -410,7 +424,64 @@ public final class ProjectionBulkLoad {
    * back into an already-extracted record), and continuing would silently drop that record's new
    * state.
    */
+  /**
+   * A chunk batch bound to this build's current field resolution — the parallel importer requests
+   * one per chunk, at dispatch, AFTER the chunk's new paths were resolved into the path summary.
+   */
+  public ProjectionChunkRowBatch newChunkBatch(final PathSummaryReader pathSummary, final int expectedRows,
+      final long recordSetKey) {
+    return builder.newChunkBatch(pathSummary, expectedRows, recordSetKey);
+  }
+
+  /**
+   * Append one worker-extracted row, in document order — the coordinator-fed replacement for the
+   * {@link #observeRecord}/{@link #drain} pair: the row's values come from the batch instead of a
+   * record re-read, and its order label from the in-order append lane instead of an ancestry walk,
+   * so nothing here reads the document. Storage and a dictionary generation are bound lazily per
+   * storage epoch; the rotation drain flushes the generation and unbinds, which is what keeps the
+   * resource-wide dictionary rotating exactly as it does for the notification-fed load.
+   */
+  public void appendCoordinatorRow(final StorageEngineWriter storageEngineWriter, final ProjectionChunkRowBatch batch,
+      final int row, final long recordKey, final long containerKey, final long documentRootKey) {
+    if (finished) {
+      throw new IllegalStateException("Projection index " + indexDef.getID() + " on " + key + " was fed record "
+          + recordKey + " after its load-time build was finished.");
+    }
+    if (recordKey <= lastClosedRecordKey) {
+      throw new IllegalStateException("Projection index " + indexDef.getID() + " on " + key
+          + " is coordinator-fed in document order, which is append-only: record " + recordKey
+          + " arrived after record " + lastClosedRecordKey + " had already been appended.");
+    }
+    try {
+      coordinatorFeed = true;
+      ProjectionStructuralOrderDirectory.Accessor directory = feedDirectory;
+      if (storage == null || directory == null) {
+        final ProjectionIndexHOTStorage currentStorage =
+            ProjectionIndexHOTStorage.forBulkBuild(storageEngineWriter, indexDef.getID());
+        this.storage = currentStorage;
+        directory = ProjectionStructuralOrderDirectory.open(currentStorage);
+        this.feedDirectory = directory;
+        builder.beginStreamingDictionaryEpoch(storageEngineWriter);
+      }
+      final SirixDeweyID orderLabel =
+          directory.fullLabelForInOrderAppend(recordKey, containerKey, documentRootKey, feedLastRecordLocal);
+      builder.appendBatchRow(batch, row, recordKey, orderLabel);
+      feedLastRecordLocal = directory.lastInOrderAppendedLocal();
+      lastClosedRecordKey = recordKey;
+      diagObserved++;
+      diagClosed++;
+    } catch (final Throwable failure) {
+      poisonAfterFailure(failure);
+      throw ProjectionBulkLoad.<RuntimeException>rethrowUnchecked(failure);
+    }
+  }
+
   public void observeRecord(final long recordKey) {
+    if (coordinatorFeed) {
+      throw new IllegalStateException("Projection index " + indexDef.getID() + " on " + key
+          + " is coordinator-fed; a change notification for record " + recordKey
+          + " would announce the same records through a second mechanism.");
+    }
     if (recordKey == currentRecordKey) {
       return;
     }
@@ -436,12 +507,22 @@ public final class ProjectionBulkLoad {
           + "(2) keep the load append-only and make these updates AFTER its final commit, where ordinary "
           + "incremental maintenance handles them.");
     }
+    closeCurrentRecord();
+    currentRecordKey = recordKey;
+  }
+
+  /**
+   * Close the open record without starting another. {@link #observeRecord} holds the current record
+   * back because a shredder's notification arrives mid-subtree: an extraction there would store a
+   * half-built row, so the record is closed only when a later one begins.
+   */
+  private void closeCurrentRecord() {
     if (currentRecordKey >= 0) {
       completedRecordKeys.add(currentRecordKey);
       lastClosedRecordKey = currentRecordKey;
       diagClosed++;
+      currentRecordKey = -1L;
     }
-    currentRecordKey = recordKey;
   }
 
   /**
@@ -459,6 +540,16 @@ public final class ProjectionBulkLoad {
     Throwable primaryFailure = null;
     try {
       countArrayRootRecords(rtx);
+      if (coordinatorFeed) {
+        // Rows were appended at adoption, straight from the worker batches; the drain's only jobs
+        // here are the record-count refresh above and closing the epoch: flush the dictionary
+        // generation begun by the epoch's first append — the rotation that lifts the per-append
+        // ceiling — and let the finally below unbind the epoch's storage and label lane.
+        if (storage != null) {
+          builder.flushStreamingDictionaryGeneration(storageEngineWriter);
+        }
+        return;
+      }
       if (completedRecordKeys.isEmpty()) {
         return;
       }
@@ -511,6 +602,7 @@ public final class ProjectionBulkLoad {
         cleanupFailure = failure;
       } finally {
         this.storage = null;
+        this.feedDirectory = null;
       }
       if (cleanupFailure != null) {
         if (primaryFailure != null) {
@@ -558,11 +650,7 @@ public final class ProjectionBulkLoad {
     if (finished) {
       return;
     }
-    if (currentRecordKey >= 0) {
-      completedRecordKeys.add(currentRecordKey);
-      lastClosedRecordKey = currentRecordKey;
-      currentRecordKey = -1L;
-    }
+    closeCurrentRecord();
     // EVERYTHING inside the try, the shape and row-count checks included: a build that fails one of
     // them is dead either way, and its registry entry has to be retired regardless or the definition
     // stays "already loading" for the life of the JVM and a retry cannot even arm. Failing before

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionBulkLoad.java
@@ -486,6 +486,15 @@ public final class ProjectionBulkLoad {
           diagExtractFailures++;
         }
       }
+      // The per-epoch generation flush is deliberate and must stay: each generation is bounded by
+      // the radix append's MAX_DISTINCT_ENTRIES_PER_APPEND ceiling, and rotating bounded writers is
+      // the ONLY way a column's dictionary exceeds that ceiling. (Skipping this call and keeping
+      // one whole-load writer was tried: the writer's own per-append ceiling aborted every
+      // high-cardinality load mid-way.) What must NOT return is the old probe regime — a released
+      // generation's values re-resolved through the persistent radix per occurrence, ~85% of load
+      // CPU — which the StreamingGlobalDictionary's resident probe front now prevents: it keeps
+      // every (value, id) of the whole load resident, so this flush releases only the WRITER, never
+      // the ability to probe. dictProbes=0 in the load banner is the witness.
       builder.flushStreamingDictionaryGeneration(storageEngineWriter);
     } catch (final Throwable failure) {
       primaryFailure = failure;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionChunkRowBatch.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionChunkRowBatch.java
@@ -10,26 +10,26 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 /**
- * One chunk's projection rows, extracted WHERE THE DATA IS: in the parallel importer's build worker,
- * from the same primitives the worker writes into page bytes, instead of read back node-by-node
- * through the transaction afterwards. The worker feeds this batch as it builds; the coordinator
- * replays the rows into the armed {@link ProjectionBulkLoad}'s streaming builder in document order
- * at adoption.
+ * One chunk's projection rows, extracted WHERE THE DATA IS: in the parallel importer's build
+ * worker, from the same primitives the worker writes into page bytes, instead of read back
+ * node-by-node through the transaction afterwards. The worker feeds this batch as it builds; the
+ * coordinator replays the rows into the armed {@link ProjectionBulkLoad}'s streaming builder in
+ * document order at adoption.
  *
  * <h2>Semantics contract</h2> Cell classification reproduces {@link ProjectionIndexRowExtractor}
  * exactly — same field matching (by PATH CLASS, the {@code pathNodeKey} every named node carries),
- * same presence/poison discipline, same numeric provenance flags, via the same shared classification
- * helpers. The one intentional divergence: the extractor's work-list DFS visits nested sibling
- * subtrees in REVERSE order, while a worker streams document order. For any field matched at most
- * once per record — every corpus the gates cover — the two are indistinguishable. A duplicate match
- * poisons the cell identically in both orders; only the residual VALUE bytes stored for such a
- * poisoned cell (and the element order of a set column fed by several arrays of one record) can
- * differ, and consumers never read either through a poisoned cell.
+ * same presence/poison discipline, same numeric provenance flags, via the same shared
+ * classification helpers. The one intentional divergence: the extractor's work-list DFS visits
+ * nested sibling subtrees in REVERSE order, while a worker streams document order. For any field
+ * matched at most once per record — every corpus the gates cover — the two are indistinguishable. A
+ * duplicate match poisons the cell identically in both orders; only the residual VALUE bytes stored
+ * for such a poisoned cell (and the element order of a set column fed by several arrays of one
+ * record) can differ, and consumers never read either through a poisoned cell.
  *
- * <h2>Memory discipline</h2> All row-indexed storage is allocated ONCE per chunk, pre-sized from the
- * feeder's member count: flat flag bytes, per-numeric-column long lanes, one growing UTF-8 arena per
- * string column. The per-record hot path allocates nothing; only set columns (absent from typical
- * corpora) allocate per row, mirroring the read-back extractor's own trim allocation.
+ * <h2>Memory discipline</h2> All row-indexed storage is allocated ONCE per chunk, pre-sized from
+ * the feeder's member count: flat flag bytes, per-numeric-column long lanes, one growing UTF-8
+ * arena per string column. The per-record hot path allocates nothing; only set columns (absent from
+ * typical corpora) allocate per row, mirroring the read-back extractor's own trim allocation.
  */
 public final class ProjectionChunkRowBatch {
 
@@ -67,7 +67,9 @@ public final class ProjectionChunkRowBatch {
   /** Numeric/boolean-encoded lanes, allocated only for numeric column kinds. */
   private final long[][] longLanes;
 
-  /** String lanes: one arena plus per-row (offset, length) per string column; length -1 = no value. */
+  /**
+   * String lanes: one arena plus per-row (offset, length) per string column; length -1 = no value.
+   */
   private final byte[][] stringArenas;
   private final int[][] stringOffsets;
   private final int[][] stringLengths;
@@ -109,7 +111,8 @@ public final class ProjectionChunkRowBatch {
     for (int column = 0; column < columns; column++) {
       switch (columnKinds[column]) {
         case ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG,
-            ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_DOUBLE -> longLanes[column] = new long[expectedRows];
+            ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_DOUBLE ->
+          longLanes[column] = new long[expectedRows];
         case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT,
             ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL -> {
           stringArenas[column] = new byte[Math.max(64, expectedRows * 8)];
@@ -141,7 +144,7 @@ public final class ProjectionChunkRowBatch {
         }
         final int[] existing = extras.get(pcr);
         if (existing == null) {
-          extras.put(pcr, new int[] { mapping });
+          extras.put(pcr, new int[] {mapping});
         } else {
           final int[] grown = Arrays.copyOf(existing, existing.length + 1);
           grown[existing.length] = mapping;
@@ -193,7 +196,8 @@ public final class ProjectionChunkRowBatch {
         flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
       } else if (columnKind == ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG) {
         byte updated = (byte) (cellFlags | FLAG_PRESENT);
-        if (ProjectionIndexRowExtractor.isNonIntegral(value) || ProjectionIndexRowExtractor.isLossyLongConversion(value)) {
+        if (ProjectionIndexRowExtractor.isNonIntegral(value)
+            || ProjectionIndexRowExtractor.isLossyLongConversion(value)) {
           updated |= FLAG_NON_INTEGRAL;
         }
         flags[cell] = updated;
@@ -317,8 +321,8 @@ public final class ProjectionChunkRowBatch {
         scratch = new String[8];
         setScratch[column] = scratch;
       } else if (elementCount == scratch.length) {
-        scratch = Arrays.copyOf(scratch, Math.min(ProjectionIndexRowExtractor.MAX_STRING_SET_ELEMENTS_PER_ROW,
-            elementCount * 2));
+        scratch = Arrays.copyOf(scratch,
+            Math.min(ProjectionIndexRowExtractor.MAX_STRING_SET_ELEMENTS_PER_ROW, elementCount * 2));
         setScratch[column] = scratch;
       }
       scratch[elementCount] = new String(utf8, 0, length, StandardCharsets.UTF_8);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionChunkRowBatch.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionChunkRowBatch.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * One chunk's projection rows, extracted WHERE THE DATA IS: in the parallel importer's build worker,
+ * from the same primitives the worker writes into page bytes, instead of read back node-by-node
+ * through the transaction afterwards. The worker feeds this batch as it builds; the coordinator
+ * replays the rows into the armed {@link ProjectionBulkLoad}'s streaming builder in document order
+ * at adoption.
+ *
+ * <h2>Semantics contract</h2> Cell classification reproduces {@link ProjectionIndexRowExtractor}
+ * exactly — same field matching (by PATH CLASS, the {@code pathNodeKey} every named node carries),
+ * same presence/poison discipline, same numeric provenance flags, via the same shared classification
+ * helpers. The one intentional divergence: the extractor's work-list DFS visits nested sibling
+ * subtrees in REVERSE order, while a worker streams document order. For any field matched at most
+ * once per record — every corpus the gates cover — the two are indistinguishable. A duplicate match
+ * poisons the cell identically in both orders; only the residual VALUE bytes stored for such a
+ * poisoned cell (and the element order of a set column fed by several arrays of one record) can
+ * differ, and consumers never read either through a poisoned cell.
+ *
+ * <h2>Memory discipline</h2> All row-indexed storage is allocated ONCE per chunk, pre-sized from the
+ * feeder's member count: flat flag bytes, per-numeric-column long lanes, one growing UTF-8 arena per
+ * string column. The per-record hot path allocates nothing; only set columns (absent from typical
+ * corpora) allocate per row, mirroring the read-back extractor's own trim allocation.
+ */
+public final class ProjectionChunkRowBatch {
+
+  private static final int FLAG_PRESENT = 1;
+  private static final int FLAG_UNREPRESENTABLE = 1 << 1;
+  private static final int FLAG_NON_INTEGRAL = 1 << 2;
+  private static final int FLAG_NON_DOUBLE_SOURCE = 1 << 3;
+  private static final int FLAG_BOOLEAN_VALUE = 1 << 4;
+
+  private static final long NO_OPEN_ARRAY = Long.MIN_VALUE;
+  private static final String[] EMPTY_ELEMENTS = new String[0];
+
+  /**
+   * Field mapping snapshot: the extractor's (pathNodeKey → column) pairs at chunk-dispatch time.
+   * {@link ProjectionIndexRowExtractor#resolveFieldPcrs} REPLACES its arrays on refresh, so these
+   * references are immutable snapshots by construction — no clone needed.
+   */
+  private final long[] fieldPcrKeys;
+  private final int[] fieldPcrColumns;
+  private final byte[] columnKinds;
+
+  /** Primary (pathNodeKey → mapping index); {@link #extraMappings} carries rare duplicate PCRs. */
+  private final Long2IntOpenHashMap firstMappingByPcr;
+  private final Long2ObjectOpenHashMap<int[]> extraMappings;
+
+  private final int expectedRows;
+  private final long recordSetKey;
+
+  /** Root node key of each record row, for the coordinator's independent cross-check. */
+  private final long[] recordRootKeys;
+
+  /** Flat column-major flags: {@code flags[column * expectedRows + row]}. */
+  private final byte[] flags;
+
+  /** Numeric/boolean-encoded lanes, allocated only for numeric column kinds. */
+  private final long[][] longLanes;
+
+  /** String lanes: one arena plus per-row (offset, length) per string column; length -1 = no value. */
+  private final byte[][] stringArenas;
+  private final int[][] stringOffsets;
+  private final int[][] stringLengths;
+  private final int[] stringArenaUsed;
+
+  /** Set lanes (rare): trimmed elements per row, plus the per-record open-collection state. */
+  private final String[][][] setElements;
+  private final String[][] setScratch;
+  private final int[] setScratchLength;
+  private final long[] openSetArrayKey;
+  private final boolean hasSetColumns;
+
+  private int rowCount = -1;
+  private boolean finishedBuild;
+
+  ProjectionChunkRowBatch(final long[] fieldPcrKeys, final int[] fieldPcrColumns, final byte[] columnKinds,
+      final int expectedRows, final long recordSetKey) {
+    if (expectedRows < 0) {
+      throw new IllegalArgumentException("expectedRows must be non-negative: " + expectedRows);
+    }
+    this.fieldPcrKeys = fieldPcrKeys;
+    this.fieldPcrColumns = fieldPcrColumns;
+    this.columnKinds = columnKinds;
+    this.expectedRows = expectedRows;
+    this.recordSetKey = recordSetKey;
+    this.recordRootKeys = new long[expectedRows];
+    final int columns = columnKinds.length;
+    this.flags = new byte[Math.multiplyExact(columns, expectedRows)];
+    this.longLanes = new long[columns][];
+    this.stringArenas = new byte[columns][];
+    this.stringOffsets = new int[columns][];
+    this.stringLengths = new int[columns][];
+    this.stringArenaUsed = new int[columns];
+    this.setElements = new String[columns][][];
+    this.setScratch = new String[columns][];
+    this.setScratchLength = new int[columns];
+    this.openSetArrayKey = new long[columns];
+    boolean anySet = false;
+    for (int column = 0; column < columns; column++) {
+      switch (columnKinds[column]) {
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG,
+            ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_DOUBLE -> longLanes[column] = new long[expectedRows];
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT,
+            ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL -> {
+          stringArenas[column] = new byte[Math.max(64, expectedRows * 8)];
+          stringOffsets[column] = new int[expectedRows];
+          final int[] lengths = new int[expectedRows];
+          Arrays.fill(lengths, -1);
+          stringLengths[column] = lengths;
+        }
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET -> {
+          setElements[column] = new String[expectedRows][];
+          anySet = true;
+        }
+        default -> {
+          // BOOLEAN needs only its flag bit.
+        }
+      }
+      openSetArrayKey[column] = NO_OPEN_ARRAY;
+    }
+    this.hasSetColumns = anySet;
+
+    this.firstMappingByPcr = new Long2IntOpenHashMap(Math.max(4, fieldPcrKeys.length * 2));
+    this.firstMappingByPcr.defaultReturnValue(-1);
+    Long2ObjectOpenHashMap<int[]> extras = null;
+    for (int mapping = 0; mapping < fieldPcrKeys.length; mapping++) {
+      final long pcr = fieldPcrKeys[mapping];
+      if (firstMappingByPcr.putIfAbsent(pcr, mapping) >= 0) {
+        if (extras == null) {
+          extras = new Long2ObjectOpenHashMap<>(4);
+        }
+        final int[] existing = extras.get(pcr);
+        if (existing == null) {
+          extras.put(pcr, new int[] { mapping });
+        } else {
+          final int[] grown = Arrays.copyOf(existing, existing.length + 1);
+          grown[existing.length] = mapping;
+          extras.put(pcr, grown);
+        }
+      }
+    }
+    this.extraMappings = extras == null
+        ? new Long2ObjectOpenHashMap<>(0)
+        : extras;
+  }
+
+  // ==== worker feed (document order, single builder thread per chunk) ==========================
+
+  /** Whether this batch has any set column — lets the worker skip child-value calls entirely. */
+  public boolean trackChildValues() {
+    return hasSetColumns;
+  }
+
+  /** The record-set container whose direct children are this batch's records. */
+  public long recordSetKey() {
+    return recordSetKey;
+  }
+
+  /** A new record root was minted; every following feed call belongs to it. */
+  public void beginRecord(final long recordRootKey) {
+    closeOpenRecord();
+    final int row = rowCount + 1;
+    if (row >= expectedRows) {
+      throw new IllegalStateException("chunk projection batch overflowed its " + expectedRows
+          + " reserved rows at record root " + recordRootKey + " — the feeder's member count and the build disagree");
+    }
+    rowCount = row;
+    recordRootKeys[row] = recordRootKey;
+  }
+
+  public void onNamedNumber(final long pathNodeKey, final Number value) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int column = fieldPcrColumns[mapping];
+      final int cell = cellOf(column);
+      final byte cellFlags = flags[cell];
+      if ((cellFlags & FLAG_PRESENT) != 0) {
+        // A second scalar matching the same declared field: no sequence semantics — poison.
+        flags[cell] = (byte) (cellFlags | FLAG_UNREPRESENTABLE);
+        continue;
+      }
+      final byte columnKind = columnKinds[column];
+      if (!ProjectionIndexRowGroupPage.isNumericKind(columnKind) || value == null) {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+      } else if (columnKind == ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG) {
+        byte updated = (byte) (cellFlags | FLAG_PRESENT);
+        if (ProjectionIndexRowExtractor.isNonIntegral(value) || ProjectionIndexRowExtractor.isLossyLongConversion(value)) {
+          updated |= FLAG_NON_INTEGRAL;
+        }
+        flags[cell] = updated;
+        longLanes[column][rowCount] = value.longValue();
+      } else {
+        final double doubleValue = value.doubleValue();
+        if (!Double.isFinite(doubleValue)) {
+          flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+        } else {
+          byte updated = (byte) (cellFlags | FLAG_PRESENT);
+          if (ProjectionIndexRowExtractor.isLossyDoubleConversion(value, doubleValue)) {
+            updated |= FLAG_NON_INTEGRAL;
+          }
+          if (!(value instanceof Double)) {
+            updated |= FLAG_NON_DOUBLE_SOURCE;
+          }
+          flags[cell] = updated;
+          longLanes[column][rowCount] = ProjectionDoubleEncoding.encode(doubleValue);
+        }
+      }
+    }
+  }
+
+  public void onNamedString(final long pathNodeKey, final byte[] utf8, final int length) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int column = fieldPcrColumns[mapping];
+      final int cell = cellOf(column);
+      final byte cellFlags = flags[cell];
+      if ((cellFlags & FLAG_PRESENT) != 0) {
+        flags[cell] = (byte) (cellFlags | FLAG_UNREPRESENTABLE);
+        continue;
+      }
+      final byte columnKind = columnKinds[column];
+      if (columnKind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT
+          || columnKind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL) {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT);
+        storeString(column, utf8, length);
+      } else {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+      }
+    }
+  }
+
+  public void onNamedBoolean(final long pathNodeKey, final boolean value) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int column = fieldPcrColumns[mapping];
+      final int cell = cellOf(column);
+      final byte cellFlags = flags[cell];
+      if ((cellFlags & FLAG_PRESENT) != 0) {
+        flags[cell] = (byte) (cellFlags | FLAG_UNREPRESENTABLE);
+        continue;
+      }
+      if (columnKinds[column] == ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN) {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT | (value
+            ? FLAG_BOOLEAN_VALUE
+            : 0));
+      } else {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+      }
+    }
+  }
+
+  /** A fused null field: present, and no column kind can represent it. */
+  public void onNamedNull(final long pathNodeKey) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int cell = cellOf(fieldPcrColumns[mapping]);
+      final byte cellFlags = flags[cell];
+      if ((cellFlags & FLAG_PRESENT) != 0) {
+        flags[cell] = (byte) (cellFlags | FLAG_UNREPRESENTABLE);
+      } else {
+        flags[cell] = (byte) (cellFlags | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+      }
+    }
+  }
+
+  /** An object-valued field: present but unrepresentable for every scalar column kind. */
+  public void onNamedObject(final long pathNodeKey) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int cell = cellOf(fieldPcrColumns[mapping]);
+      // The extractor's container branch has no first-match guard: present and poisoned, always.
+      flags[cell] = (byte) (flags[cell] | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+    }
+  }
+
+  /** An array-valued field: a SET column starts collecting its elements; every other kind poisons. */
+  public void onNamedArray(final long pathNodeKey, final long arrayNodeKey) {
+    for (int mapping = firstMapping(pathNodeKey); mapping >= 0; mapping = nextMapping(pathNodeKey, mapping)) {
+      final int column = fieldPcrColumns[mapping];
+      final int cell = cellOf(column);
+      if (columnKinds[column] == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET) {
+        // No first-match guard, mirroring collectStringSet: several arrays of one record matching
+        // the same set column ACCUMULATE elements.
+        flags[cell] = (byte) (flags[cell] | FLAG_PRESENT);
+        openSetArrayKey[column] = arrayNodeKey;
+      } else {
+        flags[cell] = (byte) (flags[cell] | FLAG_PRESENT | FLAG_UNREPRESENTABLE);
+      }
+    }
+  }
+
+  /** A plain string value node; collected when its parent is a set column's open array. */
+  public void onChildValueString(final long parentKey, final byte[] utf8, final int length) {
+    if (!hasSetColumns) {
+      return;
+    }
+    for (int column = 0; column < columnKinds.length; column++) {
+      if (openSetArrayKey[column] != parentKey) {
+        continue;
+      }
+      final int cell = cellOf(column);
+      if ((flags[cell] & FLAG_UNREPRESENTABLE) != 0) {
+        continue;
+      }
+      final int elementCount = setScratchLength[column];
+      if (elementCount == ProjectionIndexRowExtractor.MAX_STRING_SET_ELEMENTS_PER_ROW) {
+        flags[cell] = (byte) (flags[cell] | FLAG_UNREPRESENTABLE);
+        continue;
+      }
+      String[] scratch = setScratch[column];
+      if (scratch == null) {
+        scratch = new String[8];
+        setScratch[column] = scratch;
+      } else if (elementCount == scratch.length) {
+        scratch = Arrays.copyOf(scratch, Math.min(ProjectionIndexRowExtractor.MAX_STRING_SET_ELEMENTS_PER_ROW,
+            elementCount * 2));
+        setScratch[column] = scratch;
+      }
+      scratch[elementCount] = new String(utf8, 0, length, StandardCharsets.UTF_8);
+      setScratchLength[column] = elementCount + 1;
+    }
+  }
+
+  /** Any non-string child; poisons a set column whose open array is its parent. */
+  public void onChildNonString(final long parentKey) {
+    if (!hasSetColumns) {
+      return;
+    }
+    for (int column = 0; column < columnKinds.length; column++) {
+      if (openSetArrayKey[column] == parentKey) {
+        flags[cellOf(column)] = (byte) (flags[cellOf(column)] | FLAG_UNREPRESENTABLE);
+      }
+    }
+  }
+
+  /** Close the batch: verify the build produced exactly the rows the feeder counted. */
+  public void finishBuild() {
+    closeOpenRecord();
+    finishedBuild = true;
+    final int rows = rowCount + 1;
+    if (rows != expectedRows) {
+      throw new IllegalStateException("chunk projection batch holds " + rows + " records but the feeder counted "
+          + expectedRows + " members — a build/feeder divergence, and the projection would be short rows");
+    }
+  }
+
+  private void closeOpenRecord() {
+    if (rowCount < 0) {
+      return;
+    }
+    if (hasSetColumns) {
+      for (int column = 0; column < columnKinds.length; column++) {
+        if (columnKinds[column] != ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET) {
+          continue;
+        }
+        final int elementCount = setScratchLength[column];
+        if (elementCount > 0 && (flags[cellOf(column)] & FLAG_UNREPRESENTABLE) == 0) {
+          final String[] trimmed = new String[elementCount];
+          System.arraycopy(setScratch[column], 0, trimmed, 0, elementCount);
+          setElements[column][rowCount] = trimmed;
+        }
+        setScratchLength[column] = 0;
+        openSetArrayKey[column] = NO_OPEN_ARRAY;
+      }
+    }
+  }
+
+  private void storeString(final int column, final byte[] utf8, final int length) {
+    byte[] arena = stringArenas[column];
+    final int used = stringArenaUsed[column];
+    if (used + length > arena.length) {
+      int grown = Math.max(64, arena.length);
+      while (grown < used + length) {
+        grown = Math.multiplyExact(grown, 2);
+      }
+      arena = Arrays.copyOf(arena, grown);
+      stringArenas[column] = arena;
+    }
+    System.arraycopy(utf8, 0, arena, used, length);
+    stringOffsets[column][rowCount] = used;
+    stringLengths[column][rowCount] = length;
+    stringArenaUsed[column] = used + length;
+  }
+
+  private int cellOf(final int column) {
+    final int row = rowCount;
+    if (row < 0) {
+      throw new IllegalStateException("a chunk projection batch was fed a field before its first record root");
+    }
+    return column * expectedRows + row;
+  }
+
+  private int firstMapping(final long pathNodeKey) {
+    return firstMappingByPcr.get(pathNodeKey);
+  }
+
+  private int nextMapping(final long pathNodeKey, final int previousMapping) {
+    final int[] extras = extraMappings.get(pathNodeKey);
+    if (extras == null) {
+      return -1;
+    }
+    for (final int mapping : extras) {
+      if (mapping > previousMapping) {
+        return mapping;
+      }
+    }
+    return -1;
+  }
+
+  // ==== coordinator read side (after the build future resolves) ================================
+
+  public int rowCount() {
+    if (!finishedBuild) {
+      throw new IllegalStateException("chunk projection batch read before its build finished");
+    }
+    return rowCount + 1;
+  }
+
+  public long recordRootAt(final int row) {
+    return recordRootKeys[row];
+  }
+
+  byte[] columnKindsSnapshot() {
+    return columnKinds;
+  }
+
+  boolean flagPresent(final int column, final int row) {
+    return (flags[column * expectedRows + row] & FLAG_PRESENT) != 0;
+  }
+
+  boolean flagUnrepresentable(final int column, final int row) {
+    return (flags[column * expectedRows + row] & FLAG_UNREPRESENTABLE) != 0;
+  }
+
+  boolean flagNonIntegral(final int column, final int row) {
+    return (flags[column * expectedRows + row] & FLAG_NON_INTEGRAL) != 0;
+  }
+
+  boolean flagNonDoubleSource(final int column, final int row) {
+    return (flags[column * expectedRows + row] & FLAG_NON_DOUBLE_SOURCE) != 0;
+  }
+
+  boolean booleanValue(final int column, final int row) {
+    return (flags[column * expectedRows + row] & FLAG_BOOLEAN_VALUE) != 0;
+  }
+
+  long longValue(final int column, final int row) {
+    return longLanes[column][row];
+  }
+
+  byte[] stringArena(final int column) {
+    return stringArenas[column];
+  }
+
+  int stringOffset(final int column, final int row) {
+    return stringOffsets[column][row];
+  }
+
+  int stringLength(final int column, final int row) {
+    return stringLengths[column][row];
+  }
+
+  String[] setElementsAt(final int column, final int row) {
+    final String[] elements = setElements[column][row];
+    return elements == null
+        ? EMPTY_ELEMENTS
+        : elements;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -12,6 +12,7 @@ import org.jspecify.annotations.Nullable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
@@ -666,6 +667,24 @@ public final class ProjectionColumnStore {
             || columnKinds[col] == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET);
   }
 
+  /** RAW bytes the BODY chain of {@code col} spans — what a raw-bytes fill retains. */
+  private long projectedColumnBodyFillBytes(final int col) {
+    if (col < 0 || col >= columnKinds.length) {
+      return 0;
+    }
+    final int bodySegId = ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col);
+    long total = 0;
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      final byte[] descriptor = directories.get(i).descriptor();
+      final int bodyEntry = RowGroupDescriptor.entryIndexOf(descriptor, bodySegId);
+      if (bodyEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, bodyEntry);
+      }
+    }
+    return total;
+  }
+
   /**
    * RAW bytes a MASKED fill of {@code col} would fetch: the same BODY (+DICT) walk
    * {@link #projectedColumnFillBytes} does, restricted to the leaves the keep mask leaves standing.
@@ -714,7 +733,8 @@ public final class ProjectionColumnStore {
    * @return {@code true} when {@link #projectedColumnFillBytes} is within the budget
    */
   public boolean columnFillWithinBudget(final int col) {
-    return col >= 0 && col < columnKinds.length && projectedColumnFillBytes(col) <= columnFillBudgetBytes;
+    return col >= 0 && col < columnKinds.length
+        && retainedFillBytes.get() + projectedColumnFillBytes(col) <= columnFillBudgetBytes;
   }
 
   /**
@@ -769,11 +789,7 @@ public final class ProjectionColumnStore {
     // the store — the projected size is a property of the column, recomputed cheaply, and a later
     // caller with a raised budget must be able to fill.
     final long projected = projectedColumnFillBytes(col);
-    if (projected > columnFillBudgetBytes) {
-      throw new FillBudgetExceededException("Column " + col + " slice fill projects " + projected + " B over the "
-          + columnFillBudgetBytes + " B budget (sirix.projection.eagerMaterializeBytes) — declining the "
-          + "whole-column fill so the whole-leaf windowed route serves instead");
-    }
+    checkFillBudget(col, projected, "slice fill");
     // Fill OUTSIDE the monitor: the fetch+decode is the store's only I/O and must not
     // serialize other columns (or evidence readers) behind it. A same-column race does the
     // work twice with identical results — first publish wins.
@@ -787,6 +803,7 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = columns.clone();
       next[col] = slices;
       columns = next;
+      retainedFillBytes.addAndGet(projected);
     }
     return slices;
   }
@@ -888,6 +905,48 @@ public final class ProjectionColumnStore {
     }
   }
 
+  /**
+   * Bytes this store has RETAINED across every published fill — the cumulative half of the budget.
+   *
+   * <p>
+   * {@code columnFillBudgetBytes} is a per-column figure, but published fills are kept for the
+   * store's whole cache lifetime, so a handle's residency is the SUM over the columns a query mix
+   * touches, not any one of them. Without this ledger a ten-column projection with eight columns
+   * each just under the budget retains eight budgets' worth while the cache weigher charges one.
+   * Charging every publish makes that weight an honest upper bound by construction.
+   * </p>
+   *
+   * <p>
+   * The charge is per PUBLISH and may double-count BODY bytes shared between a raw-bytes fill and
+   * an identity fill of the same column. That direction is deliberate: over-counting declines
+   * earlier, which is the safe side of a residency cap.
+   * </p>
+   */
+  private final AtomicLong retainedFillBytes = new AtomicLong();
+
+  /** Bytes retained by published fills so far — observability for the budget witness. */
+  public long retainedFillBytes() {
+    return retainedFillBytes.get();
+  }
+
+  /**
+   * Refuse a fill whose bytes would not fit beside what this store already retains.
+   *
+   * @param col the column
+   * @param projected the fill's projected bytes
+   * @param mode names the fill mode in the decline message
+   * @throws FillBudgetExceededException when the cumulative cap would be exceeded
+   */
+  private void checkFillBudget(final int col, final long projected, final String mode) {
+    final long retained = retainedFillBytes.get();
+    if (retained + projected > columnFillBudgetBytes) {
+      throw new FillBudgetExceededException("Column " + col + " " + mode + " projects " + projected
+          + " B beside " + retained + " B already retained, over the " + columnFillBudgetBytes
+          + " B budget (sirix.projection.eagerMaterializeBytes) — declining the fill; the caller falls back to the "
+          + "whole-leaf windowed route");
+    }
+  }
+
   /** Whether {@code col}'s DISTINCT-IDENTITY slices are already filled and cached. */
   public boolean columnIdentityFilled(final int col) {
     final ColumnSlice[][] slots = identityColumns;
@@ -974,7 +1033,7 @@ public final class ProjectionColumnStore {
    */
   public boolean columnIdentityFillable(final int col) {
     return columnSliceable(col) && (columnFilled(col) || columnIdentityFilled(col)
-        || projectedColumnIdentityFillBytes(col) <= columnFillBudgetBytes);
+        || retainedFillBytes.get() + projectedColumnIdentityFillBytes(col) <= columnFillBudgetBytes);
   }
 
   /**
@@ -1023,6 +1082,8 @@ public final class ProjectionColumnStore {
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
+    final long projectedIdentity = projectedColumnIdentityFillBytes(col);
+    checkFillBudget(col, projectedIdentity, "distinct-identity fill");
     slices = fillIdentityColumn(col, fetcher);
     if (slices == null) {
       return column(col, fetcher); // no leaf carries hashes — the whole column falls back
@@ -1035,6 +1096,7 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = identityColumns.clone();
       next[col] = slices;
       identityColumns = next;
+      retainedFillBytes.addAndGet(projectedIdentity);
     }
     return slices;
   }
@@ -1222,12 +1284,7 @@ public final class ProjectionColumnStore {
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
-    final long projected = projectedMaskedFillBytes(col, keepWords);
-    if (projected > columnFillBudgetBytes) {
-      throw new FillBudgetExceededException("Column " + col + " masked slice fill projects " + projected
-          + " B over the " + columnFillBudgetBytes + " B budget (sirix.projection.eagerMaterializeBytes) — the "
-          + "keep mask did not prune enough to bring it under, so the whole-leaf windowed route serves instead");
-    }
+    checkFillBudget(col, projectedMaskedFillBytes(col, keepWords), "masked slice fill");
     final byte[][] segments = fetchSegmentChain(col, ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col),
         ProjectionIndexColumnSegmentCodec.SEG_KIND_BODY, false, fetcher, keepWords);
     final boolean set = columnKinds[col] == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET;
@@ -1511,6 +1568,8 @@ public final class ProjectionColumnStore {
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
+    final long projectedBody = projectedColumnBodyFillBytes(col);
+    checkFillBudget(col, projectedBody, "raw BODY fill");
     segments = fetchColumnBytes(col, fetcher);
     synchronized (this) {
       final byte[][] existing = columnBytes[col];
@@ -1520,6 +1579,7 @@ public final class ProjectionColumnStore {
       final byte[][][] next = columnBytes.clone();
       next[col] = segments;
       columnBytes = next;
+      retainedFillBytes.addAndGet(projectedBody);
     }
     return segments;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -826,6 +826,95 @@ public final class ProjectionColumnStore {
     return col >= 0 && col < slots.length && slots[col] != null;
   }
 
+  /** Whether {@code col}'s DISTINCT-IDENTITY slices are already filled and cached. */
+  public boolean columnIdentityFilled(final int col) {
+    final ColumnSlice[][] slots = identityColumns;
+    return col >= 0 && col < slots.length && slots[col] != null;
+  }
+
+  /** Lazily-computed per-column projected DISTINCT-IDENTITY fill bytes; 0 = not yet computed. */
+  private final AtomicReference<long[]> projectedIdentityFillBytes = new AtomicReference<>();
+
+  /**
+   * RAW bytes a {@link #columnDistinctIdentity} fill of {@code col} would fetch, which is a
+   * different — and on a fat dictionary a far smaller — figure than
+   * {@link #projectedColumnFillBytes}: the BODY chain plus the ~8 B/entry
+   * {@link ProjectionIndexColumnSegmentCodec#SEG_KIND_DICT_HASHES} chain, and the DICTIONARY only
+   * for the leaves that carry no hash segment (exactly the fallback keep-mask
+   * {@code fillIdentityColumn} builds).
+   *
+   * <p>
+   * Falls back to {@link #projectedColumnFillBytes} for a non-STRING_DICT column and for the case
+   * {@code fillIdentityColumn} declines outright — NO row-bearing leaf carries hashes — because that
+   * is when the identity request becomes a full fill.
+   * </p>
+   *
+   * @param col the column
+   * @return the projected identity fill bytes
+   */
+  public long projectedColumnIdentityFillBytes(final int col) {
+    if (col < 0 || col >= columnKinds.length
+        || columnKinds[col] != ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT) {
+      return projectedColumnFillBytes(col);
+    }
+    long[] cached = projectedIdentityFillBytes.get();
+    if (cached == null) {
+      cached = new long[columnKinds.length];
+      projectedIdentityFillBytes.compareAndSet(null, cached);
+      cached = projectedIdentityFillBytes.get();
+    }
+    final long known = cached[col];
+    if (known != 0) {
+      return known;
+    }
+    final int bodySegId = ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col);
+    final int dictSegId = ProjectionIndexColumnSegmentCodec.dictColumnSegmentId(col);
+    final int hashSegId = ProjectionIndexColumnSegmentCodec.dictHashColumnSegmentId(col);
+    long total = 0;
+    int rowLeaves = 0;
+    int fallbackLeaves = 0;
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      final byte[] descriptor = directories.get(i).descriptor();
+      final int bodyEntry = RowGroupDescriptor.entryIndexOf(descriptor, bodySegId);
+      if (bodyEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, bodyEntry);
+      }
+      if (RowGroupDescriptor.rowCount(descriptor) == 0) {
+        continue;
+      }
+      rowLeaves++;
+      final int hashEntry = RowGroupDescriptor.entryIndexOf(descriptor, hashSegId);
+      if (hashEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, hashEntry);
+        continue;
+      }
+      fallbackLeaves++;
+      final int dictEntry = RowGroupDescriptor.entryIndexOf(descriptor, dictSegId);
+      if (dictEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
+      }
+    }
+    if (rowLeaves > 0 && fallbackLeaves == rowLeaves) {
+      return projectedColumnFillBytes(col);
+    }
+    cached[col] = Math.max(1, total);
+    return cached[col];
+  }
+
+  /**
+   * Whether the sliced route is VIABLE for {@code col} when it will be filled in DISTINCT-IDENTITY
+   * mode — the {@code COUNT(DISTINCT)} operand's mode. Asking {@link #columnFillable} instead
+   * rejects a fat dictionary column on a projection the identity fill never fetches.
+   *
+   * @param col the column
+   * @return {@code true} when the identity fill can actually serve this column
+   */
+  public boolean columnIdentityFillable(final int col) {
+    return columnSliceable(col) && (columnFilled(col) || columnIdentityFilled(col)
+        || projectedColumnIdentityFillBytes(col) <= columnFillBudgetBytes);
+  }
+
   /**
    * A STRING_DICT column's slices in DISTINCT-IDENTITY mode: per-row dict ids beside the
    * {@link ProjectionIndexColumnSegmentCodec#SEG_KIND_DICT_HASHES} segment's precomputed content

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -766,7 +766,8 @@ public final class ProjectionColumnStore {
    */
   public boolean columnFillWithinBudget(final int col) {
     return col >= 0 && col < columnKinds.length
-        && retainedFillBytes.get() + projectedColumnFillBytes(col) <= columnFillBudgetBytes;
+        && retainedFillBytes.get() + incrementalFillBytes(col, projectedColumnFillBytes(col))
+            <= columnFillBudgetBytes;
   }
 
   /**
@@ -821,7 +822,7 @@ public final class ProjectionColumnStore {
     // the store — the projected size is a property of the column, recomputed cheaply, and a later
     // caller with a raised budget must be able to fill.
     final long projected = projectedColumnFillBytes(col);
-    checkFillBudget(col, projected, "slice fill");
+    checkFillBudget(col, incrementalFillBytes(col, projected), "slice fill");
     // Fill OUTSIDE the monitor: the fetch+decode is the store's only I/O and must not
     // serialize other columns (or evidence readers) behind it. A same-column race does the
     // work twice with identical results — first publish wins.
@@ -835,7 +836,9 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = columns.clone();
       next[col] = slices;
       columns = next;
-      chargeRetained(col, projected);
+      // Re-priced HERE, not reused from the check: the fill above ran the inner raw-BODY door,
+      // which may have published and charged that chain in between. Same helper, later moment.
+      retainedFillBytes.addAndGet(incrementalFillBytes(col, projected));
     }
     return slices;
   }
@@ -1021,9 +1024,10 @@ public final class ProjectionColumnStore {
    * </p>
    *
    * <p>
-   * The charge is per PUBLISH and may double-count BODY bytes shared between a raw-bytes fill and
-   * an identity fill of the same column. That direction is deliberate: over-counting declines
-   * earlier, which is the safe side of a residency cap.
+   * Every retained byte is counted exactly ONCE. A slice fill and an identity fill both reach
+   * {@link #columnBytes}, which publishes and charges the BODY chain itself, so the outer door adds
+   * only what it brings on top — see {@link #incrementalFillBytes}, which the budget CHECK and this
+   * ledger's CHARGE both consume so the gate and the total cannot disagree about what a fill costs.
    * </p>
    */
   private final AtomicLong retainedFillBytes = new AtomicLong();
@@ -1040,23 +1044,40 @@ public final class ProjectionColumnStore {
   }
 
   /**
-   * Charge a published fill, MINUS whatever a nested door already charged for the same bytes.
+   * What a fill of {@code col} priced at {@code projected} would ADD to this store's residency:
+   * the gross projection minus the bytes already retained AND already charged for that same column.
    *
    * <p>
-   * A slice fill and an identity fill both run through {@link #columnBytes}, which prices and
-   * charges the BODY chain on its own account — so charging the outer door's full projection on top
-   * counted one retained copy of those arrays twice. The ledger is monotonic and feeds the decline
-   * predicates, so over-charging steers servable queries off the sliced route for residency that is
-   * not there. Subtracting what is already charged makes the total independent of which door was
-   * entered first, which a re-entrancy flag alone would not: the BODY chain is equally shared when
-   * {@code columnBytes} is entered directly and the slice fill follows later.
+   * The one place that subtraction lives, because the budget CHECK and the ledger CHARGE have to
+   * agree about it. A slice fill and an identity fill both reach {@link #columnBytes}, which
+   * publishes and charges the BODY chain on its own account — so once a fused fold scan has filled
+   * those raw bytes, a later slice fill of the same column adds only its decoded arrays. Pricing
+   * the check at the gross figure while charging the increment made the gate refuse fills whose
+   * true residency fit the budget, steering servable queries onto the slower whole-leaf route for
+   * bytes that were already counted.
    * </p>
+   *
+   * <p>
+   * Only for the doors that REUSE the published BODY arrays. A masked fill re-fetches the surviving
+   * leaves into fresh arrays and a record-key fill has no column, so both are priced gross.
+   * </p>
+   *
+   * <p>
+   * Evaluated TWICE per fill, deliberately: once before the fetch to gate it, once at publish to
+   * charge it. What is already retained legitimately changes in between — the fill itself runs the
+   * inner raw-BODY door — so a single value captured up front would charge for bytes the inner door
+   * had just accounted for.
+   * </p>
+   *
+   * @param col the column, or negative for a store-wide fill
+   * @param projected the fill's gross projection
+   * @return the bytes the fill would add
    */
-  private void chargeRetained(final int col, final long projected) {
-    final long alreadyCharged = columnBytesFilled(col)
+  private long incrementalFillBytes(final int col, final long projected) {
+    final long alreadyRetained = columnBytesFilled(col)
         ? projectedColumnBodyFillBytes(col)
         : 0;
-    retainedFillBytes.addAndGet(Math.max(0, projected - alreadyCharged));
+    return Math.max(0, projected - alreadyRetained);
   }
 
   /**
@@ -1072,7 +1093,7 @@ public final class ProjectionColumnStore {
     if (retained + projected > columnFillBudgetBytes) {
       throw new FillBudgetExceededException((col < 0
           ? "The store's "
-          : "Column " + col + " ") + mode + " projects " + projected
+          : "Column " + col + " ") + mode + " adds " + projected
           + " B beside " + retained + " B already retained, over the " + columnFillBudgetBytes
           + " B budget (sirix.projection.eagerMaterializeBytes) — declining the fill; the caller falls back to the "
           + "whole-leaf windowed route");
@@ -1168,7 +1189,8 @@ public final class ProjectionColumnStore {
    */
   public boolean columnIdentityFillable(final int col) {
     return columnSliceable(col) && (columnFilled(col) || columnIdentityFilled(col)
-        || retainedFillBytes.get() + projectedColumnIdentityFillBytes(col) <= columnFillBudgetBytes);
+        || retainedFillBytes.get() + incrementalFillBytes(col, projectedColumnIdentityFillBytes(col))
+            <= columnFillBudgetBytes);
   }
 
   /**
@@ -1218,7 +1240,7 @@ public final class ProjectionColumnStore {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
     final long projectedIdentity = projectedColumnIdentityFillBytes(col);
-    checkFillBudget(col, projectedIdentity, "distinct-identity fill");
+    checkFillBudget(col, incrementalFillBytes(col, projectedIdentity), "distinct-identity fill");
     slices = fillIdentityColumn(col, fetcher);
     if (slices == null) {
       return column(col, fetcher); // no leaf carries hashes — the whole column falls back
@@ -1231,7 +1253,7 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = identityColumns.clone();
       next[col] = slices;
       identityColumns = next;
-      chargeRetained(col, projectedIdentity);
+      retainedFillBytes.addAndGet(incrementalFillBytes(col, projectedIdentity));
     }
     return slices;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -667,6 +667,37 @@ public final class ProjectionColumnStore {
             || columnKinds[col] == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET);
   }
 
+  /** RAW bytes one segment chain spans across every leaf that carries it. */
+  private long projectedSegmentChainBytes(final int segId) {
+    long total = 0;
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      final byte[] descriptor = directories.get(i).descriptor();
+      final int entry = RowGroupDescriptor.entryIndexOf(descriptor, segId);
+      if (entry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, entry);
+      }
+    }
+    return total;
+  }
+
+  /**
+   * Bytes a {@link #recordKeys} fill costs: the raw KEYS chain plus the 8 B/row {@code long[]} it
+   * DECODES INTO and retains. Unlike the column doors this counts the decoded form explicitly,
+   * because that is the part that stays — a 100M-row store retains ~800 MB of keys whose raw chain
+   * is a fraction of it, and charging only the chain would leave the larger half unaccounted.
+   *
+   * @return the projected record-key fill bytes
+   */
+  public long projectedRecordKeysFillBytes() {
+    long total = projectedSegmentChainBytes(ProjectionIndexColumnSegmentCodec.keysColumnSegmentId());
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      total += 8L * RowGroupDescriptor.rowCount(directories.get(i).descriptor());
+    }
+    return total;
+  }
+
   /** RAW bytes the BODY chain of {@code col} spans — what a raw-bytes fill retains. */
   private long projectedColumnBodyFillBytes(final int col) {
     if (col < 0 || col >= columnKinds.length) {
@@ -940,7 +971,9 @@ public final class ProjectionColumnStore {
   private void checkFillBudget(final int col, final long projected, final String mode) {
     final long retained = retainedFillBytes.get();
     if (retained + projected > columnFillBudgetBytes) {
-      throw new FillBudgetExceededException("Column " + col + " " + mode + " projects " + projected
+      throw new FillBudgetExceededException((col < 0
+          ? "The store's "
+          : "Column " + col + " ") + mode + " projects " + projected
           + " B beside " + retained + " B already retained, over the " + columnFillBudgetBytes
           + " B budget (sirix.projection.eagerMaterializeBytes) — declining the fill; the caller falls back to the "
           + "whole-leaf windowed route");
@@ -1248,6 +1281,12 @@ public final class ProjectionColumnStore {
     if (chain != null) {
       return chain;
     }
+    // CHARGED but never REFUSED. The fingerprints are what let a predicate prune leaves before any
+    // BODY/DICT byte is fetched, so refusing them to protect the budget would forfeit the pruning
+    // that keeps fills under it — the economics invert. Charging them still keeps the ledger an
+    // honest account of residency, and the pressure lands where it belongs: on the next column fill.
+    final long projectedBloom =
+        projectedSegmentChainBytes(ProjectionIndexColumnSegmentCodec.bloomColumnSegmentId(col));
     chain = fetchSegmentChain(col, ProjectionIndexColumnSegmentCodec.bloomColumnSegmentId(col),
         ProjectionIndexColumnSegmentCodec.SEG_KIND_STRING_BLOOM, true, fetcher, null);
     synchronized (this) {
@@ -1258,6 +1297,7 @@ public final class ProjectionColumnStore {
       final byte[][][] next = bloomBytes.clone();
       next[col] = chain;
       bloomBytes = next;
+      retainedFillBytes.addAndGet(projectedBloom);
     }
     return chain;
   }
@@ -1847,6 +1887,8 @@ public final class ProjectionColumnStore {
     if (keysCorrupt) {
       throw new IllegalStateException("The KEYS chain has a known-corrupt segment");
     }
+    final long projectedKeys = projectedRecordKeysFillBytes();
+    checkFillBudget(-1, projectedKeys, "record-key fill");
     // Fill outside the monitor, first publish wins — same discipline as column fills.
     final byte[][] segments = fetchSegmentChain(-1, ProjectionIndexColumnSegmentCodec.keysColumnSegmentId(),
         ProjectionIndexColumnSegmentCodec.SEG_KIND_KEYS, false, fetcher);
@@ -1866,6 +1908,7 @@ public final class ProjectionColumnStore {
         return slices;
       }
       recordKeySlices = decoded;
+      retainedFillBytes.addAndGet(projectedKeys);
     }
     return decoded;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -752,6 +752,7 @@ public final class ProjectionColumnStore {
       if (dictEntry >= 0) {
         total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
       }
+      total += decodedColumnResidentBytes(descriptor, columnKinds[col]);
     }
     return total;
   }
@@ -864,14 +865,47 @@ public final class ProjectionColumnStore {
     return previous;
   }
 
+  /**
+   * RESIDENT bytes ONE column of ONE leaf decodes into, on top of the raw segment bytes it is
+   * decoded from — a bit-packed long lane becomes 8 B per value plus its presence words, a boolean
+   * column two presence words, and everything else nothing extra.
+   *
+   * <p>
+   * The single place this arithmetic lives. The budget that DECLINES a fill and the cache weight
+   * that ADMITS the handle are two answers to one question — what does this column cost resident —
+   * and they were answered by two formulas: the weigher counted the decoded lane, the fill doors
+   * counted only packed bytes. A budget that prices packed bytes while the heap holds decoded ones
+   * admits roughly 8x what it believes it is admitting on a long-lane column. Both sides now call
+   * here, so they cannot disagree again.
+   * </p>
+   *
+   * @param descriptor the leaf's row-group descriptor
+   * @param kind the column's kind byte
+   * @return the decoded residency of that column in that leaf
+   */
+  public static long decodedColumnResidentBytes(final byte[] descriptor, final byte kind) {
+    final int rows = RowGroupDescriptor.rowCount(descriptor);
+    final long presenceBytes = ((rows + 63L) >>> 6) << 3;
+    // A LAYOUT question — how many bytes does a decoded slice occupy — so it asks the layout
+    // predicate. A global string column decodes to the same eight bytes per row as any other long
+    // lane, and counting it as weightless would let the cache hold more than it accounted for.
+    if (ProjectionIndexRowGroupPage.isLongLaneKind(kind)) {
+      return ((long) rows << 3) + presenceBytes;
+    }
+    if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN) {
+      return presenceBytes << 1;
+    }
+    return 0;
+  }
+
   /** Lazily-computed per-column projected fill bytes; 0 = not yet computed (a real sum is never 0). */
   private final AtomicReference<long[]> projectedFillBytes = new AtomicReference<>();
 
   /**
-   * RAW bytes a full slice fill of {@code col} would fetch: the BODY segment's byteLen across every
-   * leaf, plus the DICT segment's where the descriptor lists one. An UNDERestimate of the resident
-   * total (decoded id/value arrays come on top), which errs toward eager — the budget itself is a
-   * quarter-heap figure precisely so that margin exists.
+   * RESIDENT bytes a full slice fill of {@code col} costs: the BODY segment's byteLen across every
+   * leaf, plus the DICT segment's where the descriptor lists one, plus what those bytes DECODE INTO
+   * ({@link #decodedColumnResidentBytes}) — the same figure the cache weigher charges for the same
+   * column, because a fill retains both halves for the store's lifetime.
    */
   public long projectedColumnFillBytes(final int col) {
     long[] cached = projectedFillBytes.get();
@@ -898,6 +932,7 @@ public final class ProjectionColumnStore {
       if (dictEntry >= 0) {
         total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
       }
+      total += decodedColumnResidentBytes(descriptor, columnKinds[col]);
     }
     // A benign same-column race writes the identical sum twice.
     cached[col] = Math.max(1, total);
@@ -1048,6 +1083,9 @@ public final class ProjectionColumnStore {
       if (dictEntry >= 0) {
         total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
       }
+    }
+    for (int i = 0; i < n; i++) {
+      total += decodedColumnResidentBytes(directories.get(i).descriptor(), columnKinds[col]);
     }
     if (rowLeaves > 0 && fallbackLeaves == rowLeaves) {
       return projectedColumnFillBytes(col);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -319,6 +319,16 @@ public final class ProjectionColumnStore {
       for (int c = 0; c < columnCount; c++) {
         this.columnKinds[c] = RowGroupDescriptor.kind(d0, c);
       }
+      // Leaf 0 is a SAMPLE of the store's shape, and the twenty-five dispatch sites below treat it
+      // as the definition. Check the rest agree, once, here — the descriptors are already in memory
+      // (no page read) and the kinds are contiguous, so it is one range comparison per leaf.
+      //
+      // Task #45: commit-time maintenance rebuilt one leaf from the DECLARED column kinds and wrote
+      // its descriptor as STRING_DICT while the payload and the metadata stayed STRING_GLOBAL. Every
+      // guard downstream passed, because each was asking leaf 0. The wrong decode surfaced four
+      // rounds later as "known-corrupt BODY segment", which named the wrong component and the wrong
+      // problem. Refusing HERE reports the actual disagreement, at the only place that can see it.
+      verifyEveryLeafAgreesWithLeafZero(d0);
     }
     this.columns = new ColumnSlice[columnKinds.length][];
     this.identityColumns = new ColumnSlice[columnKinds.length][];
@@ -327,6 +337,51 @@ public final class ProjectionColumnStore {
     this.stringExtrema = new int[columnKinds.length][];
     this.stringSupplementary = new byte[columnKinds.length];
     this.corruptColumns = new byte[columnKinds.length];
+  }
+
+  /**
+   * Establish the invariant the whole class dispatches on: every leaf declares the same column
+   * encodings.
+   *
+   * <p>
+   * Throws rather than degrading, and that is deliberate. A kind-inconsistent store is not a store
+   * with one bad column — its leaves disagree about what the bytes MEAN, so no route over it can be
+   * trusted, including the ones that would otherwise "fall back". The throw is typed
+   * ({@link ProjectionStoreInconsistentException}) precisely so the fallback machinery can tell it
+   * apart from undecodable bytes and decline the whole store WITHOUT memoizing a column as corrupt
+   * (task #50) — the memo is what turned one mis-dispatch into a permanently disabled column.
+   * </p>
+   *
+   * @param d0 leaf 0's descriptor, already read by the caller; never {@code null}
+   */
+  private void verifyEveryLeafAgreesWithLeafZero(final byte[] d0) {
+    final int leaves = directories.size();
+    for (int leaf = 1; leaf < leaves; leaf++) {
+      final byte[] di = directories.get(leaf).descriptor();
+      if (!RowGroupDescriptor.kindsAgree(d0, di)) {
+        throw new ProjectionStoreInconsistentException(leaf, describeDisagreement(d0, di));
+      }
+    }
+  }
+
+  /**
+   * Name the first column the two descriptors disagree about, so the refusal says what is wrong
+   * instead of that something is. Cold path — only ever reached on the way to throwing.
+   */
+  private static String describeDisagreement(final byte[] d0, final byte[] di) {
+    final int columns = RowGroupDescriptor.columnCount(d0);
+    final int otherColumns = RowGroupDescriptor.columnCount(di);
+    if (columns != otherColumns) {
+      return "leaf 0 declares " + columns + " columns, this leaf declares " + otherColumns;
+    }
+    for (int c = 0; c < columns; c++) {
+      final byte expected = RowGroupDescriptor.kind(d0, c);
+      final byte actual = RowGroupDescriptor.kind(di, c);
+      if (expected != actual) {
+        return "column " + c + " is kind " + expected + " in leaf 0 but kind " + actual + " here";
+      }
+    }
+    return "column count and kinds agree — the disagreement was transient";
   }
 
   /** {@link #stringDictSupplementaryMemo} — not yet established for this column. */
@@ -633,6 +688,20 @@ public final class ProjectionColumnStore {
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
     }
+    // BUDGET, before the first fetch (task #78). A whole-column slice fill holds every leaf's BODY
+    // (and, for strings, DICT) bytes plus their decoded arrays resident AT ONCE — on a fat string
+    // column at 100M rows that is ~8-10 GB and OOMed the heap before serving a row. Over the
+    // budget, refuse THROUGH THE ESTABLISHED DECLINE DOOR (the same IllegalStateException callers
+    // already answer by falling back to the whole-leaf byte-scan route, which now serves through
+    // bounded windowed payload loads). Deliberately NOT memoized as corrupt: nothing is wrong with
+    // the store — the projected size is a property of the column, recomputed cheaply, and a later
+    // caller with a raised budget must be able to fill.
+    final long projected = projectedColumnFillBytes(col);
+    if (projected > columnFillBudgetBytes) {
+      throw new IllegalStateException("Column " + col + " slice fill projects " + projected + " B over the "
+          + columnFillBudgetBytes + " B budget (sirix.projection.eagerMaterializeBytes) — declining the "
+          + "whole-column fill so the whole-leaf windowed route serves instead");
+    }
     // Fill OUTSIDE the monitor: the fetch+decode is the store's only I/O and must not
     // serialize other columns (or evidence readers) behind it. A same-column race does the
     // work twice with identical results — first publish wins.
@@ -648,6 +717,71 @@ public final class ProjectionColumnStore {
       columns = next;
     }
     return slices;
+  }
+
+  /**
+   * Byte budget above which {@link #column(int, ColumnSegmentFetcher)} declines a whole-column
+   * slice fill. Same property and derivation as the catalog's whole-leaf eager budget
+   * ({@code sirix.projection.eagerMaterializeBytes}): a fill's raw bytes live on the heap beside
+   * the decoded slice arrays and the off-heap arena, so half the projection cache budget and a
+   * quarter of the heap bound it from both sides.
+   */
+  private static final long COLUMN_FILL_BUDGET_DEFAULT = Long.getLong("sirix.projection.eagerMaterializeBytes",
+      Math.min(Long.parseLong(System.getProperty("sirix.projection.cacheBytes", String.valueOf(8L << 30))) / 2,
+          Runtime.getRuntime().maxMemory() / 4));
+
+  private static volatile long columnFillBudgetBytes = COLUMN_FILL_BUDGET_DEFAULT;
+
+  /**
+   * Test seam: shrink the fill budget so a small store still exercises the decline.
+   *
+   * @param value the budget in bytes
+   * @return the previous budget, for restoring in a finally block
+   */
+  public static long setColumnFillBudgetBytesForTesting(final long value) {
+    final long previous = columnFillBudgetBytes;
+    columnFillBudgetBytes = value;
+    return previous;
+  }
+
+  /** Lazily-computed per-column projected fill bytes; 0 = not yet computed (a real sum is never 0). */
+  private final AtomicReference<long[]> projectedFillBytes = new AtomicReference<>();
+
+  /**
+   * RAW bytes a full slice fill of {@code col} would fetch: the BODY segment's byteLen across every
+   * leaf, plus the DICT segment's where the descriptor lists one. An UNDERestimate of the resident
+   * total (decoded id/value arrays come on top), which errs toward eager — the budget itself is a
+   * quarter-heap figure precisely so that margin exists.
+   */
+  public long projectedColumnFillBytes(final int col) {
+    long[] cached = projectedFillBytes.get();
+    if (cached == null) {
+      cached = new long[columnKinds.length];
+      projectedFillBytes.compareAndSet(null, cached);
+      cached = projectedFillBytes.get();
+    }
+    final long known = cached[col];
+    if (known != 0) {
+      return known;
+    }
+    final int bodySegId = ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col);
+    final int dictSegId = ProjectionIndexColumnSegmentCodec.dictColumnSegmentId(col);
+    long total = 0;
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      final byte[] descriptor = directories.get(i).descriptor();
+      final int bodyEntry = RowGroupDescriptor.entryIndexOf(descriptor, bodySegId);
+      if (bodyEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, bodyEntry);
+      }
+      final int dictEntry = RowGroupDescriptor.entryIndexOf(descriptor, dictSegId);
+      if (dictEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
+      }
+    }
+    // A benign same-column race writes the identical sum twice.
+    cached[col] = Math.max(1, total);
+    return cached[col];
   }
 
   /**
@@ -799,6 +933,12 @@ public final class ProjectionColumnStore {
           slices[i] = decodeOneIdentitySlice(i, col, bodySegments, hashSegments, dictSegments, fallback);
         }
       }
+    } catch (final ProjectionStoreInconsistentException inconsistent) {
+      // Leaves that disagree about a column's encoding are a WRITER fault, not undecodable bytes.
+      // Decline the store, but do NOT record this column as corrupt: that memo is store-wide and
+      // lives for the process, so one mis-dispatch would permanently disable every fast path on a
+      // column whose bytes were never in question (task #50).
+      throw inconsistent;
     } catch (final IllegalStateException corrupt) {
       corruptColumns[col] = 1;
       throw corrupt;
@@ -936,6 +1076,12 @@ public final class ProjectionColumnStore {
           slices[i] = decodeMaskedSlice(i, col, set, string, segments, dictSegments, keepWords);
         }
       }
+    } catch (final ProjectionStoreInconsistentException inconsistent) {
+      // Leaves that disagree about a column's encoding are a WRITER fault, not undecodable bytes.
+      // Decline the store, but do NOT record this column as corrupt: that memo is store-wide and
+      // lives for the process, so one mis-dispatch would permanently disable every fast path on a
+      // column whose bytes were never in question (task #50).
+      throw inconsistent;
     } catch (final IllegalStateException corrupt) {
       corruptColumns[col] = 1;
       throw corrupt;
@@ -1001,6 +1147,12 @@ public final class ProjectionColumnStore {
           slices[i] = decodeOneSlice(i, col, set, string, segments, dictSegments);
         }
       }
+    } catch (final ProjectionStoreInconsistentException inconsistent) {
+      // Leaves that disagree about a column's encoding are a WRITER fault, not undecodable bytes.
+      // Decline the store, but do NOT record this column as corrupt: that memo is store-wide and
+      // lives for the process, so one mis-dispatch would permanently disable every fast path on a
+      // column whose bytes were never in question (task #50).
+      throw inconsistent;
     } catch (final IllegalStateException corrupt) {
       corruptColumns[col] = 1;
       throw corrupt;
@@ -1546,6 +1698,12 @@ public final class ProjectionColumnStore {
       } else {
         verifyFetchedSegments(n, segments, segId, segKind, absent, keepWords);
       }
+    } catch (final ProjectionStoreInconsistentException inconsistent) {
+      // Leaves that disagree about a column's encoding are a WRITER fault, not undecodable bytes.
+      // Decline the store, but do NOT record this column as corrupt: that memo is store-wide and
+      // lives for the process, so one mis-dispatch would permanently disable every fast path on a
+      // column whose bytes were never in question (task #50).
+      throw inconsistent;
     } catch (final IllegalStateException corrupt) {
       // Structural corruption (missing segment at a resolved offset, hash/length/kind
       // mismatch) cannot heal for this build — memoize so later touches fail fast.

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -667,6 +667,46 @@ public final class ProjectionColumnStore {
   }
 
   /**
+   * RAW bytes a MASKED fill of {@code col} would fetch: the same BODY (+DICT) walk
+   * {@link #projectedColumnFillBytes} does, restricted to the leaves the keep mask leaves standing.
+   * Exact rather than scaled, because the mask names the surviving leaf set and the descriptors are
+   * already in hand — and because a prune that drops only the rowless leaves of a 3.5 GB column
+   * leaves 3.5 GB, which a leaf-count ratio would not reveal.
+   *
+   * @param col the column
+   * @param keepWords bitset over leaf indices; {@code null} means every leaf survives
+   * @return the projected masked fill bytes
+   */
+  public long projectedMaskedFillBytes(final int col, final long @Nullable [] keepWords) {
+    if (keepWords == null) {
+      return projectedColumnFillBytes(col);
+    }
+    if (col < 0 || col >= columnKinds.length) {
+      return 0;
+    }
+    final int bodySegId = ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col);
+    final int dictSegId = ProjectionIndexColumnSegmentCodec.dictColumnSegmentId(col);
+    long total = 0;
+    final int n = directories.size();
+    for (int i = 0; i < n; i++) {
+      final int word = i >>> 6;
+      if (word >= keepWords.length || (keepWords[word] & (1L << (i & 63))) == 0) {
+        continue;
+      }
+      final byte[] descriptor = directories.get(i).descriptor();
+      final int bodyEntry = RowGroupDescriptor.entryIndexOf(descriptor, bodySegId);
+      if (bodyEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, bodyEntry);
+      }
+      final int dictEntry = RowGroupDescriptor.entryIndexOf(descriptor, dictSegId);
+      if (dictEntry >= 0) {
+        total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
+      }
+    }
+    return total;
+  }
+
+  /**
    * Whether a WHOLE-COLUMN fill of {@code col} fits the fill budget — the size half of route
    * viability, which {@link #columnSliceable} (a KIND predicate) deliberately does not answer.
    *
@@ -730,7 +770,7 @@ public final class ProjectionColumnStore {
     // caller with a raised budget must be able to fill.
     final long projected = projectedColumnFillBytes(col);
     if (projected > columnFillBudgetBytes) {
-      throw new IllegalStateException("Column " + col + " slice fill projects " + projected + " B over the "
+      throw new FillBudgetExceededException("Column " + col + " slice fill projects " + projected + " B over the "
           + columnFillBudgetBytes + " B budget (sirix.projection.eagerMaterializeBytes) — declining the "
           + "whole-column fill so the whole-leaf windowed route serves instead");
     }
@@ -824,6 +864,28 @@ public final class ProjectionColumnStore {
   public boolean columnFilled(final int col) {
     final ColumnSlice[][] slots = columns;
     return col >= 0 && col < slots.length && slots[col] != null;
+  }
+
+  /**
+   * A fill DECLINED because its projected bytes exceed {@link #columnFillBudgetBytes} — not
+   * corruption, and deliberately never memoized as such.
+   *
+   * <p>
+   * A distinct type because the two conditions that reach a caller's {@code IllegalStateException}
+   * handler mean opposite things: a corrupt or truncated segment is a defect worth counting and
+   * logging, whereas this is the store REFUSING a fill it can price, so the caller should fall back
+   * to the whole-leaf windowed route the budget declined it toward — quietly, and without ticking a
+   * defect counter. It stays an {@code IllegalStateException} so every existing fail-soft handler
+   * keeps working unchanged; handlers that distinguish declines catch this first.
+   * </p>
+   */
+  public static final class FillBudgetExceededException extends IllegalStateException {
+
+    private static final long serialVersionUID = 1L;
+
+    FillBudgetExceededException(final String message) {
+      super(message);
+    }
   }
 
   /** Whether {@code col}'s DISTINCT-IDENTITY slices are already filled and cached. */
@@ -1159,6 +1221,12 @@ public final class ProjectionColumnStore {
     }
     if (corruptColumns[col] != 0) {
       throw new IllegalStateException("Column " + col + " has a known-corrupt BODY segment");
+    }
+    final long projected = projectedMaskedFillBytes(col, keepWords);
+    if (projected > columnFillBudgetBytes) {
+      throw new FillBudgetExceededException("Column " + col + " masked slice fill projects " + projected
+          + " B over the " + columnFillBudgetBytes + " B budget (sirix.projection.eagerMaterializeBytes) — the "
+          + "keep mask did not prune enough to bring it under, so the whole-leaf windowed route serves instead");
     }
     final byte[][] segments = fetchSegmentChain(col, ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col),
         ProjectionIndexColumnSegmentCodec.SEG_KIND_BODY, false, fetcher, keepWords);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -752,7 +752,7 @@ public final class ProjectionColumnStore {
       if (dictEntry >= 0) {
         total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
       }
-      total += decodedColumnResidentBytes(descriptor, columnKinds[col]);
+      total += decodedColumnResidentBytes(descriptor, col, columnKinds[col]);
     }
     return total;
   }
@@ -835,7 +835,7 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = columns.clone();
       next[col] = slices;
       columns = next;
-      retainedFillBytes.addAndGet(projected);
+      chargeRetained(col, projected);
     }
     return slices;
   }
@@ -883,7 +883,7 @@ public final class ProjectionColumnStore {
    * @param kind the column's kind byte
    * @return the decoded residency of that column in that leaf
    */
-  public static long decodedColumnResidentBytes(final byte[] descriptor, final byte kind) {
+  public static long decodedColumnResidentBytes(final byte[] descriptor, final int col, final byte kind) {
     final int rows = RowGroupDescriptor.rowCount(descriptor);
     final long presenceBytes = ((rows + 63L) >>> 6) << 3;
     // A LAYOUT question — how many bytes does a decoded slice occupy — so it asks the layout
@@ -895,7 +895,45 @@ public final class ProjectionColumnStore {
     if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN) {
       return presenceBytes << 1;
     }
+    if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT
+        || kind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET) {
+      // The terms {@link #sliceRetainedBytes} reports for a filled string slice: the per-row id
+      // lane, the presence words, and the dictionary in its DECODED form. Pricing these at zero
+      // would exempt the exact column kind the windowed route exists to serve.
+      long bytes = ((long) rows << 2) + presenceBytes;
+      if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET) {
+        // A set column keeps a per-row counts table beside the flat element run. The run itself can
+        // exceed one element per row, which no descriptor field records — one element per row is
+        // the floor, so a set column is the one shape this figure can still understate.
+        bytes += (long) rows << 2;
+      }
+      final int dictEntry =
+          RowGroupDescriptor.entryIndexOf(descriptor, ProjectionIndexColumnSegmentCodec.dictColumnSegmentId(col));
+      if (dictEntry >= 0) {
+        bytes += (long) RowGroupDescriptor.entryByteLen(descriptor, dictEntry) * DICT_DECODED_EXPANSION;
+      }
+      return bytes;
+    }
     return 0;
+  }
+
+  /**
+   * Multiple applied to a DICT segment's stored bytes to reach what a fill retains for it: an
+   * FSST-compressed dictionary is DECOMPRESSED into a fresh array on decode, and a 4 B offset per
+   * entry is built beside it. Neither the compression ratio nor the entry count is recorded in the
+   * descriptor, so this is a deliberate over-estimate — the safe direction for a residency cap,
+   * which declines a fill early rather than admitting one it cannot hold.
+   */
+  private static final int DICT_DECODED_EXPANSION = 4;
+
+  /**
+   * Decoded residency of a DISTINCT-IDENTITY slice: the per-row id lane and presence words, and
+   * NOT the dictionary — that mode reads the 8 B/entry hash chain instead, whose stored bytes are
+   * already its retained bytes.
+   */
+  private static long decodedIdentityResidentBytes(final byte[] descriptor) {
+    final int rows = RowGroupDescriptor.rowCount(descriptor);
+    return ((long) rows << 2) + (((rows + 63L) >>> 6) << 3);
   }
 
   /** Lazily-computed per-column projected fill bytes; 0 = not yet computed (a real sum is never 0). */
@@ -932,7 +970,7 @@ public final class ProjectionColumnStore {
       if (dictEntry >= 0) {
         total += RowGroupDescriptor.entryByteLen(descriptor, dictEntry);
       }
-      total += decodedColumnResidentBytes(descriptor, columnKinds[col]);
+      total += decodedColumnResidentBytes(descriptor, col, columnKinds[col]);
     }
     // A benign same-column race writes the identical sum twice.
     cached[col] = Math.max(1, total);
@@ -993,6 +1031,32 @@ public final class ProjectionColumnStore {
   /** Bytes retained by published fills so far — observability for the budget witness. */
   public long retainedFillBytes() {
     return retainedFillBytes.get();
+  }
+
+  /** Whether {@code col}'s raw BODY chain is already published — and therefore already charged. */
+  private boolean columnBytesFilled(final int col) {
+    final byte[][][] slots = columnBytes;
+    return col >= 0 && col < slots.length && slots[col] != null;
+  }
+
+  /**
+   * Charge a published fill, MINUS whatever a nested door already charged for the same bytes.
+   *
+   * <p>
+   * A slice fill and an identity fill both run through {@link #columnBytes}, which prices and
+   * charges the BODY chain on its own account — so charging the outer door's full projection on top
+   * counted one retained copy of those arrays twice. The ledger is monotonic and feeds the decline
+   * predicates, so over-charging steers servable queries off the sliced route for residency that is
+   * not there. Subtracting what is already charged makes the total independent of which door was
+   * entered first, which a re-entrancy flag alone would not: the BODY chain is equally shared when
+   * {@code columnBytes} is entered directly and the slice fill follows later.
+   * </p>
+   */
+  private void chargeRetained(final int col, final long projected) {
+    final long alreadyCharged = columnBytesFilled(col)
+        ? projectedColumnBodyFillBytes(col)
+        : 0;
+    retainedFillBytes.addAndGet(Math.max(0, projected - alreadyCharged));
   }
 
   /**
@@ -1085,7 +1149,7 @@ public final class ProjectionColumnStore {
       }
     }
     for (int i = 0; i < n; i++) {
-      total += decodedColumnResidentBytes(directories.get(i).descriptor(), columnKinds[col]);
+      total += decodedIdentityResidentBytes(directories.get(i).descriptor());
     }
     if (rowLeaves > 0 && fallbackLeaves == rowLeaves) {
       return projectedColumnFillBytes(col);
@@ -1167,7 +1231,7 @@ public final class ProjectionColumnStore {
       final ColumnSlice[][] next = identityColumns.clone();
       next[col] = slices;
       identityColumns = next;
-      retainedFillBytes.addAndGet(projectedIdentity);
+      chargeRetained(col, projectedIdentity);
     }
     return slices;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -684,8 +684,8 @@ public final class ProjectionColumnStore {
   /**
    * Bytes a {@link #recordKeys} fill costs: the raw KEYS chain plus the 8 B/row {@code long[]} it
    * DECODES INTO and retains. Unlike the column doors this counts the decoded form explicitly,
-   * because that is the part that stays — a 100M-row store retains ~800 MB of keys whose raw chain
-   * is a fraction of it, and charging only the chain would leave the larger half unaccounted.
+   * because that is the part that stays — a 100M-row store retains ~800 MB of keys whose raw chain is
+   * a fraction of it, and charging only the chain would leave the larger half unaccounted.
    *
    * @return the projected record-key fill bytes
    */
@@ -729,11 +729,11 @@ public final class ProjectionColumnStore {
   }
 
   /**
-   * Lazily-computed per-column projected BODY-chain bytes; 0 = not yet computed (a real sum is
-   * never 0). Memoized for the same reason as {@link #projectedFillBytes}, and now for a sharper
-   * one: {@link #incrementalFillBytes} puts this walk on the PLANNER path, so every gated column of
-   * every group or aggregate query would otherwise redo a per-leaf descriptor probe over the whole
-   * store once that column's raw BODY chain is published.
+   * Lazily-computed per-column projected BODY-chain bytes; 0 = not yet computed (a real sum is never
+   * 0). Memoized for the same reason as {@link #projectedFillBytes}, and now for a sharper one:
+   * {@link #incrementalFillBytes} puts this walk on the PLANNER path, so every gated column of every
+   * group or aggregate query would otherwise redo a per-leaf descriptor probe over the whole store
+   * once that column's raw BODY chain is published.
    */
   private final AtomicReference<long[]> projectedBodyFillBytes = new AtomicReference<>();
 
@@ -787,8 +787,7 @@ public final class ProjectionColumnStore {
    */
   public boolean columnFillWithinBudget(final int col) {
     return col >= 0 && col < columnKinds.length
-        && retainedFillBytes.get() + incrementalFillBytes(col, projectedColumnFillBytes(col))
-            <= columnFillBudgetBytes;
+        && retainedFillBytes.get() + incrementalFillBytes(col, projectedColumnFillBytes(col)) <= columnFillBudgetBytes;
   }
 
   /**
@@ -796,14 +795,14 @@ public final class ProjectionColumnStore {
    * fill either fits the budget or has already been paid for.
    *
    * <p>
-   * This is the predicate a PLANNER needs, not {@link #columnSliceable} alone. Kind-sliceability
-   * says the route could decode the column; it says nothing about the budget
+   * This is the predicate a PLANNER needs, not {@link #columnSliceable} alone. Kind-sliceability says
+   * the route could decode the column; it says nothing about the budget
    * {@link #column(int, ColumnSegmentFetcher)} enforces before its first fetch. A planner gating on
    * kind alone selects the sliced arm for an over-budget column, the fill then declines through the
    * budget door, and the exception escapes to a generic fail-soft catch — so the query takes the
-   * SLOWEST route and trips a defect counter, instead of the whole-leaf windowed byte scan the
-   * budget declined it toward. An already-filled column stays viable: its bytes are resident, so the
-   * budget question is moot.
+   * SLOWEST route and trips a defect counter, instead of the whole-leaf windowed byte scan the budget
+   * declined it toward. An already-filled column stays viable: its bytes are resident, so the budget
+   * question is moot.
    *
    * @param col the column
    * @return {@code true} when the sliced route can actually serve this column
@@ -865,11 +864,11 @@ public final class ProjectionColumnStore {
   }
 
   /**
-   * Byte budget above which {@link #column(int, ColumnSegmentFetcher)} declines a whole-column
-   * slice fill. Same property and derivation as the catalog's whole-leaf eager budget
-   * ({@code sirix.projection.eagerMaterializeBytes}): a fill's raw bytes live on the heap beside
-   * the decoded slice arrays and the off-heap arena, so half the projection cache budget and a
-   * quarter of the heap bound it from both sides.
+   * Byte budget above which {@link #column(int, ColumnSegmentFetcher)} declines a whole-column slice
+   * fill. Same property and derivation as the catalog's whole-leaf eager budget
+   * ({@code sirix.projection.eagerMaterializeBytes}): a fill's raw bytes live on the heap beside the
+   * decoded slice arrays and the off-heap arena, so half the projection cache budget and a quarter of
+   * the heap bound it from both sides.
    */
   private static final long COLUMN_FILL_BUDGET_DEFAULT = Long.getLong("sirix.projection.eagerMaterializeBytes",
       Math.min(Long.parseLong(System.getProperty("sirix.projection.cacheBytes", String.valueOf(8L << 30))) / 2,
@@ -890,17 +889,17 @@ public final class ProjectionColumnStore {
   }
 
   /**
-   * RESIDENT bytes ONE column of ONE leaf decodes into, on top of the raw segment bytes it is
-   * decoded from — a bit-packed long lane becomes 8 B per value plus its presence words, a boolean
-   * column two presence words, and everything else nothing extra.
+   * RESIDENT bytes ONE column of ONE leaf decodes into, on top of the raw segment bytes it is decoded
+   * from — a bit-packed long lane becomes 8 B per value plus its presence words, a boolean column two
+   * presence words, and everything else nothing extra.
    *
    * <p>
-   * The single place this arithmetic lives. The budget that DECLINES a fill and the cache weight
-   * that ADMITS the handle are two answers to one question — what does this column cost resident —
-   * and they were answered by two formulas: the weigher counted the decoded lane, the fill doors
-   * counted only packed bytes. A budget that prices packed bytes while the heap holds decoded ones
-   * admits roughly 8x what it believes it is admitting on a long-lane column. Both sides now call
-   * here, so they cannot disagree again.
+   * The single place this arithmetic lives. The budget that DECLINES a fill and the cache weight that
+   * ADMITS the handle are two answers to one question — what does this column cost resident — and
+   * they were answered by two formulas: the weigher counted the decoded lane, the fill doors counted
+   * only packed bytes. A budget that prices packed bytes while the heap holds decoded ones admits
+   * roughly 8x what it believes it is admitting on a long-lane column. Both sides now call here, so
+   * they cannot disagree again.
    * </p>
    *
    * @param descriptor the leaf's row-group descriptor
@@ -945,22 +944,24 @@ public final class ProjectionColumnStore {
    * Multiple applied to a DICT segment's stored bytes to reach what a fill retains for it: an
    * FSST-compressed dictionary is DECOMPRESSED into a fresh array on decode, and a 4 B offset per
    * entry is built beside it. Neither the compression ratio nor the entry count is recorded in the
-   * descriptor, so this is a deliberate over-estimate — the safe direction for a residency cap,
-   * which declines a fill early rather than admitting one it cannot hold.
+   * descriptor, so this is a deliberate over-estimate — the safe direction for a residency cap, which
+   * declines a fill early rather than admitting one it cannot hold.
    */
   private static final int DICT_DECODED_EXPANSION = 4;
 
   /**
-   * Decoded residency of a DISTINCT-IDENTITY slice: the per-row id lane and presence words, and
-   * NOT the dictionary — that mode reads the 8 B/entry hash chain instead, whose stored bytes are
-   * already its retained bytes.
+   * Decoded residency of a DISTINCT-IDENTITY slice: the per-row id lane and presence words, and NOT
+   * the dictionary — that mode reads the 8 B/entry hash chain instead, whose stored bytes are already
+   * its retained bytes.
    */
   private static long decodedIdentityResidentBytes(final byte[] descriptor) {
     final int rows = RowGroupDescriptor.rowCount(descriptor);
     return ((long) rows << 2) + (((rows + 63L) >>> 6) << 3);
   }
 
-  /** Lazily-computed per-column projected fill bytes; 0 = not yet computed (a real sum is never 0). */
+  /**
+   * Lazily-computed per-column projected fill bytes; 0 = not yet computed (a real sum is never 0).
+   */
   private final AtomicReference<long[]> projectedFillBytes = new AtomicReference<>();
 
   /**
@@ -1039,9 +1040,9 @@ public final class ProjectionColumnStore {
    * <p>
    * {@code columnFillBudgetBytes} is a per-column figure, but published fills are kept for the
    * store's whole cache lifetime, so a handle's residency is the SUM over the columns a query mix
-   * touches, not any one of them. Without this ledger a ten-column projection with eight columns
-   * each just under the budget retains eight budgets' worth while the cache weigher charges one.
-   * Charging every publish makes that weight an honest upper bound by construction.
+   * touches, not any one of them. Without this ledger a ten-column projection with eight columns each
+   * just under the budget retains eight budgets' worth while the cache weigher charges one. Charging
+   * every publish makes that weight an honest upper bound by construction.
    * </p>
    *
    * <p>
@@ -1065,17 +1066,17 @@ public final class ProjectionColumnStore {
   }
 
   /**
-   * What a fill of {@code col} priced at {@code projected} would ADD to this store's residency:
-   * the gross projection minus the bytes already retained AND already charged for that same column.
+   * What a fill of {@code col} priced at {@code projected} would ADD to this store's residency: the
+   * gross projection minus the bytes already retained AND already charged for that same column.
    *
    * <p>
    * The one place that subtraction lives, because the budget CHECK and the ledger CHARGE have to
    * agree about it. A slice fill and an identity fill both reach {@link #columnBytes}, which
    * publishes and charges the BODY chain on its own account — so once a fused fold scan has filled
-   * those raw bytes, a later slice fill of the same column adds only its decoded arrays. Pricing
-   * the check at the gross figure while charging the increment made the gate refuse fills whose
-   * true residency fit the budget, steering servable queries onto the slower whole-leaf route for
-   * bytes that were already counted.
+   * those raw bytes, a later slice fill of the same column adds only its decoded arrays. Pricing the
+   * check at the gross figure while charging the increment made the gate refuse fills whose true
+   * residency fit the budget, steering servable queries onto the slower whole-leaf route for bytes
+   * that were already counted.
    * </p>
    *
    * <p>
@@ -1114,8 +1115,8 @@ public final class ProjectionColumnStore {
     if (retained + projected > columnFillBudgetBytes) {
       throw new FillBudgetExceededException((col < 0
           ? "The store's "
-          : "Column " + col + " ") + mode + " adds " + projected
-          + " B beside " + retained + " B already retained, over the " + columnFillBudgetBytes
+          : "Column " + col + " ") + mode + " adds " + projected + " B beside " + retained
+          + " B already retained, over the " + columnFillBudgetBytes
           + " B budget (sirix.projection.eagerMaterializeBytes) — declining the fill; the caller falls back to the "
           + "whole-leaf windowed route");
     }
@@ -1131,11 +1132,10 @@ public final class ProjectionColumnStore {
   private final AtomicReference<long[]> projectedIdentityFillBytes = new AtomicReference<>();
 
   /**
-   * RAW bytes a {@link #columnDistinctIdentity} fill of {@code col} would fetch, which is a
-   * different — and on a fat dictionary a far smaller — figure than
-   * {@link #projectedColumnFillBytes}: the BODY chain plus the ~8 B/entry
-   * {@link ProjectionIndexColumnSegmentCodec#SEG_KIND_DICT_HASHES} chain, and the DICTIONARY only
-   * for the leaves that carry no hash segment (exactly the fallback keep-mask
+   * RAW bytes a {@link #columnDistinctIdentity} fill of {@code col} would fetch, which is a different
+   * — and on a fat dictionary a far smaller — figure than {@link #projectedColumnFillBytes}: the BODY
+   * chain plus the ~8 B/entry {@link ProjectionIndexColumnSegmentCodec#SEG_KIND_DICT_HASHES} chain,
+   * and the DICTIONARY only for the leaves that carry no hash segment (exactly the fallback keep-mask
    * {@code fillIdentityColumn} builds).
    *
    * <p>
@@ -1202,16 +1202,15 @@ public final class ProjectionColumnStore {
 
   /**
    * Whether the sliced route is VIABLE for {@code col} when it will be filled in DISTINCT-IDENTITY
-   * mode — the {@code COUNT(DISTINCT)} operand's mode. Asking {@link #columnFillable} instead
-   * rejects a fat dictionary column on a projection the identity fill never fetches.
+   * mode — the {@code COUNT(DISTINCT)} operand's mode. Asking {@link #columnFillable} instead rejects
+   * a fat dictionary column on a projection the identity fill never fetches.
    *
    * @param col the column
    * @return {@code true} when the identity fill can actually serve this column
    */
   public boolean columnIdentityFillable(final int col) {
-    return columnSliceable(col) && (columnFilled(col) || columnIdentityFilled(col)
-        || retainedFillBytes.get() + incrementalFillBytes(col, projectedColumnIdentityFillBytes(col))
-            <= columnFillBudgetBytes);
+    return columnSliceable(col) && (columnFilled(col) || columnIdentityFilled(col) || retainedFillBytes.get()
+        + incrementalFillBytes(col, projectedColumnIdentityFillBytes(col)) <= columnFillBudgetBytes);
   }
 
   /**
@@ -1430,8 +1429,7 @@ public final class ProjectionColumnStore {
     // BODY/DICT byte is fetched, so refusing them to protect the budget would forfeit the pruning
     // that keeps fills under it — the economics invert. Charging them still keeps the ledger an
     // honest account of residency, and the pressure lands where it belongs: on the next column fill.
-    final long projectedBloom =
-        projectedSegmentChainBytes(ProjectionIndexColumnSegmentCodec.bloomColumnSegmentId(col));
+    final long projectedBloom = projectedSegmentChainBytes(ProjectionIndexColumnSegmentCodec.bloomColumnSegmentId(col));
     chain = fetchSegmentChain(col, ProjectionIndexColumnSegmentCodec.bloomColumnSegmentId(col),
         ProjectionIndexColumnSegmentCodec.SEG_KIND_STRING_BLOOM, true, fetcher, null);
     synchronized (this) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -667,6 +667,38 @@ public final class ProjectionColumnStore {
   }
 
   /**
+   * Whether a WHOLE-COLUMN fill of {@code col} fits the fill budget — the size half of route
+   * viability, which {@link #columnSliceable} (a KIND predicate) deliberately does not answer.
+   *
+   * @param col the column
+   * @return {@code true} when {@link #projectedColumnFillBytes} is within the budget
+   */
+  public boolean columnFillWithinBudget(final int col) {
+    return col >= 0 && col < columnKinds.length && projectedColumnFillBytes(col) <= columnFillBudgetBytes;
+  }
+
+  /**
+   * Whether the sliced whole-column route is VIABLE for {@code col}: the kind can be sliced AND the
+   * fill either fits the budget or has already been paid for.
+   *
+   * <p>
+   * This is the predicate a PLANNER needs, not {@link #columnSliceable} alone. Kind-sliceability
+   * says the route could decode the column; it says nothing about the budget
+   * {@link #column(int, ColumnSegmentFetcher)} enforces before its first fetch. A planner gating on
+   * kind alone selects the sliced arm for an over-budget column, the fill then declines through the
+   * budget door, and the exception escapes to a generic fail-soft catch — so the query takes the
+   * SLOWEST route and trips a defect counter, instead of the whole-leaf windowed byte scan the
+   * budget declined it toward. An already-filled column stays viable: its bytes are resident, so the
+   * budget question is moot.
+   *
+   * @param col the column
+   * @return {@code true} when the sliced route can actually serve this column
+   */
+  public boolean columnFillable(final int col) {
+    return columnSliceable(col) && (columnFilled(col) || columnFillWithinBudget(col));
+  }
+
+  /**
    * The column's slices across all leaves (ascending rowGroupId), fetching + decoding its BODY
    * segments on first touch through the CALLER's own live {@code fetcher}.
    *

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java
@@ -703,6 +703,16 @@ public final class ProjectionColumnStore {
     if (col < 0 || col >= columnKinds.length) {
       return 0;
     }
+    long[] cached = projectedBodyFillBytes.get();
+    if (cached == null) {
+      cached = new long[columnKinds.length];
+      projectedBodyFillBytes.compareAndSet(null, cached);
+      cached = projectedBodyFillBytes.get();
+    }
+    final long known = cached[col];
+    if (known != 0) {
+      return known;
+    }
     final int bodySegId = ProjectionIndexColumnSegmentCodec.bodyColumnSegmentId(col);
     long total = 0;
     final int n = directories.size();
@@ -713,8 +723,19 @@ public final class ProjectionColumnStore {
         total += RowGroupDescriptor.entryByteLen(descriptor, bodyEntry);
       }
     }
-    return total;
+    // A benign same-column race writes the identical sum twice.
+    cached[col] = Math.max(1, total);
+    return cached[col];
   }
+
+  /**
+   * Lazily-computed per-column projected BODY-chain bytes; 0 = not yet computed (a real sum is
+   * never 0). Memoized for the same reason as {@link #projectedFillBytes}, and now for a sharper
+   * one: {@link #incrementalFillBytes} puts this walk on the PLANNER path, so every gated column of
+   * every group or aggregate query would otherwise redo a per-leaf descriptor probe over the whole
+   * store once that column's raw BODY chain is published.
+   */
+  private final AtomicReference<long[]> projectedBodyFillBytes = new AtomicReference<>();
 
   /**
    * RAW bytes a MASKED fill of {@code col} would fetch: the same BODY (+DICT) walk

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -40,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.LongFunction;
 
@@ -240,6 +241,22 @@ public final class ProjectionIndexBuilder {
   /** How many global columns the latest successful build to report its diagnostic produced. */
   public static int globalDictionaryColumnsBuilt() {
     return GLOBAL_DICTIONARY_COLUMNS.get();
+  }
+
+  /**
+   * Persistent-radix probes the latest reported build's dictionaries issued, same atomic-handoff
+   * semantics as {@link #globalDictionaryColumnsBuilt()}. Load-bearing witness for the intern-table
+   * retention contract: a bulk load that keeps its tables resident until {@code finish()} creates no
+   * generation mid-load, so its interns can never reach the persistent-probe branch and this must
+   * report {@code 0}. A non-zero value on a fresh bulk load means the uncached per-value radix-walk
+   * regime is back. (Loads into a resource that already carries a durable generation legitimately
+   * probe it; those report their real count.)
+   */
+  private static final AtomicLong PERSISTENT_DICTIONARY_PROBES = new AtomicLong();
+
+  /** Persistent-dictionary probes reported by the latest build's diagnostic handoff. */
+  public static long persistentDictionaryProbesReported() {
+    return PERSISTENT_DICTIONARY_PROBES.get();
   }
 
   /**
@@ -1106,10 +1123,24 @@ public final class ProjectionIndexBuilder {
 
   void publishGlobalDictionaryColumnsBuilt() {
     publishGlobalDictionaryColumnsBuilt(globalDictionaryColumns);
+    // Summed at publish time rather than accumulated at flush time so the figure is idempotent and
+    // the post-pass path (raw writers, no persistent probes by construction) reports 0 without a
+    // parallel bookkeeping field. Runs before releaseTransientState(), so the encoders are live.
+    long probes = 0;
+    final GlobalValueDictionaryEncoder[] encoders = globalDictionaryEncoders;
+    if (encoders != null) {
+      for (final GlobalValueDictionaryEncoder encoder : encoders) {
+        if (encoder instanceof final StreamingGlobalDictionary dictionary) {
+          probes += dictionary.persistentProbeCount();
+        }
+      }
+    }
+    PERSISTENT_DICTIONARY_PROBES.set(probes);
   }
 
   private static void publishGlobalDictionaryColumnsBuilt(final int columns) {
     GLOBAL_DICTIONARY_COLUMNS.set(columns);
+    PERSISTENT_DICTIONARY_PROBES.set(0);
   }
 
   /** @return total rows appended across all emitted leaves. */
@@ -1349,7 +1380,26 @@ public final class ProjectionIndexBuilder {
     private final int column;
     private final long budgetBytes;
     private final GlobalValueDictionaryWriter.AdmissionPolicy admissionPolicy;
-    private final GlobalValueDictionaryHotCache hotValues = new GlobalValueDictionaryHotCache();
+    /**
+     * Resident value→id map covering EVERY generation of this load, not just the current epoch's
+     * additions. Replaces the 64-slot hot cache AND the per-value persistent-radix probe that used to
+     * serve values from released generations — the regime measured at ~85% of load CPU. See
+     * {@link GlobalValueDictionaryProbeFront}.
+     */
+    private final GlobalValueDictionaryProbeFront residentFront;
+    /**
+     * Front-completeness invariant: {@code true} while every value in every durable generation
+     * reachable from {@link #headerKey} is present in {@link #residentFront}. Holds by construction
+     * today — (i) with {@code headerKey == 0} there are no durable generations; (ii) the constructor
+     * seeds the election writer's entries; (iii) every mint and every probe-resolved id is put into the
+     * front before it is returned; (iv) {@code flush()} moves additions to durable without changing the
+     * value set; and {@code headerKey} only ever becomes non-zero through our OWN flush. While it
+     * holds, a front miss PROVES a value is new, so minting without consulting the persistent radix
+     * cannot double-assign an id. Any future path that adopts a durable header this front did not
+     * witness (resume-into-existing-dictionary) must clear this flag, which re-arms the guarded probe
+     * below.
+     */
+    private boolean frontCoversDurableGenerations = true;
     private long headerKey;
     private int baseEntryCount;
     private @Nullable ValueDictionaryHeaderNode baseHeader;
@@ -1362,6 +1412,18 @@ public final class ProjectionIndexBuilder {
       this.budgetBytes = initialGeneration.budgetBytes();
       this.admissionPolicy = initialGeneration.admissionPolicy();
       this.additions = initialGeneration;
+      this.residentFront = new GlobalValueDictionaryProbeFront(column, this.budgetBytes);
+      // The initial generation already holds entries (election seeded the sample's distincts before
+      // this wrapper existed). The front must know them: the wrap happens AT the first flush, so a
+      // seeded value's first post-wrap occurrence would otherwise miss the front and walk the
+      // persistent radix — one probe per seeded distinct, exactly the cost class this front removes.
+      // Ids in the initial generation are the global ids (base 0).
+      final int seededEntries = initialGeneration.entryCount();
+      for (int id = 1; id <= seededEntries; id++) {
+        final byte[] valueBytes = initialGeneration.valueBytes(id);
+        residentFront.put(initialGeneration.hashAt(id), initialGeneration.secondaryHashAt(id), valueBytes, 0,
+            valueBytes.length, id);
+      }
     }
 
     void bind(final StorageEngineWriter writer) {
@@ -1406,22 +1468,25 @@ public final class ProjectionIndexBuilder {
       if (length > GlobalValueDictionaryWriter.MAX_VALUE_BYTES) {
         throw refuseOversizedValue(length);
       }
-      GlobalValueDictionaryWriter generation = additions;
-      if (generation != null) {
-        final int localId = generation.findId(source, offset, length);
-        if (localId > 0) {
-          return Math.addExact(baseEntryCount, localId);
-        }
+      // The resident front answers for every value this load has seen — whichever generation it
+      // went into — in one open-addressing probe. The hashes are computed once and shared with the
+      // put below.
+      final long hash = GlobalValueDictionary.valueHash(source, offset, length);
+      final long secondaryHash = GlobalValueDictionary.secondaryValueHash(source, offset, length);
+      final int knownId = residentFront.findId(hash, secondaryHash, source, offset, length);
+      if (knownId > 0) {
+        return knownId;
       }
-      final int hotId = hotValues.find(source, offset, length);
-      if (hotId > 0) {
-        return hotId;
-      }
-      if (headerKey != 0) {
+      if (headerKey != 0 && !frontCoversDurableGenerations) {
+        // Reachable only for a value in a durable generation this front never saw minted — i.e. a
+        // generation that predates the front. A fresh bulk load can never get here (see the
+        // front-completeness invariant on the flag), which is what dictProbes=0 in the load banner
+        // witnesses; a non-zero count on a fresh load means the ~5-page-decode-per-value probe
+        // regime is back.
         persistentProbeCount++;
         final int existing = GlobalValueDictionary.probe(headerKey, source, offset, length, writer);
         if (existing > 0) {
-          hotValues.put(source, offset, length, existing);
+          residentFront.put(hash, secondaryHash, source, offset, length, existing);
           return existing;
         }
         if (existing == GlobalValueDictionary.ID_UNKNOWN) {
@@ -1429,6 +1494,7 @@ public final class ProjectionIndexBuilder {
               "global dictionary column " + column + " cannot probe generation header " + headerKey);
         }
       }
+      GlobalValueDictionaryWriter generation = additions;
       if (generation == null) {
         generation = new GlobalValueDictionaryWriter(column, budgetBytes, admissionPolicy);
         additions = generation;
@@ -1438,6 +1504,7 @@ public final class ProjectionIndexBuilder {
       if (globalId > Integer.MAX_VALUE) {
         throw new IllegalStateException("global dictionary column " + column + " exhausted dictionary ids");
       }
+      residentFront.put(hash, secondaryHash, source, offset, length, (int) globalId);
       return (int) globalId;
     }
 
@@ -1506,6 +1573,7 @@ public final class ProjectionIndexBuilder {
         additions.release();
         additions = null;
       }
+      residentFront.release();
       baseHeader = null;
       storageEngineWriter = null;
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -117,6 +117,12 @@ public final class ProjectionIndexBuilder {
   private @Nullable SirixDeweyID lastOrderLabel;
   private final @Nullable LongFunction<SirixDeweyID> orderLabelResolver;
 
+  /** Armed by the explicit build only; the walk toggles it around top-level record-set arrays. */
+  private @Nullable InOrderLabelLane inOrderLane;
+
+  /** The document root {@link #tryFastArrayIteration} started from; -1 outside a fast iteration. */
+  private long fastIterationDocRoot = -1;
+
   /**
    * The label source a WALKING build resolves against when the caller supplied none — a heap-backed
    * {@link ProjectionStructuralOrderDirectory}, installed by {@link #build} and dropped when it
@@ -602,21 +608,55 @@ public final class ProjectionIndexBuilder {
 
   private static void buildAndPersist(final IndexDef indexDef, final PathSummaryReader pathSummary,
       final NodeReadOnlyTrx rtx, final StorageEngineWriter storageEngineWriter, final boolean emptyRecordSetAllowed) {
-    final ProjectionIndexHOTStorage storage =
-        ProjectionIndexHOTStorage.forBulkBuild(storageEngineWriter, indexDef.getID());
+    // Bounded retention: without intermediate flushes every page this build creates stays pinned in
+    // the transaction intent log until the caller's single commit — at 100M ClickBench rows that is
+    // ~20 GB of live 64 KiB frames, more than the whole off-heap arena on a 32 GB machine. Riding
+    // the writer's ordinary async-flush epochs keeps the log at one epoch of pages instead. The
+    // rotations are safe even when the transaction holds uncommitted document records this build
+    // still has to read: a flushed page of the open revision resolves back from disk through the
+    // log's recorded offsets (verified by a 40k-record forced-flush build, checksum-exact), and
+    // nothing becomes a visible revision before the caller's commit — rollback still discards
+    // every flushed page, exactly as for bulk-import epochs.
+    final boolean intermediateFlushEnabled =
+        !"false".equals(System.getProperty("sirix.projection.buildIntermediateFlush"));
+    final BulkBuildEpoch epoch = new BulkBuildEpoch(storageEngineWriter, indexDef.getID());
     // Explicit creation/recreation owns this complete index sub-tree. Reset it before emitting V0
     // so stale row groups and sparse negative record locators from an earlier incarnation cannot
     // survive under the new metadata. Ordinary transaction maintenance never takes this path.
-    storage.resetTree();
-    final ProjectionStructuralOrderDirectory.Accessor structuralOrderDirectory =
-        ProjectionStructuralOrderDirectory.open(storage);
+    epoch.storage.resetTree();
+    // Fresh build on a virgin tree: accumulate every slot write and materialize the tree in one
+    // canonical bulk pass (docs/HOT_BULK_BUILD.md §Seam 2a — measured 9–14× the per-entry path
+    // for the order-label and column-segment shapes). Point reads during the build are served
+    // from the accumulator (read-through); side-page attaches are deferred under a byte budget;
+    // a capacity trip splices the prefix and falls back to per-entry. The accumulator lives
+    // OUTSIDE the transaction-intent log, so it also LOWERS mid-build live-entry retention —
+    // epoch rebinds transplant it (BulkBuildEpoch.rebind). The finally-splice persists exactly
+    // what the per-entry path would have persisted on a failure.
+    epoch.storage.beginBulkSlotAccumulation();
+    try {
     // No document-wide pre-pass: the directory mints a record's order label the first time this
     // build asks for one, so it costs exactly one slot per emitted record and no second walk.
-    structuralOrderDirectory.seedRoot(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
+    epoch.orderDirectory.seedRoot(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
     final LongFunction<ImmutableNode> documentNodeLookup =
         nodeKey -> storageEngineWriter.getRecord(nodeKey, IndexType.DOCUMENT, -1);
-    final LongFunction<SirixDeweyID> orderLabelResolver = recordKey -> structuralOrderDirectory.fullLabel(recordKey,
-        documentNodeLookup, ProjectionStructuralOrderDirectory.RelabelSink.SEALED);
+    // In-order lane: while the walk iterates the members of a top-level record-set array, labels
+    // mint by the pure append algebra with ZERO document lookups. The general fullLabel path mints
+    // the FIRST record's label by labelling its ENTIRE maximal unlabelled sibling run — on a fresh
+    // 100M build that is a full-corpus sibling walk plus one slot write per record before the first
+    // row extracts, and none of it can flush because no leaf boundary has been reached yet. The
+    // lane is byte-equivalent for exactly this arrival order (the argument lives on
+    // fullLabelForInOrderAppend) and the carry survives epoch rebinds because the caller holds it.
+    final InOrderLabelLane inOrderLane = new InOrderLabelLane();
+    final LongFunction<SirixDeweyID> orderLabelResolver = recordKey -> {
+      if (inOrderLane.containerKey >= 0) {
+        final SirixDeweyID fullLabel = epoch.orderDirectory.fullLabelForInOrderAppend(recordKey,
+            inOrderLane.containerKey, Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), inOrderLane.previousLocal);
+        inOrderLane.previousLocal = epoch.orderDirectory.lastInOrderAppendedLocal();
+        return fullLabel;
+      }
+      return epoch.orderDirectory.fullLabel(recordKey, documentNodeLookup,
+          ProjectionStructuralOrderDirectory.RelabelSink.SEALED);
+    };
     final int priorRowGroupCount = 0;
     final ProjectionSetSummaryChunks.BuildAccumulator setSummaries = new ProjectionSetSummaryChunks.BuildAccumulator();
     if (emptyRecordSetAllowed && pathSummary.getPCRsForPaths(Set.of(indexDef.getProjectionRootPath())).isEmpty()) {
@@ -626,7 +666,7 @@ public final class ProjectionIndexBuilder {
         columnKinds[i] = mapTypeToColumnKind(fieldTypes.get(i), indexDef.getProjectionFields().get(i));
       }
       try {
-        finishPersist(indexDef, storage, LongArrayList.of(), LongArrayList.of(), priorRowGroupCount,
+        finishPersist(indexDef, epoch.storage, LongArrayList.of(), LongArrayList.of(), priorRowGroupCount,
             rtx.getRevisionNumber(), columnKinds, setSummaries, null, null);
         publishGlobalDictionaryColumnsBuilt(0);
       } finally {
@@ -644,7 +684,6 @@ public final class ProjectionIndexBuilder {
     final boolean hasSetColumn = hasStringSetColumn(indexDef);
     final ProjectionIndexColumnSegmentCodec.EncodeWorkspace encodeWorkspace =
         new ProjectionIndexColumnSegmentCodec.EncodeWorkspace();
-    final ProjectionRecordLocator.Accessor recordLocator = ProjectionRecordLocator.open(storage);
     final ProjectionIndexBuilder builder = new ProjectionIndexBuilder(indexDef, pathSummary, leaf -> {
       if (leaf.getRowCount() == 0) {
         throw new IllegalStateException("Projection leaf " + fenceWriter.rowGroupCount() + " is empty");
@@ -658,11 +697,22 @@ public final class ProjectionIndexBuilder {
       }
       final ProjectionIndexColumnSegmentCodec.EncodedRowGroup encoded =
           ProjectionIndexColumnSegmentCodec.encodeReferencedOnly(leaf, encodeWorkspace);
-      storage.putRowGroupAsColumnSegmentSlots(physicalSlot, encoded);
-      fenceWriter.append(storage, leaf.firstRecordKey(), leaf.lastRecordKey());
-      persistOrderExceptionLocators(leaf, physicalSlot, recordLocator);
-      bloomChunks.append(encoded, physicalSlot, storage);
+      epoch.storage.putRowGroupAsColumnSegmentSlots(physicalSlot, encoded);
+      fenceWriter.append(epoch.storage, leaf.firstRecordKey(), leaf.lastRecordKey());
+      persistOrderExceptionLocators(leaf, physicalSlot, epoch.recordLocator);
+      bloomChunks.append(encoded, physicalSlot, epoch.storage);
+      // Rotate the async-flush epoch at the same log-entry bound the bulk import uses, then rebind
+      // every storage-facing accessor: a flush serializes and releases the pages behind them, so a
+      // handle cached across the boundary would touch freed frames. The heap-side writers (fences,
+      // Bloom window, set summaries, dictionaries) carry build state and take storage per call, so
+      // they cross epochs untouched — the same contract ProjectionBulkLoad established for the
+      // load-time rider.
+      if (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
+        storageEngineWriter.asyncFlush();
+        epoch.rebind(storageEngineWriter, indexDef.getID());
+      }
     }, false, orderLabelResolver);
+    builder.inOrderLane = inOrderLane;
     try {
       if (rtx instanceof final JsonNodeReadOnlyTrx jsonRtx) {
         builder.build(jsonRtx);
@@ -672,15 +722,32 @@ public final class ProjectionIndexBuilder {
         throw new IllegalArgumentException("projection build requires a JSON or XML node transaction");
       }
       final byte[] columnKinds = builder.columnKinds();
-      bloomChunks.finishChunks(storage, fenceWriter.rowGroupCount(), columnKinds);
+      bloomChunks.finishChunks(epoch.storage, fenceWriter.rowGroupCount(), columnKinds);
       // Dictionaries are written after the leaves, and only once: the leaves refer to values by id,
       // so nothing can be persisted about a dictionary until every id it will ever mint is known.
       final long[] valueDictionaryHeaderKeys =
           flushValueDictionaries(builder.globalDictionaries(), storageEngineWriter);
-      fenceWriter.finish(storage, priorRowGroupCount);
-      finishPersistWithStreamingFences(indexDef, storage, fenceWriter.rowGroupCount(), priorRowGroupCount,
+      fenceWriter.finish(epoch.storage, priorRowGroupCount);
+      finishPersistWithStreamingFences(indexDef, epoch.storage, fenceWriter.rowGroupCount(), priorRowGroupCount,
           rtx.getRevisionNumber(), columnKinds, setSummaries, valueDictionaryHeaderKeys, bloomChunks);
       builder.publishGlobalDictionaryColumnsBuilt();
+      // Materialize the accumulated tree now (idempotent — the outer finally is the exception
+      // backstop) and drain the splice burst through the same epoch rotations the in-loop
+      // boundary checks use. The burst lands AFTER the last leaf's boundary check, so without
+      // this the bounded-retention contract would measure the whole freshly spliced tree as
+      // live. Bounded: the pinned-trie spill drains bottom-up (leaves, then interiors whose
+      // children became durable), and the loop stops when the boundary clears or an epoch
+      // stops reducing the log (the unspillable top-level anchors stay for the final commit).
+      epoch.storage.finalizeBulkSlotAccumulation();
+      int previousLive = Integer.MAX_VALUE;
+      while (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
+        final int live = storageEngineWriter.getLog().liveEntryCount();
+        if (live >= previousLive) {
+          break;
+        }
+        previousLive = live;
+        storageEngineWriter.asyncFlush();
+      }
     } finally {
       try {
         bloomChunks.release();
@@ -691,6 +758,61 @@ public final class ProjectionIndexBuilder {
           builder.releaseTransientState();
         }
       }
+    }
+    } finally {
+      // The CURRENT epoch's storage owns the (possibly transplanted) accumulator.
+      epoch.storage.finalizeBulkSlotAccumulation();
+    }
+  }
+
+  /**
+   * Mutable state of the explicit build's in-order order-label lane, shared between the label
+   * resolver (which mints through it while armed) and the record walk (which arms it for exactly
+   * the members of a top-level record-set array and disarms it after). The carry is held HERE, not
+   * on the directory accessor, so an async-flush epoch rebind cannot lose it.
+   */
+  static final class InOrderLabelLane {
+    /** The container whose members are currently arriving in document order; -1 = disarmed. */
+    long containerKey = -1;
+    /** The previous record's LOCAL label — the append algebra's carry. */
+    @Nullable SirixDeweyID previousLocal;
+    /** The lane serves at most ONE container per build: a second top-level record-set array would
+     * receive the same open-bounds container label as the first, so it takes the general path,
+     * whose neighbour-aware mint keeps sibling containers strictly ordered. */
+    boolean used;
+  }
+
+  /**
+   * The storage-facing bindings of one async-flush epoch of an explicit bulk build. A flush
+   * serializes and releases the pages behind these accessors, so each rotation must re-open them
+   * over the same persisted sub-tree — the contract {@link ProjectionBulkLoad} established for the
+   * load-time rider ("nothing epoch-scoped is ever cached across a commit"). Re-seeding the root
+   * label on rebind is idempotent: the seed only writes when no persisted label exists yet.
+   */
+  private static final class BulkBuildEpoch {
+    private ProjectionIndexHOTStorage storage;
+    private ProjectionStructuralOrderDirectory.Accessor orderDirectory;
+    private ProjectionRecordLocator.Accessor recordLocator;
+
+    private BulkBuildEpoch(final StorageEngineWriter storageEngineWriter, final int indexNumber) {
+      bind(storageEngineWriter, indexNumber);
+    }
+
+    private void bind(final StorageEngineWriter storageEngineWriter, final int indexNumber) {
+      storage = ProjectionIndexHOTStorage.forBulkBuild(storageEngineWriter, indexNumber);
+      orderDirectory = ProjectionStructuralOrderDirectory.open(storage);
+      recordLocator = ProjectionRecordLocator.open(storage);
+    }
+
+    private void rebind(final StorageEngineWriter storageEngineWriter, final int indexNumber) {
+      final ProjectionIndexHOTStorage previousStorage = storage;
+      bind(storageEngineWriter, indexNumber);
+      // Transplant an active bulk-slot accumulation onto the fresh storage BEFORE the re-seed:
+      // the accumulator is tree-state-independent (it holds only un-materialized slot writes for
+      // the same still-virgin tree), and the re-seed's read must see the accumulated root label
+      // through the new storage's read-through rather than minting a second one.
+      storage.adoptBulkSlotAccumulation(previousStorage);
+      orderDirectory.seedRoot(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
     }
   }
 
@@ -980,9 +1102,14 @@ public final class ProjectionIndexBuilder {
     final long docRoot = rtx.getNodeKey();
     if (rootPathNodeKeys.isEmpty())
       return false;
-    boolean processedAny = descendToRoots(rtx, docRoot);
-    rtx.moveTo(docRoot);
-    return processedAny;
+    fastIterationDocRoot = docRoot;
+    try {
+      boolean processedAny = descendToRoots(rtx, docRoot);
+      rtx.moveTo(docRoot);
+      return processedAny;
+    } finally {
+      fastIterationDocRoot = -1;
+    }
   }
 
   /**
@@ -1005,12 +1132,28 @@ public final class ProjectionIndexBuilder {
         // its children are the array elements directly.
         final boolean arrayLike = matchKind == NodeKind.ARRAY || matchKind == NodeKind.OBJECT_NAMED_ARRAY;
         if (arrayLike) {
-          if (rtx.moveToFirstChild()) {
-            do {
-              final long elementKey = rtx.getNodeKey();
-              extractRow(rtx, elementKey);
-              rtx.moveTo(elementKey);
-            } while (rtx.moveToRightSibling());
+          // The in-order label lane covers exactly the shape its contract names: the members of a
+          // TOP-LEVEL record-set array, arriving in document order, at most one such container per
+          // build. Everything else stays on the neighbour-aware general mint.
+          final boolean inOrderEligible =
+              inOrderLane != null && !inOrderLane.used && parentKey == fastIterationDocRoot && parentKey >= 0;
+          if (inOrderEligible) {
+            inOrderLane.used = true;
+            inOrderLane.containerKey = matchKey;
+            inOrderLane.previousLocal = null;
+          }
+          try {
+            if (rtx.moveToFirstChild()) {
+              do {
+                final long elementKey = rtx.getNodeKey();
+                extractRow(rtx, elementKey);
+                rtx.moveTo(elementKey);
+              } while (rtx.moveToRightSibling());
+            }
+          } finally {
+            if (inOrderEligible) {
+              inOrderLane.containerKey = -1;
+            }
           }
         } else {
           extractRow(rtx, matchKey);
@@ -1103,6 +1246,38 @@ public final class ProjectionIndexBuilder {
     }
     appendExtractedRecord(recordKey, orderLabel, orderLabelBytes, "XML");
     return true;
+  }
+
+  /**
+   * A chunk batch bound to this build's CURRENT field resolution. Called on the coordinator at
+   * chunk-dispatch time, after the chunk's new paths were resolved into the path summary, so the
+   * snapshot contains every path class the chunk's records can carry.
+   */
+  ProjectionChunkRowBatch newChunkBatch(final PathSummaryReader pathSummary, final int expectedRows,
+      final long recordSetKey) {
+    if (!streaming) {
+      throw new IllegalStateException("chunk batches are only available to a streaming builder");
+    }
+    extractor.refresh(pathSummary);
+    return new ProjectionChunkRowBatch(extractor.fieldPcrKeysRef(), extractor.fieldPcrColumnsRef(),
+        extractor.columnKindsRef(), expectedRows, recordSetKey);
+  }
+
+  /**
+   * Append one worker-extracted batch row as the next record, in the caller's order — the batch
+   * counterpart of {@link #appendRecord(JsonNodeReadOnlyTrx, long, SirixDeweyID)}: same leaf
+   * preparation, same extractor buffers, same {@link #appendExtractedRecord} packing, with the rtx
+   * navigation replaced by {@link ProjectionIndexRowExtractor#loadRowFromBatch}.
+   */
+  void appendBatchRow(final ProjectionChunkRowBatch batch, final int row, final long recordKey,
+      final SirixDeweyID orderLabel) {
+    if (!streaming) {
+      throw new IllegalStateException("appendBatchRow() is the streaming builder's entry point; this builder walks");
+    }
+    final byte[] orderLabelBytes = Objects.requireNonNull(orderLabel, "orderLabel must not be null").toBytes();
+    prepareLeafForOrderLabel(orderLabelBytes, "JSON");
+    extractor.loadRowFromBatch(batch, row);
+    appendExtractedRecord(recordKey, orderLabel, orderLabelBytes, "JSON");
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -625,7 +625,7 @@ public final class ProjectionIndexBuilder {
     // survive under the new metadata. Ordinary transaction maintenance never takes this path.
     epoch.storage.resetTree();
     // Fresh build on a virgin tree: accumulate every slot write and materialize the tree in one
-    // canonical bulk pass (docs/HOT_BULK_BUILD.md §Seam 2a — measured 9–14× the per-entry path
+    // canonical bulk pass (docs/HOT_BULK_BUILD.md §2 — measured 9–14× the per-entry path
     // for the order-label and column-segment shapes). Point reads during the build are served
     // from the accumulator (read-through); side-page attaches are deferred under a byte budget;
     // a capacity trip splices the prefix and falls back to per-entry. The accumulator lives

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexBuilder.java
@@ -634,131 +634,132 @@ public final class ProjectionIndexBuilder {
     // what the per-entry path would have persisted on a failure.
     epoch.storage.beginBulkSlotAccumulation();
     try {
-    // No document-wide pre-pass: the directory mints a record's order label the first time this
-    // build asks for one, so it costs exactly one slot per emitted record and no second walk.
-    epoch.orderDirectory.seedRoot(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
-    final LongFunction<ImmutableNode> documentNodeLookup =
-        nodeKey -> storageEngineWriter.getRecord(nodeKey, IndexType.DOCUMENT, -1);
-    // In-order lane: while the walk iterates the members of a top-level record-set array, labels
-    // mint by the pure append algebra with ZERO document lookups. The general fullLabel path mints
-    // the FIRST record's label by labelling its ENTIRE maximal unlabelled sibling run — on a fresh
-    // 100M build that is a full-corpus sibling walk plus one slot write per record before the first
-    // row extracts, and none of it can flush because no leaf boundary has been reached yet. The
-    // lane is byte-equivalent for exactly this arrival order (the argument lives on
-    // fullLabelForInOrderAppend) and the carry survives epoch rebinds because the caller holds it.
-    final InOrderLabelLane inOrderLane = new InOrderLabelLane();
-    final LongFunction<SirixDeweyID> orderLabelResolver = recordKey -> {
-      if (inOrderLane.containerKey >= 0) {
-        final SirixDeweyID fullLabel = epoch.orderDirectory.fullLabelForInOrderAppend(recordKey,
-            inOrderLane.containerKey, Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), inOrderLane.previousLocal);
-        inOrderLane.previousLocal = epoch.orderDirectory.lastInOrderAppendedLocal();
-        return fullLabel;
-      }
-      return epoch.orderDirectory.fullLabel(recordKey, documentNodeLookup,
-          ProjectionStructuralOrderDirectory.RelabelSink.SEALED);
-    };
-    final int priorRowGroupCount = 0;
-    final ProjectionSetSummaryChunks.BuildAccumulator setSummaries = new ProjectionSetSummaryChunks.BuildAccumulator();
-    if (emptyRecordSetAllowed && pathSummary.getPCRsForPaths(Set.of(indexDef.getProjectionRootPath())).isEmpty()) {
-      final List<Type> fieldTypes = indexDef.getProjectionFieldTypes();
-      final byte[] columnKinds = new byte[fieldTypes.size()];
-      for (int i = 0; i < columnKinds.length; i++) {
-        columnKinds[i] = mapTypeToColumnKind(fieldTypes.get(i), indexDef.getProjectionFields().get(i));
-      }
-      try {
-        finishPersist(indexDef, epoch.storage, LongArrayList.of(), LongArrayList.of(), priorRowGroupCount,
-            rtx.getRevisionNumber(), columnKinds, setSummaries, null, null);
-        publishGlobalDictionaryColumnsBuilt(0);
-      } finally {
-        setSummaries.release();
-      }
-      return;
-    }
-    // Streaming build (descriptor layout): each leaf is written the moment the builder emits
-    // it — one leaf in memory at a time, matching this class's streaming contract instead of
-    // buffering all encoded leaves on the heap (~240 MB at the 100 M-row scale). Retained derived
-    // state is bounded: at most one 32-leaf fence tail, one 256-leaf Bloom window per
-    // string column and only set-summary values that still fit their one persisted summary chunk.
-    final ProjectionIndexFences.BuildWriter fenceWriter = new ProjectionIndexFences.BuildWriter();
-    final ProjectionBloomChunks.Writer bloomChunks = new ProjectionBloomChunks.Writer();
-    final boolean hasSetColumn = hasStringSetColumn(indexDef);
-    final ProjectionIndexColumnSegmentCodec.EncodeWorkspace encodeWorkspace =
-        new ProjectionIndexColumnSegmentCodec.EncodeWorkspace();
-    final ProjectionIndexBuilder builder = new ProjectionIndexBuilder(indexDef, pathSummary, leaf -> {
-      if (leaf.getRowCount() == 0) {
-        throw new IllegalStateException("Projection leaf " + fenceWriter.rowGroupCount() + " is empty");
-      }
-      final int physicalSlot = fenceWriter.rowGroupCount() + 1;
-      // Accumulate the index-wide per-value ROW counts while the leaf is in hand. Summing the
-      // per-leaf counts is exact: a record lives in exactly one leaf, and the per-leaf figures
-      // already count rows rather than occurrences.
-      if (hasSetColumn) {
-        setSummaries.append(leaf);
-      }
-      final ProjectionIndexColumnSegmentCodec.EncodedRowGroup encoded =
-          ProjectionIndexColumnSegmentCodec.encodeReferencedOnly(leaf, encodeWorkspace);
-      epoch.storage.putRowGroupAsColumnSegmentSlots(physicalSlot, encoded);
-      fenceWriter.append(epoch.storage, leaf.firstRecordKey(), leaf.lastRecordKey());
-      persistOrderExceptionLocators(leaf, physicalSlot, epoch.recordLocator);
-      bloomChunks.append(encoded, physicalSlot, epoch.storage);
-      // Rotate the async-flush epoch at the same log-entry bound the bulk import uses, then rebind
-      // every storage-facing accessor: a flush serializes and releases the pages behind them, so a
-      // handle cached across the boundary would touch freed frames. The heap-side writers (fences,
-      // Bloom window, set summaries, dictionaries) carry build state and take storage per call, so
-      // they cross epochs untouched — the same contract ProjectionBulkLoad established for the
-      // load-time rider.
-      if (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
-        storageEngineWriter.asyncFlush();
-        epoch.rebind(storageEngineWriter, indexDef.getID());
-      }
-    }, false, orderLabelResolver);
-    builder.inOrderLane = inOrderLane;
-    try {
-      if (rtx instanceof final JsonNodeReadOnlyTrx jsonRtx) {
-        builder.build(jsonRtx);
-      } else if (rtx instanceof final XmlNodeReadOnlyTrx xmlRtx) {
-        builder.build(xmlRtx);
-      } else {
-        throw new IllegalArgumentException("projection build requires a JSON or XML node transaction");
-      }
-      final byte[] columnKinds = builder.columnKinds();
-      bloomChunks.finishChunks(epoch.storage, fenceWriter.rowGroupCount(), columnKinds);
-      // Dictionaries are written after the leaves, and only once: the leaves refer to values by id,
-      // so nothing can be persisted about a dictionary until every id it will ever mint is known.
-      final long[] valueDictionaryHeaderKeys =
-          flushValueDictionaries(builder.globalDictionaries(), storageEngineWriter);
-      fenceWriter.finish(epoch.storage, priorRowGroupCount);
-      finishPersistWithStreamingFences(indexDef, epoch.storage, fenceWriter.rowGroupCount(), priorRowGroupCount,
-          rtx.getRevisionNumber(), columnKinds, setSummaries, valueDictionaryHeaderKeys, bloomChunks);
-      builder.publishGlobalDictionaryColumnsBuilt();
-      // Materialize the accumulated tree now (idempotent — the outer finally is the exception
-      // backstop) and drain the splice burst through the same epoch rotations the in-loop
-      // boundary checks use. The burst lands AFTER the last leaf's boundary check, so without
-      // this the bounded-retention contract would measure the whole freshly spliced tree as
-      // live. Bounded: the pinned-trie spill drains bottom-up (leaves, then interiors whose
-      // children became durable), and the loop stops when the boundary clears or an epoch
-      // stops reducing the log (the unspillable top-level anchors stay for the final commit).
-      epoch.storage.finalizeBulkSlotAccumulation();
-      int previousLive = Integer.MAX_VALUE;
-      while (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
-        final int live = storageEngineWriter.getLog().liveEntryCount();
-        if (live >= previousLive) {
-          break;
+      // No document-wide pre-pass: the directory mints a record's order label the first time this
+      // build asks for one, so it costs exactly one slot per emitted record and no second walk.
+      epoch.orderDirectory.seedRoot(Fixed.DOCUMENT_NODE_KEY.getStandardProperty());
+      final LongFunction<ImmutableNode> documentNodeLookup =
+          nodeKey -> storageEngineWriter.getRecord(nodeKey, IndexType.DOCUMENT, -1);
+      // In-order lane: while the walk iterates the members of a top-level record-set array, labels
+      // mint by the pure append algebra with ZERO document lookups. The general fullLabel path mints
+      // the FIRST record's label by labelling its ENTIRE maximal unlabelled sibling run — on a fresh
+      // 100M build that is a full-corpus sibling walk plus one slot write per record before the first
+      // row extracts, and none of it can flush because no leaf boundary has been reached yet. The
+      // lane is byte-equivalent for exactly this arrival order (the argument lives on
+      // fullLabelForInOrderAppend) and the carry survives epoch rebinds because the caller holds it.
+      final InOrderLabelLane inOrderLane = new InOrderLabelLane();
+      final LongFunction<SirixDeweyID> orderLabelResolver = recordKey -> {
+        if (inOrderLane.containerKey >= 0) {
+          final SirixDeweyID fullLabel = epoch.orderDirectory.fullLabelForInOrderAppend(recordKey,
+              inOrderLane.containerKey, Fixed.DOCUMENT_NODE_KEY.getStandardProperty(), inOrderLane.previousLocal);
+          inOrderLane.previousLocal = epoch.orderDirectory.lastInOrderAppendedLocal();
+          return fullLabel;
         }
-        previousLive = live;
-        storageEngineWriter.asyncFlush();
+        return epoch.orderDirectory.fullLabel(recordKey, documentNodeLookup,
+            ProjectionStructuralOrderDirectory.RelabelSink.SEALED);
+      };
+      final int priorRowGroupCount = 0;
+      final ProjectionSetSummaryChunks.BuildAccumulator setSummaries =
+          new ProjectionSetSummaryChunks.BuildAccumulator();
+      if (emptyRecordSetAllowed && pathSummary.getPCRsForPaths(Set.of(indexDef.getProjectionRootPath())).isEmpty()) {
+        final List<Type> fieldTypes = indexDef.getProjectionFieldTypes();
+        final byte[] columnKinds = new byte[fieldTypes.size()];
+        for (int i = 0; i < columnKinds.length; i++) {
+          columnKinds[i] = mapTypeToColumnKind(fieldTypes.get(i), indexDef.getProjectionFields().get(i));
+        }
+        try {
+          finishPersist(indexDef, epoch.storage, LongArrayList.of(), LongArrayList.of(), priorRowGroupCount,
+              rtx.getRevisionNumber(), columnKinds, setSummaries, null, null);
+          publishGlobalDictionaryColumnsBuilt(0);
+        } finally {
+          setSummaries.release();
+        }
+        return;
       }
-    } finally {
+      // Streaming build (descriptor layout): each leaf is written the moment the builder emits
+      // it — one leaf in memory at a time, matching this class's streaming contract instead of
+      // buffering all encoded leaves on the heap (~240 MB at the 100 M-row scale). Retained derived
+      // state is bounded: at most one 32-leaf fence tail, one 256-leaf Bloom window per
+      // string column and only set-summary values that still fit their one persisted summary chunk.
+      final ProjectionIndexFences.BuildWriter fenceWriter = new ProjectionIndexFences.BuildWriter();
+      final ProjectionBloomChunks.Writer bloomChunks = new ProjectionBloomChunks.Writer();
+      final boolean hasSetColumn = hasStringSetColumn(indexDef);
+      final ProjectionIndexColumnSegmentCodec.EncodeWorkspace encodeWorkspace =
+          new ProjectionIndexColumnSegmentCodec.EncodeWorkspace();
+      final ProjectionIndexBuilder builder = new ProjectionIndexBuilder(indexDef, pathSummary, leaf -> {
+        if (leaf.getRowCount() == 0) {
+          throw new IllegalStateException("Projection leaf " + fenceWriter.rowGroupCount() + " is empty");
+        }
+        final int physicalSlot = fenceWriter.rowGroupCount() + 1;
+        // Accumulate the index-wide per-value ROW counts while the leaf is in hand. Summing the
+        // per-leaf counts is exact: a record lives in exactly one leaf, and the per-leaf figures
+        // already count rows rather than occurrences.
+        if (hasSetColumn) {
+          setSummaries.append(leaf);
+        }
+        final ProjectionIndexColumnSegmentCodec.EncodedRowGroup encoded =
+            ProjectionIndexColumnSegmentCodec.encodeReferencedOnly(leaf, encodeWorkspace);
+        epoch.storage.putRowGroupAsColumnSegmentSlots(physicalSlot, encoded);
+        fenceWriter.append(epoch.storage, leaf.firstRecordKey(), leaf.lastRecordKey());
+        persistOrderExceptionLocators(leaf, physicalSlot, epoch.recordLocator);
+        bloomChunks.append(encoded, physicalSlot, epoch.storage);
+        // Rotate the async-flush epoch at the same log-entry bound the bulk import uses, then rebind
+        // every storage-facing accessor: a flush serializes and releases the pages behind them, so a
+        // handle cached across the boundary would touch freed frames. The heap-side writers (fences,
+        // Bloom window, set summaries, dictionaries) carry build state and take storage per call, so
+        // they cross epochs untouched — the same contract ProjectionBulkLoad established for the
+        // load-time rider.
+        if (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
+          storageEngineWriter.asyncFlush();
+          epoch.rebind(storageEngineWriter, indexDef.getID());
+        }
+      }, false, orderLabelResolver);
+      builder.inOrderLane = inOrderLane;
       try {
-        bloomChunks.release();
+        if (rtx instanceof final JsonNodeReadOnlyTrx jsonRtx) {
+          builder.build(jsonRtx);
+        } else if (rtx instanceof final XmlNodeReadOnlyTrx xmlRtx) {
+          builder.build(xmlRtx);
+        } else {
+          throw new IllegalArgumentException("projection build requires a JSON or XML node transaction");
+        }
+        final byte[] columnKinds = builder.columnKinds();
+        bloomChunks.finishChunks(epoch.storage, fenceWriter.rowGroupCount(), columnKinds);
+        // Dictionaries are written after the leaves, and only once: the leaves refer to values by id,
+        // so nothing can be persisted about a dictionary until every id it will ever mint is known.
+        final long[] valueDictionaryHeaderKeys =
+            flushValueDictionaries(builder.globalDictionaries(), storageEngineWriter);
+        fenceWriter.finish(epoch.storage, priorRowGroupCount);
+        finishPersistWithStreamingFences(indexDef, epoch.storage, fenceWriter.rowGroupCount(), priorRowGroupCount,
+            rtx.getRevisionNumber(), columnKinds, setSummaries, valueDictionaryHeaderKeys, bloomChunks);
+        builder.publishGlobalDictionaryColumnsBuilt();
+        // Materialize the accumulated tree now (idempotent — the outer finally is the exception
+        // backstop) and drain the splice burst through the same epoch rotations the in-loop
+        // boundary checks use. The burst lands AFTER the last leaf's boundary check, so without
+        // this the bounded-retention contract would measure the whole freshly spliced tree as
+        // live. Bounded: the pinned-trie spill drains bottom-up (leaves, then interiors whose
+        // children became durable), and the loop stops when the boundary clears or an epoch
+        // stops reducing the log (the unspillable top-level anchors stay for the final commit).
+        epoch.storage.finalizeBulkSlotAccumulation();
+        int previousLive = Integer.MAX_VALUE;
+        while (intermediateFlushEnabled && storageEngineWriter.isAsyncFlushLogBoundaryReached()) {
+          final int live = storageEngineWriter.getLog().liveEntryCount();
+          if (live >= previousLive) {
+            break;
+          }
+          previousLive = live;
+          storageEngineWriter.asyncFlush();
+        }
       } finally {
         try {
-          setSummaries.release();
+          bloomChunks.release();
         } finally {
-          builder.releaseTransientState();
+          try {
+            setSummaries.release();
+          } finally {
+            builder.releaseTransientState();
+          }
         }
       }
-    }
     } finally {
       // The CURRENT epoch's storage owns the (possibly transplanted) accumulator.
       epoch.storage.finalizeBulkSlotAccumulation();
@@ -767,25 +768,28 @@ public final class ProjectionIndexBuilder {
 
   /**
    * Mutable state of the explicit build's in-order order-label lane, shared between the label
-   * resolver (which mints through it while armed) and the record walk (which arms it for exactly
-   * the members of a top-level record-set array and disarms it after). The carry is held HERE, not
-   * on the directory accessor, so an async-flush epoch rebind cannot lose it.
+   * resolver (which mints through it while armed) and the record walk (which arms it for exactly the
+   * members of a top-level record-set array and disarms it after). The carry is held HERE, not on the
+   * directory accessor, so an async-flush epoch rebind cannot lose it.
    */
   static final class InOrderLabelLane {
     /** The container whose members are currently arriving in document order; -1 = disarmed. */
     long containerKey = -1;
     /** The previous record's LOCAL label — the append algebra's carry. */
-    @Nullable SirixDeweyID previousLocal;
-    /** The lane serves at most ONE container per build: a second top-level record-set array would
-     * receive the same open-bounds container label as the first, so it takes the general path,
-     * whose neighbour-aware mint keeps sibling containers strictly ordered. */
+    @Nullable
+    SirixDeweyID previousLocal;
+    /**
+     * The lane serves at most ONE container per build: a second top-level record-set array would
+     * receive the same open-bounds container label as the first, so it takes the general path, whose
+     * neighbour-aware mint keeps sibling containers strictly ordered.
+     */
     boolean used;
   }
 
   /**
    * The storage-facing bindings of one async-flush epoch of an explicit bulk build. A flush
-   * serializes and releases the pages behind these accessors, so each rotation must re-open them
-   * over the same persisted sub-tree — the contract {@link ProjectionBulkLoad} established for the
+   * serializes and releases the pages behind these accessors, so each rotation must re-open them over
+   * the same persisted sub-tree — the contract {@link ProjectionBulkLoad} established for the
    * load-time rider ("nothing epoch-scoped is ever cached across a commit"). Re-seeding the root
    * label on rebind is idempotent: the seed only writes when no persisted label exists yet.
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -664,19 +664,11 @@ public final class ProjectionIndexCatalog {
     for (int i = 0; i < columnSegmentCount; i++) {
       bytes += RowGroupDescriptor.entryByteLen(descriptor, i);
     }
-    final int rows = RowGroupDescriptor.rowCount(descriptor);
-    final long presenceBytes = ((rows + 63L) >>> 6) << 3;
     final int columnCount = RowGroupDescriptor.columnCount(descriptor);
     for (int c = 0; c < columnCount; c++) {
-      final byte kind = RowGroupDescriptor.kind(descriptor, c);
-      // A LAYOUT question — how many bytes does a decoded slice occupy — so it asks the layout
-      // predicate. A global string column decodes to the same eight bytes per row as any other long
-      // lane, and counting it as weightless would let the cache hold more than it accounted for.
-      if (ProjectionIndexRowGroupPage.isLongLaneKind(kind)) {
-        bytes += ((long) rows << 3) + presenceBytes;
-      } else if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN) {
-        bytes += presenceBytes << 1;
-      }
+      // The SAME arithmetic the store's fill doors price against, so the weight that admits a
+      // handle and the budget that declines its fills cannot disagree about what a column costs.
+      bytes += ProjectionColumnStore.decodedColumnResidentBytes(descriptor, RowGroupDescriptor.kind(descriptor, c));
     }
     return bytes;
   }
@@ -853,6 +845,10 @@ public final class ProjectionIndexCatalog {
    *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()})
    * @return {@code true} when the windowed route serves this weight
    */
+  public static boolean servesWindowedPayloads(final long projectedWeightBytes) {
+    return projectedWeightBytes > eagerMaterializeBytes;
+  }
+
   /**
    * RESIDENT bytes a handle of this projected weight can hold — the figure the {@link #DATA} weigher
    * charges. Under the eager budget that is the projection itself; over it the leaves are never
@@ -874,10 +870,6 @@ public final class ProjectionIndexCatalog {
     // ceiling self-evicts the entry on insert and makes every lookup re-decode a fresh handle,
     // which is the failure this figure exists to prevent.
     return Math.max(1L, Math.min(resident, Math.max(1L, CACHE_BYTES >> 1)));
-  }
-
-  public static boolean servesWindowedPayloads(final long projectedWeightBytes) {
-    return projectedWeightBytes > eagerMaterializeBytes;
   }
 
   /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -736,16 +736,15 @@ public final class ProjectionIndexCatalog {
    * <p>
    * Derived, not invented: an eager {@code List<byte[]>} of every leaf lives inside the {@link #DATA}
    * cache's byte budget ({@code sirix.projection.cacheBytes}) — an entry heavier than half that
-   * budget is guaranteed cache-thrash — and it must also fit the heap beside the off-heap arena, so
-   * a quarter of {@code Runtime.maxMemory()} bounds it from the other side. At 100M rows a
-   * fat-string projection's leaves total ~8-10 GB; the first whole-leaf consumer (string LIKE,
-   * distinct over strings) OOMed the materializer inside the catalog load. The projected weight
-   * compared against this is the handle's worst-case RESIDENT bytes — the same conservative figure
-   * the cache weigher uses — so the route flips to windowed strictly BEFORE the eager list could
-   * have fit.
+   * budget is guaranteed cache-thrash — and it must also fit the heap beside the off-heap arena, so a
+   * quarter of {@code Runtime.maxMemory()} bounds it from the other side. At 100M rows a fat-string
+   * projection's leaves total ~8-10 GB; the first whole-leaf consumer (string LIKE, distinct over
+   * strings) OOMed the materializer inside the catalog load. The projected weight compared against
+   * this is the handle's worst-case RESIDENT bytes — the same conservative figure the cache weigher
+   * uses — so the route flips to windowed strictly BEFORE the eager list could have fit.
    */
-  private static final long EAGER_MATERIALIZE_BYTES_DEFAULT = Long.getLong(
-      "sirix.projection.eagerMaterializeBytes", Math.min(CACHE_BYTES / 2, Runtime.getRuntime().maxMemory() / 4));
+  private static final long EAGER_MATERIALIZE_BYTES_DEFAULT = Long.getLong("sirix.projection.eagerMaterializeBytes",
+      Math.min(CACHE_BYTES / 2, Runtime.getRuntime().maxMemory() / 4));
 
   private static volatile long eagerMaterializeBytes = EAGER_MATERIALIZE_BYTES_DEFAULT;
 
@@ -797,8 +796,8 @@ public final class ProjectionIndexCatalog {
    * whole-column residency that OOMed fat string columns at 100M.
    *
    * @param projectedWeightBytes the handle's worst-case resident bytes
-   *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()}), or {@code 0} to force
-   *        the eager route
+   *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()}), or {@code 0} to force the
+   *        eager route
    */
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount, final long projectedWeightBytes) {
@@ -811,8 +810,8 @@ public final class ProjectionIndexCatalog {
         public List<byte[]> get() {
           // The BUILD yields the shared cache; what leaves this method is always a thin view over
           // it carrying THIS caller's source, so no shared object ever holds one.
-          return windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes)
-              .boundTo(readerSource());
+          return windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes).boundTo(
+              readerSource());
         }
 
         @Override
@@ -872,7 +871,9 @@ public final class ProjectionIndexCatalog {
     return Math.max(1L, Math.min(resident, Math.max(1L, CACHE_BYTES >> 1)));
   }
 
-  /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */
+  /**
+   * Build the windowed payload view: one physical-order read up front, one fetch per window after.
+   */
   private static ProjectionWindowedRowGroupPayloads windowedRowGroupPayloads(final ResourceSession<?, ?> session,
       final int revision, final int defId, final int rowGroupCount, final long projectedWeightBytes) {
     ChunkedBodyConfig.recordWindowedColumnEngagement();
@@ -885,8 +886,7 @@ public final class ProjectionIndexCatalog {
     // sized by the projected per-leaf weight (conservative — includes decode expansion, so the cap
     // errs toward fewer resident windows), and never below the machine's worker count so a parallel
     // shard sweep does not thrash at its shard boundaries.
-    final long projectedWindowBytes =
-        Math.max(1L, projectedWeightBytes / Math.max(1, rowGroupCount)) * windowSize;
+    final long projectedWindowBytes = Math.max(1L, projectedWeightBytes / Math.max(1, rowGroupCount)) * windowSize;
     final int residentCap = (int) Math.min(Integer.MAX_VALUE,
         Math.max(Runtime.getRuntime().availableProcessors(), (eagerMaterializeBytes / 4) / projectedWindowBytes));
     if (DIAG) {
@@ -895,26 +895,26 @@ public final class ProjectionIndexCatalog {
     }
     // The fetcher captures the physical order and the definition id — both inert — and NOTHING
     // session-scoped: its transaction comes from the source the consult site binds.
-    return new ProjectionWindowedRowGroupPayloads(rowGroupCount, windowSize, residentCap, (source, from,
-        toExclusive) -> {
-      final byte[][] window = new byte[toExclusive - from][];
-      // A transaction PER WINDOW: concurrent read transactions are supported, one is not
-      // thread-safe, and parallel kernels touch disjoint windows concurrently.
-      try (NodeReadOnlyTrx windowRtx = source.openReader()) {
-        final StorageEngineReader reader = windowRtx.getStorageEngineReader();
-        for (int logical = from; logical < toExclusive; logical++) {
-          final byte[] payload =
-              ProjectionIndexHOTStorage.readRowGroupFromColumnSegmentSlots(reader, defId, physicalOrder[logical]);
-          if (payload == null) {
-            throw new IllegalStateException("Projection definition #" + defId + " truncated during windowed "
-                + "materialization: logical row group " + logical + " (physical slot " + physicalOrder[logical]
-                + ") has no payload");
+    return new ProjectionWindowedRowGroupPayloads(rowGroupCount, windowSize, residentCap,
+        (source, from, toExclusive) -> {
+          final byte[][] window = new byte[toExclusive - from][];
+          // A transaction PER WINDOW: concurrent read transactions are supported, one is not
+          // thread-safe, and parallel kernels touch disjoint windows concurrently.
+          try (NodeReadOnlyTrx windowRtx = source.openReader()) {
+            final StorageEngineReader reader = windowRtx.getStorageEngineReader();
+            for (int logical = from; logical < toExclusive; logical++) {
+              final byte[] payload =
+                  ProjectionIndexHOTStorage.readRowGroupFromColumnSegmentSlots(reader, defId, physicalOrder[logical]);
+              if (payload == null) {
+                throw new IllegalStateException("Projection definition #" + defId + " truncated during windowed "
+                    + "materialization: logical row group " + logical + " (physical slot " + physicalOrder[logical]
+                    + ") has no payload");
+              }
+              window[logical - from] = payload;
+            }
           }
-          window[logical - from] = payload;
-        }
-      }
-      return window;
-    });
+          return window;
+        });
   }
 
   /** Above this many row groups the slot walk partitions across per-thread readers. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -21,14 +21,11 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.concurrent.atomic.LongAdder;
@@ -147,7 +144,13 @@ public final class ProjectionIndexCatalog {
                     // insert, so a lazily-growing handle must be accounted at what it can grow to.
                     long bytes = 64;
                     if (handle.columnStoreOrNull() != null) {
-                      bytes += handle.projectedWeightBytes();
+                      // A handle over the eager budget never materializes those leaves: it serves
+                      // through bounded windows, so its RESIDENT bytes are the budget that bounds
+                      // both the window cap (a quarter of it) and each column fill (all of it) —
+                      // not the whole-leaf projection it declines to hold. Charging the projection
+                      // put a 10 GB handle over this cache's own maximumWeight, so Caffeine evicted
+                      // it on insert and every lookup re-decoded a fresh one.
+                      bytes += windowedResidentWeightBytes(handle.projectedWeightBytes());
                     } else {
                       // Eager handle: leaves are pre-materialized, so no materializer is needed.
                       for (final byte[] payload : handle.rowGroupPayloads(null)) {
@@ -806,30 +809,26 @@ public final class ProjectionIndexCatalog {
    */
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount, final long projectedWeightBytes) {
-    return rowGroupMaterializer(session, revision, defId, rowGroupCount, projectedWeightBytes,
-        new WindowedViewKey(defId, revision));
-  }
-
-  /**
-   * As above, with the HANDLE as the windowed view's owner — the overload every caller that holds
-   * one should use. The handle is keyed on the BUILD revision, so one view serves every query
-   * revision the build covers instead of one per query revision.
-   *
-   * @param handle the covering handle; supplies the definition id and the projected weight
-   * @param rowGroupCount the handle's row-group count
-   */
-  public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
-      final ProjectionIndexRegistry.Handle handle, final int rowGroupCount) {
-    Objects.requireNonNull(handle, "handle");
-    return rowGroupMaterializer(session, revision, handle.defId(), rowGroupCount, handle.projectedWeightBytes(),
-        handle);
-  }
-
-  private static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
-      final int defId, final int rowGroupCount, final long projectedWeightBytes, final Object viewOwner) {
+    Objects.requireNonNull(session, "session");
     if (servesWindowedPayloads(projectedWeightBytes)) {
-      return () -> sessionWindowedRowGroupPayloads(session, viewOwner, revision, defId, rowGroupCount,
-          projectedWeightBytes);
+      // The windowed arm hands the handle BOTH the build and this caller's reader source, so a view
+      // the handle already memoized is rebound to this live session instead of rebuilt.
+      return new ProjectionWindowedRowGroupPayloads.BoundMaterializer() {
+        @Override
+        public List<byte[]> get() {
+          final ProjectionWindowedRowGroupPayloads view =
+              windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
+          // Bind at the BUILD too, not only when a handle rebinds a memoized view, so a caller that
+          // consults this supplier directly gets a usable view.
+          view.bindReaderSource(readerSource());
+          return view;
+        }
+
+        @Override
+        public ProjectionWindowedRowGroupPayloads.ReaderSource readerSource() {
+          return () -> session.beginNodeReadOnlyTrx(revision);
+        }
+      };
     }
     return () -> {
       if (projectedWeightBytes > 0) {
@@ -855,99 +854,27 @@ public final class ProjectionIndexCatalog {
    *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()})
    * @return {@code true} when the windowed route serves this weight
    */
+  /**
+   * RESIDENT bytes a handle of this projected weight can hold — the figure the {@link #DATA} weigher
+   * charges. Under the eager budget that is the projection itself; over it the leaves are never
+   * materialized, so it is the budget that bounds the window cap and each column fill.
+   *
+   * @param projectedWeightBytes the handle's whole-leaf projection
+   * @return the resident bytes to charge
+   */
+  static long windowedResidentWeightBytes(final long projectedWeightBytes) {
+    return servesWindowedPayloads(projectedWeightBytes)
+        ? eagerMaterializeBytes
+        : projectedWeightBytes;
+  }
+
   public static boolean servesWindowedPayloads(final long projectedWeightBytes) {
     return projectedWeightBytes > eagerMaterializeBytes;
   }
 
-  /**
-   * Windowed views by the SESSION they are bound to, then by the view's OWNER. Identity keyed,
-   * because a session is an identity and never a value.
-   *
-   * <p>
-   * The view's lifetime is exactly its session's: its fetcher opens a read transaction on that
-   * session for every window, so it must not outlive it — which is why the process-wide handle
-   * cache refuses to memoize one ({@link ProjectionIndexRegistry.Handle#rowGroupPayloads(Supplier)}).
-   * It must not be built per CALLER either: a view's resident-window cap is a per-view budget, so N
-   * independent views over one session permit N times the residency the cap was sized for, plus N
-   * repeats of the physical-order walk. Sessions are shared per resource path, so keying here gives
-   * exactly one view per session and owner.
-   * </p>
-   *
-   * <p>
-   * The OWNER is the {@link ProjectionIndexRegistry.Handle} whenever the caller has one, because the
-   * handle is what determines the bytes: it is cached on the BUILD revision, so one handle serves
-   * every query revision since the build, and keying on the query revision instead would rebuild a
-   * view per revision over byte-identical leaves. A rebuild changes the handle, so reuse across
-   * query revisions is exactly as safe as the handle itself.
-   * </p>
-   *
-   * <p>
-   * Entries are dropped by {@link #invalidateSessionWindowedPayloads} when the session closes; the
-   * value holds the session strongly (through the fetcher), so weak keys alone would never collect.
-   * </p>
-   */
-  private static final Map<ResourceSession<?, ?>, ConcurrentHashMap<Object, WindowedViewHolder>>
-      SESSION_WINDOWED_PAYLOADS = new IdentityHashMap<>();
-
-  /** Owner key for callers that hold no handle — same definition and revision, same view. */
-  private record WindowedViewKey(int defId, int revision) {
-  }
-
-  /**
-   * One view's memo slot. The build happens under THIS holder's monitor, never a session-wide one:
-   * a cold build walks the whole physical order, and blocking a warm consult of an unrelated
-   * definition behind it is the stall the memo exists to remove.
-   */
-  private static final class WindowedViewHolder {
-    private volatile List<byte[]> view;
-
-    List<byte[]> get(final Supplier<List<byte[]>> build) {
-      List<byte[]> current = view;
-      if (current != null) {
-        return current;
-      }
-      synchronized (this) {
-        current = view;
-        if (current == null) {
-          current = build.get();
-          view = current;
-        }
-        return current;
-      }
-    }
-  }
-
-  /**
-   * Drop every windowed payload view bound to {@code session} — called when the session closes, so
-   * neither the view nor the session it captured is retained afterwards.
-   *
-   * @param session the closing session; {@code null} is ignored
-   */
-  public static void invalidateSessionWindowedPayloads(final @Nullable ResourceSession<?, ?> session) {
-    if (session == null) {
-      return;
-    }
-    synchronized (SESSION_WINDOWED_PAYLOADS) {
-      SESSION_WINDOWED_PAYLOADS.remove(session);
-    }
-  }
-
-  /** The session's windowed view for this owner, built once and reused. */
-  private static List<byte[]> sessionWindowedRowGroupPayloads(final ResourceSession<?, ?> session,
-      final Object viewOwner, final int revision, final int defId, final int rowGroupCount,
-      final long projectedWeightBytes) {
-    final ConcurrentHashMap<Object, WindowedViewHolder> perSession;
-    synchronized (SESSION_WINDOWED_PAYLOADS) {
-      perSession = SESSION_WINDOWED_PAYLOADS.computeIfAbsent(session, key -> new ConcurrentHashMap<>(4));
-    }
-    return perSession.computeIfAbsent(viewOwner, key -> new WindowedViewHolder())
-                     .get(() -> windowedRowGroupPayloads(session, revision, defId, rowGroupCount,
-                         projectedWeightBytes));
-  }
-
   /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */
-  private static List<byte[]> windowedRowGroupPayloads(final ResourceSession<?, ?> session, final int revision,
-      final int defId, final int rowGroupCount, final long projectedWeightBytes) {
+  private static ProjectionWindowedRowGroupPayloads windowedRowGroupPayloads(final ResourceSession<?, ?> session,
+      final int revision, final int defId, final int rowGroupCount, final long projectedWeightBytes) {
     ChunkedBodyConfig.recordWindowedColumnEngagement();
     final int windowSize = windowLeaves;
     final int[] physicalOrder;
@@ -966,11 +893,14 @@ public final class ProjectionIndexCatalog {
       System.err.println("[cat] windowed payloads: defId=" + defId + " rowGroups=" + rowGroupCount + " projected="
           + (projectedWeightBytes >> 20) + "MB windowLeaves=" + windowSize + " residentCap=" + residentCap);
     }
-    return new ProjectionWindowedRowGroupPayloads(rowGroupCount, windowSize, residentCap, (from, toExclusive) -> {
+    // The fetcher captures the physical order and the definition id — both inert — and NOTHING
+    // session-scoped: its transaction comes from the source the consult site binds.
+    return new ProjectionWindowedRowGroupPayloads(rowGroupCount, windowSize, residentCap, (source, from,
+        toExclusive) -> {
       final byte[][] window = new byte[toExclusive - from][];
       // A transaction PER WINDOW: concurrent read transactions are supported, one is not
       // thread-safe, and parallel kernels touch disjoint windows concurrently.
-      try (NodeReadOnlyTrx windowRtx = session.beginNodeReadOnlyTrx(revision)) {
+      try (NodeReadOnlyTrx windowRtx = source.openReader()) {
         final StorageEngineReader reader = windowRtx.getStorageEngineReader();
         for (int logical = from; logical < toExclusive; logical++) {
           final byte[] payload =
@@ -1290,9 +1220,6 @@ public final class ProjectionIndexCatalog {
     DEFS.invalidateAll();
     PROBES.invalidateAll();
     DATA.invalidateAll();
-    synchronized (SESSION_WINDOWED_PAYLOADS) {
-      SESSION_WINDOWED_PAYLOADS.clear();
-    }
     DESCRIPTOR_STATS.invalidateAll();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -145,11 +145,12 @@ public final class ProjectionIndexCatalog {
                     long bytes = 64;
                     if (handle.columnStoreOrNull() != null) {
                       // A handle over the eager budget never materializes those leaves: it serves
-                      // through bounded windows, so its RESIDENT bytes are the budget that bounds
-                      // both the window cap (a quarter of it) and each column fill (all of it) —
-                      // not the whole-leaf projection it declines to hold. Charging the projection
-                      // put a 10 GB handle over this cache's own maximumWeight, so Caffeine evicted
-                      // it on insert and every lookup re-decoded a fresh one.
+                      // through bounded windows, so its RESIDENT bytes are the window cap plus what
+                      // its store retains in filled columns — and the store's CUMULATIVE retained-
+                      // fill budget caps that sum at eagerMaterializeBytes, which is what makes this
+                      // flat charge an upper bound rather than a hope. Charging the whole-leaf
+                      // projection instead put a 10 GB handle over this cache's own maximumWeight,
+                      // so Caffeine evicted it on insert and every lookup re-decoded a fresh one.
                       bytes += windowedResidentWeightBytes(handle.projectedWeightBytes());
                     } else {
                       // Eager handle: leaves are pre-materialized, so no materializer is needed.
@@ -816,12 +817,10 @@ public final class ProjectionIndexCatalog {
       return new ProjectionWindowedRowGroupPayloads.BoundMaterializer() {
         @Override
         public List<byte[]> get() {
-          final ProjectionWindowedRowGroupPayloads view =
-              windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
-          // Bind at the BUILD too, not only when a handle rebinds a memoized view, so a caller that
-          // consults this supplier directly gets a usable view.
-          view.bindReaderSource(readerSource());
-          return view;
+          // The BUILD yields the shared cache; what leaves this method is always a thin view over
+          // it carrying THIS caller's source, so no shared object ever holds one.
+          return windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes)
+              .boundTo(readerSource());
         }
 
         @Override
@@ -863,9 +862,15 @@ public final class ProjectionIndexCatalog {
    * @return the resident bytes to charge
    */
   static long windowedResidentWeightBytes(final long projectedWeightBytes) {
-    return servesWindowedPayloads(projectedWeightBytes)
-        ? eagerMaterializeBytes
-        : projectedWeightBytes;
+    if (servesWindowedPayloads(projectedWeightBytes)) {
+      // The window cap is a quarter of the budget and the store's cumulative retained fills are
+      // capped at the budget; charge both so the figure bounds what the handle can actually hold.
+      return eagerMaterializeBytes + eagerMaterializeBytes / 4;
+    }
+    // An under-budget handle materializes its leaves, so the projection IS its residency — but
+    // clamp it to what this cache can admit, or a handle heavier than maximumWeight self-evicts on
+    // insert and every lookup re-decodes it.
+    return Math.min(projectedWeightBytes, Math.max(1L, CACHE_BYTES >> 1));
   }
 
   public static boolean servesWindowedPayloads(final long projectedWeightBytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -18,10 +18,10 @@ import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.page.ChunkedBodyConfig;
 import io.sirix.utils.LogWrapper;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 import java.util.ArrayList;
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -805,8 +806,30 @@ public final class ProjectionIndexCatalog {
    */
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount, final long projectedWeightBytes) {
+    return rowGroupMaterializer(session, revision, defId, rowGroupCount, projectedWeightBytes,
+        new WindowedViewKey(defId, revision));
+  }
+
+  /**
+   * As above, with the HANDLE as the windowed view's owner — the overload every caller that holds
+   * one should use. The handle is keyed on the BUILD revision, so one view serves every query
+   * revision the build covers instead of one per query revision.
+   *
+   * @param handle the covering handle; supplies the definition id and the projected weight
+   * @param rowGroupCount the handle's row-group count
+   */
+  public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
+      final ProjectionIndexRegistry.Handle handle, final int rowGroupCount) {
+    Objects.requireNonNull(handle, "handle");
+    return rowGroupMaterializer(session, revision, handle.defId(), rowGroupCount, handle.projectedWeightBytes(),
+        handle);
+  }
+
+  private static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
+      final int defId, final int rowGroupCount, final long projectedWeightBytes, final Object viewOwner) {
     if (servesWindowedPayloads(projectedWeightBytes)) {
-      return () -> sessionWindowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
+      return () -> sessionWindowedRowGroupPayloads(session, viewOwner, revision, defId, rowGroupCount,
+          projectedWeightBytes);
     }
     return () -> {
       if (projectedWeightBytes > 0) {
@@ -837,8 +860,8 @@ public final class ProjectionIndexCatalog {
   }
 
   /**
-   * Windowed views by the SESSION they are bound to, then by {@code (revision, defId)}. Identity
-   * keyed, because a session is an identity and never a value.
+   * Windowed views by the SESSION they are bound to, then by the view's OWNER. Identity keyed,
+   * because a session is an identity and never a value.
    *
    * <p>
    * The view's lifetime is exactly its session's: its fetcher opens a read transaction on that
@@ -847,7 +870,15 @@ public final class ProjectionIndexCatalog {
    * It must not be built per CALLER either: a view's resident-window cap is a per-view budget, so N
    * independent views over one session permit N times the residency the cap was sized for, plus N
    * repeats of the physical-order walk. Sessions are shared per resource path, so keying here gives
-   * exactly one view per session and revision and definition.
+   * exactly one view per session and owner.
+   * </p>
+   *
+   * <p>
+   * The OWNER is the {@link ProjectionIndexRegistry.Handle} whenever the caller has one, because the
+   * handle is what determines the bytes: it is cached on the BUILD revision, so one handle serves
+   * every query revision since the build, and keying on the query revision instead would rebuild a
+   * view per revision over byte-identical leaves. A rebuild changes the handle, so reuse across
+   * query revisions is exactly as safe as the handle itself.
    * </p>
    *
    * <p>
@@ -855,8 +886,36 @@ public final class ProjectionIndexCatalog {
    * value holds the session strongly (through the fetcher), so weak keys alone would never collect.
    * </p>
    */
-  private static final Map<ResourceSession<?, ?>, Long2ObjectOpenHashMap<List<byte[]>>> SESSION_WINDOWED_PAYLOADS =
-      new IdentityHashMap<>();
+  private static final Map<ResourceSession<?, ?>, ConcurrentHashMap<Object, WindowedViewHolder>>
+      SESSION_WINDOWED_PAYLOADS = new IdentityHashMap<>();
+
+  /** Owner key for callers that hold no handle — same definition and revision, same view. */
+  private record WindowedViewKey(int defId, int revision) {
+  }
+
+  /**
+   * One view's memo slot. The build happens under THIS holder's monitor, never a session-wide one:
+   * a cold build walks the whole physical order, and blocking a warm consult of an unrelated
+   * definition behind it is the stall the memo exists to remove.
+   */
+  private static final class WindowedViewHolder {
+    private volatile List<byte[]> view;
+
+    List<byte[]> get(final Supplier<List<byte[]>> build) {
+      List<byte[]> current = view;
+      if (current != null) {
+        return current;
+      }
+      synchronized (this) {
+        current = view;
+        if (current == null) {
+          current = build.get();
+          view = current;
+        }
+        return current;
+      }
+    }
+  }
 
   /**
    * Drop every windowed payload view bound to {@code session} — called when the session closes, so
@@ -873,23 +932,17 @@ public final class ProjectionIndexCatalog {
     }
   }
 
-  /** The session's windowed view for this revision and definition, built once and reused. */
-  private static List<byte[]> sessionWindowedRowGroupPayloads(final ResourceSession<?, ?> session, final int revision,
-      final int defId, final int rowGroupCount, final long projectedWeightBytes) {
-    final Long2ObjectOpenHashMap<List<byte[]>> perSession;
+  /** The session's windowed view for this owner, built once and reused. */
+  private static List<byte[]> sessionWindowedRowGroupPayloads(final ResourceSession<?, ?> session,
+      final Object viewOwner, final int revision, final int defId, final int rowGroupCount,
+      final long projectedWeightBytes) {
+    final ConcurrentHashMap<Object, WindowedViewHolder> perSession;
     synchronized (SESSION_WINDOWED_PAYLOADS) {
-      perSession = SESSION_WINDOWED_PAYLOADS.computeIfAbsent(session, key -> new Long2ObjectOpenHashMap<>(4));
+      perSession = SESSION_WINDOWED_PAYLOADS.computeIfAbsent(session, key -> new ConcurrentHashMap<>(4));
     }
-    final long viewKey = ((long) revision << 32) | (defId & 0xFFFF_FFFFL);
-    synchronized (perSession) {
-      final List<byte[]> memoized = perSession.get(viewKey);
-      if (memoized != null) {
-        return memoized;
-      }
-      final List<byte[]> view = windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
-      perSession.put(viewKey, view);
-      return view;
-    }
+    return perSession.computeIfAbsent(viewOwner, key -> new WindowedViewHolder())
+                     .get(() -> windowedRowGroupPayloads(session, revision, defId, rowGroupCount,
+                         projectedWeightBytes));
   }
 
   /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -802,7 +802,7 @@ public final class ProjectionIndexCatalog {
    */
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount, final long projectedWeightBytes) {
-    if (projectedWeightBytes > eagerMaterializeBytes) {
+    if (servesWindowedPayloads(projectedWeightBytes)) {
       return () -> windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
     }
     return () -> {
@@ -819,6 +819,27 @@ public final class ProjectionIndexCatalog {
           ? persisted
           : new ArrayList<>(persisted.subList(0, rowGroupCount));
     };
+  }
+
+  /**
+   * Whether a handle of this projected weight is served by the WINDOWED payload view rather than by
+   * whole-column eager materialization.
+   *
+   * <p>
+   * A windowed view is bound to the session its fetcher was built from and is therefore never
+   * memoized on the shared handle (see
+   * {@link ProjectionIndexRegistry.Handle#rowGroupPayloads(Supplier)}). Callers that consult a
+   * handle's payloads more than once within ONE session use this to memoize the view for that
+   * session's lifetime, which is what keeps the physical-order read and the resident windows from
+   * being redone per call.
+   * </p>
+   *
+   * @param projectedWeightBytes the handle's worst-case resident bytes
+   *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()})
+   * @return {@code true} when the windowed route serves this weight
+   */
+  public static boolean servesWindowedPayloads(final long projectedWeightBytes) {
+    return projectedWeightBytes > eagerMaterializeBytes;
   }
 
   /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -668,7 +668,7 @@ public final class ProjectionIndexCatalog {
     for (int c = 0; c < columnCount; c++) {
       // The SAME arithmetic the store's fill doors price against, so the weight that admits a
       // handle and the budget that declines its fills cannot disagree about what a column costs.
-      bytes += ProjectionColumnStore.decodedColumnResidentBytes(descriptor, RowGroupDescriptor.kind(descriptor, c));
+      bytes += ProjectionColumnStore.decodedColumnResidentBytes(descriptor, c, RowGroupDescriptor.kind(descriptor, c));
     }
     return bytes;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -15,6 +15,7 @@ import io.sirix.api.ResourceSession;
 import io.sirix.index.IndexDef;
 import io.sirix.index.Indexes;
 import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.page.ChunkedBodyConfig;
 import io.sirix.utils.LogWrapper;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
@@ -729,13 +730,86 @@ public final class ProjectionIndexCatalog {
   }
 
   /**
+   * Byte budget above which a whole-leaf consumer is served by a WINDOWED payload view instead of an
+   * eager whole-column materialization.
+   *
+   * <p>
+   * Derived, not invented: an eager {@code List<byte[]>} of every leaf lives inside the {@link #DATA}
+   * cache's byte budget ({@code sirix.projection.cacheBytes}) — an entry heavier than half that
+   * budget is guaranteed cache-thrash — and it must also fit the heap beside the off-heap arena, so
+   * a quarter of {@code Runtime.maxMemory()} bounds it from the other side. At 100M rows a
+   * fat-string projection's leaves total ~8-10 GB; the first whole-leaf consumer (string LIKE,
+   * distinct over strings) OOMed the materializer inside the catalog load. The projected weight
+   * compared against this is the handle's worst-case RESIDENT bytes — the same conservative figure
+   * the cache weigher uses — so the route flips to windowed strictly BEFORE the eager list could
+   * have fit.
+   */
+  private static final long EAGER_MATERIALIZE_BYTES_DEFAULT = Long.getLong(
+      "sirix.projection.eagerMaterializeBytes", Math.min(CACHE_BYTES / 2, Runtime.getRuntime().maxMemory() / 4));
+
+  private static volatile long eagerMaterializeBytes = EAGER_MATERIALIZE_BYTES_DEFAULT;
+
+  /** Logical row groups per materialized window — ~12 MB of ClickBench-shaped leaves. */
+  private static final int WINDOW_LEAVES_DEFAULT = 128;
+
+  private static volatile int windowLeaves = WINDOW_LEAVES_DEFAULT;
+
+  /**
+   * Test seam: shrink the window so a handful of leaves still spans several windows.
+   *
+   * @param value logical row groups per window
+   * @return the previous value, for restoring in a finally block
+   */
+  public static int setWindowLeavesForTesting(final int value) {
+    final int previous = windowLeaves;
+    windowLeaves = Math.max(1, value);
+    return previous;
+  }
+
+  /**
+   * Test seam: shrink the eager budget so a small store still exercises the windowed route.
+   *
+   * @param value the budget in bytes
+   * @return the previous budget, for restoring in a finally block
+   */
+  public static long setEagerMaterializeBytesForTesting(final long value) {
+    final long previous = eagerMaterializeBytes;
+    eagerMaterializeBytes = value;
+    return previous;
+  }
+
+  /**
    * Whole-leaf materializer bound to one session+revision — built by a CALLER from its OWN live
    * session and threaded into {@link ProjectionIndexRegistry.Handle#rowGroupPayloads} on demand; the
-   * handle never stores it.
+   * handle never stores it. Always eager; callers that know the handle's projected weight use the
+   * budget-aware overload.
    */
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount) {
+    return rowGroupMaterializer(session, revision, defId, rowGroupCount, 0L);
+  }
+
+  /**
+   * As above, choosing the route by projected size: under the eager budget the whole column family
+   * materializes once and serves every later query from bytes; above it the supplier returns a
+   * {@link ProjectionWindowedRowGroupPayloads} view that materializes bounded leaf windows on demand
+   * — the {@code List} contract every byte-scan kernel already programs against, without the
+   * whole-column residency that OOMed fat string columns at 100M.
+   *
+   * @param projectedWeightBytes the handle's worst-case resident bytes
+   *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()}), or {@code 0} to force
+   *        the eager route
+   */
+  public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
+      final int defId, final int rowGroupCount, final long projectedWeightBytes) {
+    if (projectedWeightBytes > eagerMaterializeBytes) {
+      return () -> windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
+    }
     return () -> {
+      if (projectedWeightBytes > 0) {
+        // A LAZY handle materialized eagerly because it fit — the banner's third counter.
+        ChunkedBodyConfig.recordEagerColumnMaterialization();
+      }
       final List<byte[]> persisted = materializeRowGroups(session, revision, defId, rowGroupCount);
       if (persisted.size() < rowGroupCount) {
         throw new IllegalStateException("Projection definition #" + defId + " truncated during " + "materialization: "
@@ -745,6 +819,48 @@ public final class ProjectionIndexCatalog {
           ? persisted
           : new ArrayList<>(persisted.subList(0, rowGroupCount));
     };
+  }
+
+  /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */
+  private static List<byte[]> windowedRowGroupPayloads(final ResourceSession<?, ?> session, final int revision,
+      final int defId, final int rowGroupCount, final long projectedWeightBytes) {
+    ChunkedBodyConfig.recordWindowedColumnEngagement();
+    final int windowSize = windowLeaves;
+    final int[] physicalOrder;
+    try (NodeReadOnlyTrx orderRtx = session.beginNodeReadOnlyTrx(revision)) {
+      physicalOrder = ProjectionIndexFences.readPhysicalOrder(orderRtx.getStorageEngineReader(), defId, rowGroupCount);
+    }
+    // Resident cap from the SAME budget that declined the eager route: a quarter of it in windows,
+    // sized by the projected per-leaf weight (conservative — includes decode expansion, so the cap
+    // errs toward fewer resident windows), and never below the machine's worker count so a parallel
+    // shard sweep does not thrash at its shard boundaries.
+    final long projectedWindowBytes =
+        Math.max(1L, projectedWeightBytes / Math.max(1, rowGroupCount)) * windowSize;
+    final int residentCap = (int) Math.min(Integer.MAX_VALUE,
+        Math.max(Runtime.getRuntime().availableProcessors(), (eagerMaterializeBytes / 4) / projectedWindowBytes));
+    if (DIAG) {
+      System.err.println("[cat] windowed payloads: defId=" + defId + " rowGroups=" + rowGroupCount + " projected="
+          + (projectedWeightBytes >> 20) + "MB windowLeaves=" + windowSize + " residentCap=" + residentCap);
+    }
+    return new ProjectionWindowedRowGroupPayloads(rowGroupCount, windowSize, residentCap, (from, toExclusive) -> {
+      final byte[][] window = new byte[toExclusive - from][];
+      // A transaction PER WINDOW: concurrent read transactions are supported, one is not
+      // thread-safe, and parallel kernels touch disjoint windows concurrently.
+      try (NodeReadOnlyTrx windowRtx = session.beginNodeReadOnlyTrx(revision)) {
+        final StorageEngineReader reader = windowRtx.getStorageEngineReader();
+        for (int logical = from; logical < toExclusive; logical++) {
+          final byte[] payload =
+              ProjectionIndexHOTStorage.readRowGroupFromColumnSegmentSlots(reader, defId, physicalOrder[logical]);
+          if (payload == null) {
+            throw new IllegalStateException("Projection definition #" + defId + " truncated during windowed "
+                + "materialization: logical row group " + logical + " (physical slot " + physicalOrder[logical]
+                + ") has no payload");
+          }
+          window[logical - from] = payload;
+        }
+      }
+      return window;
+    });
   }
 
   /** Above this many row groups the slot walk partitions across per-thread readers. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -862,15 +862,18 @@ public final class ProjectionIndexCatalog {
    * @return the resident bytes to charge
    */
   static long windowedResidentWeightBytes(final long projectedWeightBytes) {
-    if (servesWindowedPayloads(projectedWeightBytes)) {
-      // The window cap is a quarter of the budget and the store's cumulative retained fills are
-      // capped at the budget; charge both so the figure bounds what the handle can actually hold.
-      return eagerMaterializeBytes + eagerMaterializeBytes / 4;
-    }
-    // An under-budget handle materializes its leaves, so the projection IS its residency — but
-    // clamp it to what this cache can admit, or a handle heavier than maximumWeight self-evicts on
-    // insert and every lookup re-decodes it.
-    return Math.min(projectedWeightBytes, Math.max(1L, CACHE_BYTES >> 1));
+    final long resident = servesWindowedPayloads(projectedWeightBytes)
+        // The window cap is a quarter of the budget and the store's cumulative retained fills are
+        // capped at the budget; charge both so the figure bounds what the handle can actually hold.
+        ? eagerMaterializeBytes + (eagerMaterializeBytes >> 2)
+        // An under-budget handle materializes its leaves, so the projection IS its residency.
+        : projectedWeightBytes;
+    // Clamp ONCE, after the branch — EITHER branch can exceed what this cache admits, and the
+    // windowed one is the likelier: eagerMaterializeBytes is settable, so 1.25x it can pass
+    // maximumWeight while the eager branch is bounded by that same budget. A charge above the
+    // ceiling self-evicts the entry on insert and makes every lookup re-decode a fresh handle,
+    // which is the failure this figure exists to prevent.
+    return Math.max(1L, Math.min(resident, Math.max(1L, CACHE_BYTES >> 1)));
   }
 
   public static boolean servesWindowedPayloads(final long projectedWeightBytes) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java
@@ -18,6 +18,7 @@ import io.sirix.index.path.summary.PathSummaryReader;
 import io.sirix.page.ChunkedBodyConfig;
 import io.sirix.utils.LogWrapper;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,9 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.RecursiveAction;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -803,7 +806,7 @@ public final class ProjectionIndexCatalog {
   public static Supplier<List<byte[]>> rowGroupMaterializer(final ResourceSession<?, ?> session, final int revision,
       final int defId, final int rowGroupCount, final long projectedWeightBytes) {
     if (servesWindowedPayloads(projectedWeightBytes)) {
-      return () -> windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
+      return () -> sessionWindowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
     }
     return () -> {
       if (projectedWeightBytes > 0) {
@@ -825,21 +828,68 @@ public final class ProjectionIndexCatalog {
    * Whether a handle of this projected weight is served by the WINDOWED payload view rather than by
    * whole-column eager materialization.
    *
-   * <p>
-   * A windowed view is bound to the session its fetcher was built from and is therefore never
-   * memoized on the shared handle (see
-   * {@link ProjectionIndexRegistry.Handle#rowGroupPayloads(Supplier)}). Callers that consult a
-   * handle's payloads more than once within ONE session use this to memoize the view for that
-   * session's lifetime, which is what keeps the physical-order read and the resident windows from
-   * being redone per call.
-   * </p>
-   *
    * @param projectedWeightBytes the handle's worst-case resident bytes
    *        ({@link ProjectionIndexRegistry.Handle#projectedWeightBytes()})
    * @return {@code true} when the windowed route serves this weight
    */
   public static boolean servesWindowedPayloads(final long projectedWeightBytes) {
     return projectedWeightBytes > eagerMaterializeBytes;
+  }
+
+  /**
+   * Windowed views by the SESSION they are bound to, then by {@code (revision, defId)}. Identity
+   * keyed, because a session is an identity and never a value.
+   *
+   * <p>
+   * The view's lifetime is exactly its session's: its fetcher opens a read transaction on that
+   * session for every window, so it must not outlive it — which is why the process-wide handle
+   * cache refuses to memoize one ({@link ProjectionIndexRegistry.Handle#rowGroupPayloads(Supplier)}).
+   * It must not be built per CALLER either: a view's resident-window cap is a per-view budget, so N
+   * independent views over one session permit N times the residency the cap was sized for, plus N
+   * repeats of the physical-order walk. Sessions are shared per resource path, so keying here gives
+   * exactly one view per session and revision and definition.
+   * </p>
+   *
+   * <p>
+   * Entries are dropped by {@link #invalidateSessionWindowedPayloads} when the session closes; the
+   * value holds the session strongly (through the fetcher), so weak keys alone would never collect.
+   * </p>
+   */
+  private static final Map<ResourceSession<?, ?>, Long2ObjectOpenHashMap<List<byte[]>>> SESSION_WINDOWED_PAYLOADS =
+      new IdentityHashMap<>();
+
+  /**
+   * Drop every windowed payload view bound to {@code session} — called when the session closes, so
+   * neither the view nor the session it captured is retained afterwards.
+   *
+   * @param session the closing session; {@code null} is ignored
+   */
+  public static void invalidateSessionWindowedPayloads(final @Nullable ResourceSession<?, ?> session) {
+    if (session == null) {
+      return;
+    }
+    synchronized (SESSION_WINDOWED_PAYLOADS) {
+      SESSION_WINDOWED_PAYLOADS.remove(session);
+    }
+  }
+
+  /** The session's windowed view for this revision and definition, built once and reused. */
+  private static List<byte[]> sessionWindowedRowGroupPayloads(final ResourceSession<?, ?> session, final int revision,
+      final int defId, final int rowGroupCount, final long projectedWeightBytes) {
+    final Long2ObjectOpenHashMap<List<byte[]>> perSession;
+    synchronized (SESSION_WINDOWED_PAYLOADS) {
+      perSession = SESSION_WINDOWED_PAYLOADS.computeIfAbsent(session, key -> new Long2ObjectOpenHashMap<>(4));
+    }
+    final long viewKey = ((long) revision << 32) | (defId & 0xFFFF_FFFFL);
+    synchronized (perSession) {
+      final List<byte[]> memoized = perSession.get(viewKey);
+      if (memoized != null) {
+        return memoized;
+      }
+      final List<byte[]> view = windowedRowGroupPayloads(session, revision, defId, rowGroupCount, projectedWeightBytes);
+      perSession.put(viewKey, view);
+      return view;
+    }
   }
 
   /** Build the windowed payload view: one physical-order read up front, one fetch per window after. */
@@ -1187,6 +1237,9 @@ public final class ProjectionIndexCatalog {
     DEFS.invalidateAll();
     PROBES.invalidateAll();
     DATA.invalidateAll();
+    synchronized (SESSION_WINDOWED_PAYLOADS) {
+      SESSION_WINDOWED_PAYLOADS.clear();
+    }
     DESCRIPTOR_STATS.invalidateAll();
   }
 }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
@@ -1685,8 +1685,8 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     // it left the operator no number to raise the budget to. A structural ceiling weighs no bytes at
     // all, so that case states the ceiling instead of inventing a comparison.
     final String breach = tooBig.breachingTerm() == null
-        ? "declined an unsafe allocation over " + tooBig.entryCount() + " distinct values ("
-            + tooBig.retainedBytes() + " B retained): " + tooBig.admissionDetail()
+        ? "declined an unsafe allocation over " + tooBig.entryCount() + " distinct values (" + tooBig.retainedBytes()
+            + " B retained): " + tooBig.admissionDetail()
         : "needed " + tooBig.breachingBytes() + " B (" + tooBig.breachingTerm() + ") over " + tooBig.entryCount()
             + " distinct values, past its " + tooBig.budgetBytes() + " B budget (" + tooBig.retainedBytes()
             + " B retained)";

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
@@ -1673,9 +1673,19 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
    */
   private void abandonForOversizedDictionary(final ProjectionBulkLoad load,
       final GlobalDictionaryBudgetExceededException tooBig) {
-    LOGGER.warn("Projection index " + indexDef.getID() + " ABANDONED during the load. " + tooBig.getMessage(), tooBig);
+    // UNCONDITIONAL, not just LOGGER.warn (task #55). The shipped logback pins the root logger to
+    // ERROR, so the warning below is invisible on a default deployment — and this is the one event
+    // that turns a successful-looking load into a useless one. A silent degradation that the
+    // loader then reports as "projection built" is how a 26-hour run gets measured on the wrong
+    // code path. Anything a guard or an operator must see cannot travel by a suppressible channel.
+    System.err.println("[proj] PROJECTION ABANDONED during the load: index " + indexDef.getID() + ", column "
+        + tooBig.column() + " retained " + tooBig.retainedBytes() + " B over " + tooBig.entryCount()
+        + " distinct values, past its " + tooBig.budgetBytes() + " B budget. The load completes; the projection is"
+        + " STALE and every query will take the generic pipeline until jn:create-projection-index rebuilds it.");
+    LOGGER.warn("Projection index " + indexDef.getID() + " ABANDONED during the load. " + tooBig.getMessage() + " "
+        + ProjectionIndexMetadata.StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED.remedy(), tooBig);
     load.abort();
-    invalidate();
+    invalidate(ProjectionIndexMetadata.StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED);
   }
 
   @Override
@@ -3120,9 +3130,22 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
    * Corruption valve (and the legacy invalidation-only contract): overwrite slot 0 with the stale
    * tombstone so every reader falls back to the generic pipeline until a manual
    * {@code jn:create-projection-index} re-run. Regular maintenance never calls this — unattributable
-   * changes fail the owning transaction instead.
+   * changes fail the owning transaction instead. Callers with a KNOWN cause use the reason-carrying
+   * overload; this default records {@link ProjectionIndexMetadata.StaleReason#UNSPECIFIED}, the
+   * legacy-invalidation contract's honest answer.
    */
   private void invalidate() {
+    invalidate(ProjectionIndexMetadata.StaleReason.UNSPECIFIED);
+  }
+
+  /**
+   * As {@link #invalidate()}, recording WHY in the tombstone so a later decline can quote the
+   * writer's decision instead of guessing (task #55).
+   *
+   * @param reason what the writer decided and on what grounds; never {@code null}
+   */
+  private void invalidate(final ProjectionIndexMetadata.StaleReason reason) {
+    Objects.requireNonNull(reason, "reason");
     invalidated = true;
     dirtyRecordKeys = null;
     dirtyColumnWordsByRecord = null;
@@ -3135,8 +3158,8 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     // keep their own immutable snapshot.
     final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(storageEngineWriter, indexDef.getID());
     // The row-group slots survive the tombstone; the next rebuild reclaims them by probing what is
-    // physically live, so the marker carries nothing but "stale".
-    storage.putBlob(0, ProjectionIndexMetadata.staleTombstone().serialize());
+    // physically live, so the marker carries "stale" and the reason it went stale.
+    storage.putBlob(0, ProjectionIndexMetadata.staleTombstone(reason).serialize());
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java
@@ -1678,10 +1678,21 @@ public final class ProjectionIndexChangeListener implements PathNodeKeyChangeLis
     // that turns a successful-looking load into a useless one. A silent degradation that the
     // loader then reports as "projection built" is how a 26-hour run gets measured on the wrong
     // code path. Anything a guard or an operator must see cannot travel by a suppressible channel.
+    //
+    // The quantity quoted is the one the guard WEIGHED, not merely the one it retains. Every
+    // byte-budget check compares retention plus a reservation, so a line reading "retained X B ...
+    // past its Y B budget" printed X < Y on every real breach and read as a misfiring guard; worse,
+    // it left the operator no number to raise the budget to. A structural ceiling weighs no bytes at
+    // all, so that case states the ceiling instead of inventing a comparison.
+    final String breach = tooBig.breachingTerm() == null
+        ? "declined an unsafe allocation over " + tooBig.entryCount() + " distinct values ("
+            + tooBig.retainedBytes() + " B retained): " + tooBig.admissionDetail()
+        : "needed " + tooBig.breachingBytes() + " B (" + tooBig.breachingTerm() + ") over " + tooBig.entryCount()
+            + " distinct values, past its " + tooBig.budgetBytes() + " B budget (" + tooBig.retainedBytes()
+            + " B retained)";
     System.err.println("[proj] PROJECTION ABANDONED during the load: index " + indexDef.getID() + ", column "
-        + tooBig.column() + " retained " + tooBig.retainedBytes() + " B over " + tooBig.entryCount()
-        + " distinct values, past its " + tooBig.budgetBytes() + " B budget. The load completes; the projection is"
-        + " STALE and every query will take the generic pipeline until jn:create-projection-index rebuilds it.");
+        + tooBig.column() + " " + breach + ". The load completes; the projection is STALE and every query will take"
+        + " the generic pipeline until jn:create-projection-index rebuilds it.");
     LOGGER.warn("Projection index " + indexDef.getID() + " ABANDONED during the load. " + tooBig.getMessage() + " "
         + ProjectionIndexMetadata.StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED.remedy(), tooBig);
     load.abort();

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -120,9 +120,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   private final boolean stageFreshSidePages;
 
   /**
-   * Entry-count cap for bulk slot accumulation ({@code docs/HOT_BULK_BUILD.md} §Seam 2a: at 8 M
-   * entries the transient footprint — arena plus the not-yet-spill-eligible built pages — stays ≈1.6
-   * GB).
+   * Entry-count cap for bulk slot accumulation ({@code docs/HOT_BULK_BUILD.md} §2: at 8 M entries the
+   * transient footprint — arena plus the not-yet-spill-eligible built pages — stays ≈1.6 GB).
    */
   private static final int BULK_SLOT_MAX_ENTRIES = 8_000_000;
 
@@ -251,8 +250,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   /**
    * Engage bulk slot accumulation for a FRESH build: subsequent slot writes are collected in a
    * {@link HOTBulkSlotLoader} and materialized in ONE canonical {@code HOTBulkBuilder} pass (9–14×
-   * the per-entry path at 1 M–10 M slots — {@code docs/HOT_BULK_BUILD.md} §Seam 2a) instead of paying
-   * a descent per slot. A no-op unless the tree is VIRGIN — that is the positive witness the
+   * the per-entry path at 1 M–10 M slots — {@code docs/HOT_BULK_BUILD.md} §2) instead of paying a
+   * descent per slot. A no-op unless the tree is VIRGIN — that is the positive witness the
    * read-through contract rests on: while accumulating, a key is either in the loader or it was never
    * written, so point reads serve accumulated keys from the loader and everything else from the
    * (empty) tree.

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -120,9 +120,9 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   private final boolean stageFreshSidePages;
 
   /**
-   * Entry-count cap for bulk slot accumulation ({@code docs/HOT_BULK_BUILD.md} §Seam 2a: at
-   * 8 M entries the transient footprint — arena plus the not-yet-spill-eligible built pages —
-   * stays ≈1.6 GB).
+   * Entry-count cap for bulk slot accumulation ({@code docs/HOT_BULK_BUILD.md} §Seam 2a: at 8 M
+   * entries the transient footprint — arena plus the not-yet-spill-eligible built pages — stays ≈1.6
+   * GB).
    */
   private static final int BULK_SLOT_MAX_ENTRIES = 8_000_000;
 
@@ -130,10 +130,10 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   private static final long BULK_SLOT_MAX_ARENA_BYTES = 512L << 20;
 
   /**
-   * Active bulk slot accumulator, or {@code null} on the ordinary per-entry path. Engaged only on
-   * a VIRGIN tree ({@link #beginBulkSlotAccumulation}); while active, every slot write funnels
-   * into it and point reads of accumulated keys are served from it (read-through), so the
-   * accumulator and the empty tree partition the key space. See {@link HOTBulkSlotLoader}.
+   * Active bulk slot accumulator, or {@code null} on the ordinary per-entry path. Engaged only on a
+   * VIRGIN tree ({@link #beginBulkSlotAccumulation}); while active, every slot write funnels into it
+   * and point reads of accumulated keys are served from it (read-through), so the accumulator and the
+   * empty tree partition the key space. See {@link HOTBulkSlotLoader}.
    */
   private @Nullable HOTBulkSlotLoader bulkSlotLoader;
 
@@ -145,8 +145,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
 
   /**
    * Deferred side-page attaches while bulk slot accumulation is active, keyed by side-map refKey
-   * ({@code (ownerSlotKey << 16) | columnSegmentId}), insertion-ordered, last-writer-wins.
-   * Payload arrays are RETAINED, not copied — the exact ownership contract of the immediate
+   * ({@code (ownerSlotKey << 16) | columnSegmentId}), insertion-ordered, last-writer-wins. Payload
+   * arrays are RETAINED, not copied — the exact ownership contract of the immediate
    * {@code new OverflowPage(bytes)} attach they stand in for.
    */
   private final Long2ObjectLinkedOpenHashMap<byte[]> pendingSideAttaches = new Long2ObjectLinkedOpenHashMap<>();
@@ -250,20 +250,20 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
 
   /**
    * Engage bulk slot accumulation for a FRESH build: subsequent slot writes are collected in a
-   * {@link HOTBulkSlotLoader} and materialized in ONE canonical {@code HOTBulkBuilder} pass
-   * (9–14× the per-entry path at 1 M–10 M slots — {@code docs/HOT_BULK_BUILD.md} §Seam 2a)
-   * instead of paying a descent per slot. A no-op unless the tree is VIRGIN — that is the
-   * positive witness the read-through contract rests on: while accumulating, a key is either in
-   * the loader or it was never written, so point reads serve accumulated keys from the loader
-   * and everything else from the (empty) tree.
+   * {@link HOTBulkSlotLoader} and materialized in ONE canonical {@code HOTBulkBuilder} pass (9–14×
+   * the per-entry path at 1 M–10 M slots — {@code docs/HOT_BULK_BUILD.md} §Seam 2a) instead of paying
+   * a descent per slot. A no-op unless the tree is VIRGIN — that is the positive witness the
+   * read-through contract rests on: while accumulating, a key is either in the loader or it was never
+   * written, so point reads serve accumulated keys from the loader and everything else from the
+   * (empty) tree.
    *
    * <p>
    * Self-defending behavior keeps every other contract intact: a capacity trip
-   * ({@link HOTBulkSlotLoader#tryAdd} refusing) splices the accumulated prefix — the tree is
-   * still virgin at that moment, so the splice is legal — and falls back to the per-entry path;
-   * side-page attaches against accumulated owner slots ({@link #putSegmentPage}) are DEFERRED
-   * (payloads retained under the side budget, served read-through, attached through the
-   * production path right after the splice); {@link #resetTree} discards the accumulator.
+   * ({@link HOTBulkSlotLoader#tryAdd} refusing) splices the accumulated prefix — the tree is still
+   * virgin at that moment, so the splice is legal — and falls back to the per-entry path; side-page
+   * attaches against accumulated owner slots ({@link #putSegmentPage}) are DEFERRED (payloads
+   * retained under the side budget, served read-through, attached through the production path right
+   * after the splice); {@link #resetTree} discards the accumulator.
    * </p>
    */
   public void beginBulkSlotAccumulation() {
@@ -274,11 +274,11 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   }
 
   /**
-   * Materialize everything accumulated since {@link #beginBulkSlotAccumulation} as this index's
-   * tree (production {@code spliceBulkBuiltRoot}: empty-tree guard, canonical build,
-   * fresh-subtree TIL registration) and leave accumulation mode. A no-op when accumulation is
-   * not active; safe in {@code finally} blocks — on a failed build it persists exactly the
-   * prefix the per-entry path would have persisted.
+   * Materialize everything accumulated since {@link #beginBulkSlotAccumulation} as this index's tree
+   * (production {@code spliceBulkBuiltRoot}: empty-tree guard, canonical build, fresh-subtree TIL
+   * registration) and leave accumulation mode. A no-op when accumulation is not active; safe in
+   * {@code finally} blocks — on a failed build it persists exactly the prefix the per-entry path
+   * would have persisted.
    */
   public void finalizeBulkSlotAccumulation() {
     final HOTBulkSlotLoader loader = bulkSlotLoader;
@@ -292,8 +292,8 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
 
   /**
    * Attach every deferred side page against the freshly spliced leaves, through the production
-   * {@link #putSegmentPage} path (owner-residency check, replace semantics, append-pipeline
-   * staging). Runs with the loader already disabled, so the attaches hit real pages.
+   * {@link #putSegmentPage} path (owner-residency check, replace semantics, append-pipeline staging).
+   * Runs with the loader already disabled, so the attaches hit real pages.
    */
   private void attachPendingSidePages() {
     if (pendingSideAttaches.isEmpty()) {
@@ -312,14 +312,14 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   /**
    * Move an active bulk-slot accumulation from {@code source} onto this storage — the epoch-rebind
    * transplant. A post-pass build rides the writer's async-flush epochs
-   * ({@code ProjectionIndexBuilder.BulkBuildEpoch#rebind} constructs a fresh storage per epoch);
-   * the accumulator holds only un-materialized slot writes for the SAME still-virgin tree, so it
-   * is tree-state-independent and moves wholesale: loader, deferred side attaches (insertion
-   * order preserved — this map is empty on a freshly bound storage), byte accounting and the
-   * splice witness counter. A no-op when {@code source} is this storage or holds no accumulation.
+   * ({@code ProjectionIndexBuilder.BulkBuildEpoch#rebind} constructs a fresh storage per epoch); the
+   * accumulator holds only un-materialized slot writes for the SAME still-virgin tree, so it is
+   * tree-state-independent and moves wholesale: loader, deferred side attaches (insertion order
+   * preserved — this map is empty on a freshly bound storage), byte accounting and the splice witness
+   * counter. A no-op when {@code source} is this storage or holds no accumulation.
    *
-   * @throws IllegalStateException if BOTH storages accumulate — two accumulators over one tree
-   *         would fork the read-through truth
+   * @throws IllegalStateException if BOTH storages accumulate — two accumulators over one tree would
+   *         fork the read-through truth
    */
   void adoptBulkSlotAccumulation(final ProjectionIndexHOTStorage source) {
     if (source == this || source == null || source.bulkSlotLoader == null) {
@@ -3624,8 +3624,7 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
     }
     final long refKey = HOTLeafPage.overflowPageRefKey(ownerSlotKey, columnSegmentId);
     if (bulkSlotLoader != null) {
-      if (bulkSlotLoader.containsKey(ownerSlotKey)
-          && pendingSideBytes + bytes.length <= BULK_SIDE_PENDING_MAX_BYTES) {
+      if (bulkSlotLoader.containsKey(ownerSlotKey) && pendingSideBytes + bytes.length <= BULK_SIDE_PENDING_MAX_BYTES) {
         // The owning slot exists only in the accumulator, so a physical attach is impossible —
         // and splicing here would forfeit the rest of the build's accumulation. Defer instead:
         // retain the payload (the same ownership contract as the immediate OverflowPage attach)

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexHOTStorage.java
@@ -11,6 +11,7 @@ import io.sirix.cache.PageContainer;
 import io.sirix.exception.SirixIOException;
 import io.sirix.index.IndexType;
 import io.sirix.index.hot.AbstractHOTIndexWriter;
+import io.sirix.index.hot.HOTBulkSlotLoader;
 import io.sirix.index.hot.PathKeySerializer;
 import io.sirix.page.HOTIndirectPage;
 import io.sirix.page.HOTLeafPage;
@@ -23,6 +24,7 @@ import io.sirix.page.RevisionRootPage;
 import io.sirix.page.interfaces.Page;
 import io.sirix.settings.Constants;
 import io.sirix.utils.LogWrapper;
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectRBTreeMap;
 import org.jspecify.annotations.Nullable;
@@ -117,6 +119,41 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   /** Whether fresh side refs may enter the bounded pre-publication append pipeline. */
   private final boolean stageFreshSidePages;
 
+  /**
+   * Entry-count cap for bulk slot accumulation ({@code docs/HOT_BULK_BUILD.md} §Seam 2a: at
+   * 8 M entries the transient footprint — arena plus the not-yet-spill-eligible built pages —
+   * stays ≈1.6 GB).
+   */
+  private static final int BULK_SLOT_MAX_ENTRIES = 8_000_000;
+
+  /** Arena-byte cap for bulk slot accumulation (payload bytes). */
+  private static final long BULK_SLOT_MAX_ARENA_BYTES = 512L << 20;
+
+  /**
+   * Active bulk slot accumulator, or {@code null} on the ordinary per-entry path. Engaged only on
+   * a VIRGIN tree ({@link #beginBulkSlotAccumulation}); while active, every slot write funnels
+   * into it and point reads of accumulated keys are served from it (read-through), so the
+   * accumulator and the empty tree partition the key space. See {@link HOTBulkSlotLoader}.
+   */
+  private @Nullable HOTBulkSlotLoader bulkSlotLoader;
+
+  /** Witness counter: DISTINCT entries materialized by bulk splices on this storage (tests). */
+  private int bulkSplicedEntryCount;
+
+  /** Side-page payload byte budget for deferred attaches during bulk slot accumulation. */
+  private static final long BULK_SIDE_PENDING_MAX_BYTES = 512L << 20;
+
+  /**
+   * Deferred side-page attaches while bulk slot accumulation is active, keyed by side-map refKey
+   * ({@code (ownerSlotKey << 16) | columnSegmentId}), insertion-ordered, last-writer-wins.
+   * Payload arrays are RETAINED, not copied — the exact ownership contract of the immediate
+   * {@code new OverflowPage(bytes)} attach they stand in for.
+   */
+  private final Long2ObjectLinkedOpenHashMap<byte[]> pendingSideAttaches = new Long2ObjectLinkedOpenHashMap<>();
+
+  /** Total payload bytes retained in {@link #pendingSideAttaches}. */
+  private long pendingSideBytes;
+
   public ProjectionIndexHOTStorage(final StorageEngineWriter storageEngineWriter, final int indexNumber) {
     this(storageEngineWriter, indexNumber, false);
   }
@@ -198,9 +235,119 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
 
   /** Discard this definition's sub-tree and start a fresh empty one. */
   public void resetTree() {
+    final HOTBulkSlotLoader loader = bulkSlotLoader;
+    if (loader != null) {
+      // The tree restarts; accumulated state belongs to the discarded incarnation.
+      bulkSlotLoader = null;
+      loader.clear();
+      pendingSideAttaches.clear();
+      pendingSideBytes = 0;
+    }
     final ProjectionIndexPage projPage = prepareWritableProjectionIndexPage();
     projPage.resetProjectionIndexTree(storageEngineWriter, indexNumber, storageEngineWriter.getLog());
     rootReference = projPage.getOrCreateReference(indexNumber);
+  }
+
+  /**
+   * Engage bulk slot accumulation for a FRESH build: subsequent slot writes are collected in a
+   * {@link HOTBulkSlotLoader} and materialized in ONE canonical {@code HOTBulkBuilder} pass
+   * (9–14× the per-entry path at 1 M–10 M slots — {@code docs/HOT_BULK_BUILD.md} §Seam 2a)
+   * instead of paying a descent per slot. A no-op unless the tree is VIRGIN — that is the
+   * positive witness the read-through contract rests on: while accumulating, a key is either in
+   * the loader or it was never written, so point reads serve accumulated keys from the loader
+   * and everything else from the (empty) tree.
+   *
+   * <p>
+   * Self-defending behavior keeps every other contract intact: a capacity trip
+   * ({@link HOTBulkSlotLoader#tryAdd} refusing) splices the accumulated prefix — the tree is
+   * still virgin at that moment, so the splice is legal — and falls back to the per-entry path;
+   * side-page attaches against accumulated owner slots ({@link #putSegmentPage}) are DEFERRED
+   * (payloads retained under the side budget, served read-through, attached through the
+   * production path right after the splice); {@link #resetTree} discards the accumulator.
+   * </p>
+   */
+  public void beginBulkSlotAccumulation() {
+    if (bulkSlotLoader != null || !isEmptyTree()) {
+      return;
+    }
+    bulkSlotLoader = new HOTBulkSlotLoader(BULK_SLOT_MAX_ENTRIES, BULK_SLOT_MAX_ARENA_BYTES);
+  }
+
+  /**
+   * Materialize everything accumulated since {@link #beginBulkSlotAccumulation} as this index's
+   * tree (production {@code spliceBulkBuiltRoot}: empty-tree guard, canonical build,
+   * fresh-subtree TIL registration) and leave accumulation mode. A no-op when accumulation is
+   * not active; safe in {@code finally} blocks — on a failed build it persists exactly the
+   * prefix the per-entry path would have persisted.
+   */
+  public void finalizeBulkSlotAccumulation() {
+    final HOTBulkSlotLoader loader = bulkSlotLoader;
+    if (loader == null) {
+      return;
+    }
+    bulkSlotLoader = null;
+    bulkSplicedEntryCount += loader.spliceInto(this);
+    attachPendingSidePages();
+  }
+
+  /**
+   * Attach every deferred side page against the freshly spliced leaves, through the production
+   * {@link #putSegmentPage} path (owner-residency check, replace semantics, append-pipeline
+   * staging). Runs with the loader already disabled, so the attaches hit real pages.
+   */
+  private void attachPendingSidePages() {
+    if (pendingSideAttaches.isEmpty()) {
+      pendingSideBytes = 0;
+      return;
+    }
+    final long[] refKeys = pendingSideAttaches.keySet().toLongArray();
+    for (final long refKey : refKeys) {
+      final byte[] payload = pendingSideAttaches.get(refKey);
+      putSegmentPage(HOTLeafPage.overflowPageRefOwnerSlot(refKey), (int) (refKey & 0xFFFFL), payload);
+    }
+    pendingSideAttaches.clear();
+    pendingSideBytes = 0;
+  }
+
+  /**
+   * Move an active bulk-slot accumulation from {@code source} onto this storage — the epoch-rebind
+   * transplant. A post-pass build rides the writer's async-flush epochs
+   * ({@code ProjectionIndexBuilder.BulkBuildEpoch#rebind} constructs a fresh storage per epoch);
+   * the accumulator holds only un-materialized slot writes for the SAME still-virgin tree, so it
+   * is tree-state-independent and moves wholesale: loader, deferred side attaches (insertion
+   * order preserved — this map is empty on a freshly bound storage), byte accounting and the
+   * splice witness counter. A no-op when {@code source} is this storage or holds no accumulation.
+   *
+   * @throws IllegalStateException if BOTH storages accumulate — two accumulators over one tree
+   *         would fork the read-through truth
+   */
+  void adoptBulkSlotAccumulation(final ProjectionIndexHOTStorage source) {
+    if (source == this || source == null || source.bulkSlotLoader == null) {
+      return;
+    }
+    if (bulkSlotLoader != null) {
+      throw new IllegalStateException(
+          "cannot adopt a bulk slot accumulation into a storage that is already accumulating (indexNumber="
+              + indexNumber + ')');
+    }
+    bulkSlotLoader = source.bulkSlotLoader;
+    source.bulkSlotLoader = null;
+    pendingSideAttaches.putAll(source.pendingSideAttaches);
+    source.pendingSideAttaches.clear();
+    pendingSideBytes += source.pendingSideBytes;
+    source.pendingSideBytes = 0;
+    bulkSplicedEntryCount += source.bulkSplicedEntryCount;
+    source.bulkSplicedEntryCount = 0;
+  }
+
+  /** Whether bulk slot accumulation is currently active (test/diagnostic). */
+  boolean isBulkAccumulating() {
+    return bulkSlotLoader != null;
+  }
+
+  /** DISTINCT entries materialized by bulk splices on this storage so far (test/diagnostic). */
+  int bulkSplicedEntryCount() {
+    return bulkSplicedEntryCount;
   }
 
   /**
@@ -3377,6 +3524,16 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
 
   /** Writer-side raw slot read: {@code null} when the leaf/slot is absent. */
   private byte @Nullable [] readSlotValueForWrite(final long slotKey) {
+    final HOTBulkSlotLoader loader = bulkSlotLoader;
+    if (loader != null) {
+      // Read-through: while accumulating on a virgin tree, a key is either in the loader or it
+      // was never written, so an accumulated payload is authoritative (zero-length = tombstoned,
+      // exactly what this method returns for one) and a miss falls through to the empty tree.
+      final byte[] accumulated = loader.lastPayload(slotKey);
+      if (accumulated != null) {
+        return accumulated;
+      }
+    }
     final byte[] keyBuf = KEY_BUFFER.get();
     PathKeySerializer.INSTANCE.serialize(slotKey, keyBuf, 0);
     final HOTLeafPage leaf = getLeafForRead(keyBuf);
@@ -3397,6 +3554,15 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
   void writeSlotValue(final long slotKey, final byte[] value) {
     if (rootReference == null) {
       throw new SirixIOException("Projection HOT index not initialised for indexNumber=" + indexNumber);
+    }
+    final HOTBulkSlotLoader loader = bulkSlotLoader;
+    if (loader != null) {
+      if (loader.tryAdd(slotKey, value)) {
+        return;
+      }
+      // Capacity/contract trip: splice the accumulated prefix (the tree is still virgin — every
+      // write since begin was accumulated), then fall through to the per-entry path.
+      finalizeBulkSlotAccumulation();
     }
     final byte[] keyBuf = KEY_BUFFER.get();
     final int keyLen = PathKeySerializer.INSTANCE.serialize(slotKey, keyBuf, 0);
@@ -3457,6 +3623,25 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       throw new IllegalArgumentException("bytes must not be null");
     }
     final long refKey = HOTLeafPage.overflowPageRefKey(ownerSlotKey, columnSegmentId);
+    if (bulkSlotLoader != null) {
+      if (bulkSlotLoader.containsKey(ownerSlotKey)
+          && pendingSideBytes + bytes.length <= BULK_SIDE_PENDING_MAX_BYTES) {
+        // The owning slot exists only in the accumulator, so a physical attach is impossible —
+        // and splicing here would forfeit the rest of the build's accumulation. Defer instead:
+        // retain the payload (the same ownership contract as the immediate OverflowPage attach)
+        // and run it through this very method right after the splice, against real leaves.
+        final byte[] replaced = pendingSideAttaches.put(refKey, bytes);
+        if (replaced != null) {
+          pendingSideBytes -= replaced.length;
+        }
+        pendingSideBytes += bytes.length;
+        return;
+      }
+      // Owner slot not accumulated (a pre-existing caller-order bug surfaces identically on the
+      // per-entry path below) or the side budget is exhausted: materialize the prefix and attach
+      // against real pages from here on.
+      finalizeBulkSlotAccumulation();
+    }
     final byte[] keyBuf = KEY_BUFFER.get();
     final int keyLen = PathKeySerializer.INSTANCE.serialize(ownerSlotKey, keyBuf, 0);
     final LeafNavigationResult navResult = prepareLeafOfTree(rootReference, keyBuf, keyLen);
@@ -3499,6 +3684,14 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
       throw new SirixIOException("Projection HOT index not initialised for indexNumber=" + indexNumber);
     }
     final long refKey = HOTLeafPage.overflowPageRefKey(ownerSlotKey, columnSegmentId);
+    if (bulkSlotLoader != null) {
+      final byte[] pending = pendingSideAttaches.remove(refKey);
+      if (pending != null) {
+        // A deferred attach removed before the splice was simply never attached.
+        pendingSideBytes -= pending.length;
+        return;
+      }
+    }
     final byte[] keyBuf = KEY_BUFFER.get();
     PathKeySerializer.INSTANCE.serialize(ownerSlotKey, keyBuf, 0);
     // Probe read-only first: an unconditional prepareLeafOfTree would CoW the leaf (and its
@@ -3553,6 +3746,13 @@ public final class ProjectionIndexHOTStorage extends AbstractHOTIndexWriter<Long
    */
   public byte @Nullable [] getSegmentPageBytes(final long ownerSlotKey, final int columnSegmentId) {
     final long refKey = HOTLeafPage.overflowPageRefKey(ownerSlotKey, columnSegmentId);
+    if (bulkSlotLoader != null) {
+      final byte[] pending = pendingSideAttaches.get(refKey);
+      if (pending != null) {
+        // Deferred-attach read-through — the same no-mutate contract as the shared backing store.
+        return pending;
+      }
+    }
     final byte[] keyBuf = KEY_BUFFER.get();
     PathKeySerializer.INSTANCE.serialize(ownerSlotKey, keyBuf, 0);
     final HOTLeafPage leaf = getLeafForRead(keyBuf);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
@@ -57,6 +57,98 @@ public final class ProjectionIndexMetadata {
   public static final byte FLAG_STALE = 0x01;
 
   /**
+   * Flags bits 1-3: WHY the projection went stale, as a {@link StaleReason} ordinal.
+   *
+   * <p>
+   * Additive on purpose — the bits were previously always zero, so a tombstone written before this
+   * existed parses as {@link StaleReason#UNSPECIFIED} and nothing about the wire form changes. No
+   * version bump: readers that only test {@link #FLAG_STALE} are unaffected by bits they ignore.
+   * </p>
+   *
+   * <p>
+   * It exists because "stale" and "corrupt" are different claims and the difference was being lost.
+   * A projection the writer deliberately retired because it cannot maintain a resource-wide
+   * dictionary is a DECISION, and the component that made it is the only one that can explain it;
+   * every downstream decline should be able to quote that reason rather than invent one. See the
+   * kind-inconsistency class recorded in tasks #45 and #50.
+   * </p>
+   */
+  private static final byte STALE_REASON_MASK = 0x0E;
+
+  private static final int STALE_REASON_SHIFT = 1;
+
+  /**
+   * Why a projection was tombstoned. Ordinals are WIRE VALUES in bits 1-3 of the flags byte:
+   * append only, never renumber, and at most eight will ever fit.
+   */
+  public enum StaleReason {
+    /** No reason recorded — a tombstone written before reasons existed, or a caller that had none. */
+    UNSPECIFIED,
+    /**
+     * The indexed record set changed and the projection has resource-wide value dictionaries, which
+     * commit-time maintenance cannot extend: it holds no dictionary writer, so it can neither mint
+     * an id for a new value nor rewrite every leaf to a per-leaf encoding without paying O(corpus)
+     * on a single commit. Refusing keeps the store CONSISTENT; {@code jn:create-projection-index}
+     * rebuilds it.
+     */
+    GLOBAL_DICTIONARY_NOT_MAINTAINABLE,
+    /** Both the incremental patch and the full rebuild failed — the corruption valve. */
+    MAINTENANCE_FAILED,
+    /** Leaf descriptors disagreed with this metadata about a column's encoding. */
+    KIND_INCONSISTENT_STORE,
+    /**
+     * A resource-wide dictionary hit its byte budget mid-build, so the load abandoned the projection
+     * rather than the collector abandoning the load. Distinct from
+     * {@link #GLOBAL_DICTIONARY_NOT_MAINTAINABLE}: nothing is wrong with the store's shape, the
+     * projection simply never finished. Raising the budget or supplying a row-count hint avoids it.
+     */
+    GLOBAL_DICTIONARY_BUDGET_EXCEEDED,
+    /**
+     * NOT PRODUCED BY ANYTHING YET — reserved for task #52.
+     *
+     * <p>
+     * A projection that needs a full rebuild but must not pay for it inside the committing
+     * transaction. Today a refused incremental patch calls {@code rebuildFully()} on the commit
+     * thread, re-extracting every record of the resource: unbounded by corpus size, reached from
+     * its refusal sites, and on a large resource a multi-minute commit. The fix is to record the
+     * need HERE, let the commit finish, and rebuild on request or in the background.
+     * </p>
+     *
+     * <p>
+     * Declared now so #52 need not change this wire format later — it is one of the eight values the
+     * flag bits can carry, and adding it costs nothing while renumbering would cost a migration. It
+     * differs semantically from every value above: those mean "retired until someone acts", this one
+     * means "still wanted, known incomplete".
+     * </p>
+     */
+    REBUILD_PENDING;
+
+    /**
+     * The remedy for this state, in the form someone can actually run.
+     *
+     * <p>
+     * Not "rebuild required" — a reason that does not name its own fix makes the operator rediscover
+     * what the writer already knew. Downstream declines should quote this verbatim rather than
+     * paraphrase it.
+     * </p>
+     */
+    public String remedy() {
+      return switch (this) {
+        case GLOBAL_DICTIONARY_BUDGET_EXCEEDED ->
+            "Either give the loader an expected-row-count hint, so the election declines the oversized"
+                + " column up front and the rest of the projection still builds, or raise"
+                + " -Dsirix.projection.globalDict.budgetBytes; then rebuild with"
+                + " jn:create-projection-index($doc, '<root-path>', '<fields>').";
+        default ->
+            "Rebuild the projection with jn:create-projection-index($doc, '<root-path>', '<fields>')"
+                + " — the same call that created it; it re-elects encodings from the current data.";
+      };
+    }
+  }
+
+  private static final StaleReason[] STALE_REASONS = StaleReason.values();
+
+  /**
    * Wire-format version. Version zero stores set-summary capabilities separately from bounded chunks.
    * Unknown versions are declined rather than interpreted with shifted fields.
    */
@@ -188,7 +280,32 @@ public final class ProjectionIndexMetadata {
 
   /** Minimal stale marker the change listener writes over slot 0 on invalidation. */
   public static ProjectionIndexMetadata staleTombstone() {
-    return new ProjectionIndexMetadata("", new String[0], new String[0], new byte[0], 0, 0, FLAG_STALE, null, null);
+    return staleTombstone(StaleReason.UNSPECIFIED);
+  }
+
+  /**
+   * Stale marker carrying WHY, so a later decline can quote the writer instead of guessing.
+   *
+   * @param reason why the projection is being retired; never {@code null}
+   */
+  public static ProjectionIndexMetadata staleTombstone(final StaleReason reason) {
+    Objects.requireNonNull(reason, "reason");
+    final byte flags = (byte) (FLAG_STALE | (reason.ordinal() << STALE_REASON_SHIFT));
+    return new ProjectionIndexMetadata("", new String[0], new String[0], new byte[0], 0, 0, flags, null, null);
+  }
+
+  /**
+   * Why this projection was tombstoned, or {@link StaleReason#UNSPECIFIED} when it is not stale at
+   * all — callers should test {@link #isStale()} first; a reason without staleness means nothing.
+   */
+  public StaleReason staleReason() {
+    final int ordinal = (flags & STALE_REASON_MASK) >> STALE_REASON_SHIFT;
+    // A blob written by a newer build could name a reason this one has never heard of. That is not
+    // a corrupt payload and must not be treated as one: the projection is still stale, which is the
+    // only part the reader acts on.
+    return ordinal < STALE_REASONS.length
+        ? STALE_REASONS[ordinal]
+        : StaleReason.UNSPECIFIED;
   }
 
 
@@ -251,6 +368,27 @@ public final class ProjectionIndexMetadata {
 
   public byte[] columnKinds() {
     return columnKinds.clone();
+  }
+
+  /**
+   * Whether any column is encoded against a resource-wide value dictionary.
+   *
+   * <p>
+   * The question commit-time maintenance has to ask before it touches a leaf. Such a column's rows
+   * hold DICTIONARY IDS, and the id space is owned by a writer that exists only during a build — so
+   * an incremental patcher can neither mint an id for a value the dictionary has never seen nor
+   * re-encode the column without rewriting every leaf. It reads this metadata's OWN kinds rather
+   * than a leaf's, deliberately: the metadata is the authority on the store's shape and a leaf
+   * descriptor is a falsifiable sample of it, which is the whole lesson of task #45.
+   * </p>
+   */
+  public boolean hasGlobalDictionaryColumn() {
+    for (final byte kind : columnKinds) {
+      if (kind == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexMetadata.java
@@ -66,10 +66,10 @@ public final class ProjectionIndexMetadata {
    * </p>
    *
    * <p>
-   * It exists because "stale" and "corrupt" are different claims and the difference was being lost.
-   * A projection the writer deliberately retired because it cannot maintain a resource-wide
-   * dictionary is a DECISION, and the component that made it is the only one that can explain it;
-   * every downstream decline should be able to quote that reason rather than invent one. See the
+   * It exists because "stale" and "corrupt" are different claims and the difference was being lost. A
+   * projection the writer deliberately retired because it cannot maintain a resource-wide dictionary
+   * is a DECISION, and the component that made it is the only one that can explain it; every
+   * downstream decline should be able to quote that reason rather than invent one. See the
    * kind-inconsistency class recorded in tasks #45 and #50.
    * </p>
    */
@@ -78,18 +78,18 @@ public final class ProjectionIndexMetadata {
   private static final int STALE_REASON_SHIFT = 1;
 
   /**
-   * Why a projection was tombstoned. Ordinals are WIRE VALUES in bits 1-3 of the flags byte:
-   * append only, never renumber, and at most eight will ever fit.
+   * Why a projection was tombstoned. Ordinals are WIRE VALUES in bits 1-3 of the flags byte: append
+   * only, never renumber, and at most eight will ever fit.
    */
   public enum StaleReason {
     /** No reason recorded — a tombstone written before reasons existed, or a caller that had none. */
     UNSPECIFIED,
     /**
      * The indexed record set changed and the projection has resource-wide value dictionaries, which
-     * commit-time maintenance cannot extend: it holds no dictionary writer, so it can neither mint
-     * an id for a new value nor rewrite every leaf to a per-leaf encoding without paying O(corpus)
-     * on a single commit. Refusing keeps the store CONSISTENT; {@code jn:create-projection-index}
-     * rebuilds it.
+     * commit-time maintenance cannot extend: it holds no dictionary writer, so it can neither mint an
+     * id for a new value nor rewrite every leaf to a per-leaf encoding without paying O(corpus) on a
+     * single commit. Refusing keeps the store CONSISTENT; {@code jn:create-projection-index} rebuilds
+     * it.
      */
     GLOBAL_DICTIONARY_NOT_MAINTAINABLE,
     /** Both the incremental patch and the full rebuild failed — the corruption valve. */
@@ -107,11 +107,11 @@ public final class ProjectionIndexMetadata {
      * NOT PRODUCED BY ANYTHING YET — reserved for task #52.
      *
      * <p>
-     * A projection that needs a full rebuild but must not pay for it inside the committing
-     * transaction. Today a refused incremental patch calls {@code rebuildFully()} on the commit
-     * thread, re-extracting every record of the resource: unbounded by corpus size, reached from
-     * its refusal sites, and on a large resource a multi-minute commit. The fix is to record the
-     * need HERE, let the commit finish, and rebuild on request or in the background.
+     * A projection that needs a full rebuild but must not pay for it inside the committing transaction.
+     * Today a refused incremental patch calls {@code rebuildFully()} on the commit thread,
+     * re-extracting every record of the resource: unbounded by corpus size, reached from its refusal
+     * sites, and on a large resource a multi-minute commit. The fix is to record the need HERE, let the
+     * commit finish, and rebuild on request or in the background.
      * </p>
      *
      * <p>
@@ -135,13 +135,12 @@ public final class ProjectionIndexMetadata {
     public String remedy() {
       return switch (this) {
         case GLOBAL_DICTIONARY_BUDGET_EXCEEDED ->
-            "Either give the loader an expected-row-count hint, so the election declines the oversized"
-                + " column up front and the rest of the projection still builds, or raise"
-                + " -Dsirix.projection.globalDict.budgetBytes; then rebuild with"
-                + " jn:create-projection-index($doc, '<root-path>', '<fields>').";
-        default ->
-            "Rebuild the projection with jn:create-projection-index($doc, '<root-path>', '<fields>')"
-                + " — the same call that created it; it re-elects encodings from the current data.";
+          "Either give the loader an expected-row-count hint, so the election declines the oversized"
+              + " column up front and the rest of the projection still builds, or raise"
+              + " -Dsirix.projection.globalDict.budgetBytes; then rebuild with"
+              + " jn:create-projection-index($doc, '<root-path>', '<fields>').";
+        default -> "Rebuild the projection with jn:create-projection-index($doc, '<root-path>', '<fields>')"
+            + " — the same call that created it; it re-elects encodings from the current data.";
       };
     }
   }
@@ -377,9 +376,9 @@ public final class ProjectionIndexMetadata {
    * The question commit-time maintenance has to ask before it touches a leaf. Such a column's rows
    * hold DICTIONARY IDS, and the id space is owned by a writer that exists only during a build — so
    * an incremental patcher can neither mint an id for a value the dictionary has never seen nor
-   * re-encode the column without rewriting every leaf. It reads this metadata's OWN kinds rather
-   * than a leaf's, deliberately: the metadata is the authority on the store's shape and a leaf
-   * descriptor is a falsifiable sample of it, which is the whole lesson of task #45.
+   * re-encode the column without rewriting every leaf. It reads this metadata's OWN kinds rather than
+   * a leaf's, deliberately: the metadata is the authority on the store's shape and a leaf descriptor
+   * is a falsifiable sample of it, which is the whole lesson of task #45.
    * </p>
    */
   public boolean hasGlobalDictionaryColumn() {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -88,6 +88,13 @@ public final class ProjectionIndexRegistry {
     private volatile String[] fieldChains;
     /** Eagerly-hydrated raw leaves, or the lazily-materialized cache of a column-lazy handle. */
     private volatile List<byte[]> rowGroupPayloads;
+
+    /**
+     * The bounded windowed view of the same leaves, for a handle whose whole-leaf materialization is
+     * over the eager budget. Separate from {@link #rowGroupPayloads} because it is NOT resident:
+     * every route predicate that asks "are the leaves in memory" must answer no for it.
+     */
+    private volatile ProjectionWindowedRowGroupPayloads windowedPayloads;
     /**
      * Column-sliced view (P5b stage 2) — non-null marks a COLUMN-LAZY handle: constructed from
      * descriptors only; {@link #rowGroupPayloads} materializes whole raw leaves on first whole-leaf
@@ -707,36 +714,66 @@ public final class ProjectionIndexRegistry {
      * accept a {@code null} one.
      *
      * <p>
-     * ONLY a RESIDENT list is memoized. A handle lives in the catalog's process-wide cache, keyed by
-     * (resource, def, build revision) and dropped only when the resource is removed, so anything it
-     * stores outlives every session that touches it. Eager leaves are inert {@code byte[]}s and are
-     * safe to share; a {@link ProjectionWindowedRowGroupPayloads} view is NOT — it fetches its
-     * windows through the session its materializer was built from, and memoizing it would hand the
-     * next session a view bound to a closed one. Over-budget handles therefore hand each caller its
-     * own windowed view over the caller's own live session, which is also what keeps
-     * {@link #payloadsMaterialized()} meaning "resident".
+     * The two routes memoize into DIFFERENT fields, because only one of them is resident. Eager
+     * leaves are inert {@code byte[]}s and land in {@link #rowGroupPayloads}. A
+     * {@link ProjectionWindowedRowGroupPayloads} view holds only a bounded window set, so it lands
+     * in {@link #windowedPayloads} and {@link #payloadsMaterialized()} keeps meaning "resident".
+     * Both are memoized HERE, on the handle, whose (resource, def, build revision) cache key is
+     * exactly the identity of the bytes they hold — no shorter-lived owner can memoize a view
+     * without multiplying the residency its window cap bounds.
+     * </p>
+     *
+     * <p>
+     * A windowed view captures no session; every consult rebinds it to the CALLER's own live reader
+     * source, which is what makes memoizing it on a process-wide handle safe. A handle that has gone
+     * windowed STAYS windowed for its cache lifetime: raising the budget afterwards must not turn
+     * the next consult into the whole-leaf materialization this handle exists to avoid.
      * </p>
      *
      * @throws IllegalStateException when a lazy handle's materializer fails (dead-session window,
      *         truncated/corrupt store) — callers decline to the generic pipeline
      */
     public List<byte[]> rowGroupPayloads(final Supplier<List<byte[]>> materializer) {
-      List<byte[]> leaves = rowGroupPayloads;
-      if (leaves != null) {
-        return leaves;
+      final List<byte[]> resident = rowGroupPayloads;
+      if (resident != null) {
+        return resident;
+      }
+      final ProjectionWindowedRowGroupPayloads windowed = windowedPayloads;
+      if (windowed != null) {
+        return bindTo(windowed, materializer);
       }
       synchronized (materializeLock) {
-        leaves = rowGroupPayloads;
-        if (leaves != null) {
-          return leaves;
+        final List<byte[]> raced = rowGroupPayloads;
+        if (raced != null) {
+          return raced;
         }
-        leaves = Objects.requireNonNull(Objects.requireNonNull(materializer, "materializer").get(),
+        final ProjectionWindowedRowGroupPayloads racedWindow = windowedPayloads;
+        if (racedWindow != null) {
+          return bindTo(racedWindow, materializer);
+        }
+        final List<byte[]> built = Objects.requireNonNull(Objects.requireNonNull(materializer, "materializer").get(),
             "materializer returned null");
-        if (!(leaves instanceof ProjectionWindowedRowGroupPayloads)) {
-          rowGroupPayloads = leaves;
+        if (built instanceof ProjectionWindowedRowGroupPayloads view) {
+          bindTo(view, materializer);
+          windowedPayloads = view;
+        } else {
+          rowGroupPayloads = built;
         }
-        return leaves;
+        return built;
       }
+    }
+
+    /**
+     * Point a memoized windowed view at THIS caller's reader source before handing it over. A
+     * materializer that carries no source leaves the previous binding standing — which is what a
+     * pre-materialized (eager) handle and the test seams pass.
+     */
+    private static ProjectionWindowedRowGroupPayloads bindTo(final ProjectionWindowedRowGroupPayloads view,
+        final Supplier<List<byte[]>> materializer) {
+      if (materializer instanceof ProjectionWindowedRowGroupPayloads.BoundMaterializer bound) {
+        view.bindReaderSource(bound.readerSource());
+      }
+      return view;
     }
 
     /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -706,6 +706,17 @@ public final class ProjectionIndexRegistry {
      * shared — the {@code materializer} is not consulted again, so eager (pre-materialized) handles
      * accept a {@code null} one.
      *
+     * <p>
+     * ONLY a RESIDENT list is memoized. A handle lives in the catalog's process-wide cache, keyed by
+     * (resource, def, build revision) and dropped only when the resource is removed, so anything it
+     * stores outlives every session that touches it. Eager leaves are inert {@code byte[]}s and are
+     * safe to share; a {@link ProjectionWindowedRowGroupPayloads} view is NOT — it fetches its
+     * windows through the session its materializer was built from, and memoizing it would hand the
+     * next session a view bound to a closed one. Over-budget handles therefore hand each caller its
+     * own windowed view over the caller's own live session, which is also what keeps
+     * {@link #payloadsMaterialized()} meaning "resident".
+     * </p>
+     *
      * @throws IllegalStateException when a lazy handle's materializer fails (dead-session window,
      *         truncated/corrupt store) — callers decline to the generic pipeline
      */
@@ -716,9 +727,12 @@ public final class ProjectionIndexRegistry {
       }
       synchronized (materializeLock) {
         leaves = rowGroupPayloads;
-        if (leaves == null) {
-          leaves = Objects.requireNonNull(Objects.requireNonNull(materializer, "materializer").get(),
-              "materializer returned null");
+        if (leaves != null) {
+          return leaves;
+        }
+        leaves = Objects.requireNonNull(Objects.requireNonNull(materializer, "materializer").get(),
+            "materializer returned null");
+        if (!(leaves instanceof ProjectionWindowedRowGroupPayloads)) {
           rowGroupPayloads = leaves;
         }
         return leaves;
@@ -731,6 +745,12 @@ public final class ProjectionIndexRegistry {
      * contiguous byte-kernel scan beats scattered slice reads — the sliced routes exist to avoid the
      * materialization, not to replace the warm scan. Racy by design (a stale {@code null} just serves
      * one more query from slices).
+     *
+     * <p>
+     * A windowed view never sets this: its leaves are fetched per window and evicted under a cap, so
+     * reporting it as materialized would steer every later query off a viable sliced fill and into a
+     * byte-kernel scan that re-reads windows from disk.
+     * </p>
      */
     public boolean payloadsMaterialized() {
       return rowGroupPayloads != null;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -90,9 +90,9 @@ public final class ProjectionIndexRegistry {
     private volatile List<byte[]> rowGroupPayloads;
 
     /**
-     * The bounded WINDOW CACHE over the same leaves, for a handle whose whole-leaf materialization
-     * is over the eager budget. Separate from {@link #rowGroupPayloads} because it is NOT resident:
-     * every route predicate that asks "are the leaves in memory" must answer no for it. It holds no
+     * The bounded WINDOW CACHE over the same leaves, for a handle whose whole-leaf materialization is
+     * over the eager budget. Separate from {@link #rowGroupPayloads} because it is NOT resident: every
+     * route predicate that asks "are the leaves in memory" must answer no for it. It holds no
      * session-derived state, which is what makes it safe on a process-wide handle.
      */
     private volatile ProjectionWindowedRowGroupPayloads windowedPayloads;
@@ -715,22 +715,22 @@ public final class ProjectionIndexRegistry {
      * accept a {@code null} one.
      *
      * <p>
-     * The two routes memoize into DIFFERENT fields, because only one of them is resident. Eager
-     * leaves are inert {@code byte[]}s and land in {@link #rowGroupPayloads}. A
-     * {@link ProjectionWindowedRowGroupPayloads} view holds only a bounded window set, so it lands
-     * in {@link #windowedPayloads} and {@link #payloadsMaterialized()} keeps meaning "resident".
-     * Both are memoized HERE, on the handle, whose (resource, def, build revision) cache key is
-     * exactly the identity of the bytes they hold — no shorter-lived owner can memoize a view
-     * without multiplying the residency its window cap bounds.
+     * The two routes memoize into DIFFERENT fields, because only one of them is resident. Eager leaves
+     * are inert {@code byte[]}s and land in {@link #rowGroupPayloads}. A
+     * {@link ProjectionWindowedRowGroupPayloads} view holds only a bounded window set, so it lands in
+     * {@link #windowedPayloads} and {@link #payloadsMaterialized()} keeps meaning "resident". Both are
+     * memoized HERE, on the handle, whose (resource, def, build revision) cache key is exactly the
+     * identity of the bytes they hold — no shorter-lived owner can memoize a view without multiplying
+     * the residency its window cap bounds.
      * </p>
      *
      * <p>
      * What the handle memoizes on the windowed route is the WINDOW CACHE, never a list bound to a
-     * session: the cache holds no session-derived field, and each consult wraps it in a thin
-     * per-caller view carrying THAT caller's reader source. A handle that has gone windowed keeps
-     * serving through that cache for as long as callers hand it windowed materializers; it is
-     * promoted to resident leaves only when a caller's materializer actually produces them, never
-     * by the handle deciding on its own to pay for a whole-leaf materialization.
+     * session: the cache holds no session-derived field, and each consult wraps it in a thin per-caller
+     * view carrying THAT caller's reader source. A handle that has gone windowed keeps serving through
+     * that cache for as long as callers hand it windowed materializers; it is promoted to resident
+     * leaves only when a caller's materializer actually produces them, never by the handle deciding on
+     * its own to pay for a whole-leaf materialization.
      * </p>
      *
      * @throws IllegalStateException when a lazy handle's materializer fails (dead-session window,
@@ -767,12 +767,12 @@ public final class ProjectionIndexRegistry {
     }
 
     /**
-     * Wrap the memoized cache for THIS caller. The caller's source comes from its materializer, and
-     * a windowed materializer carries one, so the common path allocates one thin view and reads no
-     * bytes. A materializer that carries none is consulted: if it still built a windowed view, its
-     * cache is discarded in favour of the memoized one and only its source is kept; if it built
-     * RESIDENT leaves instead — a raised budget, or an eager handle — the handle is PROMOTED to
-     * them, because the materialization is already paid for and resident leaves beat windows.
+     * Wrap the memoized cache for THIS caller. The caller's source comes from its materializer, and a
+     * windowed materializer carries one, so the common path allocates one thin view and reads no bytes.
+     * A materializer that carries none is consulted: if it still built a windowed view, its cache is
+     * discarded in favour of the memoized one and only its source is kept; if it built RESIDENT leaves
+     * instead — a raised budget, or an eager handle — the handle is PROMOTED to them, because the
+     * materialization is already paid for and resident leaves beat windows.
      */
     private List<byte[]> boundView(final ProjectionWindowedRowGroupPayloads cache,
         final Supplier<List<byte[]>> materializer) {
@@ -780,8 +780,7 @@ public final class ProjectionIndexRegistry {
         return cache.boundTo(bound.readerSource());
       }
       final List<byte[]> built = Objects.requireNonNull(materializer, "materializer").get();
-      final ProjectionWindowedRowGroupPayloads.ReaderSource source =
-          ProjectionWindowedRowGroupPayloads.sourceOf(built);
+      final ProjectionWindowedRowGroupPayloads.ReaderSource source = ProjectionWindowedRowGroupPayloads.sourceOf(built);
       if (source != null) {
         return cache.boundTo(source);
       }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRegistry.java
@@ -90,9 +90,10 @@ public final class ProjectionIndexRegistry {
     private volatile List<byte[]> rowGroupPayloads;
 
     /**
-     * The bounded windowed view of the same leaves, for a handle whose whole-leaf materialization is
-     * over the eager budget. Separate from {@link #rowGroupPayloads} because it is NOT resident:
-     * every route predicate that asks "are the leaves in memory" must answer no for it.
+     * The bounded WINDOW CACHE over the same leaves, for a handle whose whole-leaf materialization
+     * is over the eager budget. Separate from {@link #rowGroupPayloads} because it is NOT resident:
+     * every route predicate that asks "are the leaves in memory" must answer no for it. It holds no
+     * session-derived state, which is what makes it safe on a process-wide handle.
      */
     private volatile ProjectionWindowedRowGroupPayloads windowedPayloads;
     /**
@@ -724,10 +725,12 @@ public final class ProjectionIndexRegistry {
      * </p>
      *
      * <p>
-     * A windowed view captures no session; every consult rebinds it to the CALLER's own live reader
-     * source, which is what makes memoizing it on a process-wide handle safe. A handle that has gone
-     * windowed STAYS windowed for its cache lifetime: raising the budget afterwards must not turn
-     * the next consult into the whole-leaf materialization this handle exists to avoid.
+     * What the handle memoizes on the windowed route is the WINDOW CACHE, never a list bound to a
+     * session: the cache holds no session-derived field, and each consult wraps it in a thin
+     * per-caller view carrying THAT caller's reader source. A handle that has gone windowed keeps
+     * serving through that cache for as long as callers hand it windowed materializers; it is
+     * promoted to resident leaves only when a caller's materializer actually produces them, never
+     * by the handle deciding on its own to pay for a whole-leaf materialization.
      * </p>
      *
      * @throws IllegalStateException when a lazy handle's materializer fails (dead-session window,
@@ -740,7 +743,7 @@ public final class ProjectionIndexRegistry {
       }
       final ProjectionWindowedRowGroupPayloads windowed = windowedPayloads;
       if (windowed != null) {
-        return bindTo(windowed, materializer);
+        return boundView(windowed, materializer);
       }
       synchronized (materializeLock) {
         final List<byte[]> raced = rowGroupPayloads;
@@ -749,13 +752,13 @@ public final class ProjectionIndexRegistry {
         }
         final ProjectionWindowedRowGroupPayloads racedWindow = windowedPayloads;
         if (racedWindow != null) {
-          return bindTo(racedWindow, materializer);
+          return boundView(racedWindow, materializer);
         }
         final List<byte[]> built = Objects.requireNonNull(Objects.requireNonNull(materializer, "materializer").get(),
             "materializer returned null");
-        if (built instanceof ProjectionWindowedRowGroupPayloads view) {
-          bindTo(view, materializer);
-          windowedPayloads = view;
+        final ProjectionWindowedRowGroupPayloads cache = ProjectionWindowedRowGroupPayloads.cacheOf(built);
+        if (cache != null) {
+          windowedPayloads = cache;
         } else {
           rowGroupPayloads = built;
         }
@@ -764,16 +767,26 @@ public final class ProjectionIndexRegistry {
     }
 
     /**
-     * Point a memoized windowed view at THIS caller's reader source before handing it over. A
-     * materializer that carries no source leaves the previous binding standing — which is what a
-     * pre-materialized (eager) handle and the test seams pass.
+     * Wrap the memoized cache for THIS caller. The caller's source comes from its materializer, and
+     * a windowed materializer carries one, so the common path allocates one thin view and reads no
+     * bytes. A materializer that carries none is consulted: if it still built a windowed view, its
+     * cache is discarded in favour of the memoized one and only its source is kept; if it built
+     * RESIDENT leaves instead — a raised budget, or an eager handle — the handle is PROMOTED to
+     * them, because the materialization is already paid for and resident leaves beat windows.
      */
-    private static ProjectionWindowedRowGroupPayloads bindTo(final ProjectionWindowedRowGroupPayloads view,
+    private List<byte[]> boundView(final ProjectionWindowedRowGroupPayloads cache,
         final Supplier<List<byte[]>> materializer) {
       if (materializer instanceof ProjectionWindowedRowGroupPayloads.BoundMaterializer bound) {
-        view.bindReaderSource(bound.readerSource());
+        return cache.boundTo(bound.readerSource());
       }
-      return view;
+      final List<byte[]> built = Objects.requireNonNull(materializer, "materializer").get();
+      final ProjectionWindowedRowGroupPayloads.ReaderSource source =
+          ProjectionWindowedRowGroupPayloads.sourceOf(built);
+      if (source != null) {
+        return cache.boundTo(source);
+      }
+      rowGroupPayloads = built;
+      return built;
     }
 
     /**

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRowExtractor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRowExtractor.java
@@ -201,6 +201,77 @@ public final class ProjectionIndexRowExtractor {
     return columnKinds.clone();
   }
 
+  /**
+   * The current (pathNodeKey → column) mapping arrays, for a chunk batch's dispatch snapshot.
+   * {@link #resolveFieldPcrs} REPLACES these arrays rather than mutating them, so the returned
+   * references stay valid snapshots across later refreshes.
+   */
+  long[] fieldPcrKeysRef() {
+    return fieldPcrKeys;
+  }
+
+  int[] fieldPcrColumnsRef() {
+    return fieldPcrColumns;
+  }
+
+  /**
+   * Fill the row buffers from one worker-extracted batch row, in place of {@link #extractInto}'s
+   * navigation. The batch classified every cell with this extractor's own helpers, so the buffers
+   * end in the state {@link #extractAt} would have produced for the same record; {@link #appendTo}
+   * then packs them through the identical leaf path.
+   */
+  void loadRowFromBatch(final ProjectionChunkRowBatch batch, final int row) {
+    resetRow(null);
+    for (int column = 0; column < columnKinds.length; column++) {
+      if (!batch.flagPresent(column, row)) {
+        continue;
+      }
+      rowPresent[column] = true;
+      final boolean cellUnrepresentable = batch.flagUnrepresentable(column, row);
+      if (cellUnrepresentable) {
+        rowUnrepresentable[column] = true;
+      }
+      if (batch.flagNonIntegral(column, row)) {
+        rowNonIntegral[column] = true;
+        numericColumnSawNonIntegral[column] = true;
+      }
+      if (batch.flagNonDoubleSource(column, row)) {
+        rowNonDoubleSource[column] = true;
+      }
+      switch (columnKinds[column]) {
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG,
+            ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_DOUBLE ->
+            rowLongs[column] = batch.longValue(column, row);
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN -> rowBools[column] = batch.booleanValue(column, row);
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT,
+            ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL -> {
+          final int length = batch.stringLength(column, row);
+          if (length >= 0 && !cellUnrepresentable) {
+            byte[] scratch = rowStringUtf8Scratch[column];
+            if (scratch == null || scratch.length < length) {
+              scratch = new byte[grownStringCapacity(scratch == null
+                  ? 0
+                  : scratch.length, Math.max(1, length))];
+              rowStringUtf8Scratch[column] = scratch;
+            }
+            System.arraycopy(batch.stringArena(column), batch.stringOffset(column, row), scratch, 0, length);
+            rowStringUtf8[column] = scratch;
+            rowStringUtf8Lengths[column] = length;
+          }
+        }
+        case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_SET -> {
+          if (!cellUnrepresentable) {
+            final String[] elements = batch.setElementsAt(column, row);
+            rowStringSets[column] = elements;
+            rowStringSetLen[column] = elements.length;
+          }
+        }
+        default -> throw new IllegalStateException(
+            "unknown projection column kind " + columnKinds[column] + " for column " + column);
+      }
+    }
+  }
+
   /** No-clone view for same-package hot paths (leaf construction). */
   byte[] columnKindsRef() {
     return columnKinds;
@@ -717,7 +788,7 @@ public final class ProjectionIndexRowExtractor {
    * losslessly); Long round-trips iff |value| ≤ 2^53-ish (checked by round-trip); Big* fall back to
    * an exact BigDecimal compare (allocates, but only on the rare Big* path).
    */
-  private static boolean isLossyDoubleConversion(final Number n, final double d) {
+  static boolean isLossyDoubleConversion(final Number n, final double d) {
     return switch (n) {
       case Double ignored -> false;
       case Float ignored -> false;
@@ -732,7 +803,7 @@ public final class ProjectionIndexRowExtractor {
     };
   }
 
-  private static boolean isNonIntegral(final Number n) {
+  static boolean isNonIntegral(final Number n) {
     if (n instanceof Double || n instanceof Float) {
       final double d = n.doubleValue();
       return d != Math.rint(d) || Math.abs(d) > (double) Long.MAX_VALUE;
@@ -760,7 +831,7 @@ public final class ProjectionIndexRowExtractor {
    * Flagged cells raise the value-exactness bit so value-exact consumers decline to the typed re-walk
    * / generic pipeline; counts stay servable.
    */
-  private static boolean isLossyLongConversion(final Number n) {
+  static boolean isLossyLongConversion(final Number n) {
     return switch (n) {
       case Long ignored -> false;
       case Integer ignored -> false;

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRowExtractor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexRowExtractor.java
@@ -216,9 +216,9 @@ public final class ProjectionIndexRowExtractor {
 
   /**
    * Fill the row buffers from one worker-extracted batch row, in place of {@link #extractInto}'s
-   * navigation. The batch classified every cell with this extractor's own helpers, so the buffers
-   * end in the state {@link #extractAt} would have produced for the same record; {@link #appendTo}
-   * then packs them through the identical leaf path.
+   * navigation. The batch classified every cell with this extractor's own helpers, so the buffers end
+   * in the state {@link #extractAt} would have produced for the same record; {@link #appendTo} then
+   * packs them through the identical leaf path.
    */
   void loadRowFromBatch(final ProjectionChunkRowBatch batch, final int row) {
     resetRow(null);
@@ -241,7 +241,7 @@ public final class ProjectionIndexRowExtractor {
       switch (columnKinds[column]) {
         case ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG,
             ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_DOUBLE ->
-            rowLongs[column] = batch.longValue(column, row);
+          rowLongs[column] = batch.longValue(column, row);
         case ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN -> rowBools[column] = batch.booleanValue(column, row);
         case ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT,
             ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL -> {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStoreInconsistentException.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStoreInconsistentException.java
@@ -12,9 +12,9 @@ package io.sirix.index.projection;
  * is an agreement between them, which is a WRITER's mistake and is repaired by rebuilding, not by
  * quarantining a column. The distinction is the entire point of the type. Task #45 spent four
  * rounds chasing "known-corrupt BODY segment" before the actual fault turned out to be a leaf
- * descriptor that maintenance had rewritten with the declared column kind while the payload and
- * the metadata still carried the elected one; the message blamed the bytes because the code had no
- * way to say anything else.
+ * descriptor that maintenance had rewritten with the declared column kind while the payload and the
+ * metadata still carried the elected one; the message blamed the bytes because the code had no way
+ * to say anything else.
  * </p>
  *
  * <p>

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStoreInconsistentException.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStoreInconsistentException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+/**
+ * A persisted projection's leaves disagree about what its columns MEAN — refuse the store, and say
+ * so in those words.
+ *
+ * <p>
+ * This is not corruption and must never be reported as such. The bytes decode fine; what is broken
+ * is an agreement between them, which is a WRITER's mistake and is repaired by rebuilding, not by
+ * quarantining a column. The distinction is the entire point of the type. Task #45 spent four
+ * rounds chasing "known-corrupt BODY segment" before the actual fault turned out to be a leaf
+ * descriptor that maintenance had rewritten with the declared column kind while the payload and
+ * the metadata still carried the elected one; the message blamed the bytes because the code had no
+ * way to say anything else.
+ * </p>
+ *
+ * <p>
+ * Catch sites must therefore treat this DIFFERENTLY from {@link IllegalStateException}: decline the
+ * whole store and let the query take the generic pipeline, but do NOT set the per-column corrupt
+ * memo. That memo is process-lifetime and store-wide, so recording a disagreement in it disables
+ * every fast path on a column whose bytes were never in question (task #50).
+ * </p>
+ *
+ * <p>
+ * It extends {@link IllegalStateException} so that existing handlers keep degrading safely rather
+ * than propagating a fresh unchecked type out of paths that never expected one — the narrower catch
+ * has to come first to get the better behaviour, and a handler that has not been taught the
+ * difference still fails safe.
+ * </p>
+ */
+public final class ProjectionStoreInconsistentException extends IllegalStateException {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Index of the leaf whose descriptor disagreed with leaf 0. */
+  private final int leaf;
+
+  /**
+   * @param leaf index of the disagreeing leaf within the store's directory list
+   * @param detail what the disagreement is, in terms a reader can act on
+   */
+  public ProjectionStoreInconsistentException(final int leaf, final String detail) {
+    super("Projection store is INCONSISTENT, not corrupt: leaf " + leaf + " disagrees with leaf 0 about the column"
+        + " encodings (" + detail + "). Every leaf of one projection must declare the same kinds; the store's bytes"
+        + " are fine but its leaves no longer describe the same thing, so no route over it can be trusted. Queries"
+        + " take the generic pipeline; jn:create-projection-index rebuilds the projection.");
+    this.leaf = leaf;
+  }
+
+  /** Index of the leaf whose descriptor disagreed with leaf 0. */
+  public int leaf() {
+    return leaf;
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStructuralOrderDirectory.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStructuralOrderDirectory.java
@@ -212,8 +212,8 @@ final class ProjectionStructuralOrderDirectory {
 
     /**
      * Epoch-lived prefix cache for {@link #fullLabelForInOrderAppend}: the document root's and the
-     * record-set container's local suffixes are shared by every record of an in-order load, so they
-     * are read from the store once per accessor rather than once per record.
+     * record-set container's local suffixes are shared by every record of an in-order load, so they are
+     * read from the store once per accessor rather than once per record.
      */
     private long cachedInOrderContainerKey = NULL_NODE_KEY;
     private long cachedInOrderDocumentRootKey = NULL_NODE_KEY;
@@ -239,9 +239,9 @@ final class ProjectionStructuralOrderDirectory {
      *
      * <p>
      * Byte-equivalent to {@link #fullLabel} for exactly this arrival, by the following argument. The
-     * ancestry {@code fullLabel} would walk is [record, container, document root] — the caller names
-     * it instead of reading it, which is what removes the node lookups. The record's local label is
-     * the {@code appendRun} step ({@link #firstLocalLabel()} for the first record, else
+     * ancestry {@code fullLabel} would walk is [record, container, document root] — the caller names it
+     * instead of reading it, which is what removes the node lookups. The record's local label is the
+     * {@code appendRun} step ({@link #firstLocalLabel()} for the first record, else
      * {@link #nextAppendLabel} of the PREVIOUS record's local): {@code mintRun} assigns exactly that
      * sequence whatever run batching a drain produced, because an append run's labels depend only on
      * the run's lower bound and every record's lower bound here is its predecessor. The container is
@@ -252,19 +252,19 @@ final class ProjectionStructuralOrderDirectory {
      * <p>
      * The one behaviour {@code fullLabel} has that this lane refuses instead of reproducing is the
      * bounded rebalance: it fires only when a minted label exceeds {@link #REBALANCE_DIVISIONS}
-     * divisions, which an append-only sequence reaches after several {@code nextAppendLabel} carries
-     * — beyond 10^9 records per container — and under the {@link RelabelSink#SEALED} sink a build
-     * uses the rebalance collects no siblings and keeps the minted label anyway. Refusing loudly is
-     * strictly safer than silently diverging there.
+     * divisions, which an append-only sequence reaches after several {@code nextAppendLabel} carries —
+     * beyond 10^9 records per container — and under the {@link RelabelSink#SEALED} sink a build uses
+     * the rebalance collects no siblings and keeps the minted label anyway. Refusing loudly is strictly
+     * safer than silently diverging there.
      *
      * @param previousRecordLocal the LOCAL label the previous record of this load received, or
-     *        {@code null} for the load's first record; the caller carries it across accessor
-     *        lifetimes (one accessor exists per storage epoch)
+     *        {@code null} for the load's first record; the caller carries it across accessor lifetimes
+     *        (one accessor exists per storage epoch)
      * @return the record's full label; the freshly minted LOCAL label is available from
      *         {@link #lastInOrderAppendedLocal()} for the caller to carry forward
      */
-    SirixDeweyID fullLabelForInOrderAppend(final long recordKey, final long containerKey,
-        final long documentRootKey, final @Nullable SirixDeweyID previousRecordLocal) {
+    SirixDeweyID fullLabelForInOrderAppend(final long recordKey, final long containerKey, final long documentRootKey,
+        final @Nullable SirixDeweyID previousRecordLocal) {
       validateNodeKey(recordKey, "node");
       validateNodeKey(containerKey, "container");
       validateNodeKey(documentRootKey, "document root");
@@ -321,7 +321,8 @@ final class ProjectionStructuralOrderDirectory {
     }
 
     /** The LOCAL label {@link #fullLabelForInOrderAppend} minted last — the caller's carry state. */
-    @Nullable SirixDeweyID lastInOrderAppendedLocal() {
+    @Nullable
+    SirixDeweyID lastInOrderAppendedLocal() {
       return lastInOrderAppendedLocal;
     }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStructuralOrderDirectory.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionStructuralOrderDirectory.java
@@ -210,6 +210,17 @@ final class ProjectionStructuralOrderDirectory {
   static final class Accessor {
     private final SlotStore store;
 
+    /**
+     * Epoch-lived prefix cache for {@link #fullLabelForInOrderAppend}: the document root's and the
+     * record-set container's local suffixes are shared by every record of an in-order load, so they
+     * are read from the store once per accessor rather than once per record.
+     */
+    private long cachedInOrderContainerKey = NULL_NODE_KEY;
+    private long cachedInOrderDocumentRootKey = NULL_NODE_KEY;
+    private int @Nullable [] cachedInOrderDocumentRootSuffix;
+    private int @Nullable [] cachedInOrderContainerSuffix;
+    private @Nullable SirixDeweyID lastInOrderAppendedLocal;
+
     private Accessor(final SlotStore store) {
       this.store = Objects.requireNonNull(store, "store must not be null");
     }
@@ -220,6 +231,98 @@ final class ProjectionStructuralOrderDirectory {
       if (localLabel(nodeKey) == null) {
         putLocalLabel(nodeKey, firstLocalLabel());
       }
+    }
+
+    /**
+     * The full label of {@code recordKey} appended IN DOCUMENT ORDER as the newest record of
+     * {@code containerKey}'s record set, minted without a single document lookup.
+     *
+     * <p>
+     * Byte-equivalent to {@link #fullLabel} for exactly this arrival, by the following argument. The
+     * ancestry {@code fullLabel} would walk is [record, container, document root] — the caller names
+     * it instead of reading it, which is what removes the node lookups. The record's local label is
+     * the {@code appendRun} step ({@link #firstLocalLabel()} for the first record, else
+     * {@link #nextAppendLabel} of the PREVIOUS record's local): {@code mintRun} assigns exactly that
+     * sequence whatever run batching a drain produced, because an append run's labels depend only on
+     * the run's lower bound and every record's lower bound here is its predecessor. The container is
+     * minted alone with open bounds, exactly as {@code ensureLocalLabel} mints a container whose
+     * siblings carry no labels — the caller's contract is that the container has none (the parallel
+     * importer's record set is the document root's only child).
+     *
+     * <p>
+     * The one behaviour {@code fullLabel} has that this lane refuses instead of reproducing is the
+     * bounded rebalance: it fires only when a minted label exceeds {@link #REBALANCE_DIVISIONS}
+     * divisions, which an append-only sequence reaches after several {@code nextAppendLabel} carries
+     * — beyond 10^9 records per container — and under the {@link RelabelSink#SEALED} sink a build
+     * uses the rebalance collects no siblings and keeps the minted label anyway. Refusing loudly is
+     * strictly safer than silently diverging there.
+     *
+     * @param previousRecordLocal the LOCAL label the previous record of this load received, or
+     *        {@code null} for the load's first record; the caller carries it across accessor
+     *        lifetimes (one accessor exists per storage epoch)
+     * @return the record's full label; the freshly minted LOCAL label is available from
+     *         {@link #lastInOrderAppendedLocal()} for the caller to carry forward
+     */
+    SirixDeweyID fullLabelForInOrderAppend(final long recordKey, final long containerKey,
+        final long documentRootKey, final @Nullable SirixDeweyID previousRecordLocal) {
+      validateNodeKey(recordKey, "node");
+      validateNodeKey(containerKey, "container");
+      validateNodeKey(documentRootKey, "document root");
+      if (cachedInOrderDocumentRootKey != documentRootKey || cachedInOrderDocumentRootSuffix == null) {
+        cachedInOrderDocumentRootSuffix = requireLocalLabel(documentRootKey, "document root").getDivisionValues();
+        cachedInOrderDocumentRootKey = documentRootKey;
+      }
+      if (cachedInOrderContainerKey != containerKey || cachedInOrderContainerSuffix == null) {
+        SirixDeweyID containerLocal = localLabel(containerKey);
+        if (containerLocal == null) {
+          // Mint alone with open bounds — identical to ensureLocalLabel's container mint when no
+          // sibling carries a label, which is this lane's contract.
+          containerLocal = firstLocalLabel();
+          putLocalLabel(containerKey, containerLocal);
+        }
+        cachedInOrderContainerSuffix = containerLocal.getDivisionValues();
+        cachedInOrderContainerKey = containerKey;
+      }
+      final SirixDeweyID recordLocal = previousRecordLocal == null
+          ? firstLocalLabel()
+          : nextAppendLabel(previousRecordLocal);
+      if (recordLocal.getDivisionValues().length > REBALANCE_DIVISIONS) {
+        throw new IllegalStateException("in-order projection append label for record " + recordKey + " crossed the "
+            + "rebalance threshold of " + REBALANCE_DIVISIONS + " divisions — unreachable for an append-only "
+            + "sequence below ~10^9 records per container, and the sealed drain lane would keep the label anyway");
+      }
+      putLocalLabel(recordKey, recordLocal);
+      lastInOrderAppendedLocal = recordLocal;
+
+      final int[] documentRootSuffix = cachedInOrderDocumentRootSuffix;
+      final int[] containerSuffix = cachedInOrderContainerSuffix;
+      final int[] recordDivisions = recordLocal.getDivisionValues();
+      final int documentRootSuffixLength = documentRootSuffix.length - 1;
+      final int containerSuffixLength = containerSuffix.length - 1;
+      final int recordSuffixLength = recordDivisions.length - 1;
+      final int divisionCount = 1 + documentRootSuffixLength + containerSuffixLength + recordSuffixLength;
+      if (divisionCount > MAX_FULL_LABEL_DIVISIONS) {
+        throw new IllegalStateException(
+            "projection structural label exceeds " + MAX_FULL_LABEL_DIVISIONS + " divisions");
+      }
+      final int[] divisions = new int[divisionCount];
+      divisions[0] = 1;
+      int at = 1;
+      System.arraycopy(documentRootSuffix, 1, divisions, at, documentRootSuffixLength);
+      at += documentRootSuffixLength;
+      System.arraycopy(containerSuffix, 1, divisions, at, containerSuffixLength);
+      at += containerSuffixLength;
+      System.arraycopy(recordDivisions, 1, divisions, at, recordSuffixLength);
+      final SirixDeweyID fullLabel = new SirixDeweyID(divisionCount, divisions);
+      if (fullLabel.toBytes().length > ProjectionIndexRowGroupPage.MAX_ORDER_LABEL_BYTES) {
+        throw new IllegalStateException("projection structural label exceeds the bounded order-label lane");
+      }
+      return fullLabel;
+    }
+
+    /** The LOCAL label {@link #fullLabelForInOrderAppend} minted last — the caller's carry state. */
+    @Nullable SirixDeweyID lastInOrderAppendedLocal() {
+      return lastInOrderAppendedLocal;
     }
 
     void remove(final long nodeKey) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.page.ChunkedBodyConfig;
+
+import java.util.AbstractList;
+import java.util.RandomAccess;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+/**
+ * A {@code List<byte[]>} of a projection's row-group payloads that materializes WINDOWS of leaves on
+ * demand instead of the whole column family at once.
+ *
+ * <p>
+ * The eager whole-leaf list is the right shape while it fits: every byte-scan kernel takes a
+ * {@code List<byte[]>}, materialization runs once, and the bytes serve every later query. At 100M
+ * rows it is the wrong shape by an order of magnitude — a fat-string projection's leaves total
+ * ~8-10 GB, and the first whole-leaf consumer (a string LIKE, a distinct over strings) OOMed the
+ * catalog's materializer before serving a single row. This view keeps the {@code List} contract the
+ * kernels already program against — random access, {@code subList} sharding across workers — while
+ * holding only a bounded set of windows resident.
+ *
+ * <h2>Concurrency</h2> Windows publish by CAS into an {@link AtomicReferenceArray}; a concurrent
+ * first-touch of the same window races benignly (first publish wins, content is identical — the
+ * same doctrine as {@link ProjectionColumnStore}'s column fills). Eviction is CLOCK second-chance
+ * over touched bits: a window in active iteration is re-marked on every {@link #get} and survives;
+ * readers holding {@code byte[]} references across an eviction are safe because payload arrays are
+ * immutable and reachability keeps them alive. The resident bound is therefore approximate — capped
+ * windows plus whatever consumers transiently pin — which is exactly the bound the budget asked
+ * for, not a guarantee the GC could not give anyway.
+ *
+ * <h2>Failure contract</h2> A missing leaf inside a window throws {@link IllegalStateException}
+ * from {@link #get}, the same truncated-store verdict the eager materializer throws — callers
+ * decline serving and the generic pipeline answers.
+ */
+public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[]> implements RandomAccess {
+
+  /** Materializes the payloads of the LOGICAL row-group range {@code [from, toExclusive)}. */
+  @FunctionalInterface
+  public interface WindowFetcher {
+    byte[][] fetch(int fromLogical, int toLogicalExclusive);
+  }
+
+  private final int rowGroupCount;
+  private final int windowLeaves;
+  private final int residentCap;
+  private final WindowFetcher fetcher;
+
+  private final AtomicReferenceArray<byte[][]> windows;
+  /** CLOCK touched bits, one int per window ({@code 1} = referenced since the hand last passed). */
+  private final AtomicIntegerArray touched;
+  private final AtomicInteger resident = new AtomicInteger();
+  private final AtomicInteger clockHand = new AtomicInteger();
+
+  public ProjectionWindowedRowGroupPayloads(final int rowGroupCount, final int windowLeaves, final int residentCap,
+      final WindowFetcher fetcher) {
+    if (rowGroupCount < 0) {
+      throw new IllegalArgumentException("rowGroupCount must be non-negative: " + rowGroupCount);
+    }
+    if (windowLeaves <= 0) {
+      throw new IllegalArgumentException("windowLeaves must be positive: " + windowLeaves);
+    }
+    this.rowGroupCount = rowGroupCount;
+    this.windowLeaves = windowLeaves;
+    final int windowCount = rowGroupCount == 0
+        ? 0
+        : 1 + (rowGroupCount - 1) / windowLeaves;
+    // At least two windows resident, or a kernel touching a window boundary would thrash on the
+    // spot; never more than exist.
+    this.residentCap = Math.max(2, Math.min(residentCap, Math.max(1, windowCount)));
+    this.fetcher = fetcher;
+    this.windows = new AtomicReferenceArray<>(windowCount);
+    this.touched = new AtomicIntegerArray(windowCount);
+  }
+
+  @Override
+  public int size() {
+    return rowGroupCount;
+  }
+
+  @Override
+  public byte[] get(final int index) {
+    if (index < 0 || index >= rowGroupCount) {
+      throw new IndexOutOfBoundsException("row group " + index + " of " + rowGroupCount);
+    }
+    final int window = index / windowLeaves;
+    byte[][] payloads = windows.get(window);
+    if (payloads == null) {
+      payloads = materialize(window);
+    }
+    touched.set(window, 1);
+    final byte[] payload = payloads[index - window * windowLeaves];
+    if (payload == null) {
+      throw new IllegalStateException("projection row group " + index + " missing from its materialized window — "
+          + "the store is truncated");
+    }
+    return payload;
+  }
+
+  private byte[][] materialize(final int window) {
+    final int from = window * windowLeaves;
+    final int toExclusive = Math.min(from + windowLeaves, rowGroupCount);
+    final byte[][] fetched = fetcher.fetch(from, toExclusive);
+    if (fetched == null || fetched.length != toExclusive - from) {
+      throw new IllegalStateException("window fetcher returned " + (fetched == null
+          ? "null"
+          : fetched.length + " payloads") + " for logical range [" + from + ", " + toExclusive + ")");
+    }
+    if (windows.compareAndSet(window, null, fetched)) {
+      ChunkedBodyConfig.recordColumnWindowMaterialization();
+      if (resident.incrementAndGet() > residentCap) {
+        evictOne(window);
+      }
+      return fetched;
+    }
+    // A concurrent first-touch published first; use the winner's identical content.
+    final byte[][] winner = windows.get(window);
+    return winner != null
+        ? winner
+        : fetched;
+  }
+
+  /** Advance the clock hand until a cold (untouched) window other than {@code keep} gives way. */
+  private void evictOne(final int keep) {
+    final int windowCount = windows.length();
+    // Bounded sweep: one full pass clearing touched bits plus one pass finding a victim. If every
+    // window stays hot (residentCap ~= windowCount under a scatter access pattern), give up rather
+    // than spin — the cap is a target, not an invariant, and the weigher already accounts worst
+    // case.
+    for (int step = 0; step < windowCount * 2; step++) {
+      final int candidate = Math.floorMod(clockHand.getAndIncrement(), windowCount);
+      if (candidate == keep || windows.get(candidate) == null) {
+        continue;
+      }
+      if (touched.getAndSet(candidate, 0) == 1) {
+        continue; // second chance
+      }
+      if (windows.getAndSet(candidate, null) != null) {
+        resident.decrementAndGet();
+        return;
+      }
+    }
+  }
+
+  /** Windows currently resident — observability for the engagement witness. */
+  public int residentWindows() {
+    return resident.get();
+  }
+
+  /** Total windows this view partitions the row groups into. */
+  public int windowCount() {
+    return windows.length();
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
@@ -53,15 +53,16 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 public final class ProjectionWindowedRowGroupPayloads {
 
   /**
-   * Opens a read transaction on the resource and revision this view's leaves live in.
+   * Opens a read transaction on the resource and revision this cache's leaves live in.
    *
    * <p>
-   * The view holds no session of its own. A session outlives neither the process-wide handle the
-   * view is memoized on nor, necessarily, the next query — so capturing one would pin a view to a
-   * lifetime shorter than its own. Instead each CONSULT rebinds the source to the calling reader's
-   * own live session ({@code bindReaderSource}), and a window fetch opens its transaction through
-   * whatever source is bound at that moment. The bytes are identical whichever session reads them:
-   * the revision is fixed at construction and its pages are immutable.
+   * The cache holds no session of its own. A session outlives neither the process-wide handle the
+   * cache is memoized on nor, necessarily, the next query — so capturing one would pin the cache to
+   * a lifetime shorter than its own. A source instead lives on the PER-CALLER view
+   * {@link #boundTo} returns, and is passed into {@link #payload(int, ReaderSource)} on every
+   * access, so two concurrent callers never read through each other's session. The bytes are
+   * identical whichever session reads them: the revision is fixed at construction and its pages are
+   * immutable.
    * </p>
    */
   @FunctionalInterface

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
@@ -3,10 +3,14 @@
  */
 package io.sirix.index.projection;
 
+import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.page.ChunkedBodyConfig;
 
 import java.util.AbstractList;
+import java.util.List;
+import java.util.Objects;
 import java.util.RandomAccess;
+import java.util.function.Supplier;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -33,22 +37,59 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * windows plus whatever consumers transiently pin — which is exactly the bound the budget asked
  * for, not a guarantee the GC could not give anyway.
  *
+ * <h2>Ownership</h2> The view captures NO session: its {@link WindowFetcher} is handed a
+ * {@link ReaderSource} per fetch, and each consult rebinds that source to the calling reader's own
+ * live session. That is what lets the view be memoized on the process-wide handle whose
+ * {@code (resource, def, build revision)} key is its natural identity, instead of on some shorter-
+ * lived owner that would multiply the residency this class's cap exists to bound.
+ *
  * <h2>Failure contract</h2> A missing leaf inside a window throws {@link IllegalStateException}
  * from {@link #get}, the same truncated-store verdict the eager materializer throws — callers
  * decline serving and the generic pipeline answers.
  */
 public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[]> implements RandomAccess {
 
-  /** Materializes the payloads of the LOGICAL row-group range {@code [from, toExclusive)}. */
+  /**
+   * Opens a read transaction on the resource and revision this view's leaves live in.
+   *
+   * <p>
+   * The view holds no session of its own. A session outlives neither the process-wide handle the
+   * view is memoized on nor, necessarily, the next query — so capturing one would pin a view to a
+   * lifetime shorter than its own. Instead each CONSULT rebinds the source to the calling reader's
+   * own live session ({@code bindReaderSource}), and a window fetch opens its transaction through
+   * whatever source is bound at that moment. The bytes are identical whichever session reads them:
+   * the revision is fixed at construction and its pages are immutable.
+   * </p>
+   */
+  @FunctionalInterface
+  public interface ReaderSource {
+    /** A fresh read transaction on the view's revision; the caller closes it. */
+    NodeReadOnlyTrx openReader();
+  }
+
+  /**
+   * A whole-leaf materializer that also exposes the reader source its result needs — the shape a
+   * consult site hands to a handle so a MEMOIZED windowed view can be rebound without rebuilding.
+   */
+  public interface BoundMaterializer extends Supplier<List<byte[]>> {
+    /** The caller's own live reader source. */
+    ReaderSource readerSource();
+  }
+
+  /**
+   * Materializes the payloads of the LOGICAL row-group range {@code [from, toExclusive)} through the
+   * source the view is currently bound to. Implementations must capture no session.
+   */
   @FunctionalInterface
   public interface WindowFetcher {
-    byte[][] fetch(int fromLogical, int toLogicalExclusive);
+    byte[][] fetch(ReaderSource source, int fromLogical, int toLogicalExclusive);
   }
 
   private final int rowGroupCount;
   private final int windowLeaves;
   private final int residentCap;
   private final WindowFetcher fetcher;
+  private volatile ReaderSource readerSource;
 
   private final AtomicReferenceArray<byte[][]> windows;
   /** CLOCK touched bits, one int per window ({@code 1} = referenced since the hand last passed). */
@@ -75,6 +116,17 @@ public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[
     this.fetcher = fetcher;
     this.windows = new AtomicReferenceArray<>(windowCount);
     this.touched = new AtomicIntegerArray(windowCount);
+  }
+
+  /**
+   * Bind the source a subsequent window fetch opens its transaction through. Called by every
+   * consult site with its OWN live session, so a view memoized on a shared handle is never left
+   * pointing at a closed one.
+   *
+   * @param source the caller's reader source, never {@code null}
+   */
+  public void bindReaderSource(final ReaderSource source) {
+    readerSource = Objects.requireNonNull(source, "source");
   }
 
   @Override
@@ -104,7 +156,12 @@ public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[
   private byte[][] materialize(final int window) {
     final int from = window * windowLeaves;
     final int toExclusive = Math.min(from + windowLeaves, rowGroupCount);
-    final byte[][] fetched = fetcher.fetch(from, toExclusive);
+    final ReaderSource source = readerSource;
+    if (source == null) {
+      throw new IllegalStateException("projection windowed payloads consulted before a reader source was bound — "
+          + "every consult must rebind the caller's own live session");
+    }
+    final byte[][] fetched = fetcher.fetch(source, from, toExclusive);
     if (fetched == null || fetched.length != toExclusive - from) {
       throw new IllegalStateException("window fetcher returned " + (fetched == null
           ? "null"

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
@@ -17,8 +17,8 @@ import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
- * A {@code List<byte[]>} of a projection's row-group payloads that materializes WINDOWS of leaves on
- * demand instead of the whole column family at once.
+ * A {@code List<byte[]>} of a projection's row-group payloads that materializes WINDOWS of leaves
+ * on demand instead of the whole column family at once.
  *
  * <p>
  * The eager whole-leaf list is the right shape while it fits: every byte-scan kernel takes a
@@ -57,12 +57,11 @@ public final class ProjectionWindowedRowGroupPayloads {
    *
    * <p>
    * The cache holds no session of its own. A session outlives neither the process-wide handle the
-   * cache is memoized on nor, necessarily, the next query — so capturing one would pin the cache to
-   * a lifetime shorter than its own. A source instead lives on the PER-CALLER view
-   * {@link #boundTo} returns, and is passed into {@link #payload(int, ReaderSource)} on every
-   * access, so two concurrent callers never read through each other's session. The bytes are
-   * identical whichever session reads them: the revision is fixed at construction and its pages are
-   * immutable.
+   * cache is memoized on nor, necessarily, the next query — so capturing one would pin the cache to a
+   * lifetime shorter than its own. A source instead lives on the PER-CALLER view {@link #boundTo}
+   * returns, and is passed into {@link #payload(int, ReaderSource)} on every access, so two
+   * concurrent callers never read through each other's session. The bytes are identical whichever
+   * session reads them: the revision is fixed at construction and its pages are immutable.
    * </p>
    */
   @FunctionalInterface
@@ -147,7 +146,9 @@ public final class ProjectionWindowedRowGroupPayloads {
     return rowGroupCount;
   }
 
-  /** The payload of one row group, materializing its window through {@code source} if not resident. */
+  /**
+   * The payload of one row group, materializing its window through {@code source} if not resident.
+   */
   byte[] payload(final int index, final ReaderSource source) {
     if (index < 0 || index >= rowGroupCount) {
       throw new IndexOutOfBoundsException("row group " + index + " of " + rowGroupCount);
@@ -160,8 +161,8 @@ public final class ProjectionWindowedRowGroupPayloads {
     touched.set(window, 1);
     final byte[] payload = payloads[index - window * windowLeaves];
     if (payload == null) {
-      throw new IllegalStateException("projection row group " + index + " missing from its materialized window — "
-          + "the store is truncated");
+      throw new IllegalStateException(
+          "projection row group " + index + " missing from its materialized window — " + "the store is truncated");
     }
     return payload;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java
@@ -5,6 +5,7 @@ package io.sirix.index.projection;
 
 import io.sirix.api.NodeReadOnlyTrx;
 import io.sirix.page.ChunkedBodyConfig;
+import org.jspecify.annotations.Nullable;
 
 import java.util.AbstractList;
 import java.util.List;
@@ -37,17 +38,19 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
  * windows plus whatever consumers transiently pin — which is exactly the bound the budget asked
  * for, not a guarantee the GC could not give anyway.
  *
- * <h2>Ownership</h2> The view captures NO session: its {@link WindowFetcher} is handed a
- * {@link ReaderSource} per fetch, and each consult rebinds that source to the calling reader's own
- * live session. That is what lets the view be memoized on the process-wide handle whose
- * {@code (resource, def, build revision)} key is its natural identity, instead of on some shorter-
- * lived owner that would multiply the residency this class's cap exists to bound.
+ * <h2>Ownership</h2> This object is the WINDOW CACHE, and it captures no session: its
+ * {@link WindowFetcher} is handed a {@link ReaderSource} per fetch. That is what lets it be
+ * memoized on the process-wide handle whose {@code (resource, def, build revision)} key is its
+ * natural identity, instead of on some shorter-lived owner that would multiply the residency this
+ * class's cap exists to bound. A caller never touches the cache directly: {@link #boundTo} wraps it
+ * in a thin immutable {@code List} carrying THAT caller's source, so the binding is genuinely
+ * per-caller and no shared object holds a session-derived field.
  *
  * <h2>Failure contract</h2> A missing leaf inside a window throws {@link IllegalStateException}
  * from {@link #get}, the same truncated-store verdict the eager materializer throws — callers
  * decline serving and the generic pipeline answers.
  */
-public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[]> implements RandomAccess {
+public final class ProjectionWindowedRowGroupPayloads {
 
   /**
    * Opens a read transaction on the resource and revision this view's leaves live in.
@@ -89,7 +92,6 @@ public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[
   private final int windowLeaves;
   private final int residentCap;
   private final WindowFetcher fetcher;
-  private volatile ReaderSource readerSource;
 
   private final AtomicReferenceArray<byte[][]> windows;
   /** CLOCK touched bits, one int per window ({@code 1} = referenced since the hand last passed). */
@@ -119,30 +121,40 @@ public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[
   }
 
   /**
-   * Bind the source a subsequent window fetch opens its transaction through. Called by every
-   * consult site with its OWN live session, so a view memoized on a shared handle is never left
-   * pointing at a closed one.
+   * A {@code List<byte[]>} over this shared cache that reads through {@code source} — the object a
+   * consult site hands to the byte-scan kernels.
    *
-   * @param source the caller's reader source, never {@code null}
+   * <p>
+   * The source lives HERE, on a per-caller object, and never on the cache. A single mutable source
+   * field on the shared cache would make "per-caller" mean "per most recent caller": two live
+   * sessions over one resource path are ordinary (a {@code Database} handle dedupes sessions only
+   * within itself, and the REST and MCP front ends open one store per request), so the second
+   * caller's bind would redirect the first caller's in-flight window fetches — and, once the second
+   * session closes, into a closed one. The view is immutable and cheap: two fields, allocated once
+   * per consult, against a scan that reads leaves.
+   * </p>
+   *
+   * @param source the caller's own live reader source
+   * @return a list view bound to that source
    */
-  public void bindReaderSource(final ReaderSource source) {
-    readerSource = Objects.requireNonNull(source, "source");
+  public List<byte[]> boundTo(final ReaderSource source) {
+    return new BoundView(this, Objects.requireNonNull(source, "source"));
   }
 
-  @Override
+  /** Number of row groups this cache spans. */
   public int size() {
     return rowGroupCount;
   }
 
-  @Override
-  public byte[] get(final int index) {
+  /** The payload of one row group, materializing its window through {@code source} if not resident. */
+  byte[] payload(final int index, final ReaderSource source) {
     if (index < 0 || index >= rowGroupCount) {
       throw new IndexOutOfBoundsException("row group " + index + " of " + rowGroupCount);
     }
     final int window = index / windowLeaves;
     byte[][] payloads = windows.get(window);
     if (payloads == null) {
-      payloads = materialize(window);
+      payloads = materialize(window, source);
     }
     touched.set(window, 1);
     final byte[] payload = payloads[index - window * windowLeaves];
@@ -153,14 +165,49 @@ public final class ProjectionWindowedRowGroupPayloads extends AbstractList<byte[
     return payload;
   }
 
-  private byte[][] materialize(final int window) {
+  /**
+   * The per-caller half of the split: an immutable pair of the SHARED window cache and ONE caller's
+   * reader source. Every window it materializes lands in the shared cache, so residency stays
+   * single-instance and the cap keeps meaning what it says.
+   */
+  private static final class BoundView extends AbstractList<byte[]> implements RandomAccess {
+
+    private final ProjectionWindowedRowGroupPayloads cache;
+    private final ReaderSource source;
+
+    BoundView(final ProjectionWindowedRowGroupPayloads cache, final ReaderSource source) {
+      this.cache = cache;
+      this.source = source;
+    }
+
+    @Override
+    public byte[] get(final int index) {
+      return cache.payload(index, source);
+    }
+
+    @Override
+    public int size() {
+      return cache.size();
+    }
+  }
+
+  /** The shared window cache behind {@code view}, or {@code null} when it is not a bound view. */
+  public static @Nullable ProjectionWindowedRowGroupPayloads cacheOf(final List<byte[]> view) {
+    return view instanceof BoundView bound
+        ? bound.cache
+        : null;
+  }
+
+  /** The reader source {@code view} was bound to, or {@code null} when it is not a bound view. */
+  public static @Nullable ReaderSource sourceOf(final List<byte[]> view) {
+    return view instanceof BoundView bound
+        ? bound.source
+        : null;
+  }
+
+  private byte[][] materialize(final int window, final ReaderSource source) {
     final int from = window * windowLeaves;
     final int toExclusive = Math.min(from + windowLeaves, rowGroupCount);
-    final ReaderSource source = readerSource;
-    if (source == null) {
-      throw new IllegalStateException("projection windowed payloads consulted before a reader source was bound — "
-          + "every consult must rebind the caller's own live session");
-    }
     final byte[][] fetched = fetcher.fetch(source, from, toExclusive);
     if (fetched == null || fetched.length != toExclusive - from) {
       throw new IllegalStateException("window fetcher returned " + (fetched == null

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/RowGroupDescriptor.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/RowGroupDescriptor.java
@@ -435,6 +435,35 @@ public final class RowGroupDescriptor {
     return d[OFF_KINDS + column];
   }
 
+  /**
+   * Whether two descriptors declare the SAME encoding for every column.
+   *
+   * <p>
+   * Every leaf of one projection must, and the store depends on that hard enough to read the kinds
+   * from leaf 0 alone and dispatch an entire query on them. When maintenance broke the invariant —
+   * writing one leaf's descriptor as {@code STRING_DICT} beside a payload that was still
+   * {@code STRING_GLOBAL} — nothing noticed until a decode four rounds later reported the column as
+   * corrupt (tasks #45, #50). Checking costs one range comparison because the kinds are contiguous,
+   * so the invariant can be VERIFIED instead of assumed.
+   * </p>
+   *
+   * <p>
+   * Descriptors that disagree about how many columns they have disagree, full stop: they cannot be
+   * describing the same projection.
+   * </p>
+   *
+   * @param a one descriptor; never {@code null}
+   * @param b the other; never {@code null}
+   * @return whether both declare identical kinds for identically many columns
+   */
+  public static boolean kindsAgree(final byte[] a, final byte[] b) {
+    final int columns = columnCount(a);
+    if (columns != columnCount(b)) {
+      return false;
+    }
+    return Arrays.equals(a, OFF_KINDS, OFF_KINDS + columns, b, OFF_KINDS, OFF_KINDS + columns);
+  }
+
   public static int columnSegmentCount(final byte[] d) {
     return getShortLE(d, OFF_KINDS + columnCount(d)) & 0xFFFF;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/io/HashAccesses.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/HashAccesses.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.io;
+
+import net.openhft.hashing.Access;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+
+/**
+ * {@link Access} implementations that feed openhft's hash functions WITHOUT
+ * {@code sun.misc.Unsafe}.
+ *
+ * <p>
+ * The library's default {@code Access.unsafe()} routes every read through
+ * {@code sun.misc.Unsafe.getLong/getByte}, and since JDK 25 each such call pays
+ * {@code Unsafe.beforeMemoryAccess()} — measured at up to ~10% of a bulk load's CPU on
+ * page-checksum verification alone. These accesses read through byte-array view {@link VarHandle}s
+ * and the {@link MemorySegment} API instead, which JIT-compile to the same plain loads without the
+ * deprecation check.
+ *
+ * <p>
+ * HASH-VALUE STABILITY: the hash function itself is unchanged — only the memory access strategy
+ * differs. Both accesses declare {@link ByteOrder#LITTLE_ENDIAN} and return little-endian loads,
+ * exactly what {@code Access.unsafe()} yields on every platform sirix ships on, so hashes of
+ * identical bytes are bit-identical to those already persisted. {@code HashAccessesEquivalenceTest}
+ * pins that equivalence against the library's own default access.
+ *
+ * <p>
+ * The {@code MemorySegment} access serves native and heap segments uniformly; bounds are enforced
+ * by the segment itself.
+ */
+public final class HashAccesses {
+
+  private static final VarHandle LONG_LE = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);
+  private static final VarHandle INT_LE = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
+  private static final VarHandle SHORT_LE =
+      MethodHandles.byteArrayViewVarHandle(short[].class, ByteOrder.LITTLE_ENDIAN);
+
+  private static final ValueLayout.OfLong SEGMENT_LONG_LE =
+      ValueLayout.JAVA_LONG_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+  private static final ValueLayout.OfInt SEGMENT_INT_LE =
+      ValueLayout.JAVA_INT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+  private static final ValueLayout.OfShort SEGMENT_SHORT_LE =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(ByteOrder.LITTLE_ENDIAN);
+
+  /** Little-endian byte-array access; offsets are byte offsets into the array. */
+  public static final Access<byte[]> BYTES = new ByteArrayAccess();
+
+  /** Little-endian access over a {@link MemorySegment}, native or heap alike. */
+  public static final Access<MemorySegment> SEGMENT = new SegmentAccess();
+
+  private HashAccesses() {
+    throw new AssertionError("no instances");
+  }
+
+  private static final class ByteArrayAccess extends Access<byte[]> {
+    @Override
+    public long getLong(final byte[] input, final long offset) {
+      return (long) LONG_LE.get(input, (int) offset);
+    }
+
+    @Override
+    public long getUnsignedInt(final byte[] input, final long offset) {
+      return getInt(input, offset) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public int getInt(final byte[] input, final long offset) {
+      return (int) INT_LE.get(input, (int) offset);
+    }
+
+    @Override
+    public int getUnsignedShort(final byte[] input, final long offset) {
+      return getShort(input, offset) & 0xFFFF;
+    }
+
+    @Override
+    public int getShort(final byte[] input, final long offset) {
+      return (short) SHORT_LE.get(input, (int) offset);
+    }
+
+    @Override
+    public int getUnsignedByte(final byte[] input, final long offset) {
+      return input[(int) offset] & 0xFF;
+    }
+
+    @Override
+    public int getByte(final byte[] input, final long offset) {
+      return input[(int) offset];
+    }
+
+    @Override
+    public ByteOrder byteOrder(final byte[] input) {
+      return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    protected Access<byte[]> reverseAccess() {
+      return REVERSED_BYTES;
+    }
+  }
+
+  private static final class SegmentAccess extends Access<MemorySegment> {
+    @Override
+    public long getLong(final MemorySegment input, final long offset) {
+      return input.get(SEGMENT_LONG_LE, offset);
+    }
+
+    @Override
+    public long getUnsignedInt(final MemorySegment input, final long offset) {
+      return getInt(input, offset) & 0xFFFFFFFFL;
+    }
+
+    @Override
+    public int getInt(final MemorySegment input, final long offset) {
+      return input.get(SEGMENT_INT_LE, offset);
+    }
+
+    @Override
+    public int getUnsignedShort(final MemorySegment input, final long offset) {
+      return getShort(input, offset) & 0xFFFF;
+    }
+
+    @Override
+    public int getShort(final MemorySegment input, final long offset) {
+      return input.get(SEGMENT_SHORT_LE, offset);
+    }
+
+    @Override
+    public int getUnsignedByte(final MemorySegment input, final long offset) {
+      return input.get(ValueLayout.JAVA_BYTE, offset) & 0xFF;
+    }
+
+    @Override
+    public int getByte(final MemorySegment input, final long offset) {
+      return input.get(ValueLayout.JAVA_BYTE, offset);
+    }
+
+    @Override
+    public ByteOrder byteOrder(final MemorySegment input) {
+      return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    protected Access<MemorySegment> reverseAccess() {
+      return REVERSED_SEGMENT;
+    }
+  }
+
+  /**
+   * Big-endian mirrors. The hash algorithms only consult the reverse access when an input declares
+   * the OPPOSITE byte order, which the little-endian primaries above never do — these exist to honor
+   * the {@link Access} contract rather than to be exercised.
+   */
+  private static final Access<byte[]> REVERSED_BYTES = new ReversedByteArrayAccess();
+
+  private static final Access<MemorySegment> REVERSED_SEGMENT = new ReversedSegmentAccess();
+
+  private static final class ReversedByteArrayAccess extends Access<byte[]> {
+    @Override
+    public long getLong(final byte[] input, final long offset) {
+      return Long.reverseBytes((long) LONG_LE.get(input, (int) offset));
+    }
+
+    @Override
+    public int getInt(final byte[] input, final long offset) {
+      return Integer.reverseBytes((int) INT_LE.get(input, (int) offset));
+    }
+
+    @Override
+    public int getShort(final byte[] input, final long offset) {
+      return Short.reverseBytes((short) SHORT_LE.get(input, (int) offset));
+    }
+
+    @Override
+    public int getByte(final byte[] input, final long offset) {
+      return input[(int) offset];
+    }
+
+    @Override
+    public ByteOrder byteOrder(final byte[] input) {
+      return ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    protected Access<byte[]> reverseAccess() {
+      return BYTES;
+    }
+  }
+
+  private static final class ReversedSegmentAccess extends Access<MemorySegment> {
+    @Override
+    public long getLong(final MemorySegment input, final long offset) {
+      return Long.reverseBytes(input.get(SEGMENT_LONG_LE, offset));
+    }
+
+    @Override
+    public int getInt(final MemorySegment input, final long offset) {
+      return Integer.reverseBytes(input.get(SEGMENT_INT_LE, offset));
+    }
+
+    @Override
+    public int getShort(final MemorySegment input, final long offset) {
+      return Short.reverseBytes(input.get(SEGMENT_SHORT_LE, offset));
+    }
+
+    @Override
+    public int getByte(final MemorySegment input, final long offset) {
+      return input.get(ValueLayout.JAVA_BYTE, offset);
+    }
+
+    @Override
+    public ByteOrder byteOrder(final MemorySegment input) {
+      return ByteOrder.BIG_ENDIAN;
+    }
+
+    @Override
+    protected Access<MemorySegment> reverseAccess() {
+      return SEGMENT;
+    }
+  }
+}

--- a/bundles/sirix-core/src/main/java/io/sirix/io/HashAlgorithm.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/io/HashAlgorithm.java
@@ -3,7 +3,6 @@ package io.sirix.io;
 import net.openhft.hashing.LongHashFunction;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
 
 /**
  * Hash algorithms for page checksum verification.
@@ -47,43 +46,28 @@ public enum HashAlgorithm {
 
     @Override
     public long computeHashLong(byte[] data) {
-      return HASHER.hashBytes(data);
+      // The custom accesses feed the SAME xx3 function without sun.misc.Unsafe — since JDK 25 the
+      // library's default access pays Unsafe.beforeMemoryAccess() per read, measured at up to ~10%
+      // of a bulk load's CPU. Hash values are bit-identical (see HashAccesses); persisted checksums
+      // stay valid.
+      return HASHER.hash(data, HashAccesses.BYTES, 0, data.length);
     }
 
     @Override
     public long computeHashLong(byte[] data, int offset, int length) {
-      return HASHER.hashBytes(data, offset, length);
+      return HASHER.hash(data, HashAccesses.BYTES, offset, length);
     }
 
     @Override
     public long computeHashLong(MemorySegment segment) {
-      if (segment.isNative()) {
-        // Zero-copy: hash directly from native memory address
-        return HASHER.hashMemory(segment.address(), segment.byteSize());
-      }
-
-      // MemorySegment.address() is the byte offset into heapBase() for heap segments, including
-      // slices and MemorySegment.ofBuffer(heapByteBuffer). Page serialization uses byte[]-backed
-      // segments, so hash that exact range directly instead of allocating and copying the entire
-      // compressed page through MemorySegment.toArray(). Retain the generic fallback for segments
-      // backed by another primitive array type.
-      final Object heapBase = segment.heapBase().orElse(null);
-      if (heapBase instanceof byte[] bytes) {
-        final long offset = segment.address();
-        final long length = segment.byteSize();
-        if (offset >= 0 && length <= bytes.length && offset <= bytes.length - length) {
-          return HASHER.hashBytes(bytes, (int) offset, (int) length);
-        }
-        throw new IllegalArgumentException("Heap MemorySegment range exceeds its byte-array backing: offset=" + offset
-            + ", length=" + length + ", capacity=" + bytes.length);
-      }
-
-      return HASHER.hashBytes(segment.toArray(ValueLayout.JAVA_BYTE));
+      // One access serves native and heap segments alike, zero-copy either way — the previous
+      // address()/heapBase() split existed only because the Unsafe access needed raw coordinates.
+      return HASHER.hash(segment, HashAccesses.SEGMENT, 0, segment.byteSize());
     }
 
     @Override
     public boolean verifyLong(byte[] data, long expectedHash) {
-      return HASHER.hashBytes(data) == expectedHash;
+      return computeHashLong(data) == expectedHash;
     }
 
     @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
@@ -70,6 +70,18 @@ public final class DeltaVarIntCodec {
    * We use 0 in zigzag encoding as the NULL marker since delta=0 (self-reference) is meaningless.
    */
   private static final int NULL_MARKER = 0;
+
+  /**
+   * Explicit little-endian unaligned layouts for the packed varint emitter: the byte SEQUENCE on
+   * disk is identical to the historical per-byte writes on every platform, only the store WIDTH
+   * changes.
+   */
+  private static final ValueLayout.OfLong LONG_LE =
+      ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
+  private static final ValueLayout.OfInt INT_LE =
+      ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
+  private static final ValueLayout.OfShort SHORT_LE =
+      ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
   
   /**
    * The actual NULL key value from the Fixed enum.
@@ -755,23 +767,54 @@ public final class DeltaVarIntCodec {
       segment.set(ValueLayout.JAVA_BYTE, offset, (byte) value);
       return 1;
     }
-
-    // Fast path for 2-byte values (128-16383)
-    if ((value & ~0x3FFFL) == 0) {
-      segment.set(ValueLayout.JAVA_BYTE, offset, (byte) ((value & 0x7F) | 0x80));
-      segment.set(ValueLayout.JAVA_BYTE, offset + 1, (byte) (value >>> 7));
-      return 2;
+    // Pack the varint bytes little-endian into a long and emit with the MINIMAL number of exact-
+    // width unaligned stores ({8,4,2,1} decomposition) — never a byte more than the varint needs,
+    // so nothing beyond the encoding is touched and page-edge bounds behave exactly as before.
+    // The historical per-byte writes paid VarHandle offset computation and alignment checking per
+    // byte, measured at ~11% of bulk-load fill time; the byte SEQUENCE on disk is unchanged.
+    long packed = 0;
+    int pending = 0;
+    int total = 0;
+    long remaining = value;
+    while (true) {
+      final boolean more = (remaining & ~0x7FL) != 0;
+      final long encoded = more
+          ? ((remaining & 0x7F) | 0x80)
+          : (remaining & 0x7F);
+      packed |= encoded << (pending << 3);
+      pending++;
+      if (!more) {
+        break;
+      }
+      remaining >>>= 7;
+      if (pending == 8) {
+        segment.set(LONG_LE, offset, packed);
+        offset += 8;
+        total += 8;
+        packed = 0;
+        pending = 0;
+      }
     }
-
-    // General case
-    int bytesWritten = 0;
-    while ((value & ~0x7FL) != 0) {
-      segment.set(ValueLayout.JAVA_BYTE, offset + bytesWritten, (byte) ((value & 0x7F) | 0x80));
-      value >>>= 7;
-      bytesWritten++;
+    if (pending == 8) {
+      // An exactly-8-byte varint breaks out of the loop before the in-loop flush (which only
+      // fires when a ninth byte follows); the {4,2,1} decomposition below covers 1-7 only.
+      segment.set(LONG_LE, offset, packed);
+      return total + 8;
     }
-    segment.set(ValueLayout.JAVA_BYTE, offset + bytesWritten, (byte) value);
-    return bytesWritten + 1;
+    if ((pending & 4) != 0) {
+      segment.set(INT_LE, offset, (int) packed);
+      packed >>>= 32;
+      offset += 4;
+    }
+    if ((pending & 2) != 0) {
+      segment.set(SHORT_LE, offset, (short) packed);
+      packed >>>= 16;
+      offset += 2;
+    }
+    if ((pending & 1) != 0) {
+      segment.set(ValueLayout.JAVA_BYTE, offset, (byte) packed);
+    }
+    return total + pending;
   }
 
   /**

--- a/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/DeltaVarIntCodec.java
@@ -36,19 +36,22 @@ import java.lang.foreign.ValueLayout;
 /**
  * High-performance codec for delta-encoded node keys using zigzag + varint encoding.
  * 
- * <p>Inspired by Umbra-style storage optimization: instead of storing absolute 8-byte keys,
- * we store deltas relative to the current nodeKey. Since siblings are usually adjacent
- * (delta = ±1) and parents are nearby, deltas are small and compress well.
+ * <p>
+ * Inspired by Umbra-style storage optimization: instead of storing absolute 8-byte keys, we store
+ * deltas relative to the current nodeKey. Since siblings are usually adjacent (delta = ±1) and
+ * parents are nearby, deltas are small and compress well.
  * 
  * <h2>Encoding Strategy</h2>
  * <ul>
- *   <li><b>NULL keys</b>: Encoded as a single byte 0x00 (zigzag of 0 with special meaning)</li>
- *   <li><b>Delta encoding</b>: Store (targetKey - baseKey) instead of absolute key</li>
- *   <li><b>Zigzag encoding</b>: Maps signed to unsigned (0→0, -1→1, 1→2, -2→3, 2→4, ...)</li>
- *   <li><b>Varint encoding</b>: Variable-length unsigned integer (7 bits per byte, MSB = continue)</li>
+ * <li><b>NULL keys</b>: Encoded as a single byte 0x00 (zigzag of 0 with special meaning)</li>
+ * <li><b>Delta encoding</b>: Store (targetKey - baseKey) instead of absolute key</li>
+ * <li><b>Zigzag encoding</b>: Maps signed to unsigned (0→0, -1→1, 1→2, -2→3, 2→4, ...)</li>
+ * <li><b>Varint encoding</b>: Variable-length unsigned integer (7 bits per byte, MSB =
+ * continue)</li>
  * </ul>
  * 
  * <h2>Space Savings Example</h2>
+ * 
  * <pre>
  * Absolute key 1000000 (8 bytes) → Delta +1 → Zigzag 2 → Varint 1 byte
  * Absolute key -1 (NULL, 8 bytes) → Special marker → 1 byte
@@ -56,25 +59,24 @@ import java.lang.foreign.ValueLayout;
  * 
  * <h2>Performance</h2>
  * <ul>
- *   <li>No allocations during encode/decode</li>
- *   <li>Branchless zigzag encoding</li>
- *   <li>Unrolled varint for common cases (1-2 bytes)</li>
+ * <li>No allocations during encode/decode</li>
+ * <li>Branchless zigzag encoding</li>
+ * <li>Unrolled varint for common cases (1-2 bytes)</li>
  * </ul>
  * 
  * @author Johannes Lichtenberger
  */
 public final class DeltaVarIntCodec {
-  
+
   /**
-   * Sentinel value for NULL node keys.
-   * We use 0 in zigzag encoding as the NULL marker since delta=0 (self-reference) is meaningless.
+   * Sentinel value for NULL node keys. We use 0 in zigzag encoding as the NULL marker since delta=0
+   * (self-reference) is meaningless.
    */
   private static final int NULL_MARKER = 0;
 
   /**
-   * Explicit little-endian unaligned layouts for the packed varint emitter: the byte SEQUENCE on
-   * disk is identical to the historical per-byte writes on every platform, only the store WIDTH
-   * changes.
+   * Explicit little-endian unaligned layouts for the packed varint emitter: the byte SEQUENCE on disk
+   * is identical to the historical per-byte writes on every platform, only the store WIDTH changes.
    */
   private static final ValueLayout.OfLong LONG_LE =
       ValueLayout.JAVA_LONG_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
@@ -82,26 +84,27 @@ public final class DeltaVarIntCodec {
       ValueLayout.JAVA_INT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
   private static final ValueLayout.OfShort SHORT_LE =
       ValueLayout.JAVA_SHORT_UNALIGNED.withOrder(java.nio.ByteOrder.LITTLE_ENDIAN);
-  
+
   /**
    * The actual NULL key value from the Fixed enum.
    */
   private static final long NULL_KEY = Fixed.NULL_NODE_KEY.getStandardProperty();
-  
+
   private DeltaVarIntCodec() {
     // Utility class
   }
-  
+
   // ==================== ENCODING ====================
-  
+
   /**
    * Encode a node key as a delta from a base key.
    * 
-   * <p>For structural pointers (siblings, children), the base is typically the current nodeKey.
-   * For parent pointers, the base is also the current nodeKey.
+   * <p>
+   * For structural pointers (siblings, children), the base is typically the current nodeKey. For
+   * parent pointers, the base is also the current nodeKey.
    * 
-   * @param sink    output sink to write to
-   * @param key     the key to encode (may be NULL_NODE_KEY)
+   * @param sink output sink to write to
+   * @param key the key to encode (may be NULL_NODE_KEY)
    * @param baseKey the reference key for delta calculation
    */
   public static void encodeDelta(BytesOut<?> sink, long key, long baseKey) {
@@ -110,26 +113,26 @@ public final class DeltaVarIntCodec {
       sink.writeByte((byte) NULL_MARKER);
       return;
     }
-    
+
     // Calculate delta
     long delta = key - baseKey;
-    
+
     // Zigzag encode (signed → unsigned)
     // This maps small positive/negative values to small unsigned values:
     // 0 → 0, -1 → 1, 1 → 2, -2 → 3, 2 → 4, ...
     // But we reserve 0 for NULL, so we add 1 to shift everything up
     long zigzag = zigzagEncode(delta) + 1;
-    
+
     // Varint encode
     writeVarLong(sink, zigzag);
   }
-  
+
   /**
-   * Encode an absolute key (no delta, used for nodeKey itself).
-   * Uses varint encoding directly for unsigned values.
+   * Encode an absolute key (no delta, used for nodeKey itself). Uses varint encoding directly for
+   * unsigned values.
    * 
    * @param sink output sink
-   * @param key  the absolute key (must be non-negative)
+   * @param key the absolute key (must be non-negative)
    */
   public static void encodeAbsolute(BytesOut<?> sink, long key) {
     if (key < 0) {
@@ -137,10 +140,10 @@ public final class DeltaVarIntCodec {
     }
     writeVarLong(sink, key);
   }
-  
+
   /**
-   * Encode a revision number which can be -1 (NULL_REVISION_NUMBER).
-   * Uses zigzag encoding to handle the -1 case efficiently.
+   * Encode a revision number which can be -1 (NULL_REVISION_NUMBER). Uses zigzag encoding to handle
+   * the -1 case efficiently.
    * 
    * @param sink output sink
    * @param revision the revision number (can be -1)
@@ -151,7 +154,7 @@ public final class DeltaVarIntCodec {
     long zigzag = zigzagEncode(revision);
     writeVarLong(sink, zigzag);
   }
-  
+
   /**
    * Decode a revision number which can be -1 (NULL_REVISION_NUMBER).
    * 
@@ -162,10 +165,10 @@ public final class DeltaVarIntCodec {
     long zigzag = readVarLong(source);
     return (int) zigzagDecode(zigzag);
   }
-  
+
   /**
-   * Encode a signed integer (like nameKey which is a hash and can be negative).
-   * Uses zigzag encoding to handle negative values efficiently.
+   * Encode a signed integer (like nameKey which is a hash and can be negative). Uses zigzag encoding
+   * to handle negative values efficiently.
    * 
    * @param sink output sink
    * @param value the signed integer value
@@ -174,7 +177,7 @@ public final class DeltaVarIntCodec {
     long zigzag = zigzagEncode(value);
     writeVarLong(sink, zigzag);
   }
-  
+
   /**
    * Decode a signed integer.
    * 
@@ -185,12 +188,13 @@ public final class DeltaVarIntCodec {
     long zigzag = readVarLong(source);
     return (int) zigzagDecode(zigzag);
   }
-  
+
   /**
-   * Encode a signed long value using zigzag + varint encoding.
-   * Optimized for small values: values -64 to 63 use 1 byte, -8192 to 8191 use 2 bytes.
+   * Encode a signed long value using zigzag + varint encoding. Optimized for small values: values -64
+   * to 63 use 1 byte, -8192 to 8191 use 2 bytes.
    * 
-   * <p>This is ideal for JSON numbers which are often small integers stored as long.
+   * <p>
+   * This is ideal for JSON numbers which are often small integers stored as long.
    * 
    * @param sink output sink
    * @param value the signed long value
@@ -199,7 +203,7 @@ public final class DeltaVarIntCodec {
     long zigzag = zigzagEncode(value);
     writeVarLong(sink, zigzag);
   }
-  
+
   /**
    * Decode a signed long value from zigzag + varint encoding.
    * 
@@ -210,10 +214,10 @@ public final class DeltaVarIntCodec {
     long zigzag = readVarLong(source);
     return zigzagDecode(zigzag);
   }
-  
+
   /**
-   * Encode an unsigned long value using varint encoding.
-   * Optimized for small values: values 0-127 use 1 byte, 128-16383 use 2 bytes.
+   * Encode an unsigned long value using varint encoding. Optimized for small values: values 0-127 use
+   * 1 byte, 128-16383 use 2 bytes.
    * 
    * @param sink output sink
    * @param value the unsigned long value (must be non-negative)
@@ -221,7 +225,7 @@ public final class DeltaVarIntCodec {
   public static void encodeUnsignedLong(BytesOut<?> sink, long value) {
     writeVarLong(sink, value);
   }
-  
+
   /**
    * Decode an unsigned long value from varint encoding.
    * 
@@ -231,29 +235,29 @@ public final class DeltaVarIntCodec {
   public static long decodeUnsignedLong(BytesIn<?> source) {
     return readVarLong(source);
   }
-  
+
   // ==================== DECODING ====================
-  
+
   /**
    * Decode a delta-encoded node key.
    * 
-   * @param source  input source to read from
+   * @param source input source to read from
    * @param baseKey the reference key for delta calculation
    * @return the decoded absolute key, or NULL_NODE_KEY if null marker
    */
   public static long decodeDelta(BytesIn<?> source, long baseKey) {
     long zigzag = readVarLong(source);
-    
+
     if (zigzag == NULL_MARKER) {
       return NULL_KEY;
     }
-    
+
     // Undo the +1 shift and zigzag decode
     long delta = zigzagDecode(zigzag - 1);
-    
+
     return baseKey + delta;
   }
-  
+
   /**
    * Decode an absolute key (no delta).
    * 
@@ -263,34 +267,33 @@ public final class DeltaVarIntCodec {
   public static long decodeAbsolute(BytesIn<?> source) {
     return readVarLong(source);
   }
-  
+
   // ==================== ZIGZAG ENCODING ====================
-  
+
   /**
-   * Zigzag encode a signed long to unsigned.
-   * Maps: 0→0, -1→1, 1→2, -2→3, 2→4, ...
+   * Zigzag encode a signed long to unsigned. Maps: 0→0, -1→1, 1→2, -2→3, 2→4, ...
    * 
-   * <p>This is branchless and uses arithmetic shift.
+   * <p>
+   * This is branchless and uses arithmetic shift.
    */
   private static long zigzagEncode(long value) {
     return (value << 1) ^ (value >> 63);
   }
-  
+
   /**
-   * Zigzag decode an unsigned long to signed.
-   * Inverse of zigzagEncode.
+   * Zigzag decode an unsigned long to signed. Inverse of zigzagEncode.
    */
   private static long zigzagDecode(long encoded) {
     return (encoded >>> 1) ^ -(encoded & 1);
   }
-  
+
   // ==================== VARINT ENCODING ====================
-  
+
   /**
-   * Write a variable-length unsigned long.
-   * Uses 7 bits per byte, MSB indicates continuation.
+   * Write a variable-length unsigned long. Uses 7 bits per byte, MSB indicates continuation.
    * 
-   * <p>Optimized for small values (1-2 bytes for values 0-16383).
+   * <p>
+   * Optimized for small values (1-2 bytes for values 0-16383).
    */
   private static void writeVarLong(BytesOut<?> sink, long value) {
     // Fast path for small values (fits in 1 byte: 0-127)
@@ -298,14 +301,14 @@ public final class DeltaVarIntCodec {
       sink.writeByte((byte) value);
       return;
     }
-    
+
     // Fast path for 2-byte values (128-16383)
     if ((value & ~0x3FFFL) == 0) {
       sink.writeByte((byte) ((value & 0x7F) | 0x80));
       sink.writeByte((byte) (value >>> 7));
       return;
     }
-    
+
     // General case for larger values
     while ((value & ~0x7FL) != 0) {
       sink.writeByte((byte) ((value & 0x7F) | 0x80));
@@ -313,29 +316,30 @@ public final class DeltaVarIntCodec {
     }
     sink.writeByte((byte) value);
   }
-  
+
   /**
    * Read a variable-length unsigned long.
    * 
-   * <p>Optimized with fast paths for common 1-byte and 2-byte cases.
-   * Most delta-encoded values (siblings ±1, nearby parents) fit in 1-2 bytes.
+   * <p>
+   * Optimized with fast paths for common 1-byte and 2-byte cases. Most delta-encoded values (siblings
+   * ±1, nearby parents) fit in 1-2 bytes.
    */
   private static long readVarLong(BytesIn<?> source) {
     byte b = source.readByte();
-    
+
     // Fast path: 1 byte (0-127) - most common case for small deltas
     if ((b & 0x80) == 0) {
       return b;
     }
-    
+
     long result = b & 0x7F;
     b = source.readByte();
-    
+
     // Fast path: 2 bytes (128-16383) - second most common
     if ((b & 0x80) == 0) {
       return result | ((long) b << 7);
     }
-    
+
     // General case for larger values (rare for structural keys)
     result |= (long) (b & 0x7F) << 7;
     int shift = 14;
@@ -351,7 +355,7 @@ public final class DeltaVarIntCodec {
 
     return result;
   }
-  
+
   // ==================== SIZE ESTIMATION ====================
 
   /**
@@ -365,16 +369,16 @@ public final class DeltaVarIntCodec {
     }
     return size;
   }
-  
+
   // ==================== DIRECT SEGMENT WRITE METHODS ====================
   // These methods eliminate per-byte ensureCapacity() overhead by using direct segment writes
-  
+
   /**
-   * Encode a node key as a delta from a base key, writing directly to a GrowingMemorySegment.
-   * This is the high-performance variant that eliminates per-byte capacity checks.
+   * Encode a node key as a delta from a base key, writing directly to a GrowingMemorySegment. This is
+   * the high-performance variant that eliminates per-byte capacity checks.
    * 
-   * @param seg     the segment to write to
-   * @param key     the key to encode (may be NULL_NODE_KEY)
+   * @param seg the segment to write to
+   * @param key the key to encode (may be NULL_NODE_KEY)
    * @param baseKey the reference key for delta calculation
    */
   public static void encodeDelta(GrowingMemorySegment seg, long key, long baseKey) {
@@ -383,21 +387,21 @@ public final class DeltaVarIntCodec {
       seg.writeByte((byte) NULL_MARKER);
       return;
     }
-    
+
     // Calculate delta and zigzag encode (add 1 to reserve 0 for NULL)
     long delta = key - baseKey;
     long zigzag = zigzagEncode(delta) + 1;
-    
+
     // Use direct varint write (single ensureCapacity call)
     seg.writeVarLong(zigzag);
   }
-  
+
   /**
-   * Encode a node key as a delta from a base key, writing directly to a PooledGrowingSegment.
-   * This is the high-performance variant that eliminates per-byte capacity checks.
+   * Encode a node key as a delta from a base key, writing directly to a PooledGrowingSegment. This is
+   * the high-performance variant that eliminates per-byte capacity checks.
    * 
-   * @param seg     the segment to write to
-   * @param key     the key to encode (may be NULL_NODE_KEY)
+   * @param seg the segment to write to
+   * @param key the key to encode (may be NULL_NODE_KEY)
    * @param baseKey the reference key for delta calculation
    */
   public static void encodeDelta(PooledGrowingSegment seg, long key, long baseKey) {
@@ -406,15 +410,15 @@ public final class DeltaVarIntCodec {
       seg.writeByte((byte) NULL_MARKER);
       return;
     }
-    
+
     // Calculate delta and zigzag encode (add 1 to reserve 0 for NULL)
     long delta = key - baseKey;
     long zigzag = zigzagEncode(delta) + 1;
-    
+
     // Use direct varint write (single ensureCapacity call)
     seg.writeVarLong(zigzag);
   }
-  
+
   /**
    * Encode an absolute key directly to a GrowingMemorySegment.
    * 
@@ -427,7 +431,7 @@ public final class DeltaVarIntCodec {
     }
     seg.writeVarLong(key);
   }
-  
+
   /**
    * Encode an absolute key directly to a PooledGrowingSegment.
    * 
@@ -440,79 +444,78 @@ public final class DeltaVarIntCodec {
     }
     seg.writeVarLong(key);
   }
-  
+
   /**
    * Encode a signed long value using zigzag + varint directly to a GrowingMemorySegment.
    * 
-   * @param seg   the segment to write to
+   * @param seg the segment to write to
    * @param value the signed long value
    */
   public static void encodeSignedLong(GrowingMemorySegment seg, long value) {
     long zigzag = zigzagEncode(value);
     seg.writeVarLong(zigzag);
   }
-  
+
   /**
    * Encode a signed long value using zigzag + varint directly to a PooledGrowingSegment.
    * 
-   * @param seg   the segment to write to
+   * @param seg the segment to write to
    * @param value the signed long value
    */
   public static void encodeSignedLong(PooledGrowingSegment seg, long value) {
     long zigzag = zigzagEncode(value);
     seg.writeVarLong(zigzag);
   }
-  
+
   /**
    * Encode an unsigned long value using varint directly to a GrowingMemorySegment.
    * 
-   * @param seg   the segment to write to
+   * @param seg the segment to write to
    * @param value the unsigned long value (must be non-negative)
    */
   public static void encodeUnsignedLong(GrowingMemorySegment seg, long value) {
     seg.writeVarLong(value);
   }
-  
+
   /**
    * Encode an unsigned long value using varint directly to a PooledGrowingSegment.
    * 
-   * @param seg   the segment to write to
+   * @param seg the segment to write to
    * @param value the unsigned long value (must be non-negative)
    */
   public static void encodeUnsignedLong(PooledGrowingSegment seg, long value) {
     seg.writeVarLong(value);
   }
-  
+
   // ==================== MEMORY SEGMENT SUPPORT ====================
   // These methods support zero-allocation access by reading directly from MemorySegment
-  
+
   /**
-   * Decode a delta-encoded key directly from MemorySegment.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Decode a delta-encoded key directly from MemorySegment. ZERO ALLOCATION - reads directly from
+   * memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @param baseKey the reference key for delta calculation
    * @return the decoded key
    */
   public static long decodeDeltaFromSegment(MemorySegment segment, int offset, long baseKey) {
     long zigzag = readVarLongFromSegment(segment, offset);
-    
+
     if (zigzag == NULL_MARKER) {
       return NULL_KEY;
     }
-    
+
     // Undo the +1 shift and zigzag decode
     long delta = zigzagDecode(zigzag - 1);
     return baseKey + delta;
   }
-  
+
   /**
-   * Read unsigned varint from MemorySegment.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Read unsigned varint from MemorySegment. ZERO ALLOCATION - reads directly from memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the decoded unsigned long value
    */
   public static long readVarLongFromSegment(MemorySegment segment, int offset) {
@@ -524,9 +527,11 @@ public final class DeltaVarIntCodec {
     if (offset + 8 <= segSize) {
       final long w = segment.get(LE.LONG, offset);
       final int b0 = (int) (w & 0xFF);
-      if ((b0 & 0x80) == 0) return b0;
+      if ((b0 & 0x80) == 0)
+        return b0;
       final int b1 = (int) ((w >>> 8) & 0xFF);
-      if ((b1 & 0x80) == 0) return (b0 & 0x7FL) | ((long) b1 << 7);
+      if ((b1 & 0x80) == 0)
+        return (b0 & 0x7FL) | ((long) b1 << 7);
       final int b2 = (int) ((w >>> 16) & 0xFF);
       if ((b2 & 0x80) == 0) {
         return (b0 & 0x7FL) | ((b1 & 0x7FL) << 7) | ((long) b2 << 14);
@@ -537,12 +542,11 @@ public final class DeltaVarIntCodec {
       }
       final int b4 = (int) ((w >>> 32) & 0xFF);
       if ((b4 & 0x80) == 0) {
-        return (b0 & 0x7FL) | ((b1 & 0x7FL) << 7) | ((b2 & 0x7FL) << 14)
-            | ((b3 & 0x7FL) << 21) | ((long) b4 << 28);
+        return (b0 & 0x7FL) | ((b1 & 0x7FL) << 7) | ((b2 & 0x7FL) << 14) | ((b3 & 0x7FL) << 21) | ((long) b4 << 28);
       }
       // Longer varints (rare) fall through to byte-wise tail below.
-      long result = (b0 & 0x7FL) | ((b1 & 0x7FL) << 7) | ((b2 & 0x7FL) << 14)
-          | ((b3 & 0x7FL) << 21) | ((b4 & 0x7FL) << 28);
+      long result =
+          (b0 & 0x7FL) | ((b1 & 0x7FL) << 7) | ((b2 & 0x7FL) << 14) | ((b3 & 0x7FL) << 21) | ((b4 & 0x7FL) << 28);
       int pos = offset + 5;
       int shift = 35;
       byte b;
@@ -575,40 +579,39 @@ public final class DeltaVarIntCodec {
     } while ((b & 0x80) != 0);
     return result;
   }
-  
+
   /**
-   * Read signed varint (zigzag decoded) from MemorySegment.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Read signed varint (zigzag decoded) from MemorySegment. ZERO ALLOCATION - reads directly from
+   * memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the decoded signed integer value
    */
   public static int decodeSignedFromSegment(MemorySegment segment, int offset) {
     long zigzag = readVarLongFromSegment(segment, offset);
     return (int) zigzagDecode(zigzag);
   }
-  
+
   /**
-   * Read signed long (zigzag decoded) from MemorySegment.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Read signed long (zigzag decoded) from MemorySegment. ZERO ALLOCATION - reads directly from
+   * memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the decoded signed long value
    */
   public static long decodeSignedLongFromSegment(MemorySegment segment, int offset) {
     long zigzag = readVarLongFromSegment(segment, offset);
     return zigzagDecode(zigzag);
   }
-  
+
   /**
-   * Get the byte length of a varint at the given offset.
-   * Used for computing field offsets during flyweight cursor parsing.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Get the byte length of a varint at the given offset. Used for computing field offsets during
+   * flyweight cursor parsing. ZERO ALLOCATION - reads directly from memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the number of bytes this varint occupies
    */
   public static int varintLength(MemorySegment segment, int offset) {
@@ -618,30 +621,29 @@ public final class DeltaVarIntCodec {
     }
     return len + 1;
   }
-  
+
   /**
-   * Get length of a delta-encoded value (includes NULL check).
-   * ZERO ALLOCATION - reads directly from memory.
+   * Get length of a delta-encoded value (includes NULL check). ZERO ALLOCATION - reads directly from
+   * memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the number of bytes this delta-encoded value occupies
    */
   public static int deltaLength(MemorySegment segment, int offset) {
     byte first = segment.get(ValueLayout.JAVA_BYTE, offset);
     if (first == NULL_MARKER) {
-      return 1;  // NULL is single byte
+      return 1; // NULL is single byte
     }
     return varintLength(segment, offset);
   }
-  
+
   /**
-   * Read a fixed 8-byte long value from MemorySegment.
-   * Used for hash values which are stored as fixed-length.
-   * ZERO ALLOCATION - reads directly from memory.
+   * Read a fixed 8-byte long value from MemorySegment. Used for hash values which are stored as
+   * fixed-length. ZERO ALLOCATION - reads directly from memory.
    *
    * @param segment the MemorySegment containing the data
-   * @param offset  the byte offset to start reading from
+   * @param offset the byte offset to start reading from
    * @return the 8-byte long value
    */
   public static long readLongFromSegment(MemorySegment segment, int offset) {
@@ -651,24 +653,22 @@ public final class DeltaVarIntCodec {
   // ==================== DIRECT SEGMENT WRITE METHODS (for in-place mutation) ====================
 
   /**
-   * Write a fixed 8-byte long value directly to a MemorySegment.
-   * Used for hash values which are always fixed-width, enabling in-place mutation.
-   * ZERO ALLOCATION.
+   * Write a fixed 8-byte long value directly to a MemorySegment. Used for hash values which are
+   * always fixed-width, enabling in-place mutation. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment to write to
-   * @param offset  the byte offset to write at
-   * @param value   the 8-byte long value
+   * @param offset the byte offset to write at
+   * @param value the 8-byte long value
    */
   public static void writeLongToSegment(MemorySegment segment, long offset, long value) {
     segment.set(LE.LONG, offset, value);
   }
 
   /**
-   * Compute the encoded byte width of a delta-encoded key.
-   * This is critical for in-place mutation: if the new width matches the old width,
-   * we can overwrite in-place without re-serializing the record.
+   * Compute the encoded byte width of a delta-encoded key. This is critical for in-place mutation: if
+   * the new width matches the old width, we can overwrite in-place without re-serializing the record.
    *
-   * @param key     the key to encode
+   * @param key the key to encode
    * @param baseKey the reference key for delta calculation
    * @return the number of bytes this delta would occupy
    */
@@ -704,12 +704,12 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Write a delta-encoded key directly to a MemorySegment at the given offset.
-   * ZERO ALLOCATION - writes directly to page memory.
+   * Write a delta-encoded key directly to a MemorySegment at the given offset. ZERO ALLOCATION -
+   * writes directly to page memory.
    *
    * @param segment the MemorySegment to write to
-   * @param offset  the byte offset to start writing at
-   * @param key     the key to encode (may be NULL_NODE_KEY)
+   * @param offset the byte offset to start writing at
+   * @param key the key to encode (may be NULL_NODE_KEY)
    * @param baseKey the reference key for delta calculation
    * @return the number of bytes written
    */
@@ -725,12 +725,11 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Write a signed integer (zigzag + varint) directly to a MemorySegment.
-   * ZERO ALLOCATION.
+   * Write a signed integer (zigzag + varint) directly to a MemorySegment. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment to write to
-   * @param offset  the byte offset to start writing at
-   * @param value   the signed integer value
+   * @param offset the byte offset to start writing at
+   * @param value the signed integer value
    * @return the number of bytes written
    */
   public static int writeSignedToSegment(MemorySegment segment, long offset, int value) {
@@ -739,12 +738,11 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Write a signed long (zigzag + varint) directly to a MemorySegment.
-   * ZERO ALLOCATION.
+   * Write a signed long (zigzag + varint) directly to a MemorySegment. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment to write to
-   * @param offset  the byte offset to start writing at
-   * @param value   the signed long value
+   * @param offset the byte offset to start writing at
+   * @param value the signed long value
    * @return the number of bytes written
    */
   public static int writeSignedLongToSegment(MemorySegment segment, long offset, long value) {
@@ -753,12 +751,12 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Write an unsigned varint directly to a MemorySegment.
-   * ZERO ALLOCATION - optimized with fast paths for 1-2 byte values.
+   * Write an unsigned varint directly to a MemorySegment. ZERO ALLOCATION - optimized with fast paths
+   * for 1-2 byte values.
    *
    * @param segment the MemorySegment to write to
-   * @param offset  the byte offset to start writing at
-   * @param value   the unsigned long value
+   * @param offset the byte offset to start writing at
+   * @param value the unsigned long value
    * @return the number of bytes written
    */
   public static int writeVarLongToSegment(MemorySegment segment, long offset, long value) {
@@ -818,12 +816,11 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read the encoded width (number of bytes) of a delta-encoded value
-   * at the given offset in a MemorySegment.
-   * Equivalent to {@link #deltaLength} but uses long offset for large segments.
+   * Read the encoded width (number of bytes) of a delta-encoded value at the given offset in a
+   * MemorySegment. Equivalent to {@link #deltaLength} but uses long offset for large segments.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset
+   * @param offset the byte offset
    * @return the number of bytes this encoded value occupies
    */
   public static int readDeltaEncodedWidth(MemorySegment segment, long offset) {
@@ -835,11 +832,11 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read the byte width of a varint at the given offset.
-   * Scans continuation bits without decoding the value.
+   * Read the byte width of a varint at the given offset. Scans continuation bits without decoding the
+   * value.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset
+   * @param offset the byte offset
    * @return number of bytes the varint occupies
    */
   public static int readVarintWidth(MemorySegment segment, long offset) {
@@ -851,12 +848,11 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read the byte width of a signed varint at the given offset.
-   * Signed values use zigzag encoding, but the byte-level representation
-   * is the same as unsigned varint.
+   * Read the byte width of a signed varint at the given offset. Signed values use zigzag encoding,
+   * but the byte-level representation is the same as unsigned varint.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset
+   * @param offset the byte offset
    * @return number of bytes the signed varint occupies
    */
   public static int readSignedVarintWidth(MemorySegment segment, long offset) {
@@ -866,8 +862,8 @@ public final class DeltaVarIntCodec {
   // ==================== RAW-COPY FIELD RESIZE ====================
 
   /**
-   * Encoder for a single field during raw-copy resize.
-   * Called to write the new value of the changed field into the target segment.
+   * Encoder for a single field during raw-copy resize. Called to write the new value of the changed
+   * field into the target segment.
    */
   @FunctionalInterface
   public interface FieldEncoder {
@@ -882,32 +878,32 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Resize a single field in a record by raw-copying unchanged fields and re-encoding
-   * only the changed field. This avoids the full unbind→re-serialize round-trip.
+   * Resize a single field in a record by raw-copying unchanged fields and re-encoding only the
+   * changed field. This avoids the full unbind→re-serialize round-trip.
    *
-   * <p>Uses three bulk {@link MemorySegment#copy} calls (AVX/SSE intrinsics on x86)
-   * for unchanged regions, plus one {@link FieldEncoder#encode} call for the changed field.
-   * The offset table is patched in-place to reflect the new field sizes.
+   * <p>
+   * Uses three bulk {@link MemorySegment#copy} calls (AVX/SSE intrinsics on x86) for unchanged
+   * regions, plus one {@link FieldEncoder#encode} call for the changed field. The offset table is
+   * patched in-place to reflect the new field sizes.
    *
    * <h3>Record Layout Assumed</h3>
+   * 
    * <pre>
    * [nodeKind: 1 byte][offsetTable: fieldCount × 1 byte][data region: varint fields]
    * </pre>
    *
-   * @param srcPage        source page MemorySegment
-   * @param srcRecordBase  absolute offset of the source record start
-   * @param srcRecordLen   byte length of the source record (excluding DeweyID trailer)
-   * @param fieldCount     number of fields in the offset table
-   * @param fieldIndex     index of the field to change (0 to fieldCount-1)
-   * @param dstPage        destination page MemorySegment (may be same as srcPage for different offset)
-   * @param dstRecordBase  absolute offset to write the new record at
-   * @param encoder        encodes the new field value
+   * @param srcPage source page MemorySegment
+   * @param srcRecordBase absolute offset of the source record start
+   * @param srcRecordLen byte length of the source record (excluding DeweyID trailer)
+   * @param fieldCount number of fields in the offset table
+   * @param fieldIndex index of the field to change (0 to fieldCount-1)
+   * @param dstPage destination page MemorySegment (may be same as srcPage for different offset)
+   * @param dstRecordBase absolute offset to write the new record at
+   * @param encoder encodes the new field value
    * @return total bytes written for the new record (excluding DeweyID trailer)
    */
-  public static int resizeField(
-      final MemorySegment srcPage, final long srcRecordBase, final int srcRecordLen,
-      final int fieldCount, final int fieldIndex,
-      final MemorySegment dstPage, final long dstRecordBase,
+  public static int resizeField(final MemorySegment srcPage, final long srcRecordBase, final int srcRecordLen,
+      final int fieldCount, final int fieldIndex, final MemorySegment dstPage, final long dstRecordBase,
       final FieldEncoder encoder) {
 
     // Offset table starts at recordBase + 1 (after nodeKind byte)
@@ -926,8 +922,7 @@ public final class DeltaVarIntCodec {
     final int oldFieldLen = oldFieldEnd - oldFieldStart;
 
     // --- Step 1: Copy nodeKind byte ---
-    dstPage.set(ValueLayout.JAVA_BYTE, dstRecordBase,
-        srcPage.get(ValueLayout.JAVA_BYTE, srcRecordBase));
+    dstPage.set(ValueLayout.JAVA_BYTE, dstRecordBase, srcPage.get(ValueLayout.JAVA_BYTE, srcRecordBase));
 
     // --- Step 2: Reserve space for offset table (written after field data) ---
     final long dstOffsetTable = dstRecordBase + 1;
@@ -957,8 +952,7 @@ public final class DeltaVarIntCodec {
 
     // Copy offsets for fields before the changed field (unchanged)
     for (int i = 0; i < fieldIndex; i++) {
-      dstPage.set(ValueLayout.JAVA_BYTE, dstOffsetTable + i,
-          srcPage.get(ValueLayout.JAVA_BYTE, srcOffsetTable + i));
+      dstPage.set(ValueLayout.JAVA_BYTE, dstOffsetTable + i, srcPage.get(ValueLayout.JAVA_BYTE, srcOffsetTable + i));
     }
 
     // Changed field offset is the same as old (data before it hasn't moved)
@@ -981,11 +975,10 @@ public final class DeltaVarIntCodec {
   // ==================== LONG-OFFSET SEGMENT DECODE METHODS ====================
 
   /**
-   * Decode a delta-encoded key from MemorySegment using long offset.
-   * ZERO ALLOCATION.
+   * Decode a delta-encoded key from MemorySegment using long offset. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset (long for large pages)
+   * @param offset the byte offset (long for large pages)
    * @param baseKey the reference key for delta calculation
    * @return the decoded absolute key
    */
@@ -1001,11 +994,10 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read unsigned varint from MemorySegment using long offset.
-   * ZERO ALLOCATION.
+   * Read unsigned varint from MemorySegment using long offset. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset (long)
+   * @param offset the byte offset (long)
    * @return the decoded unsigned long value
    */
   public static long readVarLongFromSegment(MemorySegment segment, long offset) {
@@ -1039,11 +1031,10 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read signed integer (zigzag decoded) from MemorySegment using long offset.
-   * ZERO ALLOCATION.
+   * Read signed integer (zigzag decoded) from MemorySegment using long offset. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset (long)
+   * @param offset the byte offset (long)
    * @return the decoded signed integer value
    */
   public static int decodeSignedFromSegment(MemorySegment segment, long offset) {
@@ -1052,11 +1043,10 @@ public final class DeltaVarIntCodec {
   }
 
   /**
-   * Read signed long (zigzag decoded) from MemorySegment using long offset.
-   * ZERO ALLOCATION.
+   * Read signed long (zigzag decoded) from MemorySegment using long offset. ZERO ALLOCATION.
    *
    * @param segment the MemorySegment
-   * @param offset  the byte offset (long)
+   * @param offset the byte offset (long)
    * @return the decoded signed long value
    */
   public static long decodeSignedLongFromSegment(MemorySegment segment, long offset) {

--- a/bundles/sirix-core/src/main/java/io/sirix/node/HashCountEntryNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/HashCountEntryNode.java
@@ -62,6 +62,15 @@ public final class HashCountEntryNode implements DataRecord {
     return this;
   }
 
+  /** Batched form of {@link #incrementValue()} for delta application; {@code delta} must be positive. */
+  public HashCountEntryNode incrementValueBy(final int delta) {
+    if (delta <= 0) {
+      throw new IllegalArgumentException("delta must be positive: " + delta);
+    }
+    value += delta;
+    return this;
+  }
+
   public HashCountEntryNode decrementValue() {
     value--;
     return this;

--- a/bundles/sirix-core/src/main/java/io/sirix/node/HashCountEntryNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/HashCountEntryNode.java
@@ -62,7 +62,9 @@ public final class HashCountEntryNode implements DataRecord {
     return this;
   }
 
-  /** Batched form of {@link #incrementValue()} for delta application; {@code delta} must be positive. */
+  /**
+   * Batched form of {@link #incrementValue()} for delta application; {@code delta} must be positive.
+   */
   public HashCountEntryNode incrementValueBy(final int delta) {
     if (delta <= 0) {
       throw new IllegalArgumentException("delta must be positive: " + delta);

--- a/bundles/sirix-core/src/main/java/io/sirix/node/NullNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/NullNode.java
@@ -89,6 +89,11 @@ public final class NullNode implements StructNode {
   }
 
   @Override
+  public void setChildCount(final long childCount) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void setHash(final long hash) {
     throw new UnsupportedOperationException();
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/node/delegates/StructNodeDelegate.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/delegates/StructNodeDelegate.java
@@ -118,8 +118,7 @@ public class StructNodeDelegate extends AbstractForwardingNode implements Struct
    * @param descendantCount number of descendants of the node
    */
   public StructNodeDelegate(final NodeDelegate nodeDelegate, final long firstChild, final long lastChild,
-      final long rightSibling, final long leftSibling, final long childCount,
-      final long descendantCount) {
+      final long rightSibling, final long leftSibling, final long childCount, final long descendantCount) {
     assert nodeDelegate != null : "del must not be null!";
     this.nodeDelegate = nodeDelegate;
     this.firstChild = firstChild;
@@ -254,14 +253,14 @@ public class StructNodeDelegate extends AbstractForwardingNode implements Struct
   @Override
   public String toString() {
     return ToStringHelper.of(this)
-                      .add("first child", getFirstChildKey())
-                      .add("last child", getLastChildKey())
-                      .add("left sib", getLeftSiblingKey())
-                      .add("right sib", getRightSiblingKey())
-                      .add("child count", getChildCount())
-                      .add("descendant count", getDescendantCount())
-                      .add("node delegate", getNodeDelegate().toString())
-                      .toString();
+                         .add("first child", getFirstChildKey())
+                         .add("last child", getLastChildKey())
+                         .add("left sib", getLeftSiblingKey())
+                         .add("right sib", getRightSiblingKey())
+                         .add("child count", getChildCount())
+                         .add("descendant count", getDescendantCount())
+                         .add("node delegate", getNodeDelegate().toString())
+                         .toString();
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/node/delegates/StructNodeDelegate.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/delegates/StructNodeDelegate.java
@@ -214,6 +214,11 @@ public class StructNodeDelegate extends AbstractForwardingNode implements Struct
   }
 
   @Override
+  public void setChildCount(final long childCount) {
+    this.childCount = childCount;
+  }
+
+  @Override
   public int hashCode() {
     return lastChild == Fixed.INVALID_KEY_FOR_TYPE_CHECK.getStandardProperty()
         ? Objects.hash(childCount, nodeDelegate, firstChild, leftSibling, rightSibling, descendantCount)

--- a/bundles/sirix-core/src/main/java/io/sirix/node/interfaces/StructNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/interfaces/StructNode.java
@@ -145,9 +145,9 @@ public interface StructNode extends Node {
   void incrementChildCount();
 
   /**
-   * Sets the child count directly — the batched form bulk loaders use at container close: one
-   * write instead of {@code count} read-modify-write increments (each of which can trigger a
-   * varint-width resize on encoded records).
+   * Sets the child count directly — the batched form bulk loaders use at container close: one write
+   * instead of {@code count} read-modify-write increments (each of which can trigger a varint-width
+   * resize on encoded records).
    *
    * @param childCount the exact child count
    */

--- a/bundles/sirix-core/src/main/java/io/sirix/node/interfaces/StructNode.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/node/interfaces/StructNode.java
@@ -145,6 +145,15 @@ public interface StructNode extends Node {
   void incrementChildCount();
 
   /**
+   * Sets the child count directly — the batched form bulk loaders use at container close: one
+   * write instead of {@code count} read-modify-write increments (each of which can trigger a
+   * varint-width resize on encoded records).
+   *
+   * @param childCount the exact child count
+   */
+  void setChildCount(long childCount);
+
+  /**
    * Decrementing the descendant count.
    */
   void decrementDescendantCount();

--- a/bundles/sirix-core/src/main/java/io/sirix/page/ChunkedBodyConfig.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/ChunkedBodyConfig.java
@@ -147,7 +147,34 @@ public final class ChunkedBodyConfig {
     }
   }
 
-  /** Pages parsed lazily since the last {@link #resetDiag()}. Zero unless {@link #diagEnabled()}. */
+  /**
+   * Record a whole-leaf consumer served by the WINDOWED projection-column route instead of an eager
+   * whole-column materialization. Cold path — once per handle engagement — so it is counted
+   * UNCONDITIONALLY: the bench banners read these counters, and a lazy route whose witness needs a
+   * separate flag is how a feature quietly stops firing while its banner still prints zeros.
+   */
+  public static void recordWindowedColumnEngagement() {
+    LAZY_LOADS.increment();
+  }
+
+  /** Record one window of row-group payloads materialized on demand. Cold path; unconditional. */
+  public static void recordColumnWindowMaterialization() {
+    CHUNK_MATERIALIZATIONS.increment();
+  }
+
+  /**
+   * Record a lazy projection handle whose whole-leaf materialization ran EAGERLY — the
+   * under-the-budget outcome. Cold path; unconditional.
+   */
+  public static void recordEagerColumnMaterialization() {
+    EAGER_FALLBACKS.increment();
+  }
+
+  /**
+   * Pages parsed lazily since the last {@link #resetDiag()}, plus windowed projection-column
+   * engagements (counted unconditionally; the per-page body events additionally require
+   * {@link #diagEnabled()}).
+   */
   public static long lazyLoads() {
     return LAZY_LOADS.sum();
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -328,10 +328,10 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
 
   /**
    * Set when a bulk-import ADOPTED page enters the intent log: nothing mutates the page after
-   * adoption, so the async snapshot flush may serialize it IN PLACE (skipping the defensive deep
-   * copy that exists to protect concurrently mutated pages) — the disposable encode then clobbers
-   * this page's own frame, which is fine because the snapshot cleanup is its single closer and
-   * nothing reads the frame after the flush.
+   * adoption, so the async snapshot flush may serialize it IN PLACE (skipping the defensive deep copy
+   * that exists to protect concurrently mutated pages) — the disposable encode then clobbers this
+   * page's own frame, which is fine because the snapshot cleanup is its single closer and nothing
+   * reads the frame after the flush.
    */
   private boolean adoptedImmutableForFlush;
 

--- a/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/KeyValueLeafPage.java
@@ -327,6 +327,15 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
   private long recordPageKey;
 
   /**
+   * Set when a bulk-import ADOPTED page enters the intent log: nothing mutates the page after
+   * adoption, so the async snapshot flush may serialize it IN PLACE (skipping the defensive deep
+   * copy that exists to protect concurrently mutated pages) — the disposable encode then clobbers
+   * this page's own frame, which is fine because the snapshot cleanup is its single closer and
+   * nothing reads the frame after the flush.
+   */
+  private boolean adoptedImmutableForFlush;
+
+  /**
    * The record-ID mapped to the records. Lazily allocated on first write to save ~8KB per page when
    * FlyweightNode records go directly to the slotted page heap (zero records[] path).
    */
@@ -827,6 +836,14 @@ public final class KeyValueLeafPage implements KeyValuePage<DataRecord>, io.siri
       return recordPageKey == other.recordPageKey && revision == other.revision;
     }
     return false;
+  }
+
+  public void markAdoptedImmutableForFlush() {
+    this.adoptedImmutableForFlush = true;
+  }
+
+  public boolean isAdoptedImmutableForFlush() {
+    return adoptedImmutableForFlush;
   }
 
   @Override

--- a/bundles/sirix-core/src/main/java/io/sirix/page/NamePage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/NamePage.java
@@ -682,6 +682,31 @@ public final class NamePage extends AbstractForwardingPage {
   }
 
   /**
+   * Adds {@code delta} occurrences to an EXISTING interned name's count in one record touch — the
+   * batched sibling of {@link #setName}'s per-occurrence increment. JSON object keys only for now
+   * (the parallel bulk importer's use case); other kinds extend the switch when they need it.
+   *
+   * @param key the interned name key
+   * @param delta additional occurrences; must be positive
+   * @param nodeKind kind of node, selecting the dictionary
+   * @param storageEngineWriter the writer for the count-record modification
+   */
+  public void addCount(final int key, final int delta, final NodeKind nodeKind,
+      final StorageEngineWriter storageEngineWriter) {
+    // $CASES-OMITTED$
+    switch (nodeKind) {
+      case OBJECT_NAMED_OBJECT, OBJECT_NAMED_ARRAY, OBJECT_NAMED_BOOLEAN, OBJECT_NAMED_NUMBER, OBJECT_NAMED_STRING,
+          OBJECT_NAMED_NULL -> {
+        if (jsonObjectKeys == null) {
+          jsonObjectKeys = getNames(storageEngineWriter, JSON_OBJECT_KEY_REFERENCE_OFFSET);
+        }
+        jsonObjectKeys.addCount(key, delta, storageEngineWriter);
+      }
+      default -> throw new IllegalStateException("addCount currently supports JSON object keys only");
+    }
+  }
+
+  /**
    * Resolve the key a name owns without storing it or counting an occurrence — see
    * {@code StorageEngineWriter#keyForName}.
    *
@@ -832,7 +857,21 @@ public final class NamePage extends AbstractForwardingPage {
     if (nodeKey <= 0) {
       throw new IllegalArgumentException("value dictionary node key must be positive, got " + nodeKey);
     }
-    return storageEngineReader.getRecord(nodeKey, IndexType.NAME, projectionValueDictionaryOffset(databaseType));
+    // Writer-scoped memo (no-op defaults for read-only transactions): once the async flush has
+    // released a dictionary page from the intent log, an uncached read here decodes the WHOLE page
+    // — IO, checksum, LZ77, version combine — for one record, and the radix walks re-read the same
+    // upper-level nodes constantly. Soundness (CoW fresh keys, header evict-on-put, single thread)
+    // is argued on the interface hooks.
+    final DataRecord cached = storageEngineReader.cachedProjectionDictionaryRecord(nodeKey);
+    if (cached != null) {
+      return cached;
+    }
+    final DataRecord record =
+        storageEngineReader.getRecord(nodeKey, IndexType.NAME, projectionValueDictionaryOffset(databaseType));
+    if (record != null) {
+      storageEngineReader.cacheProjectionDictionaryRecord(nodeKey, record);
+    }
+    return record;
   }
 
   /**
@@ -856,6 +895,10 @@ public final class NamePage extends AbstractForwardingPage {
     Objects.requireNonNull(databaseType, "databaseType must not be null");
     Objects.requireNonNull(storageEngineWriter, "storageEngineWriter must not be null");
     Objects.requireNonNull(log, "log must not be null");
+    // Evict BEFORE persisting: nearly every dictionary write lands under a freshly minted key, but
+    // the generation header is rewritten under its stable key, and a memoized pre-rewrite header
+    // would resurrect a stale entry count on the next read.
+    storageEngineWriter.evictProjectionDictionaryRecord(record.getNodeKey());
     createProjectionValueDictionaryTree(databaseType, storageEngineWriter, log);
     storageEngineWriter.persistRecord(record, IndexType.NAME, projectionValueDictionaryOffset(databaseType));
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/page/RevisionRootPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/RevisionRootPage.java
@@ -107,8 +107,8 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   private static final int VALIDTIME_REFERENCE_OFFSET = 10;
 
   /**
-   * Number of sibling references held in this revision root page (the highest reference offset
-   * plus one). Kept in sync with the {@code *_REFERENCE_OFFSET} constants above and with the
+   * Number of sibling references held in this revision root page (the highest reference offset plus
+   * one). Kept in sync with the {@code *_REFERENCE_OFFSET} constants above and with the
    * {@code BitmapReferencesPage} deserialization in {@code PageKind.REVISIONROOTPAGE}.
    */
   public static final int REVISION_ROOT_PAGE_REFERENCE_COUNT = 11;
@@ -393,12 +393,12 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   }
 
   /**
-   * Reserves {@code count} consecutive document-index node keys and returns the FIRST reserved
-   * key. The parallel bulk importer assigns each build chunk an exact contiguous range up front so
-   * workers can encode final record bytes off-thread; the single-writer mint
-   * ({@link #incrementAndGetMaxNodeKeyInDocumentIndex()}) and this reservation share the one
-   * counter, so the field equals the true high-water mark at all times — the invariant the commit
-   * relies on when it serializes this page.
+   * Reserves {@code count} consecutive document-index node keys and returns the FIRST reserved key.
+   * The parallel bulk importer assigns each build chunk an exact contiguous range up front so workers
+   * can encode final record bytes off-thread; the single-writer mint
+   * ({@link #incrementAndGetMaxNodeKeyInDocumentIndex()}) and this reservation share the one counter,
+   * so the field equals the true high-water mark at all times — the invariant the commit relies on
+   * when it serializes this page.
    *
    * @param count how many keys to reserve; must be positive
    * @return the first key of the reserved contiguous range
@@ -525,19 +525,19 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   @Override
   public String toString() {
     return ToStringHelper.of(this)
-                      .add("revisionTimestamp", revisionTimestamp)
-                      .add("maxNodeKey", maxNodeKeyInDocumentIndex)
-                      .add("delegate", delegate)
-                      .add("nodePage", getOrCreateReference(INDIRECT_DOCUMENT_INDEX_REFERENCE_OFFSET))
-                      .add("namePage", getOrCreateReference(NAME_REFERENCE_OFFSET))
-                      .add("pathSummaryPage", getOrCreateReference(PATH_SUMMARY_REFERENCE_OFFSET))
-                      .add("pathPage", getOrCreateReference(PATH_REFERENCE_OFFSET))
-                      .add("CASPage", getOrCreateReference(CAS_REFERENCE_OFFSET))
-                      .add("deweyIDPage", getOrCreateReference(DEWEYID_REFERENCE_OFFSET))
-                      .add("vectorPage", getOrCreateReference(VECTOR_REFERENCE_OFFSET))
-                      .add("projectionPage", getOrCreateReference(PROJECTION_REFERENCE_OFFSET))
-                      .add("validTimePage", getOrCreateReference(VALIDTIME_REFERENCE_OFFSET))
-                      .toString();
+                         .add("revisionTimestamp", revisionTimestamp)
+                         .add("maxNodeKey", maxNodeKeyInDocumentIndex)
+                         .add("delegate", delegate)
+                         .add("nodePage", getOrCreateReference(INDIRECT_DOCUMENT_INDEX_REFERENCE_OFFSET))
+                         .add("namePage", getOrCreateReference(NAME_REFERENCE_OFFSET))
+                         .add("pathSummaryPage", getOrCreateReference(PATH_SUMMARY_REFERENCE_OFFSET))
+                         .add("pathPage", getOrCreateReference(PATH_REFERENCE_OFFSET))
+                         .add("CASPage", getOrCreateReference(CAS_REFERENCE_OFFSET))
+                         .add("deweyIDPage", getOrCreateReference(DEWEYID_REFERENCE_OFFSET))
+                         .add("vectorPage", getOrCreateReference(VECTOR_REFERENCE_OFFSET))
+                         .add("projectionPage", getOrCreateReference(PROJECTION_REFERENCE_OFFSET))
+                         .add("validTimePage", getOrCreateReference(VALIDTIME_REFERENCE_OFFSET))
+                         .toString();
   }
 
   @Override
@@ -569,8 +569,8 @@ public final class RevisionRootPage extends AbstractForwardingPage {
    * @param storageEngineReader {@link StorageEngineReader} instance
    * @param log the transaction intent log
    */
-  public void createChangedNodesIndexTree(final DatabaseType databaseType, final StorageEngineReader storageEngineReader,
-      final TransactionIntentLog log) {
+  public void createChangedNodesIndexTree(final DatabaseType databaseType,
+      final StorageEngineReader storageEngineReader, final TransactionIntentLog log) {
     PageReference reference = getIndirectChangedNodesIndexPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
         && reference.getLogKey() == Constants.NULL_ID_INT) {
@@ -586,8 +586,8 @@ public final class RevisionRootPage extends AbstractForwardingPage {
    * @param storageEngineReader {@link StorageEngineReader} instance
    * @param log the transaction intent log
    */
-  public void createRecordToRevisionsIndexTree(final DatabaseType databaseType, final StorageEngineReader storageEngineReader,
-      final TransactionIntentLog log) {
+  public void createRecordToRevisionsIndexTree(final DatabaseType databaseType,
+      final StorageEngineReader storageEngineReader, final TransactionIntentLog log) {
     PageReference reference = getIndirectRecordToRevisionsIndexPageReference();
     if (reference.getPage() == null && reference.getKey() == Constants.NULL_ID_LONG
         && reference.getLogKey() == Constants.NULL_ID_INT) {

--- a/bundles/sirix-core/src/main/java/io/sirix/page/RevisionRootPage.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/page/RevisionRootPage.java
@@ -393,6 +393,26 @@ public final class RevisionRootPage extends AbstractForwardingPage {
   }
 
   /**
+   * Reserves {@code count} consecutive document-index node keys and returns the FIRST reserved
+   * key. The parallel bulk importer assigns each build chunk an exact contiguous range up front so
+   * workers can encode final record bytes off-thread; the single-writer mint
+   * ({@link #incrementAndGetMaxNodeKeyInDocumentIndex()}) and this reservation share the one
+   * counter, so the field equals the true high-water mark at all times — the invariant the commit
+   * relies on when it serializes this page.
+   *
+   * @param count how many keys to reserve; must be positive
+   * @return the first key of the reserved contiguous range
+   */
+  public long reserveKeyRangeInDocumentIndex(final long count) {
+    if (count <= 0) {
+      throw new IllegalArgumentException("count must be positive: " + count);
+    }
+    final long first = maxNodeKeyInDocumentIndex + 1;
+    maxNodeKeyInDocumentIndex += count;
+    return first;
+  }
+
+  /**
    * Get last allocated node key in changed nodes index.
    *
    * @return Last allocated node key in changed nodes index

--- a/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
@@ -1272,10 +1272,10 @@ public enum VersioningType {
    * {@code mergeHOTFragmentsByKey} is the DEFAULT READ path — its single-fragment branch runs on
    * every versioned page read — and {@code carryForwardAgingHOTEntries} runs inside the COMMIT path
    * once per entry of an aging fragment (measured: 1018 entries in one ordinary commit). A shared
-   * atomic on either is a contended cache line on a hot path, which is precisely what the
-   * performance rules in CLAUDE.md forbid. The gate is a {@code static final} read of a
-   * non-constant, so the branch is folded away entirely once C2 sees it: with diagnostics off these
-   * counters cost nothing at all.
+   * atomic on either is a contended cache line on a hot path, which is precisely what the performance
+   * rules in CLAUDE.md forbid. The gate is a {@code static final} read of a non-constant, so the
+   * branch is folded away entirely once C2 sees it: with diagnostics off these counters cost nothing
+   * at all.
    *
    * <h2>And nothing shared is touched per iteration, even when ON</h2>
    *
@@ -1296,8 +1296,8 @@ public enum VersioningType {
    * complete dump — a dump is a replacement snapshot, and walking past it could resurrect keys a
    * split relocated (task #57) — so this counter is structurally zero today. It is kept as a
    * permanent sentinel: if a future change removes or weakens that break, the counter goes nonzero
-   * and the tests asserting on it point back at this investigation, instead of at a corrupt
-   * database months later. Observability only — nothing here changes what the merge does.
+   * and the tests asserting on it point back at this investigation, instead of at a corrupt database
+   * months later. Observability only — nothing here changes what the merge does.
    * </p>
    */
   private static final boolean HOT_MERGE_DIAG = Boolean.getBoolean("sirix.hot.mergeDiag");
@@ -1361,10 +1361,10 @@ public enum VersioningType {
   }
 
   /**
-   * Older fragments walked THROUGH despite a fragment having declared the chain complete — the
-   * task #57 precondition. Structurally zero while the merge loop's complete-dump break stands; it
-   * is kept as a permanent sentinel so that if the break is ever removed or weakened, a test fails
-   * instead of a database quietly corrupting.
+   * Older fragments walked THROUGH despite a fragment having declared the chain complete — the task
+   * #57 precondition. Structurally zero while the merge loop's complete-dump break stands; it is kept
+   * as a permanent sentinel so that if the break is ever removed or weakened, a test fails instead of
+   * a database quietly corrupting.
    */
   public static long completeDumpsWalkedPast() {
     return COMPLETE_DUMPS_WALKED_PAST.sum();

--- a/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/settings/VersioningType.java
@@ -1264,6 +1264,124 @@ public enum VersioningType {
   private static final byte[] EMPTY_VALUE = new byte[0];
 
   /**
+   * Fragment-merge instrumentation, OFF unless {@code -Dsirix.hot.mergeDiag=true}, following the
+   * {@link #COMBINE_DIAG} convention already used in this file.
+   *
+   * <h2>Why this is gated rather than always-on</h2>
+   *
+   * {@code mergeHOTFragmentsByKey} is the DEFAULT READ path — its single-fragment branch runs on
+   * every versioned page read — and {@code carryForwardAgingHOTEntries} runs inside the COMMIT path
+   * once per entry of an aging fragment (measured: 1018 entries in one ordinary commit). A shared
+   * atomic on either is a contended cache line on a hot path, which is precisely what the
+   * performance rules in CLAUDE.md forbid. The gate is a {@code static final} read of a
+   * non-constant, so the branch is folded away entirely once C2 sees it: with diagnostics off these
+   * counters cost nothing at all.
+   *
+   * <h2>And nothing shared is touched per iteration, even when ON</h2>
+   *
+   * The two loops accumulate into LOCALS and publish ONE add per merge / per rotation. So the
+   * per-entry cost is a register increment rather than an atomic, and the counters keep their exact
+   * values. Granularity of the STORAGE is per-call; granularity of the NUMBER is unchanged.
+   *
+   * <h2>The counters themselves</h2>
+   *
+   * This path had NO instrumentation at all, which is why a versioned-merge test once passed while
+   * its merge counters read zero: a warm cache served already-merged pages, every assertion was
+   * satisfied by the single-fragment path, and nothing could tell the difference. Any gate that
+   * claims to exercise fragment reconstruction has to prove it ENTERED — an absence of failures
+   * proves only that the code may never have run.
+   *
+   * <p>
+   * {@link #completeDumpsWalkedPast()} is the sharp one. The merge loop below now TERMINATES at a
+   * complete dump — a dump is a replacement snapshot, and walking past it could resurrect keys a
+   * split relocated (task #57) — so this counter is structurally zero today. It is kept as a
+   * permanent sentinel: if a future change removes or weakens that break, the counter goes nonzero
+   * and the tests asserting on it point back at this investigation, instead of at a corrupt
+   * database months later. Observability only — nothing here changes what the merge does.
+   * </p>
+   */
+  private static final boolean HOT_MERGE_DIAG = Boolean.getBoolean("sirix.hot.mergeDiag");
+
+  private static final LongAdder SINGLE_FRAGMENT_READS = new LongAdder();
+
+  private static final LongAdder MULTI_FRAGMENT_MERGES = new LongAdder();
+
+  private static final LongAdder FRAGMENTS_WALKED = new LongAdder();
+
+  private static final LongAdder COMPLETE_DUMP_SHORT_CIRCUITS = new LongAdder();
+
+  private static final LongAdder COMPLETE_DUMPS_WALKED_PAST = new LongAdder();
+
+  private static final LongAdder CARRY_FORWARD_ROTATIONS = new LongAdder();
+
+  private static final LongAdder CARRY_FORWARD_ENTRIES_REEMITTED = new LongAdder();
+
+  /**
+   * Whether merge diagnostics are collecting. A test that asserts on these counters MUST check this
+   * first: with the gate off every counter reads zero, and "zero walked past a complete dump" from a
+   * disabled instrument is indistinguishable from the same reading from a healthy one. Assert the
+   * instrument is live, then assert on it.
+   */
+  public static boolean hotMergeDiagEnabled() {
+    return HOT_MERGE_DIAG;
+  }
+
+  /** SLIDING_SNAPSHOT window rotations that ran the aging-entry carry-forward. */
+  public static long carryForwardRotations() {
+    return CARRY_FORWARD_ROTATIONS.sum();
+  }
+
+  /**
+   * Entries the carry-forward re-emitted. A VOLUME COUNTER, NOT A DEFECT WITNESS — re-emitting live
+   * entries that would otherwise age out is the carry-forward's job, and a healthy commit measures
+   * over a thousand. Use it as a denominator, never as evidence that something went wrong.
+   */
+  public static long carryForwardEntriesReemitted() {
+    return CARRY_FORWARD_ENTRIES_REEMITTED.sum();
+  }
+
+  /** Reads served by a single fragment — no reconstruction happened. */
+  public static long singleFragmentReads() {
+    return SINGLE_FRAGMENT_READS.sum();
+  }
+
+  /** Reads that actually reconstructed a page from a chain of fragments. */
+  public static long multiFragmentMerges() {
+    return MULTI_FRAGMENT_MERGES.sum();
+  }
+
+  /** Older fragments visited across all merges. */
+  public static long fragmentsWalked() {
+    return FRAGMENTS_WALKED.sum();
+  }
+
+  /** Merges answered wholly by a complete newest fragment. */
+  public static long completeDumpShortCircuits() {
+    return COMPLETE_DUMP_SHORT_CIRCUITS.sum();
+  }
+
+  /**
+   * Older fragments walked THROUGH despite a fragment having declared the chain complete — the
+   * task #57 precondition. Structurally zero while the merge loop's complete-dump break stands; it
+   * is kept as a permanent sentinel so that if the break is ever removed or weakened, a test fails
+   * instead of a database quietly corrupting.
+   */
+  public static long completeDumpsWalkedPast() {
+    return COMPLETE_DUMPS_WALKED_PAST.sum();
+  }
+
+  /** Zero every merge counter; a counter that cannot be reset cannot witness a specific operation. */
+  public static void resetFragmentMergeCounters() {
+    SINGLE_FRAGMENT_READS.reset();
+    MULTI_FRAGMENT_MERGES.reset();
+    FRAGMENTS_WALKED.reset();
+    COMPLETE_DUMP_SHORT_CIRCUITS.reset();
+    COMPLETE_DUMPS_WALKED_PAST.reset();
+    CARRY_FORWARD_ROTATIONS.reset();
+    CARRY_FORWARD_ENTRIES_REEMITTED.reset();
+  }
+
+  /**
    * Merge HOT fragments by full key. Single newest-fragment fast path returns the page directly.
    * Multi-fragment path copies the newest, then walks older fragments inserting any keys absent from
    * the result until it reaches a complete dump. Tombstones in newer fragments shadow older entries;
@@ -1271,12 +1389,22 @@ public enum VersioningType {
    */
   private static HOTLeafPage mergeHOTFragmentsByKey(final List<HOTLeafPage> pages) {
     if (pages.size() == 1) {
+      // THE DEFAULT READ PATH. Gated so it folds to nothing when diagnostics are off.
+      if (HOT_MERGE_DIAG) {
+        SINGLE_FRAGMENT_READS.increment();
+      }
       return pages.getFirst();
     }
 
     final HOTLeafPage newest = pages.getFirst();
     if (newest.isCompleteDump()) {
+      if (HOT_MERGE_DIAG) {
+        COMPLETE_DUMP_SHORT_CIRCUITS.increment();
+      }
       return newest;
+    }
+    if (HOT_MERGE_DIAG) {
+      MULTI_FRAGMENT_MERGES.increment();
     }
 
     // Newest fragment is the base; copy() bulk-copies its entries and resets the dirty bitmap on
@@ -1287,8 +1415,22 @@ public enum VersioningType {
     result.setCompletePageRef(null);
     result.clearDirtyBitmap();
 
+    // TASK #57 SENTINEL — OBSERVATION ONLY. The break at the bottom of this loop is the guard: a
+    // complete dump is a replacement snapshot, and walking past it could resurrect keys a split
+    // relocated. The locals below count what the walk does, and walkedPastDump can only become
+    // nonzero if a future change removes or weakens that break — at which point the counter goes
+    // nonzero and the tests asserting on it point back here instead of at a corrupt database
+    // months later. Accumulated in LOCALS and published once below, so the loop never touches
+    // shared state.
+    boolean pastACompleteDump = false;
+    int walked = 0;
+    int walkedPastDump = 0;
     for (int i = 1; i < pages.size(); i++) {
       final HOTLeafPage olderPage = pages.get(i);
+      walked++;
+      if (pastACompleteDump) {
+        walkedPastDump++;
+      }
       final int olderCount = olderPage.getEntryCount();
       for (int j = 0; j < olderCount; j++) {
         final byte[] key = olderPage.getKey(j);
@@ -1322,8 +1464,17 @@ public enum VersioningType {
       // former range. Continuing past this boundary would merge those stale entries back into the
       // left-hand leaf and make them visible again.
       if (olderPage.isCompleteDump()) {
+        // Arm the sentinel before breaking: if this break is ever removed, the next iteration is
+        // exactly what walkedPastDump records.
+        pastACompleteDump = true;
         break;
       }
+    }
+
+    // ONE publish per merge rather than one per fragment.
+    if (HOT_MERGE_DIAG) {
+      FRAGMENTS_WALKED.add(walked);
+      COMPLETE_DUMPS_WALKED_PAST.add(walkedPastDump);
     }
 
     // Re-tighten the prefix after cross-fragment fills — the original combine path lacked this
@@ -1632,6 +1783,13 @@ public enum VersioningType {
     if (fragmentCount == 0) {
       return;
     }
+    if (HOT_MERGE_DIAG) {
+      CARRY_FORWARD_ROTATIONS.increment();
+    }
+    // Re-emissions accumulate in a LOCAL and publish once at the end: this loop runs once per entry
+    // of the aging fragment on the DEFAULT COMMIT PATH — over a thousand iterations in an ordinary
+    // commit — so it must not touch a shared counter per iteration.
+    long reemitted = 0;
     final HOTLeafPage oldest = fragmentsNewestFirst.get(fragmentCount - 1);
     final int oldestEntryCount = oldest.getEntryCount();
     for (int j = 0; j < oldestEntryCount; j++) {
@@ -1657,8 +1815,20 @@ public enum VersioningType {
       }
       final int idx = modifiedLeaf.findEntry(key);
       if (idx >= 0) {
+        // NOTE WHAT IS RE-EMITTED: the entry of modifiedLeaf — the CURRENT combined state — and
+        // never the aging fragment's bytes. That is why carry-forward cannot resurrect a deleted
+        // key: for a tombstoned key the current entry IS the tombstone, so marking it dirty
+        // re-emits the DELETE. The shadowing test above is therefore an optimisation (skip work a
+        // newer fragment already covers), not a correctness guard — verified by mutation, which
+        // made it treat a newer tombstone as non-shadowing and changed only the re-emission count
+        // (6->7, 18->19), never an answer.
+        reemitted++;
         modifiedLeaf.markEntryDirty(idx);
       }
+    }
+    // ONE publish per rotation rather than one per entry.
+    if (HOT_MERGE_DIAG) {
+      CARRY_FORWARD_ENTRIES_REEMITTED.add(reemitted);
     }
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/BulkAssemblyEquivalenceOracleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/BulkAssemblyEquivalenceOracleTest.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.axis.DescendantAxis;
+import io.sirix.axis.IncludeSelf;
+import io.sirix.index.path.summary.PathSummaryReader;
+import io.sirix.node.NodeKind;
+import io.sirix.service.json.shredder.JsonShredder;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The differential oracle for the bulk page-assembly loader — built and inversion-proven BEFORE the
+ * assembler exists, per the campaign's discipline: a comparator that has never failed proves
+ * nothing.
+ *
+ * <p>
+ * The oracle's statement: two loaders fed the same JSON must produce resources whose CANONICAL
+ * DUMPS are string-identical. The dump walks every node in document order through the public read
+ * API and prints the complete structural identity the cursor loader guarantees — node key, kind,
+ * name, value, parent/left-sibling/right-sibling/first-child keys, child count, path node key —
+ * plus the resource-level max node key. Anything the future assembler gets wrong in key minting,
+ * pointer wiring, name/path resolution or value bytes must surface as a first differing line.
+ *
+ * <p>
+ * Self-proofs in this class: (1) DETERMINISM — the cursor loader run twice over the same input
+ * yields identical dumps, so the oracle's ground truth is stable; (2) SENSITIVITY — a one-value
+ * change, a field-order swap, and a nesting change each flip the dump, so the comparator can
+ * actually say "no" along the value, order and structure axes it claims to cover. The assembler arm
+ * plugs in later as a second {@link Consumer} loading the same input.
+ */
+final class BulkAssemblyEquivalenceOracleTest {
+
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  private static final String FLAT_RECORDS =
+      "[{\"id\":1,\"name\":\"alpha\",\"ok\":true},{\"id\":2,\"name\":\"beta\",\"ok\":false},"
+          + "{\"id\":3,\"name\":\"gamma\",\"nested\":{\"x\":1.5,\"y\":null}}]";
+
+  private static final String EDGE_SHAPES =
+      "{\"empty\":{},\"emptyArr\":[],\"uni\":\"\\u00e4\\u00df\\u2713\",\"esc\":\"a\\\"b\\\\c\","
+          + "\"nums\":[0,-1,9007199254740993,1.0e-3],\"deep\":[[[[{\"leaf\":\"v\"}]]]]}";
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @Test
+  @DisplayName("ground truth: the cursor loader is deterministic — same input, twice, identical dumps")
+  void cursorLoaderIsDeterministic() {
+    final String first = dumpAfterLoad("det-a", cursorLoader(FLAT_RECORDS));
+    final String second = dumpAfterLoad("det-b", cursorLoader(FLAT_RECORDS));
+    assertEquals(first, second, "two cursor loads of the same input must be structurally identical");
+    assertTrue(first.lines().count() > 10, "the dump must actually enumerate nodes, not be vacuously empty");
+  }
+
+  @Test
+  @DisplayName("ground truth holds for edge shapes (empty containers, unicode, escapes, deep nesting)")
+  void cursorLoaderIsDeterministicOnEdgeShapes() {
+    final String first = dumpAfterLoad("edge-a", cursorLoader(EDGE_SHAPES));
+    final String second = dumpAfterLoad("edge-b", cursorLoader(EDGE_SHAPES));
+    assertEquals(first, second);
+    // Non-vacuity witnesses: the decoded unicode VALUE and the escaped quote must have survived the
+    // shred into the dump — a comparator over dumps that dropped values would pass equality checks
+    // while checking nothing.
+    assertTrue(first.contains("äß✓"), "edge dump must carry the decoded unicode value");
+    assertTrue(first.contains("a\"b\\c"), "edge dump must carry the unescaped string value");
+  }
+
+  @Test
+  @DisplayName("sensitivity: a single changed VALUE flips the dump")
+  void oracleSeesValueDifference() {
+    final String base = dumpAfterLoad("val-a", cursorLoader(FLAT_RECORDS));
+    final String mutated = dumpAfterLoad("val-b", cursorLoader(FLAT_RECORDS.replace("\"beta\"", "\"BETA\"")));
+    assertNotEquals(base, mutated, "a one-value change must flip the canonical dump");
+  }
+
+  @Test
+  @DisplayName("sensitivity: swapped FIELD ORDER flips the dump")
+  void oracleSeesOrderDifference() {
+    final String base = dumpAfterLoad("ord-a", cursorLoader("[{\"a\":1,\"b\":2}]"));
+    final String swapped = dumpAfterLoad("ord-b", cursorLoader("[{\"b\":2,\"a\":1}]"));
+    assertNotEquals(base, swapped, "sibling order is part of the structural identity");
+  }
+
+  @Test
+  @DisplayName("sensitivity: a NESTING change flips the dump even when the scalar content matches")
+  void oracleSeesStructureDifference() {
+    final String flat = dumpAfterLoad("str-a", cursorLoader("[{\"a\":1,\"b\":2}]"));
+    final String nested = dumpAfterLoad("str-b", cursorLoader("[{\"a\":1,\"n\":{\"b\":2}}]"));
+    assertNotEquals(flat, nested);
+  }
+
+  /** The cursor arm every comparison anchors on. */
+  static Consumer<JsonNodeTrx> cursorLoader(final String json) {
+    return wtx -> wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(json));
+  }
+
+  /**
+   * The bulk-assembly arm under test. The cursor arm parses with Gson while this arm uses the
+   * BulkJsonScanner, so every differential fixture is ALSO a tokenizer-equivalence test — escapes,
+   * unicode, surrogates and number forms must decode identically or the dumps diverge.
+   */
+  static Consumer<JsonNodeTrx> bulkLoader(final String json) {
+    return wtx -> BulkJsonTreeAssembler.assemble(wtx, new StringReader(json));
+  }
+
+  @Test
+  @DisplayName("SCANNER EDGES: number-form zoo decodes identically to Gson + JsonNumber")
+  void scannerNumberZooMatchesCursor() {
+    final String json = "[-0,0,1,-1,2147483648,-2147483649,9223372036854775807,-9223372036854775808,"
+        + "9223372036854775808,1.5,-0.5,1e3,1E-3,1.25e2,3.0e0,1e400]";
+    assertEquals(dumpAfterLoad("z-cur", cursorLoader(json)), dumpAfterLoad("z-blk", bulkLoader(json)));
+  }
+
+  @Test
+  @DisplayName("SCANNER EDGES: lone surrogate escapes encode like String.getBytes(UTF_8)")
+  void scannerLoneSurrogateMatchesCursor() {
+    final String json = "[\"a\\uD800b\",\"c\\uDC00d\",\"pair:\\uD83D\\uDE00!\"]";
+    assertEquals(dumpAfterLoad("s-cur", cursorLoader(json)), dumpAfterLoad("s-blk", bulkLoader(json)));
+  }
+
+  @Test
+  @DisplayName("SCANNER EDGES: a 7-char buffer forces refills inside every token, dumps unchanged")
+  void scannerTinyBufferMatchesDefault() {
+    final String json = EDGE_SHAPES;
+    final String viaDefault = dumpAfterLoad("t-def", bulkLoader(json));
+    final String viaTiny = dumpAfterLoad("t-tiny",
+        wtx -> BulkJsonTreeAssembler.assemble(wtx, new BulkJsonScanner(new StringReader(json), 7)));
+    assertEquals(viaDefault, viaTiny);
+  }
+
+  @Test
+  @DisplayName("DIFFERENTIAL: bulk assembly ≡ cursor loader on flat records")
+  void bulkMatchesCursorOnFlatRecords() {
+    assertEquals(dumpAfterLoad("d-cur-flat", cursorLoader(FLAT_RECORDS)),
+        dumpAfterLoad("d-blk-flat", bulkLoader(FLAT_RECORDS)));
+  }
+
+  @Test
+  @DisplayName("DIFFERENTIAL: bulk assembly ≡ cursor loader on edge shapes")
+  void bulkMatchesCursorOnEdgeShapes() {
+    assertEquals(dumpAfterLoad("d-cur-edge", cursorLoader(EDGE_SHAPES)),
+        dumpAfterLoad("d-blk-edge", bulkLoader(EDGE_SHAPES)));
+  }
+
+  @Test
+  @DisplayName("DIFFERENTIAL: bulk assembly ≡ cursor loader on a deeply nested document")
+  void bulkMatchesCursorOnDeepNesting() {
+    // 200 levels: beyond the assembler's initial 64-frame stack (exercises growth) while under
+    // Gson's own 255-deep tokenizer limit, which binds BOTH arms equally.
+    final StringBuilder deep = new StringBuilder(1 << 13);
+    for (int i = 0; i < 200; i++) {
+      deep.append("{\"level").append(i).append("\":");
+    }
+    deep.append("\"bottom\"");
+    deep.append("}".repeat(200));
+    final String json = deep.toString();
+    assertEquals(dumpAfterLoad("d-cur-deep", cursorLoader(json)), dumpAfterLoad("d-blk-deep", bulkLoader(json)));
+  }
+
+  @Test
+  @DisplayName("DIFFERENTIAL: bulk assembly ≡ cursor loader on a top-level array of mixed elements")
+  void bulkMatchesCursorOnTopLevelArray() {
+    final String json = "[1,\"two\",true,null,{\"a\":[]},[3,4],{},[[5]],\"tail\"]";
+    assertEquals(dumpAfterLoad("d-cur-arr", cursorLoader(json)), dumpAfterLoad("d-blk-arr", bulkLoader(json)));
+  }
+
+  /**
+   * The parallel-import arm: same input, chunked through the coordinator/worker pipeline with a
+   * DELIBERATELY tiny chunk budget so even small fixtures exercise many chunks, page-0 stitches
+   * and cross-chunk sibling boundaries.
+   */
+  static Consumer<JsonNodeTrx> parallelLoader(final String json, final int chunkCharBudget) {
+    return wtx -> ParallelBulkJsonImporter.assemble(wtx, new StringReader(json), chunkCharBudget);
+  }
+
+  @Test
+  @DisplayName("PARALLEL DIFFERENTIAL: chunked import ≡ sequential bulk on flat records")
+  void parallelMatchesBulkOnFlatRecords() {
+    assertEquals(dumpAfterLoad("p-seq-flat", bulkLoader(FLAT_RECORDS)),
+        dumpAfterLoad("p-par-flat", parallelLoader(FLAT_RECORDS, 48)));
+  }
+
+  @Test
+  @DisplayName("PARALLEL DIFFERENTIAL: chunked import ≡ sequential bulk on a mixed top-level array")
+  void parallelMatchesBulkOnMixedTopLevelArray() {
+    final String json = "[1,\"two\",true,null,{\"a\":[]},[3,4],{},[[5]],\"tail\"]";
+    assertEquals(dumpAfterLoad("p-seq-mix", bulkLoader(json)), dumpAfterLoad("p-par-mix", parallelLoader(json, 8)));
+  }
+
+  @Test
+  @DisplayName("PARALLEL DIFFERENTIAL: chunked import ≡ sequential bulk across MULTIPLE record pages")
+  void parallelMatchesBulkAcrossPages() {
+    // ~600 members x ~5 nodes each = ~3000 nodes = 3 record pages: exercises whole-page adoption,
+    // the held-tail protocol at chunk boundaries mid-page, and the page-0 prologue stitch.
+    final StringBuilder json = new StringBuilder(1 << 16).append('[');
+    for (int i = 0; i < 600; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"id\":").append(i).append(",\"name\":\"row").append(i).append("\",\"flag\":")
+          .append((i & 1) == 0).append(",\"note\":null}");
+    }
+    final String corpus = json.append(']').toString();
+    assertEquals(dumpAfterLoad("p-seq-pages", bulkLoader(corpus)),
+        dumpAfterLoad("p-par-pages", parallelLoader(corpus, 1024)));
+  }
+
+  @Test
+  @DisplayName("PARALLEL DIFFERENTIAL: single-chunk import (budget larger than input) still matches")
+  void parallelMatchesBulkSingleChunk() {
+    assertEquals(dumpAfterLoad("p-seq-one", bulkLoader(FLAT_RECORDS)),
+        dumpAfterLoad("p-par-one", parallelLoader(FLAT_RECORDS, 1 << 20)));
+  }
+
+  @Test
+  @DisplayName("PARALLEL DIFFERENTIAL: non-array top level falls back to the sequential assembler")
+  void parallelFallsBackOnObjectTopLevel() {
+    final String json = "{\"a\":1,\"b\":[true,false]}";
+    assertEquals(dumpAfterLoad("p-seq-obj", bulkLoader(json)), dumpAfterLoad("p-par-obj", parallelLoader(json, 16)));
+  }
+
+  @Test
+  @DisplayName("UNIFIED ARRAY PATH: sibling arrays share the first-child array's __array__ path class")
+  void siblingArraysShareOnePathClass() {
+    // [[1],[2]] — the second inner array is a SIBLING insert. Before the unification it resolved a
+    // separate "array" path step; now both inner arrays carry the SAME path node key, and both
+    // loaders agree on it.
+    final String json = "[[1],[2],[3]]";
+    final String cursor = dumpAfterLoad("u-cur", cursorLoader(json));
+    final String bulk = dumpAfterLoad("u-blk", bulkLoader(json));
+    assertEquals(cursor, bulk);
+    // Witness the merge itself: the three inner ARRAY lines must carry ONE identical pathNodeKey.
+    final long distinctInnerArrayPcrs = cursor.lines()
+                                              .filter(line -> line.contains("|ARRAY|"))
+                                              .map(line -> line.substring(line.lastIndexOf('|') + 1))
+                                              .skip(1) // the outer array has its own class
+                                              .distinct()
+                                              .count();
+    assertEquals(1, distinctInnerArrayPcrs, "all sibling inner arrays must share one path class");
+  }
+
+  @Test
+  @DisplayName("DIFFERENTIAL: bulk ≡ cursor with intermediate async-flush EPOCHS firing mid-load")
+  void bulkMatchesCursorAcrossEpochs() {
+    // 400 small records under a 64-node auto-commit threshold: both arms rotate intermediate
+    // async-flush epochs many times mid-load, so this pins the assembler's record-boundary epoch
+    // accounting (bulkAccountMutations) against the cursor path's per-insert accounting.
+    final StringBuilder many = new StringBuilder(1 << 14);
+    many.append('[');
+    for (int i = 0; i < 400; i++) {
+      if (i > 0) {
+        many.append(',');
+      }
+      many.append("{\"k").append(i % 7).append("\":").append(i).append(",\"s\":\"v").append(i).append("\"}");
+    }
+    many.append(']');
+    final String json = many.toString();
+    assertEquals(dumpAfterEpochLoad("e-cur", cursorLoader(json)), dumpAfterEpochLoad("e-blk", bulkLoader(json)));
+  }
+
+  /** As {@link #dumpAfterLoad} but with a 64-node KEEP_OPEN_ASYNC_FLUSH auto-commit transaction. */
+  private static String dumpAfterEpochLoad(final String resourceName, final Consumer<JsonNodeTrx> loader) {
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      database.createResource(ResourceConfiguration.newBuilder(resourceName)
+                                                   .useDeweyIDs(false)
+                                                   .hashKind(HashType.NONE)
+                                                   .storeNodeHistory(false)
+                                                   .build());
+      try (JsonResourceSession session = database.beginResourceSession(resourceName)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(64, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          loader.accept(wtx);
+          wtx.commit();
+        }
+        try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+          return canonicalDump(rtx) + summaryDump(session);
+        }
+      }
+    }
+  }
+
+  /** Load {@code json} into a fresh resource via {@code loader}, then produce the canonical dump. */
+  private static String dumpAfterLoad(final String resourceName, final Consumer<JsonNodeTrx> loader) {
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(DATABASE_PATH)) {
+      // NONE hashes + no DeweyIDs: the bulk-import configuration both loaders are compared under
+      // (and the shape the assembler's up-front refusal admits).
+      database.createResource(ResourceConfiguration.newBuilder(resourceName)
+                                                   .useDeweyIDs(false)
+                                                   .hashKind(HashType.NONE)
+                                                   .storeNodeHistory(false)
+                                                   .build());
+      try (JsonResourceSession session = database.beginResourceSession(resourceName)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          loader.accept(wtx);
+          wtx.commit();
+        }
+        try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx()) {
+          return canonicalDump(rtx) + summaryDump(session);
+        }
+      }
+    }
+  }
+
+  /**
+   * The path summary's OWN structural identity, REFERENCE COUNTS included. The per-node dump below
+   * cannot see reference counting — a loader that resolved path classes correctly but deferred or
+   * dropped the per-occurrence reference increments would pass it silently. This section makes the
+   * memoized/delta-counted bulk path falsifiable.
+   */
+  private static String summaryDump(final JsonResourceSession session) {
+    final StringBuilder dump = new StringBuilder(1 << 10);
+    dump.append("--- path summary ---\n");
+    try (PathSummaryReader summary = session.openPathSummary()) {
+      summary.moveToDocumentRoot();
+      final DescendantAxis axis = new DescendantAxis(summary, IncludeSelf.YES);
+      while (axis.hasNext()) {
+        axis.nextLong();
+        if (summary.getNodeKey() == 0) {
+          continue; // the summary root carries no path step
+        }
+        dump.append(summary.getNodeKey())
+            .append('|')
+            .append(summary.getName() == null
+                ? "-"
+                : summary.getName().getLocalName())
+            .append('|')
+            .append(summary.getReferences())
+            .append('\n');
+      }
+    }
+    return dump.toString();
+  }
+
+  /**
+   * One line per node in document order, covering the full structural identity the assembler must
+   * reproduce. Kept deliberately explicit — every field here is an invariant, and a field removed
+   * from this dump is an invariant the oracle silently stops checking.
+   */
+  static String canonicalDump(final JsonNodeReadOnlyTrx rtx) {
+    final StringBuilder dump = new StringBuilder(1 << 12);
+    dump.append("maxNodeKey=").append(rtx.getMaxNodeKey()).append('\n');
+    rtx.moveToDocumentRoot();
+    final DescendantAxis axis = new DescendantAxis(rtx, IncludeSelf.YES);
+    while (axis.hasNext()) {
+      axis.nextLong();
+      final NodeKind kind = rtx.getKind();
+      dump.append(rtx.getNodeKey())
+          .append('|')
+          .append(kind)
+          .append('|')
+          .append(rtx.getName() == null
+              ? "-"
+              : rtx.getName().getLocalName())
+          .append('|')
+          .append(valueOf(rtx, kind))
+          .append('|')
+          .append(rtx.getParentKey())
+          .append('|')
+          .append(rtx.getLeftSiblingKey())
+          .append('|')
+          .append(rtx.getRightSiblingKey())
+          .append('|')
+          .append(rtx.getFirstChildKey())
+          .append('|')
+          .append(rtx.getChildCount())
+          .append('|')
+          .append(rtx.getDescendantCount())
+          .append('|')
+          .append(pathNodeKeyOf(rtx))
+          .append('\n');
+    }
+    return dump.toString();
+  }
+
+  private static String valueOf(final JsonNodeReadOnlyTrx rtx, final NodeKind kind) {
+    return switch (kind) {
+      case STRING_VALUE, NUMBER_VALUE, BOOLEAN_VALUE, OBJECT_NAMED_STRING, OBJECT_NAMED_NUMBER, OBJECT_NAMED_BOOLEAN ->
+        String.valueOf(rtx.getValue());
+      case NULL_VALUE, OBJECT_NAMED_NULL -> "null";
+      default -> "-";
+    };
+  }
+
+  private static String pathNodeKeyOf(final JsonNodeReadOnlyTrx rtx) {
+    try {
+      return String.valueOf(rtx.getPathNodeKey());
+    } catch (final RuntimeException unsupportedForThisKind) {
+      return "-";
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/BulkAssemblyEquivalenceOracleTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/BulkAssemblyEquivalenceOracleTest.java
@@ -196,8 +196,8 @@ final class BulkAssemblyEquivalenceOracleTest {
 
   /**
    * The parallel-import arm: same input, chunked through the coordinator/worker pipeline with a
-   * DELIBERATELY tiny chunk budget so even small fixtures exercise many chunks, page-0 stitches
-   * and cross-chunk sibling boundaries.
+   * DELIBERATELY tiny chunk budget so even small fixtures exercise many chunks, page-0 stitches and
+   * cross-chunk sibling boundaries.
    */
   static Consumer<JsonNodeTrx> parallelLoader(final String json, final int chunkCharBudget) {
     return wtx -> ParallelBulkJsonImporter.assemble(wtx, new StringReader(json), chunkCharBudget);
@@ -227,8 +227,13 @@ final class BulkAssemblyEquivalenceOracleTest {
       if (i > 0) {
         json.append(',');
       }
-      json.append("{\"id\":").append(i).append(",\"name\":\"row").append(i).append("\",\"flag\":")
-          .append((i & 1) == 0).append(",\"note\":null}");
+      json.append("{\"id\":")
+          .append(i)
+          .append(",\"name\":\"row")
+          .append(i)
+          .append("\",\"flag\":")
+          .append((i & 1) == 0)
+          .append(",\"note\":null}");
     }
     final String corpus = json.append(']').toString();
     assertEquals(dumpAfterLoad("p-seq-pages", bulkLoader(corpus)),

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/ParallelBulkPrimitiveIndexEquivalenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/ParallelBulkPrimitiveIndexEquivalenceTest.java
@@ -113,8 +113,8 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
         // Parallel leg: same definitions, worker-collected tuples, adversarial chunking.
         try (JsonNodeTrx wtx = parallelSession.beginNodeTrx()) {
           parallelSession.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(indexDefs(), wtx);
-          ParallelBulkJsonImporter.assembleBytes(wtx,
-              new ByteArrayInputStream(corpus.getBytes(StandardCharsets.UTF_8)), CHUNK_BUDGET_BYTES, BUILDERS);
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus.getBytes(StandardCharsets.UTF_8)),
+              CHUNK_BUDGET_BYTES, BUILDERS);
           wtx.commit();
         }
 
@@ -141,12 +141,9 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
         compareNameProbe(sequentialSession, parallelSession, NAME_SELECTIVE_DEF_NO, "name", 0);
 
         // ==== CAS ====
-        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d3",
-            countDept(3));
-        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d6",
-            countDept(6));
-        compareCasProbe(sequentialSession, parallelSession, CAS_SCORE_DEF_NO, "/[]/score", Type.LON, "300",
-            1);
+        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d3", countDept(3));
+        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d6", countDept(6));
+        compareCasProbe(sequentialSession, parallelSession, CAS_SCORE_DEF_NO, "/[]/score", Type.LON, "300", 1);
         compareCasProbe(sequentialSession, parallelSession, CAS_TAG_ELEMENT_DEF_NO, "/[]/tags/[]", Type.STR, "t7",
             countTagElements("t7"));
         // Strings that cannot convert to xs:long are SKIPPED by both legs, not indexed as garbage.
@@ -166,10 +163,10 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
           JsonNodeTrx wtx = session.beginNodeTrx()) {
         session.getWtxIndexController(wtx.getRevisionNumber())
                .getIndexes()
-               .add(IndexDefs.createValidTimeIdxDef(
-                   Set.of(Path.parse("/[]/from", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON));
-        final IllegalStateException refusal = assertThrows(IllegalStateException.class,
-            () -> ParallelBulkJsonImporter.assembleBytes(wtx,
+               .add(IndexDefs.createValidTimeIdxDef(Set.of(Path.parse("/[]/from", PathParser.Type.JSON)), 0,
+                   IndexDef.DbType.JSON));
+        final IllegalStateException refusal =
+            assertThrows(IllegalStateException.class, () -> ParallelBulkJsonImporter.assembleBytes(wtx,
                 new ByteArrayInputStream(corpus().getBytes(StandardCharsets.UTF_8)), CHUNK_BUDGET_BYTES, 1));
         assertTrue(refusal.getMessage().contains("valid-time"),
             "expected the exact valid-time refusal, got: " + refusal.getMessage());
@@ -179,8 +176,8 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
 
   // ==== probes =================================================================================
 
-  private void comparePathProbe(final JsonResourceSession sequentialSession,
-      final JsonResourceSession parallelSession, final int defNumber, final String path, final int expectedCount) {
+  private void comparePathProbe(final JsonResourceSession sequentialSession, final JsonResourceSession parallelSession,
+      final int defNumber, final String path, final int expectedCount) {
     final TreeSet<Long> sequential = pathProbe(sequentialSession, defNumber, path);
     final TreeSet<Long> parallel = pathProbe(parallelSession, defNumber, path);
     assertEquals(expectedCount, sequential.size(),
@@ -188,8 +185,8 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
     assertEquals(sequential, parallel, "PATH probe " + path + " (def " + defNumber + ") differs across arms");
   }
 
-  private void compareNameProbe(final JsonResourceSession sequentialSession,
-      final JsonResourceSession parallelSession, final int defNumber, final String name, final int expectedCount) {
+  private void compareNameProbe(final JsonResourceSession sequentialSession, final JsonResourceSession parallelSession,
+      final int defNumber, final String name, final int expectedCount) {
     final TreeSet<Long> sequential = nameProbe(sequentialSession, defNumber, name);
     final TreeSet<Long> parallel = nameProbe(parallelSession, defNumber, name);
     assertEquals(expectedCount, sequential.size(),
@@ -197,9 +194,8 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
     assertEquals(sequential, parallel, "NAME probe " + name + " (def " + defNumber + ") differs across arms");
   }
 
-  private void compareCasProbe(final JsonResourceSession sequentialSession,
-      final JsonResourceSession parallelSession, final int defNumber, final String path, final Type type,
-      final String lexicalValue, final int expectedCount) {
+  private void compareCasProbe(final JsonResourceSession sequentialSession, final JsonResourceSession parallelSession,
+      final int defNumber, final String path, final Type type, final String lexicalValue, final int expectedCount) {
     final TreeSet<Long> sequential = casProbe(sequentialSession, defNumber, path, type, lexicalValue);
     final TreeSet<Long> parallel = casProbe(parallelSession, defNumber, path, type, lexicalValue);
     assertEquals(expectedCount, sequential.size(), "sequential CAS probe " + path + " = " + lexicalValue + " (def "
@@ -223,13 +219,15 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
       final IndexDef indexDef = controller.getIndexes().getIndexDef(defNumber, IndexType.NAME);
       if (indexDef == null) {
         throw new IllegalStateException("NAME def " + defNumber + " missing after reopen; registry holds: "
-            + controller.getIndexes().getIndexDefs().stream()
+            + controller.getIndexes()
+                        .getIndexDefs()
+                        .stream()
                         .map(def -> def.getType() + "#" + def.getID())
                         .sorted()
                         .toList());
       }
-      return collect(controller.openNameIndex(trx.getStorageEngineReader(), indexDef,
-          controller.createNameFilter(Set.of(name))));
+      return collect(
+          controller.openNameIndex(trx.getStorageEngineReader(), indexDef, controller.createNameFilter(Set.of(name))));
     }
   }
 
@@ -272,14 +270,12 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
   }
 
   private static Set<IndexDef> indexDefs() {
-    return Set.of(
-        IndexDefs.createPathIdxDef(Set.of(), PATH_ALL_DEF_NO, IndexDef.DbType.JSON),
+    return Set.of(IndexDefs.createPathIdxDef(Set.of(), PATH_ALL_DEF_NO, IndexDef.DbType.JSON),
         IndexDefs.createPathIdxDef(
             Set.of(Path.parse("/[]/tags", PathParser.Type.JSON), Path.parse("/[]/nested", PathParser.Type.JSON)),
             PATH_SELECTIVE_DEF_NO, IndexDef.DbType.JSON),
         IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON),
-        IndexDefs.createSelectiveNameIdxDef(Set.of(new QNm("dept"), new QNm("latecomer")), 1,
-            IndexDef.DbType.JSON),
+        IndexDefs.createSelectiveNameIdxDef(Set.of(new QNm("dept"), new QNm("latecomer")), 1, IndexDef.DbType.JSON),
         IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/dept", PathParser.Type.JSON)),
             CAS_DEPT_DEF_NO, IndexDef.DbType.JSON),
         IndexDefs.createCASIdxDef(false, Type.LON, Set.of(Path.parse("/[]/score", PathParser.Type.JSON)),
@@ -294,8 +290,8 @@ final class ParallelBulkPrimitiveIndexEquivalenceTest {
 
   /**
    * Same adversarial shape as the projection equivalence corpus: varying record widths, absent
-   * fields, a nested object, a named string array, and a field whose FIRST occurrence is in the
-   * last quarter of the records.
+   * fields, a nested object, a named string array, and a field whose FIRST occurrence is in the last
+   * quarter of the records.
    */
   private static String corpus() {
     final StringBuilder json = new StringBuilder(RECORDS * 160);

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/ParallelBulkPrimitiveIndexEquivalenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/node/json/ParallelBulkPrimitiveIndexEquivalenceTest.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.access.trx.node.json;
+
+import io.brackit.query.atomic.Atomic;
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.atomic.Str;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.AtomicUtil;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.IndexType;
+import io.sirix.index.SearchMode;
+import io.sirix.index.path.json.JsonPCRCollector;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.roaringbitmap.longlong.LongIterator;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Seam-1 gate: a PARALLEL bulk import with PATH/CAS/NAME indexes catalogued must answer index
+ * queries identically to a SEQUENTIAL import of the same corpus — the sequential path maintains
+ * those families through per-node change notifications, which is the semantics oracle the parallel
+ * importer's worker-collected tuple feed has to reproduce.
+ *
+ * <p>
+ * Every probe is checked THREE ways: the two arms must agree with each other AND with the exact
+ * count the corpus generator's arithmetic predicts — a defect that empties or inflates both arms
+ * identically cannot pass. The corpus is adversarial by construction: tiny chunks force boundaries
+ * mid-page, a field name first occurs only in the LAST quarter of the records (so its path class
+ * and dictionary key are minted many chunks in), a named array exercises the OBJECT_NAMED_ARRAY
+ * dual-role mirror entry, array elements exercise CAS over plain value nodes, and a mistyped CAS
+ * definition exercises the skip-on-conversion-failure lane.
+ */
+final class ParallelBulkPrimitiveIndexEquivalenceTest {
+
+  private static final java.nio.file.Path SEQUENTIAL_DB_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+  private static final java.nio.file.Path PARALLEL_DB_PATH = JsonTestHelper.PATHS.PATH2.getFile();
+
+  private static final int RECORDS = 4000;
+  private static final int CHUNK_BUDGET_BYTES = 6 * 1024;
+  private static final int BUILDERS = 4;
+
+  // Definition numbers are DENSE PER TYPE — the NamePage-backed dictionaries key sub-structures by
+  // definition number within a family, and sparse numbering leaves gapped offsets no commit can
+  // serialize.
+  private static final int PATH_ALL_DEF_NO = 0;
+  private static final int PATH_SELECTIVE_DEF_NO = 1;
+  // The NAME factory shifts ids into its own offset space — derive the effective ids from it
+  // rather than assuming the raw numbers.
+  private static final int NAME_ALL_DEF_NO = IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON).getID();
+  private static final int NAME_SELECTIVE_DEF_NO =
+      IndexDefs.createSelectiveNameIdxDef(Set.of(new QNm("dept")), 1, IndexDef.DbType.JSON).getID();
+  private static final int CAS_DEPT_DEF_NO = 0;
+  private static final int CAS_SCORE_DEF_NO = 1;
+  private static final int CAS_TAG_ELEMENT_DEF_NO = 2;
+  private static final int CAS_MISTYPED_DEF_NO = 3;
+  /** A definition whose path FIRST EXISTS many chunks in — pins the stale-path-class-cache defect. */
+  private static final int CAS_LATECOMER_DEF_NO = 4;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void aParallelImportAnswersIndexQueriesLikeASequentialImport() throws IOException {
+    final String corpus = corpus();
+
+    try (Database<JsonResourceSession> sequentialDb = createDatabase(SEQUENTIAL_DB_PATH);
+        Database<JsonResourceSession> parallelDb = createDatabase(PARALLEL_DB_PATH)) {
+      try (JsonResourceSession sequentialSession = sequentialDb.beginResourceSession(JsonTestHelper.RESOURCE);
+          JsonResourceSession parallelSession = parallelDb.beginResourceSession(JsonTestHelper.RESOURCE)) {
+
+        // Sequential oracle leg: catalogue the definitions on the EMPTY resource, then shred with
+        // the notifying bulk sink — the listeners maintain every family per node.
+        try (JsonNodeTrx wtx = sequentialSession.beginNodeTrx()) {
+          sequentialSession.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(indexDefs(), wtx);
+          BulkJsonTreeAssembler.assemble(wtx, new StringReader(corpus));
+          wtx.commit();
+        }
+
+        // Parallel leg: same definitions, worker-collected tuples, adversarial chunking.
+        try (JsonNodeTrx wtx = parallelSession.beginNodeTrx()) {
+          parallelSession.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(indexDefs(), wtx);
+          ParallelBulkJsonImporter.assembleBytes(wtx,
+              new ByteArrayInputStream(corpus.getBytes(StandardCharsets.UTF_8)), CHUNK_BUDGET_BYTES, BUILDERS);
+          wtx.commit();
+        }
+
+        // ==== PATH ====
+        // The index-everything definition: the top-level array is the coordinator-fed entry the
+        // workers never see; "/[]/dept" covers one fused field per record.
+        comparePathProbe(sequentialSession, parallelSession, PATH_ALL_DEF_NO, "/[]", 1);
+        comparePathProbe(sequentialSession, parallelSession, PATH_ALL_DEF_NO, "/[]/dept", RECORDS);
+        comparePathProbe(sequentialSession, parallelSession, PATH_ALL_DEF_NO, "/[]/nested", countNested());
+        comparePathProbe(sequentialSession, parallelSession, PATH_ALL_DEF_NO, "/[]/latecomer", countLatecomer());
+        // The selective definition resolves "/[]/tags" at the OBJECT_KEY layer, which only the
+        // OBJECT_NAMED_ARRAY dual-role MIRROR entry serves.
+        comparePathProbe(sequentialSession, parallelSession, PATH_SELECTIVE_DEF_NO, "/[]/tags", countTagRecords());
+        comparePathProbe(sequentialSession, parallelSession, PATH_SELECTIVE_DEF_NO, "/[]/nested", countNested());
+
+        // ==== NAME ====
+        compareNameProbe(sequentialSession, parallelSession, NAME_ALL_DEF_NO, "dept", RECORDS);
+        compareNameProbe(sequentialSession, parallelSession, NAME_ALL_DEF_NO, "tags", countTagRecords());
+        compareNameProbe(sequentialSession, parallelSession, NAME_ALL_DEF_NO, "inner", countNested());
+        compareNameProbe(sequentialSession, parallelSession, NAME_ALL_DEF_NO, "latecomer", countLatecomer());
+        compareNameProbe(sequentialSession, parallelSession, NAME_SELECTIVE_DEF_NO, "dept", RECORDS);
+        compareNameProbe(sequentialSession, parallelSession, NAME_SELECTIVE_DEF_NO, "latecomer", countLatecomer());
+        // Not included in the selective definition — present in the corpus, absent from the index.
+        compareNameProbe(sequentialSession, parallelSession, NAME_SELECTIVE_DEF_NO, "name", 0);
+
+        // ==== CAS ====
+        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d3",
+            countDept(3));
+        compareCasProbe(sequentialSession, parallelSession, CAS_DEPT_DEF_NO, "/[]/dept", Type.STR, "d6",
+            countDept(6));
+        compareCasProbe(sequentialSession, parallelSession, CAS_SCORE_DEF_NO, "/[]/score", Type.LON, "300",
+            1);
+        compareCasProbe(sequentialSession, parallelSession, CAS_TAG_ELEMENT_DEF_NO, "/[]/tags/[]", Type.STR, "t7",
+            countTagElements("t7"));
+        // Strings that cannot convert to xs:long are SKIPPED by both legs, not indexed as garbage.
+        compareCasProbe(sequentialSession, parallelSession, CAS_MISTYPED_DEF_NO, "/[]/name", Type.LON, "5", 0);
+        // The definition's path acquires a path CLASS only in the last quarter of the load — a
+        // stale resolved-path cache in any drained builder would leave this probe empty.
+        compareCasProbe(sequentialSession, parallelSession, CAS_LATECOMER_DEF_NO, "/[]/latecomer", Type.STR, "L5",
+            countLatecomerValue("L5"));
+      }
+    }
+  }
+
+  @Test
+  void aValidTimeIndexStillRefusesWithTheExactFamilyMessage() throws IOException {
+    try (Database<JsonResourceSession> db = createDatabase(SEQUENTIAL_DB_PATH)) {
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+          JsonNodeTrx wtx = session.beginNodeTrx()) {
+        session.getWtxIndexController(wtx.getRevisionNumber())
+               .getIndexes()
+               .add(IndexDefs.createValidTimeIdxDef(
+                   Set.of(Path.parse("/[]/from", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON));
+        final IllegalStateException refusal = assertThrows(IllegalStateException.class,
+            () -> ParallelBulkJsonImporter.assembleBytes(wtx,
+                new ByteArrayInputStream(corpus().getBytes(StandardCharsets.UTF_8)), CHUNK_BUDGET_BYTES, 1));
+        assertTrue(refusal.getMessage().contains("valid-time"),
+            "expected the exact valid-time refusal, got: " + refusal.getMessage());
+      }
+    }
+  }
+
+  // ==== probes =================================================================================
+
+  private void comparePathProbe(final JsonResourceSession sequentialSession,
+      final JsonResourceSession parallelSession, final int defNumber, final String path, final int expectedCount) {
+    final TreeSet<Long> sequential = pathProbe(sequentialSession, defNumber, path);
+    final TreeSet<Long> parallel = pathProbe(parallelSession, defNumber, path);
+    assertEquals(expectedCount, sequential.size(),
+        "sequential PATH probe " + path + " (def " + defNumber + ") disagrees with the corpus arithmetic");
+    assertEquals(sequential, parallel, "PATH probe " + path + " (def " + defNumber + ") differs across arms");
+  }
+
+  private void compareNameProbe(final JsonResourceSession sequentialSession,
+      final JsonResourceSession parallelSession, final int defNumber, final String name, final int expectedCount) {
+    final TreeSet<Long> sequential = nameProbe(sequentialSession, defNumber, name);
+    final TreeSet<Long> parallel = nameProbe(parallelSession, defNumber, name);
+    assertEquals(expectedCount, sequential.size(),
+        "sequential NAME probe " + name + " (def " + defNumber + ") disagrees with the corpus arithmetic");
+    assertEquals(sequential, parallel, "NAME probe " + name + " (def " + defNumber + ") differs across arms");
+  }
+
+  private void compareCasProbe(final JsonResourceSession sequentialSession,
+      final JsonResourceSession parallelSession, final int defNumber, final String path, final Type type,
+      final String lexicalValue, final int expectedCount) {
+    final TreeSet<Long> sequential = casProbe(sequentialSession, defNumber, path, type, lexicalValue);
+    final TreeSet<Long> parallel = casProbe(parallelSession, defNumber, path, type, lexicalValue);
+    assertEquals(expectedCount, sequential.size(), "sequential CAS probe " + path + " = " + lexicalValue + " (def "
+        + defNumber + ") disagrees with the corpus arithmetic");
+    assertEquals(sequential, parallel,
+        "CAS probe " + path + " = " + lexicalValue + " (def " + defNumber + ") differs across arms");
+  }
+
+  private TreeSet<Long> pathProbe(final JsonResourceSession session, final int defNumber, final String path) {
+    try (JsonNodeTrx trx = session.beginNodeTrx()) {
+      final JsonIndexController controller = session.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef indexDef = controller.getIndexes().getIndexDef(defNumber, IndexType.PATH);
+      return collect(controller.openPathIndex(trx.getStorageEngineReader(), indexDef,
+          controller.createPathFilter(Set.of(path), trx)));
+    }
+  }
+
+  private TreeSet<Long> nameProbe(final JsonResourceSession session, final int defNumber, final String name) {
+    try (JsonNodeTrx trx = session.beginNodeTrx()) {
+      final JsonIndexController controller = session.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef indexDef = controller.getIndexes().getIndexDef(defNumber, IndexType.NAME);
+      if (indexDef == null) {
+        throw new IllegalStateException("NAME def " + defNumber + " missing after reopen; registry holds: "
+            + controller.getIndexes().getIndexDefs().stream()
+                        .map(def -> def.getType() + "#" + def.getID())
+                        .sorted()
+                        .toList());
+      }
+      return collect(controller.openNameIndex(trx.getStorageEngineReader(), indexDef,
+          controller.createNameFilter(Set.of(name))));
+    }
+  }
+
+  private TreeSet<Long> casProbe(final JsonResourceSession session, final int defNumber, final String path,
+      final Type type, final String lexicalValue) {
+    try (JsonNodeTrx trx = session.beginNodeTrx()) {
+      final JsonIndexController controller = session.getWtxIndexController(trx.getRevisionNumber());
+      final IndexDef indexDef = controller.getIndexes().getIndexDef(defNumber, IndexType.CAS);
+      final Atomic probeKey = type == Type.STR
+          ? new Str(lexicalValue)
+          : AtomicUtil.toType(new Str(lexicalValue), type);
+      return collect(controller.openCASIndex(trx.getStorageEngineReader(), indexDef,
+          controller.createCASFilter(Set.of(path), probeKey, SearchMode.EQUAL, new JsonPCRCollector(trx))));
+    }
+  }
+
+  private static TreeSet<Long> collect(final Iterator<NodeReferences> hits) {
+    final TreeSet<Long> nodeKeys = new TreeSet<>();
+    while (hits.hasNext()) {
+      final LongIterator nodeKeyIterator = hits.next().getNodeKeys().getLongIterator();
+      while (nodeKeyIterator.hasNext()) {
+        nodeKeys.add(nodeKeyIterator.next());
+      }
+    }
+    return nodeKeys;
+  }
+
+  // ==== fixtures ===============================================================================
+
+  private static Database<JsonResourceSession> createDatabase(final java.nio.file.Path databasePath) {
+    Databases.createJsonDatabase(new DatabaseConfiguration(databasePath));
+    final Database<JsonResourceSession> database = Databases.openJsonDatabase(databasePath);
+    database.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                                 .useDeweyIDs(false)
+                                                 .hashKind(HashType.NONE)
+                                                 .storeNodeHistory(false)
+                                                 .buildPathSummary(true)
+                                                 .build());
+    return database;
+  }
+
+  private static Set<IndexDef> indexDefs() {
+    return Set.of(
+        IndexDefs.createPathIdxDef(Set.of(), PATH_ALL_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createPathIdxDef(
+            Set.of(Path.parse("/[]/tags", PathParser.Type.JSON), Path.parse("/[]/nested", PathParser.Type.JSON)),
+            PATH_SELECTIVE_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON),
+        IndexDefs.createSelectiveNameIdxDef(Set.of(new QNm("dept"), new QNm("latecomer")), 1,
+            IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/dept", PathParser.Type.JSON)),
+            CAS_DEPT_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.LON, Set.of(Path.parse("/[]/score", PathParser.Type.JSON)),
+            CAS_SCORE_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/tags/[]", PathParser.Type.JSON)),
+            CAS_TAG_ELEMENT_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.LON, Set.of(Path.parse("/[]/name", PathParser.Type.JSON)),
+            CAS_MISTYPED_DEF_NO, IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/latecomer", PathParser.Type.JSON)),
+            CAS_LATECOMER_DEF_NO, IndexDef.DbType.JSON));
+  }
+
+  /**
+   * Same adversarial shape as the projection equivalence corpus: varying record widths, absent
+   * fields, a nested object, a named string array, and a field whose FIRST occurrence is in the
+   * last quarter of the records.
+   */
+  private static String corpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * 160);
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"name\":\"n").append(record).append('-').append("x".repeat(record % 17)).append('"');
+      json.append(",\"dept\":\"d").append(record % 7).append('"');
+      json.append(",\"score\":").append(record * 3L);
+      json.append(",\"active\":").append((record & 1) == 0);
+      if (record % 3 == 0) {
+        json.append(",\"tags\":[\"t").append(record % 11).append("\",\"t").append(record % 13).append("\"]");
+      }
+      if (record % 4 == 0) {
+        json.append(",\"nested\":{\"inner\":").append(record * 2L).append('}');
+      }
+      if (record >= RECORDS - RECORDS / 4) {
+        json.append(",\"latecomer\":\"L").append(record % 23).append('"');
+      }
+      json.append('}');
+    }
+    return json.append(']').toString();
+  }
+
+  private static int countDept(final int deptModulo) {
+    int count = 0;
+    for (int record = 0; record < RECORDS; record++) {
+      if (record % 7 == deptModulo) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int countTagRecords() {
+    int count = 0;
+    for (int record = 0; record < RECORDS; record++) {
+      if (record % 3 == 0) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int countTagElements(final String tag) {
+    int count = 0;
+    for (int record = 0; record < RECORDS; record++) {
+      if (record % 3 != 0) {
+        continue;
+      }
+      if (("t" + record % 11).equals(tag)) {
+        count++;
+      }
+      if (("t" + record % 13).equals(tag)) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int countNested() {
+    int count = 0;
+    for (int record = 0; record < RECORDS; record++) {
+      if (record % 4 == 0) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private static int countLatecomer() {
+    return RECORDS / 4;
+  }
+
+  private static int countLatecomerValue(final String value) {
+    int count = 0;
+    for (int record = RECORDS - RECORDS / 4; record < RECORDS; record++) {
+      if (("L" + record % 23).equals(value)) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/page/AsyncFlushHftPhaseTelemetryTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/page/AsyncFlushHftPhaseTelemetryTest.java
@@ -91,6 +91,24 @@ final class AsyncFlushHftPhaseTelemetryTest {
         "hftMaxForegroundFlushNanos"));
     assertTrue(booleanField(measuredWriter, "hftMaxWorkerEpochDataGrowExact"));
     assertTrue(booleanField(measuredWriter, "hftMaxBlockedEpochDataGrowExact"));
+
+    // The per-epoch tuples above retain the slowest and the most-blocking epoch, which on a bulk
+    // import is the JIT-warm-up epoch in both cases; the run totals are what attributes the steady
+    // state. Each total sums every worker run INCLUDING the retained maximum, so it can never be
+    // smaller than it — an accumulation that is dropped or wired to the wrong phase reads as zero
+    // against a positive maximum and fails here rather than silently reporting a flat profile.
+    assertTrue(longField(measuredWriter, "hftSerializeJoinWaitNanosTotal") >= longField(measuredWriter,
+        "hftMaxWorkerEpochSerializeJoinWaitNanos"), "serialize-join total must cover the slowest epoch's share");
+    assertTrue(longField(measuredWriter, "hftKvlAppendNanosTotal") >= longField(measuredWriter,
+        "hftMaxWorkerEpochKvlAppendNanos"), "KVL-append total must cover the slowest epoch's share");
+    assertTrue(longField(measuredWriter, "hftSideNanosTotal") >= longField(measuredWriter,
+        "hftMaxWorkerEpochSideNanos"), "side-page total must cover the slowest epoch's share");
+    assertTrue(longField(measuredWriter, "hftFinalFlushNanosTotal") >= longField(measuredWriter,
+        "hftMaxWorkerEpochFinalFlushNanos"), "final-flush total must cover the slowest epoch's share");
+    // Both phases run in every combined epoch, so with more than one epoch the totals must exceed
+    // any single epoch's contribution rather than merely equal the retained maximum.
+    assertTrue(longField(measuredWriter, "hftKvlAppendNanosTotal") > longField(measuredWriter,
+        "hftMaxWorkerEpochKvlAppendNanos"), "several epochs appended, so the total must exceed one epoch");
   }
 
   @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/access/trx/page/AsyncFlushHftPhaseTelemetryTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/access/trx/page/AsyncFlushHftPhaseTelemetryTest.java
@@ -101,8 +101,9 @@ final class AsyncFlushHftPhaseTelemetryTest {
         "hftMaxWorkerEpochSerializeJoinWaitNanos"), "serialize-join total must cover the slowest epoch's share");
     assertTrue(longField(measuredWriter, "hftKvlAppendNanosTotal") >= longField(measuredWriter,
         "hftMaxWorkerEpochKvlAppendNanos"), "KVL-append total must cover the slowest epoch's share");
-    assertTrue(longField(measuredWriter, "hftSideNanosTotal") >= longField(measuredWriter,
-        "hftMaxWorkerEpochSideNanos"), "side-page total must cover the slowest epoch's share");
+    assertTrue(
+        longField(measuredWriter, "hftSideNanosTotal") >= longField(measuredWriter, "hftMaxWorkerEpochSideNanos"),
+        "side-page total must cover the slowest epoch's share");
     assertTrue(longField(measuredWriter, "hftFinalFlushNanosTotal") >= longField(measuredWriter,
         "hftMaxWorkerEpochFinalFlushNanos"), "final-flush total must cover the slowest epoch's share");
     // Both phases run in every combined epoch, so with more than one epoch the totals must exceed

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
@@ -645,4 +645,21 @@ class FrameSlotAllocatorTest {
     assertEquals(slotSize, allocator.getPhysicalMemoryBytes());
   }
 
+  @Test
+  void slabCommitmentCannotStarveTheOversizedHeadroom() {
+    final long budget = 256L * 1024 * 1024;
+    final long headroom = allocator.oversizedHeadroomBytes();
+    assertEquals(budget / 16, headroom, "default headroom is 1/16th of the budget");
+    // Drive the slab arm to its cap: slab commitments are permanent until shutdown, so they must
+    // refuse beyond budget − headroom…
+    assertTrue(allocator.reserveSlabCommittedBytes(budget - headroom));
+    assertFalse(allocator.reserveSlabCommittedBytes(1),
+        "slab commitment must stop short of the oversized headroom");
+    // …while the oversized arm still admits inside the headroom — the retry that could never say
+    // yes after a slab peak now can.
+    assertTrue(allocator.reserveCommittedBytes(headroom),
+        "an oversized reservation must succeed inside the headroom at slab peak");
+    assertFalse(allocator.reserveCommittedBytes(1), "the full budget is then exhausted");
+  }
+
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/cache/FrameSlotAllocatorTest.java
@@ -653,8 +653,7 @@ class FrameSlotAllocatorTest {
     // Drive the slab arm to its cap: slab commitments are permanent until shutdown, so they must
     // refuse beyond budget − headroom…
     assertTrue(allocator.reserveSlabCommittedBytes(budget - headroom));
-    assertFalse(allocator.reserveSlabCommittedBytes(1),
-        "slab commitment must stop short of the oversized headroom");
+    assertFalse(allocator.reserveSlabCommittedBytes(1), "slab commitment must stop short of the oversized headroom");
     // …while the oversized arm still admits inside the headroom — the retry that could never say
     // yes after a slab peak now can.
     assertTrue(allocator.reserveCommittedBytes(headroom),

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/BetaIsDiscBitRoutingProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/BetaIsDiscBitRoutingProbe.java
@@ -136,7 +136,15 @@ final class BetaIsDiscBitRoutingProbe {
         bc.nodeRef.setPage(foldedNode);
 
         // ---- Q1: STRICT no-fallback routing of K from the real root ----
-        final HOTLeafPage routed = strictDescend(root, k);
+        // Depth-0 folds replace the ROOT itself: the real writer re-points the spine
+        // reference and every later descent goes through it, but this probe's `root` is a
+        // plain Page variable — descending the stale pre-fold object would report a false
+        // misroute. (Unreachable before the highest-fitting-subtree leaf cut: canonical
+        // roots were always FULL and full nodes divert to the Q4 decomposition.)
+        final Page descentRoot = bc.node == root
+            ? foldedNode
+            : root;
+        final HOTLeafPage routed = strictDescend(descentRoot, k);
         if (routed != null && routed.findEntry(k) >= 0) {
           strictRouteOk++;
         } else {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/BetaIsDiscBitRoutingProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/BetaIsDiscBitRoutingProbe.java
@@ -25,14 +25,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Decisive empirical probe for the HOT branch-insert {@code betaIsDiscBit} case.
  *
- * <p>Goal — settle whether {@link HOTIncrementalInsert#addChildAtCombination} (the not-full
+ * <p>
+ * Goal — settle whether {@link HOTIncrementalInsert#addChildAtCombination} (the not-full
  * {@code betaIsDiscBit} path) is genuinely routing-correct under STRICT, no-fallback root-to-leaf
  * {@link HOTIndirectPage#findChildIndex} descent, and whether the canonical {@link HOTBulkBuilder}
  * tree of the same key set both routes 100% and contains a child at exactly {@code comboPartial}.
  *
- * <p>The probe faithfully replicates {@code AbstractHOTIndexWriter.tryBranchIncremental}'s
- * {@code betaIsDiscBit} branch: it builds a canonical HOT, picks a fresh in-range key K, performs
- * a real strict descent to a leaf, runs {@link HOTIncrementalInsert#analyzeDescent} +
+ * <p>
+ * The probe faithfully replicates {@code AbstractHOTIndexWriter.tryBranchIncremental}'s
+ * {@code betaIsDiscBit} branch: it builds a canonical HOT, picks a fresh in-range key K, performs a
+ * real strict descent to a leaf, runs {@link HOTIncrementalInsert#analyzeDescent} +
  * {@link HOTIncrementalInsert#getInsertInformation}, and — when {@code info.betaIsDiscBit()} and
  * the insert-depth node is not full — computes {@code comboPartial} exactly as the writer does,
  * folds K's leaf via {@code addChildAtCombination}, and verifies the result.
@@ -69,8 +71,8 @@ final class BetaIsDiscBitRoutingProbe {
 
     for (final KeySet ks : sets) {
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(ks.keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(ks.keys), 1, IndexType.CAS, allocator::getAndIncrement);
       Page root = built.rootPage();
       if (!(root instanceof HOTIndirectPage)) {
         closeLeaves(root);
@@ -106,9 +108,12 @@ final class BetaIsDiscBitRoutingProbe {
         // ---- replicate tryBranchIncremental's comboPartial exactly ----
         final int[] nodeDiscBits = HOTIncrementalInsert.discriminativeBits(bc.node);
         final int betaColumn = java.util.Arrays.binarySearch(nodeDiscBits, bc.analysis.mismatchBit());
-        final int betaValue = HOTBulkBuilder.bitAt(k, bc.analysis.mismatchBit()) ? 1 : 0;
-        final int comboPartial = bc.info.subtreePrefix()
-            | (betaValue == 1 ? 1 << (nodeDiscBits.length - 1 - betaColumn) : 0);
+        final int betaValue = HOTBulkBuilder.bitAt(k, bc.analysis.mismatchBit())
+            ? 1
+            : 0;
+        final int comboPartial = bc.info.subtreePrefix() | (betaValue == 1
+            ? 1 << (nodeDiscBits.length - 1 - betaColumn)
+            : 0);
 
         // ---- Q2: comboPartial vs K's real densePK at this node ----
         final int densePK = bc.node.computeDensePartialKey(k);
@@ -124,8 +129,8 @@ final class BetaIsDiscBitRoutingProbe {
         assertTrue(comboLeaf.put(k, VALUE), "fresh single-entry leaf must accept the key");
         final HOTIndirectPage foldedNode;
         try {
-          foldedNode = HOTIncrementalInsert.addChildAtCombination(bc.node, comboPartial,
-              swizzle(comboLeaf), bc.node.getHeight(), 1, allocator::getAndIncrement);
+          foldedNode = HOTIncrementalInsert.addChildAtCombination(bc.node, comboPartial, swizzle(comboLeaf),
+              bc.node.getHeight(), 1, allocator::getAndIncrement);
         } catch (IllegalArgumentException dup) {
           // comboPartial already a child partial — addChildAtCombination rejects it.
           comboLeaf.close();
@@ -157,10 +162,10 @@ final class BetaIsDiscBitRoutingProbe {
                 "[%s] K=%s MISROUTE: node discBits=%s comboPartial=0x%x densePK=0x%x "
                     + "betaCol=%d betaVal=%d | findChildIndex->slot %d (partial 0x%x) "
                     + "comboLeafSlot has partial 0x%x | nodePartials=%s",
-                ks.name, HEX.formatHex(k), java.util.Arrays.toString(nodeDiscBits),
-                comboPartial, densePK, betaColumn, betaValue, chosen,
-                chosen >= 0 && partials != null && chosen < partials.length
-                    ? partials[chosen] : -1,
+                ks.name, HEX.formatHex(k), java.util.Arrays.toString(nodeDiscBits), comboPartial, densePK, betaColumn,
+                betaValue, chosen, chosen >= 0 && partials != null && chosen < partials.length
+                    ? partials[chosen]
+                    : -1,
                 comboPartial, partialsHex(partials)));
           }
         }
@@ -172,19 +177,20 @@ final class BetaIsDiscBitRoutingProbe {
     }
 
     System.out.println("=== Q1/Q2 — not-full betaIsDiscBit addChildAtCombination ===");
-    System.out.printf("  betaIsDiscBit firings=%d | not-full cases folded=%d%n",
-        betaIsDiscBitFirings, notFullCases);
+    System.out.printf("  betaIsDiscBit firings=%d | not-full cases folded=%d%n", betaIsDiscBitFirings, notFullCases);
     System.out.println("  d* child-count histogram at firings: " + childCountHistogram);
     System.out.printf("  Q2: comboPartial == densePK : %d%n", comboEqualsDensePK);
     System.out.printf("  Q2: comboPartial STRICT-SUBSET of densePK : %d%n", comboSubsetOfDensePK);
-    System.out.printf("  Q1: strict route OK=%d | strict MISROUTES=%d%n",
-        strictRouteOk, strictMisroutes);
+    System.out.printf("  Q1: strict route OK=%d | strict MISROUTES=%d%n", strictRouteOk, strictMisroutes);
     for (final String d : misrouteDetails) {
       System.out.println("  " + d);
     }
-    System.out.println("  DECISIVE: not-full betaIsDiscBit routes 100% strict = "
-        + (strictMisroutes == 0 && notFullCases > 0 ? "YES" : strictMisroutes > 0 ? "NO"
-            : "INCONCLUSIVE (no case)"));
+    System.out.println(
+        "  DECISIVE: not-full betaIsDiscBit routes 100% strict = " + (strictMisroutes == 0 && notFullCases > 0
+            ? "YES"
+            : strictMisroutes > 0
+                ? "NO"
+                : "INCONCLUSIVE (no case)"));
     assertTrue(notFullCases > 0, "no not-full betaIsDiscBit case exercised — coverage gap");
     assertTrue(strictMisroutes == 0,
         "not-full betaIsDiscBit addChildAtCombination misrouted " + strictMisroutes + " keys");
@@ -194,9 +200,9 @@ final class BetaIsDiscBitRoutingProbe {
   // Q4 — full-node betaIsDiscBit: the splitIndirect decomposition.
   //
   // For a FULL node where betaIsDiscBit fires, the rebuild fallback can be replaced by:
-  //   splitIndirect(node) -> BiNode on node.MSB; the two halves are not-full;
-  //   K routes (by node.MSB) into one half; addChildAtCombination into that half;
-  //   reassemble the BiNode.
+  // splitIndirect(node) -> BiNode on node.MSB; the two halves are not-full;
+  // K routes (by node.MSB) into one half; addChildAtCombination into that half;
+  // reassemble the BiNode.
   // This probe builds that decomposition and verifies strict routing of K + every key,
   // and cross-checks against HOTBulkBuilder of the same key set.
   // ====================================================================
@@ -222,8 +228,8 @@ final class BetaIsDiscBitRoutingProbe {
 
     for (final KeySet ks : sets) {
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(ks.keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(ks.keys), 1, IndexType.CAS, allocator::getAndIncrement);
       final Page root = built.rootPage();
       if (!(root instanceof HOTIndirectPage)) {
         closeLeaves(root);
@@ -239,14 +245,15 @@ final class BetaIsDiscBitRoutingProbe {
           break;
         }
         final BetaCase bc = analyzeBetaCase(root, k);
-        if (bc == null || !bc.info.betaIsDiscBit()
-            || bc.node.getNumChildren() < HOTIndirectPage.MAX_NODE_ENTRIES) {
+        if (bc == null || !bc.info.betaIsDiscBit() || bc.node.getNumChildren() < HOTIndirectPage.MAX_NODE_ENTRIES) {
           continue; // need a FULL d*
         }
         casesThisSet++;
         fullCases++;
         final int beta = bc.analysis.mismatchBit();
-        final int betaValue = HOTBulkBuilder.bitAt(k, beta) ? 1 : 0;
+        final int betaValue = HOTBulkBuilder.bitAt(k, beta)
+            ? 1
+            : 0;
 
         // ---- the decomposition: splitIndirect(node) at node.MSB ----
         final HOTIncrementalInsert.BiNode split =
@@ -254,7 +261,9 @@ final class BetaIsDiscBitRoutingProbe {
         // K routes into one half by node.MSB.
         final int nodeMsb = bc.node.getMostSignificantBitIndex();
         final boolean kMsbBit = HOTBulkBuilder.bitAt(k, nodeMsb);
-        final PageReference halfRef = kMsbBit ? split.right() : split.left();
+        final PageReference halfRef = kMsbBit
+            ? split.right()
+            : split.left();
         if (!(halfRef.getPage() instanceof HOTIndirectPage half)) {
           // K's half is a single leaf — addChildAtCombination needs an indirect; skip.
           continue;
@@ -271,41 +280,40 @@ final class BetaIsDiscBitRoutingProbe {
         }
         final HOTIncrementalInsert.InsertInfo halfInfo =
             HOTIncrementalInsert.getInsertInformation(half, childIdx, beta);
-        final HOTLeafPage comboLeaf =
-            new HOTLeafPage(allocator.getAndIncrement(), 1, IndexType.CAS);
+        final HOTLeafPage comboLeaf = new HOTLeafPage(allocator.getAndIncrement(), 1, IndexType.CAS);
         assertTrue(comboLeaf.put(k, VALUE));
         final HOTIndirectPage foldedHalf;
         // comboPartial is meaningful only for the betaCol>=0 (still-betaIsDiscBit) branch.
         final int comboPartial = betaCol >= 0
-            ? halfInfo.subtreePrefix() | (betaValue == 1 ? 1 << (halfDiscBits.length - 1 - betaCol)
+            ? halfInfo.subtreePrefix() | (betaValue == 1
+                ? 1 << (halfDiscBits.length - 1 - betaCol)
                 : 0)
             : -1;
         try {
           if (betaCol >= 0) {
             betaSurvivesInHalf++;
-            foldedHalf = HOTIncrementalInsert.addChildAtCombination(half, comboPartial,
-                swizzle(comboLeaf), half.getHeight(), 1, allocator::getAndIncrement);
+            foldedHalf = HOTIncrementalInsert.addChildAtCombination(half, comboPartial, swizzle(comboLeaf),
+                half.getHeight(), 1, allocator::getAndIncrement);
           } else {
             betaLostInHalf++;
             // beta is new to the half — fold it as a fresh disc bit via addEntryWithInsertInfo.
-            foldedHalf = HOTIncrementalInsert.addEntryWithInsertInfo(half, beta, betaValue,
-                halfInfo.firstAffected(), halfInfo.affectedCount(), halfInfo.subtreePrefix(),
-                swizzle(comboLeaf), half.getHeight(), 1, allocator::getAndIncrement);
+            foldedHalf = HOTIncrementalInsert.addEntryWithInsertInfo(half, beta, betaValue, halfInfo.firstAffected(),
+                halfInfo.affectedCount(), halfInfo.subtreePrefix(), swizzle(comboLeaf), half.getHeight(), 1,
+                allocator::getAndIncrement);
           }
         } catch (IllegalArgumentException | IllegalStateException ex) {
           comboLeaf.close();
           decomposeFailed++;
           if (failDetails.size() < 6) {
-            failDetails.add(String.format("[%s] K=%s beta=%d decomposition op threw: %s",
-                ks.name, HEX.formatHex(k), beta, ex.getMessage()));
+            failDetails.add(String.format("[%s] K=%s beta=%d decomposition op threw: %s", ks.name, HEX.formatHex(k),
+                beta, ex.getMessage()));
           }
           continue;
         }
         halfRef.setPage(foldedHalf);
         // Reassemble the BiNode with the folded half.
-        final HOTIndirectPage decomposed = HOTIndirectPage.createBiNode(
-            allocator.getAndIncrement(), 1, split.discriminativeBitIndex(),
-            split.left(), split.right(), split.height());
+        final HOTIndirectPage decomposed = HOTIndirectPage.createBiNode(allocator.getAndIncrement(), 1,
+            split.discriminativeBitIndex(), split.left(), split.right(), split.height());
         decomposedOk++;
 
         // ---- STRICT routing of K from the decomposed BiNode ----
@@ -318,8 +326,8 @@ final class BetaIsDiscBitRoutingProbe {
             final int chosen = decomposed.findChildIndex(k);
             failDetails.add(String.format(
                 "[%s] K=%s MISROUTE in decomposed BiNode: beta=%d comboPartial=0x%x "
-                    + "half discBits=%s -> BiNode child %d", ks.name, HEX.formatHex(k), beta,
-                comboPartial, java.util.Arrays.toString(halfDiscBits), chosen));
+                    + "half discBits=%s -> BiNode child %d",
+                ks.name, HEX.formatHex(k), beta, comboPartial, java.util.Arrays.toString(halfDiscBits), chosen));
           }
         }
         comboLeaf.close();
@@ -329,24 +337,22 @@ final class BetaIsDiscBitRoutingProbe {
 
     System.out.println("=== Q4 — full-node betaIsDiscBit splitIndirect decomposition ===");
     System.out.printf("  full-node betaIsDiscBit cases=%d%n", fullCases);
-    System.out.printf("  beta SURVIVES in K's half=%d | beta LOST in half=%d%n",
-        betaSurvivesInHalf, betaLostInHalf);
-    System.out.printf("  decomposition built OK=%d | decomposition not applicable=%d%n",
-        decomposedOk, decomposeFailed);
-    System.out.printf("  strict route OK=%d | strict MISROUTES=%d%n",
-        strictRouteOk, strictMisroutes);
+    System.out.printf("  beta SURVIVES in K's half=%d | beta LOST in half=%d%n", betaSurvivesInHalf, betaLostInHalf);
+    System.out.printf("  decomposition built OK=%d | decomposition not applicable=%d%n", decomposedOk, decomposeFailed);
+    System.out.printf("  strict route OK=%d | strict MISROUTES=%d%n", strictRouteOk, strictMisroutes);
     for (final String d : failDetails) {
       System.out.println("  " + d);
     }
-    System.out.println("  DECISIVE: full-node betaIsDiscBit decomposition routes strict = "
-        + (decomposedOk > 0 && strictMisroutes == 0 ? "YES"
-            : strictMisroutes > 0 ? "NO (misroutes)"
-            : "BLOCKED (beta lost in half / not applicable)"));
+    System.out.println(
+        "  DECISIVE: full-node betaIsDiscBit decomposition routes strict = " + (decomposedOk > 0 && strictMisroutes == 0
+            ? "YES"
+            : strictMisroutes > 0
+                ? "NO (misroutes)"
+                : "BLOCKED (beta lost in half / not applicable)"));
     assertTrue(fullCases > 0, "no full-node betaIsDiscBit case exercised — coverage gap");
     // Report-only: a decomposition that cannot apply (beta lost) is the finding, not a failure.
     if (decomposedOk > 0) {
-      assertTrue(strictMisroutes == 0,
-          "full-node decomposition misrouted " + strictMisroutes + " keys");
+      assertTrue(strictMisroutes == 0, "full-node decomposition misrouted " + strictMisroutes + " keys");
     }
   }
 
@@ -372,8 +378,8 @@ final class BetaIsDiscBitRoutingProbe {
 
     for (final KeySet ks : sets) {
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(ks.keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(ks.keys), 1, IndexType.CAS, allocator::getAndIncrement);
       Page root = built.rootPage();
       if (!(root instanceof HOTIndirectPage)) {
         closeLeaves(root);
@@ -390,27 +396,28 @@ final class BetaIsDiscBitRoutingProbe {
           break;
         }
         final BetaCase bc = analyzeBetaCase(root, k);
-        if (bc == null || !bc.info.betaIsDiscBit()
-            || bc.node.getNumChildren() >= HOTIndirectPage.MAX_NODE_ENTRIES) {
+        if (bc == null || !bc.info.betaIsDiscBit() || bc.node.getNumChildren() >= HOTIndirectPage.MAX_NODE_ENTRIES) {
           continue;
         }
         casesThisSet++;
         casesChecked++;
 
         final int[] nodeDiscBits = HOTIncrementalInsert.discriminativeBits(bc.node);
-        final int betaColumn =
-            java.util.Arrays.binarySearch(nodeDiscBits, bc.analysis.mismatchBit());
-        final int betaValue = HOTBulkBuilder.bitAt(k, bc.analysis.mismatchBit()) ? 1 : 0;
-        final int comboPartial = bc.info.subtreePrefix()
-            | (betaValue == 1 ? 1 << (nodeDiscBits.length - 1 - betaColumn) : 0);
+        final int betaColumn = java.util.Arrays.binarySearch(nodeDiscBits, bc.analysis.mismatchBit());
+        final int betaValue = HOTBulkBuilder.bitAt(k, bc.analysis.mismatchBit())
+            ? 1
+            : 0;
+        final int comboPartial = bc.info.subtreePrefix() | (betaValue == 1
+            ? 1 << (nodeDiscBits.length - 1 - betaColumn)
+            : 0);
 
         // Build the canonical tree over the SAME key set PLUS K.
         final TreeSet<byte[]> withK = new TreeSet<>(java.util.Arrays::compareUnsigned);
         withK.addAll(ks.keys);
         withK.add(k);
         final AtomicLong canonAlloc = new AtomicLong(1);
-        final HOTBulkBuilder.BuildResult canon = HOTBulkBuilder.build(
-            entries(new ArrayList<>(withK)), 1, IndexType.CAS, canonAlloc::getAndIncrement);
+        final HOTBulkBuilder.BuildResult canon =
+            HOTBulkBuilder.build(entries(new ArrayList<>(withK)), 1, IndexType.CAS, canonAlloc::getAndIncrement);
 
         // Canonical routes ALL keys strict?
         int misroutes = 0;
@@ -433,9 +440,8 @@ final class BetaIsDiscBitRoutingProbe {
             // What partial DID the canonical tree give K's child?
             final int canonChildPartial = canonicalChildPartialForKey(canon.rootPage(), k);
             noComboDetails.add(String.format(
-                "[%s] K=%s incremental comboPartial=0x%x but canonical child partial=0x%x "
-                    + "(node discBits=%s)", ks.name, HEX.formatHex(k), comboPartial,
-                canonChildPartial, java.util.Arrays.toString(nodeDiscBits)));
+                "[%s] K=%s incremental comboPartial=0x%x but canonical child partial=0x%x " + "(node discBits=%s)",
+                ks.name, HEX.formatHex(k), comboPartial, canonChildPartial, java.util.Arrays.toString(nodeDiscBits)));
           }
         }
         closeLeaves(canon.rootPage());
@@ -461,8 +467,8 @@ final class BetaIsDiscBitRoutingProbe {
   // ====================================================================
 
   /** Bundle of one betaIsDiscBit descent's state. */
-  private record BetaCase(HOTIndirectPage node, PageReference nodeRef, DescentAnalysis analysis,
-                          InsertInfo info) {}
+  private record BetaCase(HOTIndirectPage node, PageReference nodeRef, DescentAnalysis analysis, InsertInfo info) {
+  }
 
   /**
    * Strict-descend {@code key} from {@code root}, build the path-node stack, run
@@ -509,8 +515,8 @@ final class BetaIsDiscBitRoutingProbe {
     }
     final int insertDepth = analysis.insertDepth();
     final HOTIndirectPage node = pn[insertDepth];
-    final InsertInfo info = HOTIncrementalInsert.getInsertInformation(node,
-        analysis.affectedChildIndex(), analysis.mismatchBit());
+    final InsertInfo info =
+        HOTIncrementalInsert.getInsertInformation(node, analysis.affectedChildIndex(), analysis.mismatchBit());
     // pathRefs[insertDepth] is the reference whose page is `node`; for the root it is null,
     // so wrap the root in a synthetic reference for splice-in.
     PageReference nodeRef = pathRefs.get(insertDepth);
@@ -523,10 +529,10 @@ final class BetaIsDiscBitRoutingProbe {
 
   /**
    * Recursively replace every FULL ({@code MAX_NODE_ENTRIES}-child) indirect node with the
-   * materialized {@link HOTIncrementalInsert#splitIndirect} BiNode, producing a tree whose
-   * interior nodes are all not-full — the state the incremental writer's
-   * {@code addChildAtCombination} actually operates on (after an earlier split). Routing is
-   * preserved: splitIndirect is verified routing-correct by {@code HOTIndirectPageSplitFaithfulTest}.
+   * materialized {@link HOTIncrementalInsert#splitIndirect} BiNode, producing a tree whose interior
+   * nodes are all not-full — the state the incremental writer's {@code addChildAtCombination}
+   * actually operates on (after an earlier split). Routing is preserved: splitIndirect is verified
+   * routing-correct by {@code HOTIndirectPageSplitFaithfulTest}.
    */
   private static Page splitAllFullNodes(final Page page, final AtomicLong allocator) {
     if (!(page instanceof HOTIndirectPage node)) {
@@ -542,21 +548,19 @@ final class BetaIsDiscBitRoutingProbe {
     if (node.getNumChildren() < HOTIndirectPage.MAX_NODE_ENTRIES) {
       return node;
     }
-    final HOTIncrementalInsert.BiNode split =
-        HOTIncrementalInsert.splitIndirect(node, 1, allocator::getAndIncrement);
-    return HOTIndirectPage.createBiNode(allocator.getAndIncrement(), 1,
-        split.discriminativeBitIndex(), split.left(), split.right(), split.height());
+    final HOTIncrementalInsert.BiNode split = HOTIncrementalInsert.splitIndirect(node, 1, allocator::getAndIncrement);
+    return HOTIndirectPage.createBiNode(allocator.getAndIncrement(), 1, split.discriminativeBitIndex(), split.left(),
+        split.right(), split.height());
   }
 
   /**
    * Generate betaIsDiscBit candidate keys: walk to every leaf carrying the accumulated set of
-   * ancestor discriminative bits; for several sample keys in each leaf and every ancestor disc
-   * bit {@code b}, emit {@code flip(sample, b)}. The flipped key K then has
+   * ancestor discriminative bits; for several sample keys in each leaf and every ancestor disc bit
+   * {@code b}, emit {@code flip(sample, b)}. The flipped key K then has
    * {@code msdb(K, resident) == b}, an existing ancestor disc bit — exactly the betaIsDiscBit
    * branch-insert scenario. Skips any flip that collides with a present key.
    */
-  private static List<byte[]> betaIsDiscBitCandidates(final Page root,
-      final TreeSet<byte[]> present) {
+  private static List<byte[]> betaIsDiscBitCandidates(final Page root, final TreeSet<byte[]> present) {
     final List<byte[]> out = new ArrayList<>();
     final TreeSet<byte[]> emitted = new TreeSet<>(java.util.Arrays::compareUnsigned);
     collectBetaCandidates(root, new int[0], present, emitted, out);
@@ -618,16 +622,17 @@ final class BetaIsDiscBitRoutingProbe {
       }
       page = ref.getPage();
     }
-    return page instanceof HOTLeafPage leaf ? leaf : null;
+    return page instanceof HOTLeafPage leaf
+        ? leaf
+        : null;
   }
 
   /**
-   * Walk K's strict descent in {@code canonRoot}; at the node whose disc-bit set best matches
-   * the incremental node, check whether any child's stored partial equals {@code comboPartial}.
+   * Walk K's strict descent in {@code canonRoot}; at the node whose disc-bit set best matches the
+   * incremental node, check whether any child's stored partial equals {@code comboPartial}.
    * Conservative: returns true if ANY node on K's path has a child at comboPartial.
    */
-  private static boolean canonicalHasChildAtPartial(final Page canonRoot, final byte[] key,
-      final int comboPartial) {
+  private static boolean canonicalHasChildAtPartial(final Page canonRoot, final byte[] key, final int comboPartial) {
     Page page = canonRoot;
     int depth = 0;
     while (page instanceof HOTIndirectPage node) {
@@ -669,7 +674,9 @@ final class BetaIsDiscBitRoutingProbe {
         break;
       }
       final int[] partials = node.getPartialKeys();
-      lastPartial = partials != null && ci < partials.length ? partials[ci] : -1;
+      lastPartial = partials != null && ci < partials.length
+          ? partials[ci]
+          : -1;
       final PageReference ref = node.getChildReference(ci);
       if (ref == null) {
         break;
@@ -683,7 +690,8 @@ final class BetaIsDiscBitRoutingProbe {
   // Key sets and utilities.
   // ====================================================================
 
-  private record KeySet(String name, List<byte[]> keys) {}
+  private record KeySet(String name, List<byte[]> keys) {
+  }
 
   private static List<byte[]> ascending(final int n) {
     final List<byte[]> keys = new ArrayList<>(n);
@@ -725,8 +733,8 @@ final class BetaIsDiscBitRoutingProbe {
   }
 
   /**
-   * 40-byte keys: an 8-value byte-0 prefix plus a far-out random tail at bytes 30-39 — disc
-   * bits span &gt; 8 bytes, forcing the MultiMask layout (mirrors {@code
+   * 40-byte keys: an 8-value byte-0 prefix plus a far-out random tail at bytes 30-39 — disc bits span
+   * &gt; 8 bytes, forcing the MultiMask layout (mirrors {@code
    * HOTIndirectPageSplitFaithfulTest.WIDE_SPAN}; reproduces the prior "WIDE_SPAN beta=242" case).
    */
   private static List<byte[]> widespan(final int n) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/BulkSpliceTestBridge.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/BulkSpliceTestBridge.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.sirix.cache.PageContainer;
+import io.sirix.cache.TransactionIntentLog;
+import io.sirix.page.interfaces.Page;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Test-only package bridge: exposes {@link AbstractHOTIndexWriter#spliceBulkBuiltRoot} (package
+ * private by design — production callers are the {@link AbstractHOTBulkIndexLoader} family) to
+ * benchmarks and probes living outside {@code io.sirix.index.hot}, so the bulk arm of a
+ * differential measures the REAL splice path rather than a re-implementation.
+ */
+public final class BulkSpliceTestBridge {
+
+  private BulkSpliceTestBridge() {
+    throw new AssertionError("no instances");
+  }
+
+  /**
+   * Splice {@code sortedEntries} as {@code writer}'s whole index tree — the production
+   * {@code spliceBulkBuiltRoot} path (empty-tree guard, {@link HOTBulkBuilder#build},
+   * fresh-subtree TIL registration).
+   *
+   * @param writer a writer whose index tree is still empty
+   * @param sortedEntries entries sorted strictly ascending by unsigned key, no duplicates
+   */
+  public static void spliceBulkBuiltRoot(final AbstractHOTIndexWriter<?> writer,
+      final List<HOTBulkBuilder.Entry> sortedEntries) {
+    Objects.requireNonNull(writer, "writer");
+    Objects.requireNonNull(sortedEntries, "sortedEntries");
+    writer.spliceBulkBuiltRoot(sortedEntries);
+  }
+
+  /**
+   * Run {@link HOTMalformedSubtreeDetector} over {@code writer}'s in-transaction tree and return
+   * the number of malformed subtrees (0 = clean). The resolver consults the transaction-intent
+   * log for pages whose in-memory reference was nulled by {@code log.put}, swizzling them back
+   * so the walk sees the whole tree.
+   */
+  public static int malformedSubtreeCount(final AbstractHOTIndexWriter<?> writer) {
+    Objects.requireNonNull(writer, "writer");
+    final TransactionIntentLog log = writer.storageEngineWriter.getLog();
+    final HOTMalformedSubtreeDetector.PageResolver resolver = pageRef -> {
+      final Page page = pageRef.getPage();
+      if (page != null) {
+        return page;
+      }
+      final PageContainer container = log.get(pageRef);
+      if (container != null && container.getModified() != null) {
+        pageRef.setPage(container.getModified());
+        return container.getModified();
+      }
+      return null;
+    };
+    return HOTMalformedSubtreeDetector.detect(writer.getRootReference(), resolver).size();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/BulkSpliceTestBridge.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/BulkSpliceTestBridge.java
@@ -24,8 +24,8 @@ public final class BulkSpliceTestBridge {
 
   /**
    * Splice {@code sortedEntries} as {@code writer}'s whole index tree — the production
-   * {@code spliceBulkBuiltRoot} path (empty-tree guard, {@link HOTBulkBuilder#build},
-   * fresh-subtree TIL registration).
+   * {@code spliceBulkBuiltRoot} path (empty-tree guard, {@link HOTBulkBuilder#build}, fresh-subtree
+   * TIL registration).
    *
    * @param writer a writer whose index tree is still empty
    * @param sortedEntries entries sorted strictly ascending by unsigned key, no duplicates
@@ -38,10 +38,10 @@ public final class BulkSpliceTestBridge {
   }
 
   /**
-   * Run {@link HOTMalformedSubtreeDetector} over {@code writer}'s in-transaction tree and return
-   * the number of malformed subtrees (0 = clean). The resolver consults the transaction-intent
-   * log for pages whose in-memory reference was nulled by {@code log.put}, swizzling them back
-   * so the walk sees the whole tree.
+   * Run {@link HOTMalformedSubtreeDetector} over {@code writer}'s in-transaction tree and return the
+   * number of malformed subtrees (0 = clean). The resolver consults the transaction-intent log for
+   * pages whose in-memory reference was nulled by {@code log.put}, swizzling them back so the walk
+   * sees the whole tree.
    */
   public static int malformedSubtreeCount(final AbstractHOTIndexWriter<?> writer) {
     Objects.requireNonNull(writer, "writer");

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -37,6 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * key-set generators mirror {@code HOTFormalModelTest} — ascending, descending, uniform random,
  * bimodal, common-prefix, and sparse distributions — plus variable-length keys and tombstone
  * entries, which the model (fixed 64-bit keys) does not exercise.
+ *
+ * <p>
+ * V6 additionally pins the <em>packing</em> policy, which the invariants alone do not constrain:
+ * any frontier is invariant-correct by Theorem 1, so a frontier that tears a page-fitting
+ * {@code R(S)} subtree apart passes every check above while producing several under-filled pages.
+ * V6 asserts the built leaf count against {@link #maximalFittingSubtrees}, an oracle derived from
+ * {@code R(S)} alone.
  *
  * <p>
  * The validator needs a {@link StorageEngineReader}; since every page produced by
@@ -166,11 +175,11 @@ final class HOTBulkBuilderTest {
       while (keyList.size() < n) {
         final byte[] k = new byte[1 + r.nextInt(40)];
         r.nextBytes(k);
-        if (seenHex.add(java.util.HexFormat.of().formatHex(k))) {
+        if (seenHex.add(HexFormat.of().formatHex(k))) {
           keyList.add(k);
         }
       }
-      keyList.sort(java.util.Arrays::compareUnsigned);
+      keyList.sort(Arrays::compareUnsigned);
       final List<HOTBulkBuilder.Entry> entries = new ArrayList<>(keyList.size());
       for (int i = 0; i < keyList.size(); i++) {
         // Sprinkle tombstones (every 7th key) — they are keys and must be placed like any entry.
@@ -288,7 +297,7 @@ final class HOTBulkBuilderTest {
               : beKey(r.nextLong())));
         }
       }
-      entries.sort((a, b) -> java.util.Arrays.compareUnsigned(a.key(), b.key()));
+      entries.sort((a, b) -> Arrays.compareUnsigned(a.key(), b.key()));
       final HOTBulkBuilder.BuildResult result =
           HOTBulkBuilder.build(entries, /* revision */ 2, IndexType.CAS, new AtomicLong()::getAndIncrement);
       assertEquals(null, checkAll(result, entries, "multimask variant=" + variant));
@@ -297,6 +306,181 @@ final class HOTBulkBuilderTest {
       closeLeaves(result.rootPage());
     }
     System.out.println("[V5] MultiMask layout exercised and validated clean");
+  }
+
+  // ======================================================================
+  // V6 — leaf packing: the frontier never expands a page-fitting R(S) subtree.
+  // ======================================================================
+
+  /**
+   * A regression key pattern for the packing invariant, with the leaf geometry the
+   * highest-fitting-subtree cut must produce. The counts are derived by hand from {@code R(S)} and
+   * are re-derived independently at run time by {@link #maximalFittingSubtrees}; asserting both means
+   * neither a builder regression nor an oracle regression can pass unnoticed.
+   *
+   * @param label diagnostic name
+   * @param keys strictly ascending unsigned 8-byte-encodable keys
+   * @param expectedLeaves leaf pages the cut policy must produce
+   * @param expectedMinFill entries in the least-filled leaf
+   * @param expectedMaxFill entries in the most-filled leaf
+   */
+  private record PackingShape(String label, long[] keys, int expectedLeaves, int expectedMinFill, int expectedMaxFill) {
+  }
+
+  @Test
+  @DisplayName("V6: leaf count equals the highest-fitting-subtree count (no fitting group is expanded)")
+  void v6HighestFittingSubtreePacking() {
+    // The shapes that exposed the packing defect. Before the frontier's leaf-boundary stop,
+    // buildIndirect split the LARGEST frontier branch until the block held 32 children, so a
+    // page-fitting R(S) subtree was torn across frontier slots and each fragment compressed into
+    // its own under-filled page: the 1024-key block fragmented into 32 leaves of 32, and the
+    // 20 000-key sets built 280 leaves (mean fill ~71) instead of 40 (mean fill 500).
+    final PackingShape[] shapes = {
+        // 1024 dense keys: R(S) splits once into two 512-groups, both of which fit a page.
+        new PackingShape("dense-1024", denseKeys(1_024), 2, 512, 512),
+        // Same trie shape through the projection column-segment slot encoding (i << 16 | 3):
+        // a left shift plus constant low bits is an R(S) isomorphism, so the cut is identical.
+        new PackingShape("strided-1024", stridedKeys(1_024), 2, 512, 512),
+        // 20 000 dense keys: 39 full 512-leaves plus a 32-key tail leaf.
+        new PackingShape("dense-20000", denseKeys(20_000), 40, 32, 512),
+        new PackingShape("strided-20000", stridedKeys(20_000), 40, 32, 512),};
+
+    for (final PackingShape shape : shapes) {
+      final long[] keys = shape.keys();
+      final List<HOTBulkBuilder.Entry> entries = entriesFromSortedLongs(keys);
+      final HOTBulkBuilder.BuildResult result =
+          HOTBulkBuilder.build(entries, /* revision */ 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
+      final LeafStats stats = leafStats(result.rootPage());
+      final int oracle = maximalFittingSubtrees(keys, 0, keys.length - 1);
+
+      assertEquals(shape.expectedLeaves(), oracle,
+          shape.label() + ": the hand-derived leaf count disagrees with the R(S) oracle");
+      assertEquals(oracle, result.leafCount(), shape.label() + ": built " + result.leafCount() + " leaves but only "
+          + oracle + " maximal page-fitting R(S) subtrees exist — a fitting group was expanded");
+      assertEquals(oracle, stats.leaves(), shape.label() + ": reported leafCount disagrees with the built pages");
+      assertEquals(keys.length, stats.entries(), shape.label() + ": leaves do not hold every entry");
+      assertEquals(shape.expectedMinFill(), stats.minFill(), shape.label() + ": least-filled leaf");
+      assertEquals(shape.expectedMaxFill(), stats.maxFill(), shape.label() + ": most-filled leaf");
+      assertEquals((double) keys.length / shape.expectedLeaves(), stats.meanFill(), 1e-9,
+          shape.label() + ": mean leaf fill regressed");
+
+      assertEquals(null, checkAll(result, entries, "packing " + shape.label()));
+      closeLeaves(result.rootPage());
+      System.out.println("[V6] " + shape.label() + ": " + stats.leaves() + " leaves, fill " + stats.minFill() + ".."
+          + stats.maxFill() + ", mean " + String.format("%.1f", stats.meanFill()));
+    }
+
+    // The invariant is not shape-specific: across every adversarial generator the built leaf count
+    // must equal the number of maximal page-fitting R(S) subtrees. Values are 8 bytes (tombstones
+    // 1), so 512 * (4 + 8 + 8) bytes stay far inside HOTLeafPage.DEFAULT_SIZE and the entry count
+    // is the only binding capacity — which is what lets the oracle stop purely on group size.
+    final int[] sizes = {2_000, 8_000, 20_000};
+    int checked = 0;
+    final List<String> failures = new ArrayList<>();
+    for (int g = 0; g < GENERATORS.length; g++) {
+      for (final int n : sizes) {
+        for (int seed = 0; seed < 3; seed++) {
+          final Set<Long> set = new HashSet<>();
+          GENERATORS[g].fill(n, new Random((((long) g) << 40) ^ (((long) n) << 20) ^ seed), set);
+          final long[] keys = sortedUnsigned(set);
+          if (keys.length < 2) {
+            continue;
+          }
+          final List<HOTBulkBuilder.Entry> entries = entriesFromSortedLongs(keys);
+          final HOTBulkBuilder.BuildResult result =
+              HOTBulkBuilder.build(entries, /* revision */ 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
+          checked++;
+          final int oracle = maximalFittingSubtrees(keys, 0, keys.length - 1);
+          if (result.leafCount() != oracle && failures.size() < 12) {
+            failures.add("gen=" + g + " n=" + keys.length + " seed=" + seed + ": built " + result.leafCount()
+                + " leaves, highest-fitting-subtree cut is " + oracle);
+          }
+          closeLeaves(result.rootPage());
+        }
+      }
+    }
+    assertTrue(failures.isEmpty(), "leaf packing is not the highest-fitting-subtree cut in " + checked + " trials:\n"
+        + String.join("\n", failures));
+    System.out.println("[V6] " + checked + " adversarial key sets — leaf count == highest-fitting-subtree count");
+  }
+
+  /**
+   * Oracle for the cut policy, independent of {@link HOTBulkBuilder}'s frontier logic: the number of
+   * MAXIMAL {@code R(S)} subtrees whose key group fits one leaf page. Recurses the MSDB split of the
+   * sorted key range and stops as soon as a group fits, so it counts exactly the pages the documented
+   * policy ("cut a leaf at the highest {@code R(S)} subtree whose key group fits a page") prescribes.
+   *
+   * <p>
+   * Only valid where entry count — not byte capacity — is the binding limit; every V6 key set is
+   * built with 8-byte keys and values so that holds. For 8-byte big-endian keys the MSDB of the range
+   * is simply the highest differing bit of {@code keys[lo] ^ keys[hi]}, and because the range is
+   * sorted unsigned and agrees above that bit, the {@code 0 -> 1} transition is a single point found
+   * by binary search.
+   */
+  private static int maximalFittingSubtrees(final long[] sortedUnsigned, final int lo, final int hi) {
+    if (hi - lo + 1 <= HOTLeafPage.MAX_ENTRIES) {
+      return 1;
+    }
+    final long bit = Long.highestOneBit(sortedUnsigned[lo] ^ sortedUnsigned[hi]);
+    int low = lo + 1;
+    int high = hi;
+    while (low < high) {
+      final int mid = (low + high) >>> 1;
+      if ((sortedUnsigned[mid] & bit) != 0) {
+        high = mid;
+      } else {
+        low = mid + 1;
+      }
+    }
+    return maximalFittingSubtrees(sortedUnsigned, lo, low - 1) + maximalFittingSubtrees(sortedUnsigned, low, hi);
+  }
+
+  /** Aggregated leaf geometry of a built subtree. */
+  private record LeafStats(int leaves, long entries, int minFill, int maxFill) {
+    double meanFill() {
+      return (double) entries / leaves;
+    }
+  }
+
+  private static LeafStats leafStats(final Page root) {
+    final int[] acc = {0, 0, Integer.MAX_VALUE, 0}; // leaves, entries, minFill, maxFill
+    accumulateLeafStats(root, acc);
+    return new LeafStats(acc[0], acc[1], acc[2], acc[3]);
+  }
+
+  private static void accumulateLeafStats(final Page page, final int[] acc) {
+    if (page instanceof HOTLeafPage leaf) {
+      final int fill = leaf.getEntryCount();
+      acc[0]++;
+      acc[1] += fill;
+      acc[2] = Math.min(acc[2], fill);
+      acc[3] = Math.max(acc[3], fill);
+    } else if (page instanceof HOTIndirectPage indirect) {
+      for (int i = 0; i < indirect.getNumChildren(); i++) {
+        final PageReference ref = indirect.getChildReference(i);
+        if (ref != null && ref.getPage() != null) {
+          accumulateLeafStats(ref.getPage(), acc);
+        }
+      }
+    }
+  }
+
+  /** Dense monotone keys {@code 0..n-1} — the order-label / locator-id shape. */
+  private static long[] denseKeys(final int n) {
+    final long[] keys = new long[n];
+    for (int i = 0; i < n; i++) {
+      keys[i] = i;
+    }
+    return keys;
+  }
+
+  /** Strided keys {@code (i << 16) | 3} — the projection column-segment slot shape. */
+  private static long[] stridedKeys(final int n) {
+    final long[] keys = new long[n];
+    for (int i = 0; i < n; i++) {
+      keys[i] = ((long) i << 16) | 3L;
+    }
+    return keys;
   }
 
   // ======================================================================
@@ -409,16 +593,14 @@ final class HOTBulkBuilderTest {
         return false;
       }
       for (int i = 0; i < la.getEntryCount(); i++) {
-        if (!java.util.Arrays.equals(la.getKey(i), lb.getKey(i))
-            || !java.util.Arrays.equals(la.getValue(i), lb.getValue(i))) {
+        if (!Arrays.equals(la.getKey(i), lb.getKey(i)) || !Arrays.equals(la.getValue(i), lb.getValue(i))) {
           return false;
         }
       }
       return true;
     }
     if (a instanceof HOTIndirectPage ia && b instanceof HOTIndirectPage ib) {
-      if (ia.getNumChildren() != ib.getNumChildren()
-          || !java.util.Arrays.equals(ia.getPartialKeys(), ib.getPartialKeys())
+      if (ia.getNumChildren() != ib.getNumChildren() || !Arrays.equals(ia.getPartialKeys(), ib.getPartialKeys())
           || ia.getLayoutType() != ib.getLayoutType()) {
         return false;
       }
@@ -442,15 +624,29 @@ final class HOTBulkBuilderTest {
    * a tombstone; the rest get a small deterministic value derived from the key.
    */
   private static List<HOTBulkBuilder.Entry> entriesFromLongs(final Set<Long> set, final int valueSalt) {
+    return entriesFromSortedLongs(sortedUnsigned(set), valueSalt);
+  }
+
+  /** The key set as a strictly ascending unsigned {@code long[]}. */
+  private static long[] sortedUnsigned(final Set<Long> set) {
     final long[] longs = set.stream().mapToLong(Long::longValue).toArray();
     // Sort unsigned (flip the sign bit so signed sort agrees with unsigned).
     for (int i = 0; i < longs.length; i++) {
       longs[i] ^= Long.MIN_VALUE;
     }
-    java.util.Arrays.sort(longs);
+    Arrays.sort(longs);
     for (int i = 0; i < longs.length; i++) {
       longs[i] ^= Long.MIN_VALUE;
     }
+    return longs;
+  }
+
+  /** {@link #entriesFromLongs} over an already ascending key array, with an unsalted value. */
+  private static List<HOTBulkBuilder.Entry> entriesFromSortedLongs(final long[] longs) {
+    return entriesFromSortedLongs(longs, 0);
+  }
+
+  private static List<HOTBulkBuilder.Entry> entriesFromSortedLongs(final long[] longs, final int valueSalt) {
     final List<HOTBulkBuilder.Entry> entries = new ArrayList<>(longs.length);
     for (int i = 0; i < longs.length; i++) {
       final byte[] key = beKey(longs[i]);
@@ -505,6 +701,6 @@ final class HOTBulkBuilderTest {
   }
 
   private static String hex(final byte[] b) {
-    return java.util.HexFormat.of().formatHex(b);
+    return HexFormat.of().formatHex(b);
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
@@ -26,21 +26,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Verification of {@link HOTBulkBuilder} against the eight-invariant oracle
- * {@link HOTInvariantValidator} and a routing oracle (descend each key and assert it lands in
- * the leaf that actually holds it).
+ * {@link HOTInvariantValidator} and a routing oracle (descend each key and assert it lands in the
+ * leaf that actually holds it).
  *
- * <p>This is the executable form of Theorem 1 / Theorem 2 from {@code
+ * <p>
+ * This is the executable form of Theorem 1 / Theorem 2 from {@code
  * docs/HOT_FORMAL_FOUNDATION.md}: {@code HOTBulkBuilder.build} of any adversarial key set must
- * produce a HOT with zero invariant violations, and every stored key must PEXT-route
- * (descend via {@link HOTIndirectPage#findChildIndex}) from the root to the leaf that holds it.
- * The adversarial key-set generators mirror {@code HOTFormalModelTest} — ascending, descending,
- * uniform random, bimodal, common-prefix, and sparse distributions — plus variable-length keys
- * and tombstone entries, which the model (fixed 64-bit keys) does not exercise.
+ * produce a HOT with zero invariant violations, and every stored key must PEXT-route (descend via
+ * {@link HOTIndirectPage#findChildIndex}) from the root to the leaf that holds it. The adversarial
+ * key-set generators mirror {@code HOTFormalModelTest} — ascending, descending, uniform random,
+ * bimodal, common-prefix, and sparse distributions — plus variable-length keys and tombstone
+ * entries, which the model (fixed 64-bit keys) does not exercise.
  *
- * <p>The validator needs a {@link StorageEngineReader}; since every page produced by
+ * <p>
+ * The validator needs a {@link StorageEngineReader}; since every page produced by
  * {@code HOTBulkBuilder} is swizzled into its {@link PageReference} via
- * {@link PageReference#setPage}, a lenient Mockito stub suffices — its {@code loadHOTPage}
- * returns {@code null}, and the validator falls through to the in-memory page.
+ * {@link PageReference#setPage}, a lenient Mockito stub suffices — its {@code loadHOTPage} returns
+ * {@code null}, and the validator falls through to the in-memory page.
  */
 @DisplayName("HOTBulkBuilder — invariant and routing verification")
 final class HOTBulkBuilderTest {
@@ -58,14 +60,26 @@ final class HOTBulkBuilderTest {
 
   private static final Gen[] GENERATORS = {
       // dense low — values 0..n-1
-      (n, r, out) -> { for (int i = 0; i < n; i++) out.add((long) i); },
+      (n, r, out) -> {
+        for (int i = 0; i < n; i++)
+          out.add((long) i);
+      },
       // dense high — values shifted into the top bits
-      (n, r, out) -> { for (int i = 0; i < n; i++) out.add(((long) i) << 40); },
+      (n, r, out) -> {
+        for (int i = 0; i < n; i++)
+          out.add(((long) i) << 40);
+      },
       // descending dense — same key set as dense-low but generated high-to-low (the sorted
       // input is identical; this exercises that build() is insertion-order-independent)
-      (n, r, out) -> { for (int i = n - 1; i >= 0; i--) out.add((long) i); },
+      (n, r, out) -> {
+        for (int i = n - 1; i >= 0; i--)
+          out.add((long) i);
+      },
       // uniform random over the full 64-bit domain (straddles the sign bit)
-      (n, r, out) -> { while (out.size() < n) out.add(r.nextLong()); },
+      (n, r, out) -> {
+        while (out.size() < n)
+          out.add(r.nextLong());
+      },
       // bimodal — two far-apart clusters
       (n, r, out) -> {
         while (out.size() < n) {
@@ -76,17 +90,18 @@ final class HOTBulkBuilderTest {
       },
       // common high prefix — differ only in the low bits (the CAS value/nodeKey case)
       (n, r, out) -> {
-        while (out.size() < n) out.add(0x1234_5678_9ABC_0000L | (r.nextLong() & 0xFFFFL));
+        while (out.size() < n)
+          out.add(0x1234_5678_9ABC_0000L | (r.nextLong() & 0xFFFFL));
       },
       // sparse — a handful of set bits, so R(S) is deep and unbalanced
       (n, r, out) -> {
         while (out.size() < n) {
           long k = 0;
-          for (int b = 0; b < 4; b++) k |= 1L << r.nextInt(64);
+          for (int b = 0; b < 4; b++)
+            k |= 1L << r.nextInt(64);
           out.add(k);
         }
-      },
-  };
+      },};
 
   // ======================================================================
   // V1 — construction soundness: validate(build(S)) is empty for adversarial key sets.
@@ -109,14 +124,13 @@ final class HOTBulkBuilderTest {
             continue;
           }
           final List<HOTBulkBuilder.Entry> entries = entriesFromLongs(set, seed);
-          final HOTBulkBuilder.BuildResult result = HOTBulkBuilder.build(
-              entries, /*revision*/ 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
+          final HOTBulkBuilder.BuildResult result =
+              HOTBulkBuilder.build(entries, /* revision */ 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
           checked++;
           if (treeHeight(result.rootPage()) >= 3) {
             multiLevelTries++;
           }
-          final String failure = checkAll(result, entries, "gen=" + g + " n=" + entries.size()
-              + " seed=" + seed);
+          final String failure = checkAll(result, entries, "gen=" + g + " n=" + entries.size() + " seed=" + seed);
           if (failure != null && failures.size() < 12) {
             failures.add(failure);
           }
@@ -125,13 +139,12 @@ final class HOTBulkBuilderTest {
       }
     }
     assertTrue(failures.isEmpty(),
-        "construction violated invariants in " + checked + " trials:\n"
-            + String.join("\n", failures));
+        "construction violated invariants in " + checked + " trials:\n" + String.join("\n", failures));
     // Sanity: the large key sets must actually exercise multi-level (indirect-of-indirect)
     // tries, otherwise V1 would only test shallow structure.
     assertTrue(multiLevelTries > 0, "no multi-level tries were exercised — coverage gap");
-    System.out.println("[V1] " + checked + " adversarial key sets — 0 invariant violations ("
-        + multiLevelTries + " multi-level tries)");
+    System.out.println("[V1] " + checked + " adversarial key sets — 0 invariant violations (" + multiLevelTries
+        + " multi-level tries)");
   }
 
   // ======================================================================
@@ -169,8 +182,8 @@ final class HOTBulkBuilderTest {
           entries.add(new HOTBulkBuilder.Entry(keyList.get(i), v));
         }
       }
-      final HOTBulkBuilder.BuildResult result = HOTBulkBuilder.build(
-          entries, /*revision*/ 3, IndexType.PATH, new AtomicLong(1000)::getAndIncrement);
+      final HOTBulkBuilder.BuildResult result =
+          HOTBulkBuilder.build(entries, /* revision */ 3, IndexType.PATH, new AtomicLong(1000)::getAndIncrement);
       checked++;
       final String failure = checkAll(result, entries, "varlen seed=" + seed + " n=" + n);
       if (failure != null && failures.size() < 12) {
@@ -190,10 +203,9 @@ final class HOTBulkBuilderTest {
   @DisplayName("V3: degenerate sizes (1 entry, single-page key sets) build correctly")
   void v3DegenerateSizes() {
     // Single entry — root is a leaf page.
-    final List<HOTBulkBuilder.Entry> one = List.of(
-        new HOTBulkBuilder.Entry(beKey(42L), new byte[] {1, 2, 3}));
-    final HOTBulkBuilder.BuildResult single = HOTBulkBuilder.build(
-        one, 1, IndexType.NAME, new AtomicLong()::getAndIncrement);
+    final List<HOTBulkBuilder.Entry> one = List.of(new HOTBulkBuilder.Entry(beKey(42L), new byte[] {1, 2, 3}));
+    final HOTBulkBuilder.BuildResult single =
+        HOTBulkBuilder.build(one, 1, IndexType.NAME, new AtomicLong()::getAndIncrement);
     assertTrue(single.rootPage() instanceof HOTLeafPage, "single-entry root must be a leaf");
     assertEquals(1, single.leafCount());
     assertEquals(0, single.indirectCount());
@@ -205,8 +217,8 @@ final class HOTBulkBuilderTest {
     for (long k = 0; k < 50; k++) {
       few.add(new HOTBulkBuilder.Entry(beKey(k), new byte[] {(byte) k}));
     }
-    final HOTBulkBuilder.BuildResult fewResult = HOTBulkBuilder.build(
-        few, 1, IndexType.NAME, new AtomicLong()::getAndIncrement);
+    final HOTBulkBuilder.BuildResult fewResult =
+        HOTBulkBuilder.build(few, 1, IndexType.NAME, new AtomicLong()::getAndIncrement);
     assertTrue(fewResult.rootPage() instanceof HOTLeafPage, "50-entry root must be a leaf");
     assertEquals(null, checkAll(fewResult, few, "fifty-entries"));
     closeLeaves(fewResult.rootPage());
@@ -228,12 +240,11 @@ final class HOTBulkBuilderTest {
       }
       final List<HOTBulkBuilder.Entry> a = entriesFromLongs(set, 0);
       final List<HOTBulkBuilder.Entry> b = entriesFromLongs(set, 0);
-      final HOTBulkBuilder.BuildResult ra = HOTBulkBuilder.build(
-          a, 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
-      final HOTBulkBuilder.BuildResult rb = HOTBulkBuilder.build(
-          b, 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
-      assertTrue(structurallyEqual(ra.rootPage(), rb.rootPage()),
-          "gen=" + g + ": build is not deterministic");
+      final HOTBulkBuilder.BuildResult ra =
+          HOTBulkBuilder.build(a, 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
+      final HOTBulkBuilder.BuildResult rb =
+          HOTBulkBuilder.build(b, 1, IndexType.CAS, new AtomicLong()::getAndIncrement);
+      assertTrue(structurallyEqual(ra.rootPage(), rb.rootPage()), "gen=" + g + ": build is not deterministic");
       assertEquals(ra.leafCount(), rb.leafCount(), "gen=" + g + " leaf count differs");
       assertEquals(ra.indirectCount(), rb.indirectCount(), "gen=" + g + " indirect count differs");
       closeLeaves(ra.rootPage());
@@ -272,13 +283,14 @@ final class HOTBulkBuilderTest {
           // A distinct low tail keeps keys unique without disturbing the wide MSDB spread.
           key[span] = (byte) (low >>> 8);
           key[span + 1] = (byte) low;
-          entries.add(new HOTBulkBuilder.Entry(key,
-              (low % 9 == 4) ? TOMBSTONE : beKey(r.nextLong())));
+          entries.add(new HOTBulkBuilder.Entry(key, (low % 9 == 4)
+              ? TOMBSTONE
+              : beKey(r.nextLong())));
         }
       }
       entries.sort((a, b) -> java.util.Arrays.compareUnsigned(a.key(), b.key()));
-      final HOTBulkBuilder.BuildResult result = HOTBulkBuilder.build(
-          entries, /*revision*/ 2, IndexType.CAS, new AtomicLong()::getAndIncrement);
+      final HOTBulkBuilder.BuildResult result =
+          HOTBulkBuilder.build(entries, /* revision */ 2, IndexType.CAS, new AtomicLong()::getAndIncrement);
       assertEquals(null, checkAll(result, entries, "multimask variant=" + variant));
       assertTrue(countMultiMaskIndirects(result.rootPage()) > 0,
           "variant=" + variant + ": expected the MultiMask layout to be exercised");
@@ -293,12 +305,12 @@ final class HOTBulkBuilderTest {
 
   /**
    * Returns {@code null} if the built HOT passes every check, otherwise a one-line failure
-   * description. Checks: (1) all eight {@link HOTInvariantValidator} invariants; (2) every
-   * stored key descends to the leaf that holds it (I6, against the production routing); (3)
-   * the leaf key set equals the input key set exactly (no key lost, no key invented).
+   * description. Checks: (1) all eight {@link HOTInvariantValidator} invariants; (2) every stored key
+   * descends to the leaf that holds it (I6, against the production routing); (3) the leaf key set
+   * equals the input key set exactly (no key lost, no key invented).
    */
-  private static String checkAll(final HOTBulkBuilder.BuildResult result,
-      final List<HOTBulkBuilder.Entry> entries, final String label) {
+  private static String checkAll(final HOTBulkBuilder.BuildResult result, final List<HOTBulkBuilder.Entry> entries,
+      final String label) {
     final PageReference rootRef = result.rootReference();
     assertNotNull(rootRef.getPage(), label + ": root page not swizzled");
 
@@ -316,8 +328,8 @@ final class HOTBulkBuilderTest {
         return label + " -> I6: key " + hex(e.key()) + " did not route to any leaf";
       }
       if (routed.findEntry(e.key()) < 0) {
-        return label + " -> I6: key " + hex(e.key()) + " routed to leaf "
-            + routed.getPageKey() + " which does not hold it";
+        return label + " -> I6: key " + hex(e.key()) + " routed to leaf " + routed.getPageKey()
+            + " which does not hold it";
       }
     }
 
@@ -329,8 +341,7 @@ final class HOTBulkBuilderTest {
     final Set<String> leafKeys = new HashSet<>(entries.size() * 2);
     collectLeafKeys(rootRef.getPage(), leafKeys);
     if (!leafKeys.equals(inputKeys)) {
-      return label + " -> key-set: leaf keys (" + leafKeys.size() + ") != input keys ("
-          + inputKeys.size() + ")";
+      return label + " -> key-set: leaf keys (" + leafKeys.size() + ") != input keys (" + inputKeys.size() + ")";
     }
     return null;
   }
@@ -353,7 +364,9 @@ final class HOTBulkBuilderTest {
       }
       page = childRef.getPage();
     }
-    return page instanceof HOTLeafPage leaf ? leaf : null;
+    return page instanceof HOTLeafPage leaf
+        ? leaf
+        : null;
   }
 
   private static void collectLeafKeys(final Page page, final Set<String> out) {
@@ -372,9 +385,9 @@ final class HOTBulkBuilderTest {
   }
 
   /**
-   * Release the off-heap {@code MemorySegment} of every leaf page in a built subtree. The
-   * builder allocates real 64 KiB leaf pages; a test that builds thousands of trees must free
-   * them or it transiently exhausts the off-heap budget.
+   * Release the off-heap {@code MemorySegment} of every leaf page in a built subtree. The builder
+   * allocates real 64 KiB leaf pages; a test that builds thousands of trees must free them or it
+   * transiently exhausts the off-heap budget.
    */
   private static void closeLeaves(final Page page) {
     if (page instanceof HOTLeafPage leaf) {
@@ -410,8 +423,7 @@ final class HOTBulkBuilderTest {
         return false;
       }
       for (int i = 0; i < ia.getNumChildren(); i++) {
-        if (!structurallyEqual(ia.getChildReference(i).getPage(),
-            ib.getChildReference(i).getPage())) {
+        if (!structurallyEqual(ia.getChildReference(i).getPage(), ib.getChildReference(i).getPage())) {
           return false;
         }
       }
@@ -425,12 +437,11 @@ final class HOTBulkBuilderTest {
   // ======================================================================
 
   /**
-   * Build a sorted, distinct entry list from a set of long keys. Keys are 8-byte big-endian
-   * (so unsigned-lexicographic order on the bytes equals unsigned order on the longs). Every
-   * 5th entry is a tombstone; the rest get a small deterministic value derived from the key.
+   * Build a sorted, distinct entry list from a set of long keys. Keys are 8-byte big-endian (so
+   * unsigned-lexicographic order on the bytes equals unsigned order on the longs). Every 5th entry is
+   * a tombstone; the rest get a small deterministic value derived from the key.
    */
-  private static List<HOTBulkBuilder.Entry> entriesFromLongs(final Set<Long> set,
-      final int valueSalt) {
+  private static List<HOTBulkBuilder.Entry> entriesFromLongs(final Set<Long> set, final int valueSalt) {
     final long[] longs = set.stream().mapToLong(Long::longValue).toArray();
     // Sort unsigned (flip the sign bit so signed sort agrees with unsigned).
     for (int i = 0; i < longs.length; i++) {
@@ -446,8 +457,7 @@ final class HOTBulkBuilderTest {
       if (i % 5 == 2) {
         entries.add(new HOTBulkBuilder.Entry(key, TOMBSTONE));
       } else {
-        entries.add(new HOTBulkBuilder.Entry(key,
-            beKey(longs[i] * 0x9E37_79B9_7F4A_7C15L + valueSalt)));
+        entries.add(new HOTBulkBuilder.Entry(key, beKey(longs[i] * 0x9E37_79B9_7F4A_7C15L + valueSalt)));
       }
     }
     return entries;
@@ -458,7 +468,9 @@ final class HOTBulkBuilderTest {
     if (!(page instanceof HOTIndirectPage indirect)) {
       return 0;
     }
-    int count = indirect.getLayoutType() == HOTIndirectPage.LayoutType.MULTI_MASK ? 1 : 0;
+    int count = indirect.getLayoutType() == HOTIndirectPage.LayoutType.MULTI_MASK
+        ? 1
+        : 0;
     for (int i = 0; i < indirect.getNumChildren(); i++) {
       final PageReference ref = indirect.getChildReference(i);
       if (ref != null && ref.getPage() != null) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTBulkBuilderTest.java
@@ -254,13 +254,19 @@ final class HOTBulkBuilderTest {
     // pairwise MSDBs land at bytes 0..27, so the root compound node — once its block expands —
     // captures discriminative bits across the whole 28-byte range, forcing the MultiMask layout
     // (and its chunked computeMultiMaskPartialKey routing decode).
+    //
+    // Each byte-position group deliberately EXCEEDS one leaf page (> MAX_ENTRIES keys): the
+    // leaf-boundary frontier stop leaves page-fitting subtrees whole, so with small groups the
+    // expansion would halt after a few peels with disc bits spanning < 8 bytes (SingleMask).
+    // Oversized groups keep every byte-position subtree expandable until all 28 are separate
+    // children, pinning the block's disc-bit span at 28 bytes.
     final int span = 28;
     for (int variant = 0; variant < 8; variant++) {
       final Random r = new Random(0x7E57_0000L ^ variant);
       final List<HOTBulkBuilder.Entry> entries = new ArrayList<>();
-      // Many keys per byte position so leaves overflow and indirect structure is forced.
+      // Enough keys per byte position that each group overflows a leaf page (600 > 512).
       for (int bytePos = 0; bytePos < span; bytePos++) {
-        for (int low = 0; low < 24; low++) {
+        for (int low = 0; low < 600; low++) {
           final byte[] key = new byte[span + 2];
           key[bytePos] = (byte) 0x80;
           // A distinct low tail keeps keys unique without disturbing the wide MSDB spread.

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIndirectPageSplitFaithfulTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIndirectPageSplitFaithfulTest.java
@@ -413,11 +413,9 @@ final class HOTIndirectPageSplitFaithfulTest {
       }
       HOTIndirectPage root = canonical;
       for (int slot = 0; slot < root.getNumChildren(); slot++) {
-        if (root.getChildReference(slot).getPage() instanceof HOTLeafPage splittable
-            && splittable.getEntryCount() >= 2
+        if (root.getChildReference(slot).getPage() instanceof HOTLeafPage splittable && splittable.getEntryCount() >= 2
             && Arrays.binarySearch(HOTIncrementalInsert.discriminativeBits(root),
-                HOTBulkBuilder.msdb(splittable.getKey(0),
-                    splittable.getKey(splittable.getEntryCount() - 1))) < 0) {
+                HOTBulkBuilder.msdb(splittable.getKey(0), splittable.getKey(splittable.getEntryCount() - 1))) < 0) {
           final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(splittable,
               splittable.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
           root = HOTIncrementalInsert.addEntry(root, leafSplit, slot, 1, allocator::getAndIncrement);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIndirectPageSplitFaithfulTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIndirectPageSplitFaithfulTest.java
@@ -396,16 +396,33 @@ final class HOTIndirectPageSplitFaithfulTest {
   void mergeBiNodePairedLeavesProducesCleanResult() {
     int checked = 0;
     boolean sawCompoundResult = false;
-    // WIDE_SPAN's 8 byte-0 groups give a height-1 root with small leaf children, so adjacent
-    // BiNode-paired leaves have a union that still fits one page — the mergeable case.
+    // A fresh bulk build can no longer contain a mergeable BiNode pair BY CONSTRUCTION — the
+    // highest-fitting-subtree cut already keeps every page-fitting R(S) subtree whole. The
+    // over-partitioned shape the merge exists for is produced by the INCREMENTAL path, so the
+    // scenario manufactures it the production way: splitLeafPage a canonical leaf (re-inserting
+    // an existing key keeps the key set), fold the halves back in via addEntry, and merge the
+    // resulting BiNode-paired pair — the exact split-then-consolidate flow of the live writer.
     for (final int size : new int[] {700, 1_400}) {
       final AtomicLong allocator = new AtomicLong(1);
       final List<byte[]> keys = Workload.WIDE_SPAN.generate(size, 3);
       final HOTBulkBuilder.BuildResult built =
           HOTBulkBuilder.build(entries(keys), 1, IndexType.CAS, allocator::getAndIncrement);
-      if (!(built.rootPage() instanceof HOTIndirectPage root) || root.getHeight() != 1) {
+      if (!(built.rootPage() instanceof HOTIndirectPage canonical) || canonical.getHeight() != 1) {
         closeLeavesOf(built.rootPage());
         continue;
+      }
+      HOTIndirectPage root = canonical;
+      for (int slot = 0; slot < root.getNumChildren(); slot++) {
+        if (root.getChildReference(slot).getPage() instanceof HOTLeafPage splittable
+            && splittable.getEntryCount() >= 2
+            && Arrays.binarySearch(HOTIncrementalInsert.discriminativeBits(root),
+                HOTBulkBuilder.msdb(splittable.getKey(0),
+                    splittable.getKey(splittable.getEntryCount() - 1))) < 0) {
+          final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(splittable,
+              splittable.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
+          root = HOTIncrementalInsert.addEntry(root, leafSplit, slot, 1, allocator::getAndIncrement);
+          break;
+        }
       }
       final TreeSet<String> rootKeys = collectKeys(root);
       final List<HOTLeafPage> mergedLeaves = new ArrayList<>();
@@ -443,6 +460,9 @@ final class HOTIndirectPageSplitFaithfulTest {
         assertRoutesAll(mergedRef, toByteList(rootKeys), label);
         checked++;
       }
+      // The folded root holds the split halves (fresh pages the canonical tree never saw);
+      // close() is idempotent, so the shared canonical leaves tolerate the double visit.
+      closeLeavesOf(root);
       closeLeavesOf(built.rootPage());
       for (final HOTLeafPage mergedLeaf : mergedLeaves) {
         mergedLeaf.close();

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java
@@ -39,20 +39,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * SHAPE-CANONICITY PROBE (task #76 phase 1): is a live sirix HOT trie's structure a function of
- * its key set alone, or of the insertion order?
+ * SHAPE-CANONICITY PROBE (task #76 phase 1): is a live sirix HOT trie's structure a function of its
+ * key set alone, or of the insertion order?
  *
- * <p>Feeds the SAME (key, nodeKey) set through the PRODUCTION per-entry insert path
+ * <p>
+ * Feeds the SAME (key, nodeKey) set through the PRODUCTION per-entry insert path
  * ({@code AbstractHOTIndexWriter.doIndex} via {@link HOTLongIndexWriter#indexNodeKey}) in three
  * different orders — ascending, descending, shuffled — plus once through the bulk loader
- * ({@link HOTLongBulkIndexLoader} → {@link HOTBulkBuilder}), each into its own index number of
- * the same transaction. Then walks every resulting trie and compares full structural signatures
- * (node kinds, heights, discriminative bits, partials, leaf partitioning, leaf content hashes —
+ * ({@link HOTLongBulkIndexLoader} → {@link HOTBulkBuilder}), each into its own index number of the
+ * same transaction. Then walks every resulting trie and compares full structural signatures (node
+ * kinds, heights, discriminative bits, partials, leaf partitioning, leaf content hashes —
  * everything except allocator-dependent page keys).
  *
- * <p>The probe ASSERTS only semantic equivalence (every key readable with an identical postings
- * value in all four tries). Shape equality is REPORTED, not asserted — measuring it is the
- * purpose of the probe.
+ * <p>
+ * The probe ASSERTS only semantic equivalence (every key readable with an identical postings value
+ * in all four tries). Shape equality is REPORTED, not asserted — measuring it is the purpose of the
+ * probe.
  */
 final class HOTInsertionOrderShapeProbe {
 
@@ -198,9 +200,9 @@ final class HOTInsertionOrderShapeProbe {
   // ====================================================================
 
   /**
-   * Full structural signature of the writer's trie: node kinds, heights, disc bits, partials,
-   * child counts, leaf entry counts and leaf content hashes. Page keys are deliberately excluded
-   * (allocator order differs across the four builds by construction).
+   * Full structural signature of the writer's trie: node kinds, heights, disc bits, partials, child
+   * counts, leaf entry counts and leaf content hashes. Page keys are deliberately excluded (allocator
+   * order differs across the four builds by construction).
    */
   private static String signature(final HOTLongIndexWriter writer, final StorageEngineWriter sew) {
     final StringBuilder sb = new StringBuilder(1 << 16);
@@ -225,7 +227,9 @@ final class HOTInsertionOrderShapeProbe {
         .append("L{n=")
         .append(leaf.getEntryCount())
         .append(",first=")
-        .append(leaf.getEntryCount() > 0 ? HexFormat.of().formatHex(leaf.getKey(0)) : "-")
+        .append(leaf.getEntryCount() > 0
+            ? HexFormat.of().formatHex(leaf.getKey(0))
+            : "-")
         .append(",content=")
         .append(Long.toHexString(contentHash))
         .append("}\n");
@@ -271,9 +275,14 @@ final class HOTInsertionOrderShapeProbe {
     stats[2] = Integer.MAX_VALUE;
     collectStats(writer.getRootReference(), sew.getLog(), stats);
     final Page root = resolve(writer.getRootReference(), sew.getLog());
-    final int height = root instanceof HOTIndirectPage ind ? ind.getHeight() : 0;
+    final int height = root instanceof HOTIndirectPage ind
+        ? ind.getHeight()
+        : 0;
     System.out.println(label + " leaves=" + stats[0] + " indirects=" + stats[1] + " height=" + height + " leafFill=["
-        + (stats[2] == Integer.MAX_VALUE ? 0 : stats[2]) + ".." + stats[3] + "]/" + HOTLeafPage.MAX_ENTRIES);
+        + (stats[2] == Integer.MAX_VALUE
+            ? 0
+            : stats[2])
+        + ".." + stats[3] + "]/" + HOTLeafPage.MAX_ENTRIES);
   }
 
   private static void collectStats(final PageReference ref, final TransactionIntentLog log, final int[] stats) {
@@ -309,7 +318,9 @@ final class HOTInsertionOrderShapeProbe {
   }
 
   private static String trimTo(final String s, final int max) {
-    return s.length() <= max ? s : s.substring(0, max) + "…";
+    return s.length() <= max
+        ? s
+        : s.substring(0, max) + "…";
   }
 
   private static String indentOf(final int depth) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.hot;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.cache.PageContainer;
+import io.sirix.cache.TransactionIntentLog;
+import io.sirix.index.IndexType;
+import io.sirix.index.SearchMode;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+import io.sirix.page.HOTIndirectPage;
+import io.sirix.page.HOTLeafPage;
+import io.sirix.page.PageReference;
+import io.sirix.page.interfaces.Page;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * SHAPE-CANONICITY PROBE (task #76 phase 1): is a live sirix HOT trie's structure a function of
+ * its key set alone, or of the insertion order?
+ *
+ * <p>Feeds the SAME (key, nodeKey) set through the PRODUCTION per-entry insert path
+ * ({@code AbstractHOTIndexWriter.doIndex} via {@link HOTLongIndexWriter#indexNodeKey}) in three
+ * different orders — ascending, descending, shuffled — plus once through the bulk loader
+ * ({@link HOTLongBulkIndexLoader} → {@link HOTBulkBuilder}), each into its own index number of
+ * the same transaction. Then walks every resulting trie and compares full structural signatures
+ * (node kinds, heights, discriminative bits, partials, leaf partitioning, leaf content hashes —
+ * everything except allocator-dependent page keys).
+ *
+ * <p>The probe ASSERTS only semantic equivalence (every key readable with an identical postings
+ * value in all four tries). Shape equality is REPORTED, not asserted — measuring it is the
+ * purpose of the probe.
+ */
+final class HOTInsertionOrderShapeProbe {
+
+  private static final String RESOURCE_NAME = "hot-order-probe";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  private static final int N = 20_000;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(
+          ResourceConfiguration.newBuilder(RESOURCE_NAME).versioningApproach(VersioningType.SLIDING_SNAPSHOT).build());
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void insertionOrderShapeDifferential() {
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE_NAME);
+        JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final StorageEngineWriter sew = wtx.getStorageEngineWriter();
+
+      probePattern(sew, "dense", denseKeys(), 0);
+      probePattern(sew, "strided(rowGroup<<16|slot)", stridedKeys(), 4);
+    }
+  }
+
+  /** Dense monotone keys 0..N-1 — the shape of order labels / locator ids. */
+  private static long[] denseKeys() {
+    final long[] keys = new long[N];
+    for (int i = 0; i < N; i++) {
+      keys[i] = i;
+    }
+    return keys;
+  }
+
+  /** Strided keys (i << 16) | 3 — the projection column-segment slot shape. */
+  private static long[] stridedKeys() {
+    final long[] keys = new long[N];
+    for (int i = 0; i < N; i++) {
+      keys[i] = ((long) i << 16) | 3L;
+    }
+    return keys;
+  }
+
+  private static void probePattern(final StorageEngineWriter sew, final String label, final long[] ascending,
+      final int indexNumberBase) {
+    final long[] descending = reverse(ascending);
+    final long[] shuffled = shuffle(ascending, 42L);
+
+    final HOTLongIndexWriter ascWriter = insertIncrementally(sew, indexNumberBase, ascending);
+    final HOTLongIndexWriter descWriter = insertIncrementally(sew, indexNumberBase + 1, descending);
+    final HOTLongIndexWriter shufWriter = insertIncrementally(sew, indexNumberBase + 2, shuffled);
+    final HOTLongIndexWriter bulkWriter = insertViaBulkLoader(sew, indexNumberBase + 3, shuffled);
+    // Second bulk build from a DIFFERENT feed order — the loader sorts, so if the builder is
+    // deterministic the two bulk tries must be structurally identical.
+    final HOTLongIndexWriter bulk2Writer = insertViaBulkLoader(sew, indexNumberBase + 100, descending);
+
+    final String ascSig = signature(ascWriter, sew);
+    final String descSig = signature(descWriter, sew);
+    final String shufSig = signature(shufWriter, sew);
+    final String bulkSig = signature(bulkWriter, sew);
+    requireNonTrivial(ascSig);
+    requireNonTrivial(descSig);
+    requireNonTrivial(shufSig);
+    requireNonTrivial(bulkSig);
+
+    System.out.println("==== pattern " + label + " (N=" + N + ") ====");
+    printStats("ascending  ", ascWriter, sew);
+    printStats("descending ", descWriter, sew);
+    printStats("shuffled   ", shufWriter, sew);
+    printStats("bulk       ", bulkWriter, sew);
+    System.out.println("shape asc==desc : " + ascSig.equals(descSig));
+    System.out.println("shape asc==shuf : " + ascSig.equals(shufSig));
+    System.out.println("shape desc==shuf: " + descSig.equals(shufSig));
+    System.out.println("shape asc==bulk : " + ascSig.equals(bulkSig));
+    System.out.println("shape desc==bulk: " + descSig.equals(bulkSig));
+    System.out.println("shape shuf==bulk: " + shufSig.equals(bulkSig));
+    final String bulk2Sig = signature(bulk2Writer, sew);
+    requireNonTrivial(bulk2Sig);
+    System.out.println("shape bulk==bulk2 (determinism): " + bulkSig.equals(bulk2Sig));
+    System.out.println("-- descending tree head (height-consistency check) --");
+    final String[] descLines = descSig.split("\n");
+    for (int i = 0; i < Math.min(descLines.length, 12); i++) {
+      System.out.println("  " + trimTo(descLines[i], 150));
+    }
+    if (!ascSig.equals(bulkSig)) {
+      printFirstDivergence("asc-vs-bulk", ascSig, bulkSig);
+    }
+    if (!ascSig.equals(descSig)) {
+      printFirstDivergence("asc-vs-desc", ascSig, descSig);
+    }
+
+    // The one hard gate: SEMANTIC equivalence. Every key must be present with the identical
+    // postings payload in all four tries regardless of insertion order or build route.
+    for (final long key : ascending) {
+      final NodeReferences fromAsc = ascWriter.get(key, SearchMode.EQUAL);
+      final NodeReferences fromDesc = descWriter.get(key, SearchMode.EQUAL);
+      final NodeReferences fromShuf = shufWriter.get(key, SearchMode.EQUAL);
+      final NodeReferences fromBulk = bulkWriter.get(key, SearchMode.EQUAL);
+      assertNotNull(fromAsc, "asc missing key " + key);
+      assertNotNull(fromDesc, "desc missing key " + key);
+      assertNotNull(fromShuf, "shuf missing key " + key);
+      assertNotNull(fromBulk, "bulk missing key " + key);
+      assertEquals(fromAsc.getNodeKeys(), fromDesc.getNodeKeys(), "asc/desc postings differ at key " + key);
+      assertEquals(fromAsc.getNodeKeys(), fromShuf.getNodeKeys(), "asc/shuf postings differ at key " + key);
+      assertEquals(fromAsc.getNodeKeys(), fromBulk.getNodeKeys(), "asc/bulk postings differ at key " + key);
+    }
+    System.out.println("semantic equivalence (all 4 routes, " + N + " keys): OK");
+  }
+
+  private static HOTLongIndexWriter insertIncrementally(final StorageEngineWriter sew, final int indexNumber,
+      final long[] keys) {
+    final HOTLongIndexWriter writer = HOTLongIndexWriter.create(sew, IndexType.PATH, indexNumber);
+    for (final long key : keys) {
+      writer.indexNodeKey(key, key);
+    }
+    return writer;
+  }
+
+  private static HOTLongIndexWriter insertViaBulkLoader(final StorageEngineWriter sew, final int indexNumber,
+      final long[] keys) {
+    final HOTLongIndexWriter writer = HOTLongIndexWriter.create(sew, IndexType.PATH, indexNumber);
+    final HOTLongBulkIndexLoader loader = writer.createBulkLoader();
+    for (final long key : keys) {
+      loader.add(key, key);
+    }
+    loader.flush();
+    return writer;
+  }
+
+  // ====================================================================
+  // Structural signature
+  // ====================================================================
+
+  /**
+   * Full structural signature of the writer's trie: node kinds, heights, disc bits, partials,
+   * child counts, leaf entry counts and leaf content hashes. Page keys are deliberately excluded
+   * (allocator order differs across the four builds by construction).
+   */
+  private static String signature(final HOTLongIndexWriter writer, final StorageEngineWriter sew) {
+    final StringBuilder sb = new StringBuilder(1 << 16);
+    walk(writer.getRootReference(), sew.getLog(), sb, 0);
+    return sb.toString();
+  }
+
+  private static void walk(final PageReference ref, final TransactionIntentLog log, final StringBuilder sb,
+      final int depth) {
+    final Page page = resolve(ref, log);
+    if (page == null) {
+      sb.append(indentOf(depth)).append("UNRESOLVED\n");
+      return;
+    }
+    if (page instanceof HOTLeafPage leaf) {
+      long contentHash = 1469598103934665603L;
+      for (int i = 0; i < leaf.getEntryCount(); i++) {
+        contentHash = fnv(contentHash, leaf.getKey(i));
+        contentHash = fnv(contentHash, leaf.getValue(i));
+      }
+      sb.append(indentOf(depth))
+        .append("L{n=")
+        .append(leaf.getEntryCount())
+        .append(",first=")
+        .append(leaf.getEntryCount() > 0 ? HexFormat.of().formatHex(leaf.getKey(0)) : "-")
+        .append(",content=")
+        .append(Long.toHexString(contentHash))
+        .append("}\n");
+      return;
+    }
+    final HOTIndirectPage indirect = (HOTIndirectPage) page;
+    sb.append(indentOf(depth))
+      .append("I{type=")
+      .append(indirect.getNodeType())
+      .append(",h=")
+      .append(indirect.getHeight())
+      .append(",n=")
+      .append(indirect.getNumChildren())
+      .append(",bits=")
+      .append(Arrays.toString(HOTIncrementalInsert.discriminativeBits(indirect)))
+      .append(",partials=")
+      .append(Arrays.toString(Arrays.copyOf(indirect.getPartialKeysRef(), indirect.getNumChildren())))
+      .append("}\n");
+    for (int i = 0; i < indirect.getNumChildren(); i++) {
+      walk(indirect.getChildReference(i), log, sb, depth + 1);
+    }
+  }
+
+  /** In-transaction page resolution: swizzled page first, then the transaction-intent log. */
+  private static Page resolve(final PageReference ref, final TransactionIntentLog log) {
+    final Page page = ref.getPage();
+    if (page != null) {
+      return page;
+    }
+    final PageContainer container = log.get(ref);
+    if (container != null) {
+      final Page modified = container.getModified();
+      if (modified != null) {
+        ref.setPage(modified);
+        return modified;
+      }
+    }
+    return null;
+  }
+
+  private static void printStats(final String label, final HOTLongIndexWriter writer, final StorageEngineWriter sew) {
+    final int[] stats = new int[4]; // {leaves, indirects, minFill, maxFill}
+    stats[2] = Integer.MAX_VALUE;
+    collectStats(writer.getRootReference(), sew.getLog(), stats);
+    final Page root = resolve(writer.getRootReference(), sew.getLog());
+    final int height = root instanceof HOTIndirectPage ind ? ind.getHeight() : 0;
+    System.out.println(label + " leaves=" + stats[0] + " indirects=" + stats[1] + " height=" + height + " leafFill=["
+        + (stats[2] == Integer.MAX_VALUE ? 0 : stats[2]) + ".." + stats[3] + "]/" + HOTLeafPage.MAX_ENTRIES);
+  }
+
+  private static void collectStats(final PageReference ref, final TransactionIntentLog log, final int[] stats) {
+    final Page page = resolve(ref, log);
+    if (page instanceof HOTLeafPage leaf) {
+      stats[0]++;
+      stats[2] = Math.min(stats[2], leaf.getEntryCount());
+      stats[3] = Math.max(stats[3], leaf.getEntryCount());
+      return;
+    }
+    if (page instanceof HOTIndirectPage indirect) {
+      stats[1]++;
+      for (int i = 0; i < indirect.getNumChildren(); i++) {
+        collectStats(indirect.getChildReference(i), log, stats);
+      }
+    }
+  }
+
+  private static void printFirstDivergence(final String label, final String a, final String b) {
+    final String[] linesA = a.split("\n");
+    final String[] linesB = b.split("\n");
+    final int limit = Math.min(linesA.length, linesB.length);
+    for (int i = 0; i < limit; i++) {
+      if (!linesA[i].equals(linesB[i])) {
+        System.out.println("first divergence (" + label + ") at walk line " + i + ":");
+        System.out.println("  A: " + trimTo(linesA[i], 160));
+        System.out.println("  B: " + trimTo(linesB[i], 160));
+        return;
+      }
+    }
+    System.out.println("divergence (" + label + "): one walk is a prefix of the other (lines " + linesA.length + " vs "
+        + linesB.length + ")");
+  }
+
+  private static String trimTo(final String s, final int max) {
+    return s.length() <= max ? s : s.substring(0, max) + "…";
+  }
+
+  private static String indentOf(final int depth) {
+    return "  ".repeat(depth);
+  }
+
+  private static long fnv(long hash, final byte[] bytes) {
+    for (final byte b : bytes) {
+      hash = (hash ^ (b & 0xFF)) * 1099511628211L;
+    }
+    return hash;
+  }
+
+  private static long[] reverse(final long[] keys) {
+    final long[] out = keys.clone();
+    for (int i = 0, j = out.length - 1; i < j; i++, j--) {
+      final long tmp = out[i];
+      out[i] = out[j];
+      out[j] = tmp;
+    }
+    return out;
+  }
+
+  private static long[] shuffle(final long[] keys, final long seed) {
+    final List<Long> list = new ArrayList<>(keys.length);
+    for (final long key : keys) {
+      list.add(key);
+    }
+    Collections.shuffle(list, new Random(seed));
+    final long[] out = new long[keys.length];
+    for (int i = 0; i < out.length; i++) {
+      out[i] = list.get(i);
+    }
+    return out;
+  }
+
+  /** Guard against silently probing an empty tree (a vacuous signature comparison). */
+  private static void requireNonTrivial(final String sig) {
+    if (sig.isEmpty() || sig.startsWith("UNRESOLVED")) {
+      fail("probe walked an empty or unresolvable trie — the comparison would be vacuous");
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIntegrateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIntegrateTest.java
@@ -30,17 +30,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Verification of {@link HOTIncrementalInsert#integrate} — step 4 of the faithful incremental
- * port ({@code docs/HOT_INCREMENTAL_PORT_PLAN.md} §3 step 4): the spine integration of a
- * {@link BiNode}, including the capacity cascade.
+ * Verification of {@link HOTIncrementalInsert#integrate} — step 4 of the faithful incremental port
+ * ({@code docs/HOT_INCREMENTAL_PORT_PLAN.md} §3 step 4): the spine integration of a {@link BiNode},
+ * including the capacity cascade.
  *
- * <p>Each scenario builds a canonical trie with {@link HOTBulkBuilder}, overflows one leaf via
+ * <p>
+ * Each scenario builds a canonical trie with {@link HOTBulkBuilder}, overflows one leaf via
  * {@link HOTIncrementalInsert#splitLeafPage} (re-using an existing key, so the key multiset is
  * preserved), integrates the resulting {@code BiNode}, and checks the rebuilt trie two ways:
  * structurally clean ({@link HOTMalformedSubtreeDetector} reports nothing) and routing-correct
- * (every key still PEXT-descends to a leaf that contains it). The four integration cases —
- * direct new root, addEntry into a not-full node, single-level cascade, and a multi-level
- * cascade — are each exercised.
+ * (every key still PEXT-descends to a leaf that contains it). The four integration cases — direct
+ * new root, addEntry into a not-full node, single-level cascade, and a multi-level cascade — are
+ * each exercised.
  */
 @DisplayName("HOTIncrementalInsert.integrate — spine integration + capacity cascade")
 final class HOTIntegrateTest {
@@ -57,12 +58,13 @@ final class HOTIntegrateTest {
     assertTrue(built.rootPage() instanceof HOTLeafPage, "200 keys must fit a single leaf page");
 
     final HOTLeafPage rootLeaf = (HOTLeafPage) built.rootPage();
-    final BiNode biNode = HOTIncrementalInsert.splitLeafPage(rootLeaf, rootLeaf.getKey(0), VALUE,
-        1, IndexType.CAS, allocator::getAndIncrement);
+    final BiNode biNode = HOTIncrementalInsert.splitLeafPage(rootLeaf, rootLeaf.getKey(0), VALUE, 1, IndexType.CAS,
+        allocator::getAndIncrement);
     final PageReference rootRef = built.rootReference();
-    final PageReference newRoot = HOTIncrementalInsert.integrate(new HOTIndirectPage[0],
-        new PageReference[] {rootRef}, new int[0], 0, biNode, 1, allocator::getAndIncrement)
-        .rootRef();
+    final PageReference newRoot = HOTIncrementalInsert
+                                                      .integrate(new HOTIndirectPage[0], new PageReference[] {rootRef},
+                                                          new int[0], 0, biNode, 1, allocator::getAndIncrement)
+                                                      .rootRef();
 
     assertSame(rootRef, newRoot, "depth-0 integration re-points the index-root reference");
     assertCleanAndRoutes(newRoot, keys, "direct-new-root");
@@ -79,12 +81,13 @@ final class HOTIntegrateTest {
     final HOTIndirectPage root = (HOTIndirectPage) built.rootPage();
 
     // splitIndirect yields a not-full compound node with leaf children — the addEntry target.
-    final BiNode rootSplit = HOTIncrementalInsert.splitIndirect(root, 1,
-        allocator::getAndIncrement);
+    final BiNode rootSplit = HOTIncrementalInsert.splitIndirect(root, 1, allocator::getAndIncrement);
     final PageReference halfRef = rootSplit.left().getPage() instanceof HOTIndirectPage
-        ? rootSplit.left() : rootSplit.right();
+        ? rootSplit.left()
+        : rootSplit.right();
     final PageReference orphanHalfRef = halfRef == rootSplit.left()
-        ? rootSplit.right() : rootSplit.left();
+        ? rootSplit.right()
+        : rootSplit.left();
     final HOTIndirectPage half = (HOTIndirectPage) halfRef.getPage();
     assertTrue(half.getNumChildren() < HOTIndirectPage.MAX_NODE_ENTRIES, "half is not full");
 
@@ -93,12 +96,14 @@ final class HOTIntegrateTest {
     final HOTLeafPage leaf = (HOTLeafPage) half.getChildReference(slot).getPage();
     final TreeSet<String> subtreeKeys = collectKeys(half);
 
-    final BiNode biNode = HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1,
-        IndexType.CAS, allocator::getAndIncrement);
+    final BiNode biNode =
+        HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
     // integrate folds the BiNode in via addEntry — a clean canonical fold.
-    final PageReference newRoot = HOTIncrementalInsert.integrate(new HOTIndirectPage[] {half},
-        new PageReference[] {halfRef, half.getChildReference(slot)},
-        new int[] {slot}, 1, biNode, 1, allocator::getAndIncrement).rootRef();
+    final PageReference newRoot = HOTIncrementalInsert
+                                                      .integrate(new HOTIndirectPage[] {half},
+                                                          new PageReference[] {halfRef, half.getChildReference(slot)},
+                                                          new int[] {slot}, 1, biNode, 1, allocator::getAndIncrement)
+                                                      .rootRef();
     assertSame(halfRef, newRoot, "addEntry re-points the parent's reference, the root reference");
     assertCleanAndRoutesKeys(newRoot, subtreeKeys, "addEntry");
     assertEquals(subtreeKeys, collectKeys(newRoot.getPage()), "addEntry preserves the key set");
@@ -122,12 +127,15 @@ final class HOTIntegrateTest {
     final int slot = firstMultiEntryLeafSlot(root);
     assertTrue(slot >= 0, "a full height-1 root must have a splittable leaf child");
     final HOTLeafPage leaf = (HOTLeafPage) root.getChildReference(slot).getPage();
-    final BiNode biNode = HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0),
-        VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
+    final BiNode biNode =
+        HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
     // The full root cascades — splitIndirect + addEntry into a half + a fresh root.
-    final PageReference newRoot = HOTIncrementalInsert.integrate(new HOTIndirectPage[] {root},
-        new PageReference[] {built.rootReference(), root.getChildReference(slot)},
-        new int[] {slot}, 1, biNode, 1, allocator::getAndIncrement).rootRef();
+    final PageReference newRoot = HOTIncrementalInsert
+                                                      .integrate(new HOTIndirectPage[] {root},
+                                                          new PageReference[] {built.rootReference(),
+                                                              root.getChildReference(slot)},
+                                                          new int[] {slot}, 1, biNode, 1, allocator::getAndIncrement)
+                                                      .rootRef();
     final HOTIndirectPage newRootPage = (HOTIndirectPage) newRoot.getPage();
     assertEquals(2, newRootPage.getNumChildren(), "the cascade grows a fresh 2-entry root");
     assertEquals(root.getHeight() + 1, newRootPage.getHeight(), "the trie height grows by one");
@@ -168,14 +176,12 @@ final class HOTIntegrateTest {
     final HOTIndirectPage mid = (HOTIndirectPage) root.getChildReference(midSlot).getPage();
     final HOTLeafPage leaf = (HOTLeafPage) mid.getChildReference(leafSlot).getPage();
 
-    final BiNode biNode = HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0),
-        VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
+    final BiNode biNode =
+        HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
     // The cascade folds the leaf split through the full mid and the full root via addEntry at
     // each level — a clean two-level cascade.
-    final PageReference newRoot = HOTIncrementalInsert.integrate(
-        new HOTIndirectPage[] {root, mid},
-        new PageReference[] {built.rootReference(), root.getChildReference(midSlot),
-            mid.getChildReference(leafSlot)},
+    final PageReference newRoot = HOTIncrementalInsert.integrate(new HOTIndirectPage[] {root, mid},
+        new PageReference[] {built.rootReference(), root.getChildReference(midSlot), mid.getChildReference(leafSlot)},
         new int[] {midSlot, leafSlot}, 2, biNode, 1, allocator::getAndIncrement).rootRef();
     assertEquals(root.getHeight() + 1, ((HOTIndirectPage) newRoot.getPage()).getHeight(),
         "a full-path cascade grows the height by exactly one");
@@ -189,8 +195,7 @@ final class HOTIntegrateTest {
   // Verification helpers.
   // ======================================================================
 
-  private static void assertCleanAndRoutes(final PageReference root, final List<Long> keys,
-      final String label) {
+  private static void assertCleanAndRoutes(final PageReference root, final List<Long> keys, final String label) {
     final List<MalformedSubtree> malformed = HOTMalformedSubtreeDetector.detect(root, RESOLVER);
     assertTrue(malformed.isEmpty(), label + ": malformed subtree(s) " + malformed);
     for (final long key : keys) {
@@ -198,8 +203,8 @@ final class HOTIntegrateTest {
     }
   }
 
-  private static void assertCleanAndRoutesKeys(final PageReference root,
-      final TreeSet<String> hexKeys, final String label) {
+  private static void assertCleanAndRoutesKeys(final PageReference root, final TreeSet<String> hexKeys,
+      final String label) {
     final List<MalformedSubtree> malformed = HOTMalformedSubtreeDetector.detect(root, RESOLVER);
     assertTrue(malformed.isEmpty(), label + ": malformed subtree(s) " + malformed);
     for (final String hex : hexKeys) {
@@ -207,8 +212,7 @@ final class HOTIntegrateTest {
     }
   }
 
-  private static void assertRoutes(final PageReference root, final byte[] key,
-      final String label) {
+  private static void assertRoutes(final PageReference root, final byte[] key, final String label) {
     Page page = root.getPage();
     int depth = 0;
     while (page instanceof HOTIndirectPage indirect) {
@@ -216,8 +220,7 @@ final class HOTIntegrateTest {
         fail(label + ": descent for " + HexFormat.of().formatHex(key) + " exceeded depth 64");
       }
       final int childIndex = indirect.findChildIndex(key);
-      assertTrue(childIndex >= 0, label + ": routing NOT_FOUND for "
-          + HexFormat.of().formatHex(key));
+      assertTrue(childIndex >= 0, label + ": routing NOT_FOUND for " + HexFormat.of().formatHex(key));
       page = indirect.getChildReference(childIndex).getPage();
     }
     assertTrue(page instanceof HOTLeafPage, label + ": descent did not reach a leaf");
@@ -229,20 +232,20 @@ final class HOTIntegrateTest {
   // Leaf selection + page / key utilities.
   // ======================================================================
 
-  /** The first slot of a {@code >= 2}-entry (so splittable) leaf child of {@code node}, or
-   *  {@code -1} if none. */
+  /**
+   * The first slot of a {@code >= 2}-entry (so splittable) leaf child of {@code node}, or {@code -1}
+   * if none.
+   */
   private static int firstMultiEntryLeafSlot(final HOTIndirectPage node) {
     for (int i = 0; i < node.getNumChildren(); i++) {
-      if (node.getChildReference(i).getPage() instanceof HOTLeafPage leaf
-          && leaf.getEntryCount() >= 2) {
+      if (node.getChildReference(i).getPage() instanceof HOTLeafPage leaf && leaf.getEntryCount() >= 2) {
         return i;
       }
     }
     return -1;
   }
 
-  private static HOTBulkBuilder.BuildResult build(final List<Long> sortedKeys,
-      final AtomicLong allocator) {
+  private static HOTBulkBuilder.BuildResult build(final List<Long> sortedKeys, final AtomicLong allocator) {
     final List<HOTBulkBuilder.Entry> entries = new ArrayList<>(sortedKeys.size());
     for (final long key : sortedKeys) {
       entries.add(new HOTBulkBuilder.Entry(beKey(key), VALUE));
@@ -260,12 +263,12 @@ final class HOTIntegrateTest {
   }
 
   /**
-   * Keys whose top 5 bits carry a group id 0..31: the {@code R(S)} recursion consumes those
-   * bits first, so the build yields exactly one leaf per group under a FULL 32-child height-1
-   * root — the cascade scenario's precondition, forced by the keys themselves rather than by
-   * any leaf-packing heuristic. Requires {@code 256 < perGroup ≤ 512}: a single group must fit
-   * one leaf page while a PAIR of groups must not, or the highest-fitting-subtree cut lands a
-   * level higher and halves the child count.
+   * Keys whose top 5 bits carry a group id 0..31: the {@code R(S)} recursion consumes those bits
+   * first, so the build yields exactly one leaf per group under a FULL 32-child height-1 root — the
+   * cascade scenario's precondition, forced by the keys themselves rather than by any leaf-packing
+   * heuristic. Requires {@code 256 < perGroup ≤ 512}: a single group must fit one leaf page while a
+   * PAIR of groups must not, or the highest-fitting-subtree cut lands a level higher and halves the
+   * child count.
    */
   private static List<Long> groupedKeys(final int perGroup, final long seed) {
     final TreeSet<Long> set = new TreeSet<>(Long::compareUnsigned);
@@ -281,9 +284,9 @@ final class HOTIntegrateTest {
   }
 
   /**
-   * Two-level variant: bits 63–59 root group, bits 58–54 mid group — a FULL height-2 root whose
-   * 32 children are each FULL height-1 nodes over 32 multi-entry leaves. Same pair-overflow
-   * constraint as {@link #groupedKeys}: {@code 256 < perLeaf ≤ 512}.
+   * Two-level variant: bits 63–59 root group, bits 58–54 mid group — a FULL height-2 root whose 32
+   * children are each FULL height-1 nodes over 32 multi-entry leaves. Same pair-overflow constraint
+   * as {@link #groupedKeys}: {@code 256 < perLeaf ≤ 512}.
    */
   private static List<Long> groupedKeys2(final int perLeaf, final long seed) {
     final TreeSet<Long> set = new TreeSet<>(Long::compareUnsigned);
@@ -349,8 +352,7 @@ final class HOTIntegrateTest {
     }
   }
 
-  private static void assertSame(final PageReference expected, final PageReference actual,
-      final String message) {
+  private static void assertSame(final PageReference expected, final PageReference actual, final String message) {
     assertTrue(expected == actual, message);
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIntegrateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTIntegrateTest.java
@@ -110,7 +110,10 @@ final class HOTIntegrateTest {
   @DisplayName("a full root: integrate cascades — split the root, integrate, grow a new root")
   void integratesViaCascadeToNewRoot() {
     final AtomicLong allocator = new AtomicLong(1);
-    final List<Long> keys = randomKeys(5_000, 33L);
+    // 32 key-designed groups of 400 → exactly one leaf per group under a FULL height-1 root
+    // (see groupedKeys): the precondition no longer emerges from random keys now that the
+    // builder cuts leaves at the highest fitting R(S) subtree.
+    final List<Long> keys = groupedKeys(400, 33L);
     final HOTBulkBuilder.BuildResult built = build(keys, allocator);
     final HOTIndirectPage root = (HOTIndirectPage) built.rootPage();
     assertEquals(HOTIndirectPage.MAX_NODE_ENTRIES, root.getNumChildren(), "root is full");
@@ -138,10 +141,13 @@ final class HOTIntegrateTest {
   @DisplayName("a two-level full trie: the cascade propagates mid -> root -> new root")
   void integratesViaMultiLevelCascade() {
     final AtomicLong allocator = new AtomicLong(1);
-    final List<Long> keys = randomKeys(50_000, 44L);
+    // 32×32 key-designed groups of 300 → a FULL height-2 root over FULL height-1 mids over
+    // multi-entry leaves (see groupedKeys2) — the full-path-cascade precondition by key
+    // design, independent of the builder's leaf-packing policy.
+    final List<Long> keys = groupedKeys2(300, 44L);
     final HOTBulkBuilder.BuildResult built = build(keys, allocator);
     final HOTIndirectPage root = (HOTIndirectPage) built.rootPage();
-    assertEquals(2, root.getHeight(), "50k keys must yield a height-2 root");
+    assertEquals(2, root.getHeight(), "grouped keys must yield a height-2 root");
 
     assertEquals(HOTIndirectPage.MAX_NODE_ENTRIES, root.getNumChildren(), "root is full");
     // Pick a full mid child and a splittable leaf inside it, so the cascade propagates
@@ -249,6 +255,47 @@ final class HOTIntegrateTest {
     final Random random = new Random(seed);
     while (set.size() < count) {
       set.add(random.nextLong());
+    }
+    return new ArrayList<>(set);
+  }
+
+  /**
+   * Keys whose top 5 bits carry a group id 0..31: the {@code R(S)} recursion consumes those
+   * bits first, so the build yields exactly one leaf per group under a FULL 32-child height-1
+   * root — the cascade scenario's precondition, forced by the keys themselves rather than by
+   * any leaf-packing heuristic. Requires {@code 256 < perGroup ≤ 512}: a single group must fit
+   * one leaf page while a PAIR of groups must not, or the highest-fitting-subtree cut lands a
+   * level higher and halves the child count.
+   */
+  private static List<Long> groupedKeys(final int perGroup, final long seed) {
+    final TreeSet<Long> set = new TreeSet<>(Long::compareUnsigned);
+    final Random random = new Random(seed);
+    for (int g = 0; g < HOTIndirectPage.MAX_NODE_ENTRIES; g++) {
+      final long prefix = (long) g << 59;
+      final int before = set.size();
+      while (set.size() < before + perGroup) {
+        set.add(prefix | (random.nextLong() >>> 5));
+      }
+    }
+    return new ArrayList<>(set);
+  }
+
+  /**
+   * Two-level variant: bits 63–59 root group, bits 58–54 mid group — a FULL height-2 root whose
+   * 32 children are each FULL height-1 nodes over 32 multi-entry leaves. Same pair-overflow
+   * constraint as {@link #groupedKeys}: {@code 256 < perLeaf ≤ 512}.
+   */
+  private static List<Long> groupedKeys2(final int perLeaf, final long seed) {
+    final TreeSet<Long> set = new TreeSet<>(Long::compareUnsigned);
+    final Random random = new Random(seed);
+    for (int g = 0; g < HOTIndirectPage.MAX_NODE_ENTRIES; g++) {
+      for (int m = 0; m < HOTIndirectPage.MAX_NODE_ENTRIES; m++) {
+        final long prefix = ((long) g << 59) | ((long) m << 54);
+        final int before = set.size();
+        while (set.size() < before + perLeaf) {
+          set.add(prefix | (random.nextLong() >>> 10));
+        }
+      }
     }
     return new ArrayList<>(set);
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/StraddleCanonicityProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/StraddleCanonicityProbe.java
@@ -239,10 +239,15 @@ final class StraddleCanonicityProbe {
     final HOTMalformedSubtreeDetector.PageResolver resolver = PageReference::getPage;
 
     // ---- (A) operation-level: addEntry folds never inflate a height-1 node. ----
+    // Grouped keys (top 5 bits = group id, 300 keys per group) force the shape the scenario
+    // needs BY KEY DESIGN — a height-1 root with 16 leaf children — independent of the
+    // builder's leaf-packing policy. A random set no longer reaches it: honest highest-
+    // fitting-subtree cuts turn 20K random keys into ~50 well-filled leaves whose height-1
+    // nodes are too small for splitIndirect to yield indirect halves.
     int foldsChecked = 0;
     int foldsRejectedByGuard = 0;
     for (final int seed : new int[] {99, 100, 101, 102}) {
-      final List<byte[]> keys = random(20_000, seed);
+      final List<byte[]> keys = grouped(16, 300, seed);
       final AtomicLong allocator = new AtomicLong(1);
       final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(keys), 1,
           IndexType.CAS, allocator::getAndIncrement);
@@ -557,6 +562,30 @@ final class StraddleCanonicityProbe {
       set.add(rng.nextLong());
     }
     final List<byte[]> keys = new ArrayList<>(n);
+    for (final long k : set) {
+      keys.add(beKey(k));
+    }
+    return keys;
+  }
+
+  /**
+   * Keys whose top 5 bits carry a group id: the {@code R(S)} recursion consumes exactly those
+   * bits first, so a build yields one leaf per group under a root compound node with
+   * {@code groups} children — the shape is forced by the KEYS, not by any leaf-packing
+   * heuristic of the builder. Requires {@code 256 < perGroup ≤ 512}: one group must fit a leaf
+   * page while a PAIR must not, or the highest-fitting-subtree cut lands a level higher.
+   */
+  private static List<byte[]> grouped(final int groups, final int perGroup, final long seed) {
+    final Random rng = new Random(0xA5A5_5A5AL ^ seed);
+    final TreeSet<Long> set = new TreeSet<>(Long::compareUnsigned);
+    for (int g = 0; g < groups; g++) {
+      final long prefix = (long) g << 59;
+      final int before = set.size();
+      while (set.size() < before + perGroup) {
+        set.add(prefix | (rng.nextLong() >>> 5));
+      }
+    }
+    final List<byte[]> keys = new ArrayList<>(set.size());
     for (final long k : set) {
       keys.add(beKey(k));
     }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/hot/StraddleCanonicityProbe.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/hot/StraddleCanonicityProbe.java
@@ -23,10 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Decisive empirical probe: does the canonical {@link HOTBulkBuilder} ever itself produce a
  * compound node with a child that straddles one of that node's own discriminative bits?
  *
- * <p>A child "straddles" disc bit {@code b} when the keys in that child's subtree are not all
- * equal at bit {@code b} (some 0, some 1). For every compound node and every disc bit, this
- * probe walks every child's whole subtree and checks bit-constancy. It also independently
- * verifies that PEXT routing reaches the leaf actually containing each key.
+ * <p>
+ * A child "straddles" disc bit {@code b} when the keys in that child's subtree are not all equal at
+ * bit {@code b} (some 0, some 1). For every compound node and every disc bit, this probe walks
+ * every child's whole subtree and checks bit-constancy. It also independently verifies that PEXT
+ * routing reaches the leaf actually containing each key.
  */
 final class StraddleCanonicityProbe {
 
@@ -50,8 +51,8 @@ final class StraddleCanonicityProbe {
 
     for (final KeySet ks : sets) {
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(ks.keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(ks.keys), 1, IndexType.CAS, allocator::getAndIncrement);
       final Page root = built.rootPage();
 
       final int[] stat = new int[3]; // {compounds, straddles, misroutes}
@@ -62,10 +63,8 @@ final class StraddleCanonicityProbe {
           stat[2]++;
         }
       }
-      System.out.printf("[%s] keys=%d leafPages=%d indirectPages=%d "
-              + "compoundNodes=%d straddles=%d misroutes=%d%n",
-          ks.name, ks.keys.size(), built.leafCount(), built.indirectCount(),
-          stat[0], stat[1], stat[2]);
+      System.out.printf("[%s] keys=%d leafPages=%d indirectPages=%d " + "compoundNodes=%d straddles=%d misroutes=%d%n",
+          ks.name, ks.keys.size(), built.leafCount(), built.indirectCount(), stat[0], stat[1], stat[2]);
       totalCompounds += stat[0];
       totalStraddles += stat[1];
       totalMisroutes += stat[2];
@@ -74,17 +73,18 @@ final class StraddleCanonicityProbe {
     }
 
     System.out.println("=======================================================");
-    System.out.printf("TOTAL: compoundNodes=%d straddles=%d misroutes=%d%n",
-        totalCompounds, totalStraddles, totalMisroutes);
-    System.out.println("DECISIVE: HOTBulkBuilder produces straddling children = "
-        + (totalStraddles > 0 ? "YES" : "NO"));
-    System.out.println("DECISIVE: canonical trees route 100% correctly = "
-        + (totalMisroutes == 0 ? "YES" : "NO"));
+    System.out.printf("TOTAL: compoundNodes=%d straddles=%d misroutes=%d%n", totalCompounds, totalStraddles,
+        totalMisroutes);
+    System.out.println("DECISIVE: HOTBulkBuilder produces straddling children = " + (totalStraddles > 0
+        ? "YES"
+        : "NO"));
+    System.out.println("DECISIVE: canonical trees route 100% correctly = " + (totalMisroutes == 0
+        ? "YES"
+        : "NO"));
 
     // The probe asserts only routing soundness — straddle COUNT is reported, not asserted,
     // because answering whether straddles occur is the very question under investigation.
-    assertTrue(totalMisroutes == 0,
-        "canonical HOTBulkBuilder tree misrouted " + totalMisroutes + " keys");
+    assertTrue(totalMisroutes == 0, "canonical HOTBulkBuilder tree misrouted " + totalMisroutes + " keys");
   }
 
   // ====================================================================
@@ -120,27 +120,25 @@ final class StraddleCanonicityProbe {
     }
     for (final KeySet workload : sets) {
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(workload.keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(workload.keys), 1, IndexType.CAS, allocator::getAndIncrement);
       if (!(built.rootPage() instanceof HOTIndirectPage root) || root.getHeight() != 1) {
         closeLeaves(built.rootPage());
         continue;
       }
-      final HOTIncrementalInsert.BiNode split =
-          HOTIncrementalInsert.splitIndirect(root, 1, allocator::getAndIncrement);
+      final HOTIncrementalInsert.BiNode split = HOTIncrementalInsert.splitIndirect(root, 1, allocator::getAndIncrement);
       final PageReference targetRef = split.left().getPage() instanceof HOTIndirectPage
-          ? split.left() : split.right();
+          ? split.left()
+          : split.right();
       if (!(targetRef.getPage() instanceof HOTIndirectPage target)) {
         closeLeaves(built.rootPage());
         continue;
       }
       for (int slot = 0; slot < target.getNumChildren(); slot++) {
-        if (!(target.getChildReference(slot).getPage() instanceof HOTLeafPage leaf)
-            || leaf.getEntryCount() < 2) {
+        if (!(target.getChildReference(slot).getPage() instanceof HOTLeafPage leaf) || leaf.getEntryCount() < 2) {
           continue;
         }
-        final int beta =
-            HOTBulkBuilder.msdb(leaf.getKey(0), leaf.getKey(leaf.getEntryCount() - 1));
+        final int beta = HOTBulkBuilder.msdb(leaf.getKey(0), leaf.getKey(leaf.getEntryCount() - 1));
         // addEntry folds a NEW disc bit; skip leaves whose MSDB is already a node disc bit
         // (that is addEntryWithInsertInfo's job, not addEntry's).
         if (java.util.Arrays.binarySearch(absoluteDiscBits(target), beta) >= 0) {
@@ -151,21 +149,21 @@ final class StraddleCanonicityProbe {
         final boolean straddleFree = !someSiblingStraddles(target, slot, beta);
 
         // Re-inserting an existing key keeps the key set unchanged; addEntry folds the split.
-        final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(
-            leaf, leaf.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
-        final HOTIndirectPage integrated = HOTIncrementalInsert.addEntry(target, leafSplit, slot, 1,
-            allocator::getAndIncrement);
+        final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1,
+            IndexType.CAS, allocator::getAndIncrement);
+        final HOTIndirectPage integrated =
+            HOTIncrementalInsert.addEntry(target, leafSplit, slot, 1, allocator::getAndIncrement);
         final PageReference integratedRef = new PageReference();
         integratedRef.setPage(integrated);
 
-        final String label = workload.name + " slot=" + slot
-            + (straddleFree ? " (straddle-free)" : " (STRADDLING — guard would fire)");
+        final String label = workload.name + " slot=" + slot + (straddleFree
+            ? " (straddle-free)"
+            : " (STRADDLING — guard would fire)");
 
         // (a) CANONICITY: zero malformed subtrees per the production detector.
         final List<HOTMalformedSubtreeDetector.MalformedSubtree> malformed =
             HOTMalformedSubtreeDetector.detect(integratedRef, resolver);
-        assertTrue(malformed.isEmpty(),
-            label + ": addEntry fold produced malformed subtree(s) " + malformed);
+        assertTrue(malformed.isEmpty(), label + ": addEntry fold produced malformed subtree(s) " + malformed);
 
         // (b) ROUTING: every key PEXT-descends to its real leaf.
         final List<byte[]> nk = new ArrayList<>();
@@ -181,8 +179,8 @@ final class StraddleCanonicityProbe {
         final AtomicLong refAlloc = new AtomicLong(1);
         final TreeSet<byte[]> nodeKeys = new TreeSet<>(java.util.Arrays::compareUnsigned);
         nodeKeys.addAll(nk);
-        final HOTBulkBuilder.BuildResult ref = HOTBulkBuilder.build(
-            entries(new ArrayList<>(nodeKeys)), 1, IndexType.CAS, refAlloc::getAndIncrement);
+        final HOTBulkBuilder.BuildResult ref =
+            HOTBulkBuilder.build(entries(new ArrayList<>(nodeKeys)), 1, IndexType.CAS, refAlloc::getAndIncrement);
         if (ref.rootPage() instanceof HOTIndirectPage refRoot
             && java.util.Arrays.equals(absoluteDiscBits(refRoot), absoluteDiscBits(integrated))
             && refRoot.getNumChildren() == integrated.getNumChildren()) {
@@ -190,9 +188,8 @@ final class StraddleCanonicityProbe {
           final int[] rp = refRoot.getPartialKeys();
           final int[] ip = integrated.getPartialKeys();
           for (int i = 0; i < integrated.getNumChildren(); i++) {
-            assertTrue(rp[i] == ip[i],
-                label + ": partial[" + i + "] differs — bulk=0x" + Integer.toHexString(rp[i])
-                    + " addEntry=0x" + Integer.toHexString(ip[i]));
+            assertTrue(rp[i] == ip[i], label + ": partial[" + i + "] differs — bulk=0x" + Integer.toHexString(rp[i])
+                + " addEntry=0x" + Integer.toHexString(ip[i]));
           }
           discBitMatches++;
         }
@@ -206,8 +203,7 @@ final class StraddleCanonicityProbe {
       closeLeaves(built.rootPage());
     }
     System.out.printf("[step4] addEntry folds checked=%d (STRADDLING=%d) | all canonical "
-        + "(0 malformed) + route 100%% | disc-bit-identical to HOTBulkBuilder in %d cases | "
-        + "guardRejections=%d%n",
+        + "(0 malformed) + route 100%% | disc-bit-identical to HOTBulkBuilder in %d cases | " + "guardRejections=%d%n",
         totalFoldsChecked, straddlingCasesChecked, discBitMatches, guardRejections);
     // With the guard ENABLED, straddling folds are rejected (guardRejections > 0) and the
     // accepted folds are all straddle-free. With the guard DISABLED, every straddling fold
@@ -220,16 +216,16 @@ final class StraddleCanonicityProbe {
   // ====================================================================
   // STEP 3 — minimum-height preservation. Two complementary checks:
   //
-  //  (A) OPERATION-LEVEL no-inflation: an addEntry fold of a leaf-page split into a
-  //      height-1 node keeps the node at height 1 (height = 1 + max child height; the
-  //      split's halves are leaf pages, height 0). The removed guard used to force a
-  //      rebuildSubtree instead — same height but O(subtree) cost. A pure pessimization.
+  // (A) OPERATION-LEVEL no-inflation: an addEntry fold of a leaf-page split into a
+  // height-1 node keeps the node at height 1 (height = 1 + max child height; the
+  // split's halves are leaf pages, height 0). The removed guard used to force a
+  // rebuildSubtree instead — same height but O(subtree) cost. A pure pessimization.
   //
-  //  (B) SCALE: a random ~20K key set built by HOTBulkBuilder, and the same set whose
-  //      canonical height is what the incremental writer's end-to-end canaries also
-  //      reach (HOTFormalVerificationTest.comprehensiveRandomWithReplacement reports
-  //      observedHeight=2 at ~20K, built via the addEntry/integrate path). We assert the
-  //      bulk height equals that incremental observedHeight (2) — incremental == bulk.
+  // (B) SCALE: a random ~20K key set built by HOTBulkBuilder, and the same set whose
+  // canonical height is what the incremental writer's end-to-end canaries also
+  // reach (HOTFormalVerificationTest.comprehensiveRandomWithReplacement reports
+  // observedHeight=2 at ~20K, built via the addEntry/integrate path). We assert the
+  // bulk height equals that incremental observedHeight (2) — incremental == bulk.
   //
   // Every folded node is also asserted canonical (0 malformed subtrees) and 100%-routing.
   // ====================================================================
@@ -249,8 +245,8 @@ final class StraddleCanonicityProbe {
     for (final int seed : new int[] {99, 100, 101, 102}) {
       final List<byte[]> keys = grouped(16, 300, seed);
       final AtomicLong allocator = new AtomicLong(1);
-      final HOTBulkBuilder.BuildResult built = HOTBulkBuilder.build(entries(keys), 1,
-          IndexType.CAS, allocator::getAndIncrement);
+      final HOTBulkBuilder.BuildResult built =
+          HOTBulkBuilder.build(entries(keys), 1, IndexType.CAS, allocator::getAndIncrement);
       if (!(built.rootPage() instanceof HOTIndirectPage root)) {
         closeLeaves(built.rootPage());
         continue;
@@ -264,7 +260,8 @@ final class StraddleCanonicityProbe {
       final HOTIncrementalInsert.BiNode split =
           HOTIncrementalInsert.splitIndirect(height1Node, 1, allocator::getAndIncrement);
       final PageReference targetRef = split.left().getPage() instanceof HOTIndirectPage
-          ? split.left() : split.right();
+          ? split.left()
+          : split.right();
       if (!(targetRef.getPage() instanceof HOTIndirectPage target) || target.getHeight() != 1) {
         closeLeaves(built.rootPage());
         continue;
@@ -272,24 +269,22 @@ final class StraddleCanonicityProbe {
       HOTIndirectPage node = target;
       for (int slot = 0; slot < node.getNumChildren()
           && node.getNumChildren() < HOTIndirectPage.MAX_NODE_ENTRIES; slot++) {
-        if (!(node.getChildReference(slot).getPage() instanceof HOTLeafPage leaf)
-            || leaf.getEntryCount() < 2) {
+        if (!(node.getChildReference(slot).getPage() instanceof HOTLeafPage leaf) || leaf.getEntryCount() < 2) {
           continue;
         }
-        final int beta =
-            HOTBulkBuilder.msdb(leaf.getKey(0), leaf.getKey(leaf.getEntryCount() - 1));
+        final int beta = HOTBulkBuilder.msdb(leaf.getKey(0), leaf.getKey(leaf.getEntryCount() - 1));
         if (java.util.Arrays.binarySearch(absoluteDiscBits(node), beta) >= 0) {
           continue; // MSDB already a node disc bit — addEntryWithInsertInfo's job
         }
         final int heightBefore = node.getHeight();
-        final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(
-            leaf, leaf.getKey(0), VALUE, 1, IndexType.CAS, allocator::getAndIncrement);
-        final HOTIndirectPage folded = HOTIncrementalInsert.addEntry(node, leafSplit, slot, 1,
-            allocator::getAndIncrement);
+        final HOTIncrementalInsert.BiNode leafSplit = HOTIncrementalInsert.splitLeafPage(leaf, leaf.getKey(0), VALUE, 1,
+            IndexType.CAS, allocator::getAndIncrement);
+        final HOTIndirectPage folded =
+            HOTIncrementalInsert.addEntry(node, leafSplit, slot, 1, allocator::getAndIncrement);
         node = folded;
         assertTrue(node.getHeight() == heightBefore,
-            "seed=" + seed + " slot=" + slot + ": addEntry fold inflated height "
-                + heightBefore + " -> " + node.getHeight() + " — minimum-height VIOLATED");
+            "seed=" + seed + " slot=" + slot + ": addEntry fold inflated height " + heightBefore + " -> "
+                + node.getHeight() + " — minimum-height VIOLATED");
         foldsChecked++;
       }
       // The fully-folded node is canonical and routes every key.
@@ -297,8 +292,7 @@ final class StraddleCanonicityProbe {
       incRef.setPage(node);
       final List<HOTMalformedSubtreeDetector.MalformedSubtree> malformed =
           HOTMalformedSubtreeDetector.detect(incRef, resolver);
-      assertTrue(malformed.isEmpty(),
-          "seed=" + seed + ": folded node malformed " + malformed);
+      assertTrue(malformed.isEmpty(), "seed=" + seed + ": folded node malformed " + malformed);
       final List<byte[]> incKeys = new ArrayList<>();
       collectKeys(node, incKeys);
       for (final byte[] k : incKeys) {
@@ -311,27 +305,27 @@ final class StraddleCanonicityProbe {
     // Guard ENABLED: every leaf-split fold here straddles a sibling, so all are rejected
     // (foldsRejectedByGuard > 0, foldsChecked == 0). Guard DISABLED: all folds accepted and
     // verified non-inflating (foldsChecked > 0). Either path exercised the operation.
-    assertTrue(foldsChecked > 0 || foldsRejectedByGuard > 0,
-        "no addEntry fold exercised — coverage gap");
+    assertTrue(foldsChecked > 0 || foldsRejectedByGuard > 0, "no addEntry fold exercised — coverage gap");
 
     // ---- (B) scale: HOTBulkBuilder height of a 20K random set == the height the
     // incremental addEntry/integrate path reaches end-to-end on the same scale. ----
     final List<byte[]> bulk20K = random(20_000, 7);
     final AtomicLong bulkAlloc = new AtomicLong(1);
-    final HOTBulkBuilder.BuildResult bulk = HOTBulkBuilder.build(entries(bulk20K), 1,
-        IndexType.CAS, bulkAlloc::getAndIncrement);
-    final int bulkHeight = bulk.rootPage() instanceof HOTIndirectPage bh ? bh.getHeight() : 0;
+    final HOTBulkBuilder.BuildResult bulk =
+        HOTBulkBuilder.build(entries(bulk20K), 1, IndexType.CAS, bulkAlloc::getAndIncrement);
+    final int bulkHeight = bulk.rootPage() instanceof HOTIndirectPage bh
+        ? bh.getHeight()
+        : 0;
     // HOTFormalVerificationTest.comprehensiveRandomWithReplacement (run in step 2 with the
     // guard disabled) reported observedHeight=2 for its ~20K-distinct random set built via
     // the addEntry/integrate path. A canonical 20K random HOT is height 2.
-    System.out.printf("[step3] (A) %d addEntry folds accepted (none inflated height), "
+    System.out.printf(
+        "[step3] (A) %d addEntry folds accepted (none inflated height), "
             + "%d rejected by the straddle guard | (B) HOTBulkBuilder(20K random) height=%d "
-            + "(incremental addEntry path reaches observedHeight=2 — see "
-            + "HOTFormalVerificationTest canary)%n",
+            + "(incremental addEntry path reaches observedHeight=2 — see " + "HOTFormalVerificationTest canary)%n",
         foldsChecked, foldsRejectedByGuard, bulkHeight);
-    assertTrue(bulkHeight == 2,
-        "HOTBulkBuilder(20K random) height " + bulkHeight + " != 2 (the incremental "
-            + "observedHeight) — incremental and bulk heights diverge");
+    assertTrue(bulkHeight == 2, "HOTBulkBuilder(20K random) height " + bulkHeight + " != 2 (the incremental "
+        + "observedHeight) — incremental and bulk heights diverge");
     closeLeaves(bulk.rootPage());
   }
 
@@ -355,7 +349,9 @@ final class StraddleCanonicityProbe {
         final ConstancyState st = bitConstancy(subtreeKeys, b);
         if (st == ConstancyState.MIXED) {
           stat[1]++;
-          final int sparse = partials != null && c < partials.length ? partials[c] : -1;
+          final int sparse = partials != null && c < partials.length
+              ? partials[c]
+              : -1;
           // Is bit b on the child's block-path? Under sparse-path encoding the child's stored
           // partial has the column for an on-path-AND-took-1-side disc bit set. We report the
           // stored partial, the bit column, and whether that column bit is set, plus the full
@@ -368,14 +364,15 @@ final class StraddleCanonicityProbe {
               break;
             }
           }
-          final int colBitWeight = col >= 0 ? (1 << (m - 1 - col)) : 0;
+          final int colBitWeight = col >= 0
+              ? (1 << (m - 1 - col))
+              : 0;
           final boolean colBitSet = sparse >= 0 && (sparse & colBitWeight) != 0;
           System.out.printf(
               "  STRADDLE [%s] node(pk=%d,layout=%s) child[%d] straddles discBit=%d "
-                  + "(col=%d, colWeight=0x%x, storedPartial=0x%x, colBitSet=%b) "
-                  + "subtreeKeys=%d discBits=%s%n",
-              label, node.getPageKey(), node.getLayoutType(), c, b, col, colBitWeight,
-              sparse, colBitSet, subtreeKeys.size(), java.util.Arrays.toString(discBits));
+                  + "(col=%d, colWeight=0x%x, storedPartial=0x%x, colBitSet=%b) " + "subtreeKeys=%d discBits=%s%n",
+              label, node.getPageKey(), node.getLayoutType(), c, b, col, colBitWeight, sparse, colBitSet,
+              subtreeKeys.size(), java.util.Arrays.toString(discBits));
         }
       }
     }
@@ -385,12 +382,11 @@ final class StraddleCanonicityProbe {
   }
 
   /**
-   * Whether some non-affected sibling of {@code node} (any child slot != {@code affectedSlot})
-   * has a subtree that straddles bit {@code beta} — the structural condition the now-removed
-   * straddle guard used to reject; this probe still detects it for diagnostic counting.
+   * Whether some non-affected sibling of {@code node} (any child slot != {@code affectedSlot}) has a
+   * subtree that straddles bit {@code beta} — the structural condition the now-removed straddle guard
+   * used to reject; this probe still detects it for diagnostic counting.
    */
-  private static boolean someSiblingStraddles(final HOTIndirectPage node, final int affectedSlot,
-      final int beta) {
+  private static boolean someSiblingStraddles(final HOTIndirectPage node, final int affectedSlot, final int beta) {
     for (int c = 0; c < node.getNumChildren(); c++) {
       if (c == affectedSlot) {
         continue;
@@ -404,7 +400,9 @@ final class StraddleCanonicityProbe {
     return false;
   }
 
-  private enum ConstancyState { ALL_ZERO, ALL_ONE, MIXED, EMPTY }
+  private enum ConstancyState {
+    ALL_ZERO, ALL_ONE, MIXED, EMPTY
+  }
 
   private static ConstancyState bitConstancy(final List<byte[]> keys, final int absBit) {
     boolean seen0 = false;
@@ -429,8 +427,8 @@ final class StraddleCanonicityProbe {
   }
 
   /**
-   * The node's discriminative bits as absolute MSB-first positions, reconstructed from the
-   * page's mask (SingleMask) or extraction positions+masks (MultiMask).
+   * The node's discriminative bits as absolute MSB-first positions, reconstructed from the page's
+   * mask (SingleMask) or extraction positions+masks (MultiMask).
    */
   private static int[] absoluteDiscBits(final HOTIndirectPage node) {
     final TreeSet<Integer> bits = new TreeSet<>();
@@ -453,8 +451,7 @@ final class StraddleCanonicityProbe {
         final int keyBytePos = extractionPositions[i] & 0xFF;
         final int chunkIdx = i / 8;
         final int byteOffsetInChunk = i % 8;
-        final long byteMask =
-            (extractionMasks[chunkIdx] >>> ((7 - byteOffsetInChunk) * 8)) & 0xFFL;
+        final long byteMask = (extractionMasks[chunkIdx] >>> ((7 - byteOffsetInChunk) * 8)) & 0xFFL;
         for (int b = 0; b < 8; b++) {
           if ((byteMask & (1L << (7 - b))) != 0) {
             bits.add(keyBytePos * 8 + b);
@@ -500,8 +497,7 @@ final class StraddleCanonicityProbe {
     return best[0];
   }
 
-  private static void findLargestHeight1Node(final Page page, final HOTIndirectPage[] best,
-      final int[] bestKeys) {
+  private static void findLargestHeight1Node(final Page page, final HOTIndirectPage[] best, final int[] bestKeys) {
     if (!(page instanceof HOTIndirectPage node)) {
       return;
     }
@@ -545,7 +541,8 @@ final class StraddleCanonicityProbe {
   // Key sets.
   // ====================================================================
 
-  private record KeySet(String name, List<byte[]> keys) {}
+  private record KeySet(String name, List<byte[]> keys) {
+  }
 
   private static List<byte[]> ascending(final int n) {
     final List<byte[]> keys = new ArrayList<>(n);
@@ -569,11 +566,11 @@ final class StraddleCanonicityProbe {
   }
 
   /**
-   * Keys whose top 5 bits carry a group id: the {@code R(S)} recursion consumes exactly those
-   * bits first, so a build yields one leaf per group under a root compound node with
-   * {@code groups} children — the shape is forced by the KEYS, not by any leaf-packing
-   * heuristic of the builder. Requires {@code 256 < perGroup ≤ 512}: one group must fit a leaf
-   * page while a PAIR must not, or the highest-fitting-subtree cut lands a level higher.
+   * Keys whose top 5 bits carry a group id: the {@code R(S)} recursion consumes exactly those bits
+   * first, so a build yields one leaf per group under a root compound node with {@code groups}
+   * children — the shape is forced by the KEYS, not by any leaf-packing heuristic of the builder.
+   * Requires {@code 256 < perGroup ≤ 512}: one group must fit a leaf page while a PAIR must not, or
+   * the highest-fitting-subtree cut lands a level higher.
    */
   private static List<byte[]> grouped(final int groups, final int perGroup, final long seed) {
     final Random rng = new Random(0xA5A5_5A5AL ^ seed);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/GlobalValueDictionaryWriterBudgetTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/GlobalValueDictionaryWriterBudgetTest.java
@@ -10,6 +10,9 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,6 +52,61 @@ final class GlobalValueDictionaryWriterBudgetTest {
     assertTrue(thrown.retainedBytes() <= thrown.budgetBytes() + (64L << 10), "retained " + thrown.retainedBytes()
         + " overshot the " + thrown.budgetBytes() + " budget by more than one growth step — the check runs too late");
     assertTrue(thrown.getMessage().contains("budget"), thrown.getMessage());
+
+    // A byte-budget decline has to carry the term it WEIGHED, not merely what it retains. Every
+    // guard here compares retention plus a reservation, and a dictionary whose retention alone had
+    // passed the bound would have been refused one admission earlier — so a decline reporting
+    // retention states a figure BELOW the budget it announces as breached, and the operator gets no
+    // number to raise the budget to.
+    assertNotNull(thrown.breachingTerm(), "a byte-budget decline must name the term that tripped it: " + thrown);
+    assertTrue(thrown.breachingBytes() > thrown.budgetBytes(),
+        "the quantity the decline blames must actually exceed the budget it quotes (" + thrown.breachingBytes()
+            + " B vs " + thrown.budgetBytes() + " B, term " + thrown.breachingTerm() + ")");
+    assertTrue(thrown.retainedBytes() <= thrown.breachingBytes(),
+        "retention cannot exceed the retention-plus-reservation term weighed against the budget");
+    assertTrue(
+        thrown.getMessage().contains(thrown.breachingTerm())
+            && thrown.getMessage().contains(Long.toString(thrown.breachingBytes())),
+        "the message must state its own arithmetic, named and valued: " + thrown.getMessage());
+    assertTrue(
+        thrown.getMessage().contains("Raise the configured byte budget to at least " + thrown.breachingBytes() + " B"),
+        "the remedy must quote a budget worth raising to: " + thrown.getMessage());
+  }
+
+  @Test
+  @DisplayName("A structural ceiling declines without claiming any quantity exceeded the byte budget")
+  void structuralDeclinesWeighNoBytesAgainstTheBudget() {
+    // The other half of the contract. These ceilings are counts and lengths, not bytes: nothing was
+    // compared against the budget, so the decline must not invent a comparison the way the old
+    // single-constructor message did.
+    final GlobalValueDictionaryWriter atTheChunkCeiling = new GlobalValueDictionaryWriter();
+    for (int i = 0; i < GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND; i++) {
+      final byte[] bytes = compactValue(i);
+      atTheChunkCeiling.intern(bytes, 0, bytes.length);
+    }
+    final byte[] pastTheChunkCeiling = compactValue(GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND);
+
+    // A fresh writer for the length ceiling, so the entry-count guard cannot shadow it.
+    final GlobalValueDictionaryWriter empty = new GlobalValueDictionaryWriter();
+    final byte[] pastTheValueCeiling = new byte[GlobalValueDictionaryWriter.MAX_VALUE_BYTES + 1];
+
+    for (final GlobalDictionaryBudgetExceededException structural : new GlobalDictionaryBudgetExceededException[] {
+        assertThrows(GlobalDictionaryBudgetExceededException.class,
+            () -> atTheChunkCeiling.intern(pastTheChunkCeiling, 0, pastTheChunkCeiling.length)),
+        assertThrows(GlobalDictionaryBudgetExceededException.class,
+            () -> empty.intern(pastTheValueCeiling, 0, pastTheValueCeiling.length))}) {
+      assertNull(structural.breachingTerm(),
+          "a structural ceiling weighs no bytes, so it must name no breaching term: " + structural.getMessage());
+      assertEquals(structural.retainedBytes(), structural.breachingBytes(),
+          "with nothing weighed, the reported quantity is simply what is retained");
+      assertNotNull(structural.admissionDetail(), "a structural decline must state which ceiling it hit");
+      assertTrue(structural.getMessage().contains(structural.admissionDetail()),
+          "the message must state the ceiling, not a byte comparison: " + structural.getMessage());
+      assertFalse(structural.getMessage().contains("past the"),
+          "a structural decline must not announce a budget breach it never measured: " + structural.getMessage());
+      assertTrue(structural.getMessage().contains("raising the byte budget cannot override"),
+          "the remedy must say a bigger budget will not help here: " + structural.getMessage());
+    }
   }
 
   @Test

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ParallelBulkProjectionEquivalenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ParallelBulkProjectionEquivalenceTest.java
@@ -1,0 +1,472 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The v2 gate: a PARALLEL bulk import with a projection definition armed must produce, in the same
+ * single pass, a projection identical to the one the post-pass build derives from the finished
+ * resource.
+ *
+ * <p>
+ * "Identical" is taken literally here rather than at the row-group level the sequential gate settled
+ * for: {@link ProjectionStorageSnapshot} sweeps every slot family the projection sub-tree owns —
+ * metadata, row-group descriptors, column-segment slots, the assembled leaves, fence chunks
+ * including the physical-order header, per-column Bloom manifests and chunks, set-summary chunks,
+ * the sparse record locator, the structural-order directory and the value-dictionary blobs — and
+ * compares the raw bytes of each. The one field deliberately excluded is the metadata's
+ * {@code buildRevision}: it records WHICH revision built the index, and a post-pass build cannot run
+ * in the load's own revision by construction (it walks a resource that must already be committed).
+ * Every byte that encodes DATA is compared.
+ */
+final class ParallelBulkProjectionEquivalenceTest {
+
+  private static final java.nio.file.Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+  private static final java.nio.file.Path POST_PASS_DATABASE_PATH = JsonTestHelper.PATHS.PATH2.getFile();
+  private static final int INDEX_NUMBER = 0;
+
+  private static final String ROOT_PATH = "/[]";
+  private static final List<String> FIELD_PATHS =
+      List.of("/[]/name", "/[]/dept", "/[]/score", "/[]/ratio", "/[]/active", "/[]/tags/[]", "/[]/latecomer",
+          "/[]/nested/inner");
+  private static final List<Type> FIELD_TYPES =
+      List.of(Type.STR, Type.STR, Type.LON, Type.DBL, Type.BOOL, Type.STR, Type.STR, Type.LON);
+
+  /** Small enough to run everywhere, large enough to span many pages, chunks and leaves. */
+  private static final int RECORDS = 4000;
+  /** Forces chunk boundaries to land mid-page and page-sharing stitches on nearly every chunk. */
+  private static final int CHUNK_BUDGET_BYTES = 6 * 1024;
+  private static final int BUILDERS = 4;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    JsonTestHelper.deleteEverything();
+    ProjectionBulkLoad.clearActive();
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    ProjectionBulkLoad.clearActive();
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void aParallelOnePassLoadProducesTheSameProjectionAsThePostPassBuild() throws Exception {
+    final byte[] corpus = corpus(RECORDS);
+
+    final ProjectionStorageSnapshot onePass = loadOnePassParallel(DATABASE_PATH, corpus);
+    final ProjectionStorageSnapshot postPass = loadParallelThenPostPass(POST_PASS_DATABASE_PATH, corpus);
+
+    assertFalse(onePass.stale(), "the one-pass build must have replaced its own tombstone");
+    assertFalse(postPass.stale(), "the post-pass build must have published live metadata");
+    assertTrue(onePass.rowGroupCount() > 1,
+        "the corpus must span several leaves or the differential proves nothing; got " + onePass.rowGroupCount());
+    assertEquivalent(onePass, postPass);
+  }
+
+  @Test
+  void theDifferentialCanFail() throws Exception {
+    // A guard that cannot say "no" is not evidence. Two corpora differing in ONE cell of ONE record
+    // must produce snapshots the comparator rejects.
+    final ProjectionStorageSnapshot a = loadOnePassParallel(DATABASE_PATH, corpus(RECORDS));
+    final ProjectionStorageSnapshot b = loadOnePassParallel(POST_PASS_DATABASE_PATH, corpusWithMutatedRecord(RECORDS));
+
+    assertThrows(AssertionError.class, () -> assertEquivalent(a, b),
+        "the comparator must reject two projections that differ in a single cell");
+  }
+
+  @Test
+  void anUnarmedParallelImportStillRefusesACataloguedProjection() throws Exception {
+    // Arming is optional, but a catalogued projection with no armed load must not be silently left
+    // unmaintained: the importer's workers never notify, so nothing would ever feed it.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE);
+          JsonNodeTrx wtx = session.beginNodeTrx()) {
+        session.getWtxIndexController(wtx.getRevisionNumber()).getIndexes().add(projectionDef());
+        final IllegalStateException refusal = assertThrows(IllegalStateException.class,
+            () -> ParallelBulkJsonImporter.assemble(wtx, new ByteArrayInputStream(corpus(8))));
+        assertTrue(refusal.getMessage().contains("no load-time build armed"),
+            "expected the arm refusal, got: " + refusal.getMessage());
+      }
+    }
+  }
+
+
+  @Test
+  void aRecordStraddlingTheHeldTailPageSurvivesTheFlushEpoch() throws Exception {
+    // The bug this pins: a chunk's last record can BEGIN in a page already adopted into the intent
+    // log and END in the page held back for the boundary stitch. It cannot be handed to the build
+    // until its tail arrives, and if the epoch flushes in between, its head is written out and the
+    // record can no longer be read whole — the extraction then reads a recycled page frame and dies
+    // (or, worse, would have silently dropped the row). Tiny chunks plus a 64-node flush bound make
+    // that straddle happen constantly.
+    final byte[] corpus = corpus(400);
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(64, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          final JsonIndexController controller = session.getWtxIndexController(wtx.getRevisionNumber());
+          controller.createProjectionIndexAtLoadStart(projectionDef(), wtx, 400);
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus), 200, 1);
+          wtx.commit();
+        }
+        // The build's own end-of-load check compares rows emitted against the record-set array's
+        // child count and refuses loudly when it comes up short, so reaching a live (non-stale)
+        // metadata at all is the witness that every record was read whole.
+        final ProjectionStorageSnapshot onePass = snapshot(session);
+        assertFalse(onePass.stale(), "every record must have been extracted before its epoch flushed");
+      }
+    }
+  }
+
+  // ==== arms ===================================================================================
+
+  /** Arm (i): one transaction, projection armed before the data, records attributed by the load. */
+  private static ProjectionStorageSnapshot loadOnePassParallel(final java.nio.file.Path databasePath,
+      final byte[] corpus) throws Exception {
+    Databases.createJsonDatabase(new DatabaseConfiguration(databasePath));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(databasePath)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          final JsonIndexController controller = session.getWtxIndexController(wtx.getRevisionNumber());
+          controller.createProjectionIndexAtLoadStart(projectionDef(), wtx, RECORDS);
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus), CHUNK_BUDGET_BYTES, BUILDERS);
+          wtx.commit();
+        }
+        return snapshot(session);
+      }
+    }
+  }
+
+  /** Arm (ii): the same parallel import with nothing armed, then the ordinary post-pass build. */
+  private static ProjectionStorageSnapshot loadParallelThenPostPass(final java.nio.file.Path databasePath,
+      final byte[] corpus) throws Exception {
+    Databases.createJsonDatabase(new DatabaseConfiguration(databasePath));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(databasePath)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(1024, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus), CHUNK_BUDGET_BYTES, BUILDERS);
+          wtx.commit();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        return snapshot(session);
+      }
+    }
+  }
+
+  private static ResourceConfiguration resourceConfig() {
+    return ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                .useDeweyIDs(false)
+                                .hashKind(HashType.NONE)
+                                .storeNodeHistory(false)
+                                .buildPathSummary(true)
+                                .build();
+  }
+
+  private static IndexDef projectionDef() {
+    final List<Path<QNm>> fieldPaths = new ArrayList<>(FIELD_PATHS.size());
+    for (final String fieldPath : FIELD_PATHS) {
+      fieldPaths.add(Path.parse(fieldPath, PathParser.Type.JSON));
+    }
+    return IndexDefs.createProjectionIdxDef(Path.parse(ROOT_PATH, PathParser.Type.JSON), fieldPaths, FIELD_TYPES,
+        INDEX_NUMBER, IndexDef.DbType.JSON);
+  }
+
+  // ==== corpus =================================================================================
+
+  /**
+   * Adversarial by construction: records of varying width so chunk boundaries fall mid-page, a field
+   * that first occurs only in a LATE chunk, absent fields, nulls, a set column with a non-string
+   * element in some records, integral and non-integral numbers, and a nested object.
+   */
+  private static byte[] corpus(final int records) {
+    return buildCorpus(records, -1);
+  }
+
+  private static byte[] corpusWithMutatedRecord(final int records) {
+    return buildCorpus(records, records / 2);
+  }
+
+  private static byte[] buildCorpus(final int records, final int mutatedRecord) {
+    final StringBuilder json = new StringBuilder(records * 160);
+    json.append('[');
+    for (int record = 0; record < records; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"name\":\"n").append(record).append('-').append("x".repeat(record % 17)).append('"');
+      json.append(",\"dept\":\"d").append(record % 7).append('"');
+      json.append(",\"score\":").append(record == mutatedRecord
+          ? 999999
+          : record * 3L);
+      if (record % 5 != 0) {
+        json.append(",\"ratio\":").append(record).append('.').append(record % 100);
+      }
+      json.append(",\"active\":").append((record & 1) == 0);
+      if (record % 3 == 0) {
+        json.append(",\"tags\":[\"t").append(record % 11).append("\",\"t").append(record % 13).append("\"]");
+      } else if (record % 3 == 1) {
+        // A non-string element makes the whole set cell unrepresentable — a poisoning path the
+        // extractor owns and any worker-side reimplementation would have to reproduce.
+        json.append(",\"tags\":[\"t").append(record % 11).append("\",").append(record).append(']');
+      }
+      if (record % 4 == 0) {
+        json.append(",\"nested\":{\"inner\":").append(record * 2L).append('}');
+      } else if (record % 4 == 1) {
+        json.append(",\"nested\":{\"inner\":null}");
+      }
+      // First occurrence deliberately late: the field acquires a path class only after many chunks
+      // have already been resolved, reserved, built and adopted.
+      if (record >= records - records / 4) {
+        json.append(",\"latecomer\":\"L").append(record % 23).append('"');
+      }
+      json.append('}');
+    }
+    json.append(']');
+    return json.toString().getBytes(StandardCharsets.UTF_8);
+  }
+
+  // ==== the slot-for-slot comparator ===========================================================
+
+  /**
+   * Every persisted byte of one projection sub-tree, keyed by a human-readable slot name so a
+   * failure names the family that diverged.
+   */
+  private record ProjectionStorageSnapshot(String rootPath, String[] fieldPaths, String[] fieldNames,
+      byte[] columnKinds, int rowGroupCount, boolean stale, long[] valueDictionaryHeaderKeys,
+      Map<Integer, Map<String, Long>> setValueRowCounts, Map<String, byte[]> slots) {
+  }
+
+  /**
+   * Every persisted slot of the projection sub-tree, read through a writer-backed storage handle —
+   * the reader-side raw-slot API only serves the negative sparse-locator namespace, and the
+   * structural-order directory lives in a positive one. The transaction is opened on the committed
+   * revision and closed without committing, so it observes rather than changes anything.
+   */
+  private static ProjectionStorageSnapshot snapshot(final JsonResourceSession session) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final StorageEngineWriter writer = wtx.getStorageEngineWriter();
+      final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(writer, INDEX_NUMBER);
+      final byte[] rawMetadata = storage.getBlob(0L);
+      assertNotNull(rawMetadata, "the projection must have metadata at slot 0");
+      final ProjectionIndexMetadata metadata = ProjectionIndexMetadata.parse(rawMetadata);
+      final int rowGroups = metadata.rowGroupCount();
+      final int columns = metadata.columnKinds().length;
+      final Map<String, byte[]> slots = new LinkedHashMap<>();
+
+      // Row groups: the canonical assembled leaf. Its bytes ARE the concatenation of the row
+      // group's descriptor and column-segment slots, so comparing it compares those slots.
+      for (int rowGroup = 1; rowGroup <= rowGroups; rowGroup++) {
+        put(slots, "leaf[" + rowGroup + "]",
+            ProjectionIndexHOTStorage.readRowGroupFromColumnSegmentSlots(writer, INDEX_NUMBER, rowGroup));
+        put(slots, "rowGroupDescriptor[" + rowGroup + "]",
+            blob(storage, ProjectionIndexHOTStorage.rowGroupDescriptorSlotKey(rowGroup)));
+      }
+
+      // Fences, including the physical-order header the order-exception lane reads.
+      put(slots, "fenceOrderHeader", blob(storage, ProjectionIndexFences.ORDER_HEADER_SLOT));
+      for (int chunk = 0; chunk < chunkSweep(rowGroups); chunk++) {
+        put(slots, "fenceChunk[" + chunk + "]", blob(storage, ProjectionIndexFences.CHUNK_SLOT_BASE + chunk));
+      }
+
+      // Bloom manifests + chunks, and set summaries, per column.
+      for (int column = 0; column < columns; column++) {
+        put(slots, "bloomManifest[" + column + "]",
+            blob(storage, ProjectionIndexHOTStorage.bloomBlockSlotKey(column)));
+        put(slots, "setSummary[" + column + "]", blob(storage, ProjectionSetSummaryChunks.slotKey(column)));
+        for (int chunk = 0; chunk < chunkSweep(rowGroups); chunk++) {
+          put(slots, "bloomChunk[" + column + "][" + chunk + "]",
+              blob(storage, ProjectionBloomChunks.chunkSlotKey(column, chunk)));
+        }
+      }
+
+      // Value dictionaries: the header blobs the metadata points at, plus a window above each in
+      // case a dictionary spilled into continuation slots.
+      final long[] dictionaryHeaderKeys = metadata.valueDictionaryHeaderKeys();
+      if (dictionaryHeaderKeys != null) {
+        for (int column = 0; column < dictionaryHeaderKeys.length; column++) {
+          final long headerKey = dictionaryHeaderKeys[column];
+          if (headerKey <= 0) {
+            continue;
+          }
+          for (int offset = 0; offset < 64; offset++) {
+            put(slots, "dictionary[" + column + "][+" + offset + "]", blob(storage, headerKey + offset));
+          }
+        }
+      }
+
+      // Record locator + structural-order directory, per record key. Both are keyed by DOCUMENT
+      // node key, and the two arms load the identical corpus with the identical importer, so the
+      // node keys are the same on both sides by construction.
+      for (final long recordKey : recordKeys(wtx)) {
+        final int locator = ProjectionRecordLocator.read(writer, INDEX_NUMBER, recordKey);
+        if (locator != 0) {
+          slots.put("recordLocator[" + recordKey + "]", new byte[] { (byte) locator, (byte) (locator >>> 8),
+              (byte) (locator >>> 16), (byte) (locator >>> 24) });
+        }
+        put(slots, "structuralOrder[" + recordKey + "]",
+            structuralOrderSlot(storage, ProjectionStructuralOrderDirectory.BASE + recordKey));
+      }
+
+      return new ProjectionStorageSnapshot(metadata.rootPath(), metadata.fieldPaths(), metadata.fieldNames(),
+          metadata.columnKinds(), rowGroups, metadata.isStale(), dictionaryHeaderKeys, metadata.setValueRowCounts(),
+          slots);
+    }
+  }
+
+  /** Fence and Bloom chunks each cover a fixed window of leaves; sweep generously past the last. */
+  private static int chunkSweep(final int rowGroupCount) {
+    return Math.max(8, rowGroupCount / 8 + 8);
+  }
+
+  /**
+   * A blob slot's bytes, or {@code null} when the slot holds nothing OR holds something that is not
+   * a blob. The sweep deliberately probes past the end of every family, and a slot key one past a
+   * family's last entry can land on an unrelated raw slot; that is "absent" for this comparison,
+   * and both arms are probed identically, so a real divergence still shows.
+   */
+  private static byte[] blob(final ProjectionIndexHOTStorage storage, final long slotKey) {
+    try {
+      return storage.getBlob(slotKey);
+    } catch (final RuntimeException notABlob) {
+      return null;
+    }
+  }
+
+  /** One structural-order directory slot (a raw, positive-namespace slot), or {@code null}. */
+  private static byte[] structuralOrderSlot(final ProjectionIndexHOTStorage storage, final long slotKey) {
+    try {
+      return storage.getStructuralOrderSlot(slotKey);
+    } catch (final RuntimeException absent) {
+      return null;
+    }
+  }
+
+  private static void put(final Map<String, byte[]> slots, final String name, final byte[] value) {
+    if (value != null) {
+      slots.put(name, value);
+    }
+  }
+
+  private static long[] recordKeys(final JsonNodeReadOnlyTrx rtx) {
+    rtx.moveToDocumentRoot();
+    assertTrue(rtx.moveToFirstChild(), "the resource must expose its top-level array");
+    final long arrayKey = rtx.getNodeKey();
+    if (!rtx.moveToFirstChild()) {
+      return new long[] { arrayKey };
+    }
+    final java.util.ArrayList<Long> keys = new java.util.ArrayList<>();
+    keys.add(arrayKey);
+    do {
+      keys.add(rtx.getNodeKey());
+    } while (rtx.moveToRightSibling());
+    final long[] out = new long[keys.size()];
+    for (int i = 0; i < out.length; i++) {
+      out[i] = keys.get(i);
+    }
+    return out;
+  }
+
+  private static void assertEquivalent(final ProjectionStorageSnapshot onePass,
+      final ProjectionStorageSnapshot postPass) {
+    assertEquals(postPass.rootPath(), onePass.rootPath(), "root path");
+    assertArrayEquals(postPass.fieldPaths(), onePass.fieldPaths(), "field paths");
+    assertArrayEquals(postPass.fieldNames(), onePass.fieldNames(), "field names");
+    assertArrayEquals(postPass.columnKinds(), onePass.columnKinds(),
+        "column kinds (per-column dictionary decisions included)");
+    assertEquals(postPass.rowGroupCount(), onePass.rowGroupCount(), "row-group count");
+    assertEquals(postPass.stale(), onePass.stale(), "stale flag");
+    assertEquals(postPass.setValueRowCounts(), onePass.setValueRowCounts(), "set-value row counts");
+    assertArrayEquals(postPass.valueDictionaryHeaderKeys(), onePass.valueDictionaryHeaderKeys(),
+        "value-dictionary header keys");
+
+    final Set<String> onlyInOnePass = new java.util.TreeSet<>(onePass.slots().keySet());
+    onlyInOnePass.removeAll(postPass.slots().keySet());
+    final Set<String> onlyInPostPass = new java.util.TreeSet<>(postPass.slots().keySet());
+    onlyInPostPass.removeAll(onePass.slots().keySet());
+    assertTrue(onlyInOnePass.isEmpty(), "slots present only in the one-pass build: " + onlyInOnePass);
+    assertTrue(onlyInPostPass.isEmpty(), "slots present only in the post-pass build: " + onlyInPostPass);
+
+    for (final Map.Entry<String, byte[]> entry : postPass.slots().entrySet()) {
+      final byte[] expected = entry.getValue();
+      final byte[] actual = onePass.slots().get(entry.getKey());
+      if (!Arrays.equals(expected, actual)) {
+        throw new AssertionError("projection slot " + entry.getKey() + " differs: post-pass " + expected.length
+            + " bytes, one-pass " + (actual == null
+                ? "absent"
+                : actual.length + " bytes"));
+      }
+    }
+    // Non-vacuity: name what was actually compared, and refuse to pass on a sweep that found only
+    // a couple of families. A differential that silently compared two empty maps proves nothing.
+    final Map<String, Integer> census = new java.util.TreeMap<>();
+    for (final String name : onePass.slots().keySet()) {
+      final int bracket = name.indexOf('[');
+      census.merge(bracket < 0 ? name : name.substring(0, bracket), 1, Integer::sum);
+    }
+    System.out.println("PROJECTION DIFFERENTIAL: " + onePass.slots().size() + " slots compared byte-for-byte across "
+        + census.size() + " families " + census + "; rowGroups=" + onePass.rowGroupCount() + ", columnKinds="
+        + Arrays.toString(onePass.columnKinds()));
+    for (final String required : List.of("leaf", "rowGroupDescriptor", "structuralOrder")) {
+      assertTrue(census.containsKey(required), "the sweep found no " + required + " slots: " + census);
+    }
+    assertTrue(census.containsKey("fenceChunk") || onePass.slots().containsKey("fenceOrderHeader"),
+        "the sweep found no fence slots: " + census);
+  }
+
+  @SuppressWarnings("unused")
+  private static long sizeOf(final java.nio.file.Path path) throws IOException {
+    return Files.size(path);
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ParallelBulkProjectionEquivalenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ParallelBulkProjectionEquivalenceTest.java
@@ -51,15 +51,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * resource.
  *
  * <p>
- * "Identical" is taken literally here rather than at the row-group level the sequential gate settled
- * for: {@link ProjectionStorageSnapshot} sweeps every slot family the projection sub-tree owns —
- * metadata, row-group descriptors, column-segment slots, the assembled leaves, fence chunks
+ * "Identical" is taken literally here rather than at the row-group level the sequential gate
+ * settled for: {@link ProjectionStorageSnapshot} sweeps every slot family the projection sub-tree
+ * owns — metadata, row-group descriptors, column-segment slots, the assembled leaves, fence chunks
  * including the physical-order header, per-column Bloom manifests and chunks, set-summary chunks,
  * the sparse record locator, the structural-order directory and the value-dictionary blobs — and
  * compares the raw bytes of each. The one field deliberately excluded is the metadata's
- * {@code buildRevision}: it records WHICH revision built the index, and a post-pass build cannot run
- * in the load's own revision by construction (it walks a resource that must already be committed).
- * Every byte that encodes DATA is compared.
+ * {@code buildRevision}: it records WHICH revision built the index, and a post-pass build cannot
+ * run in the load's own revision by construction (it walks a resource that must already be
+ * committed). Every byte that encodes DATA is compared.
  */
 final class ParallelBulkProjectionEquivalenceTest {
 
@@ -68,9 +68,8 @@ final class ParallelBulkProjectionEquivalenceTest {
   private static final int INDEX_NUMBER = 0;
 
   private static final String ROOT_PATH = "/[]";
-  private static final List<String> FIELD_PATHS =
-      List.of("/[]/name", "/[]/dept", "/[]/score", "/[]/ratio", "/[]/active", "/[]/tags/[]", "/[]/latecomer",
-          "/[]/nested/inner");
+  private static final List<String> FIELD_PATHS = List.of("/[]/name", "/[]/dept", "/[]/score", "/[]/ratio",
+      "/[]/active", "/[]/tags/[]", "/[]/latecomer", "/[]/nested/inner");
   private static final List<Type> FIELD_TYPES =
       List.of(Type.STR, Type.STR, Type.LON, Type.DBL, Type.BOOL, Type.STR, Type.STR, Type.LON);
 
@@ -247,9 +246,10 @@ final class ParallelBulkProjectionEquivalenceTest {
       }
       json.append("{\"name\":\"n").append(record).append('-').append("x".repeat(record % 17)).append('"');
       json.append(",\"dept\":\"d").append(record % 7).append('"');
-      json.append(",\"score\":").append(record == mutatedRecord
-          ? 999999
-          : record * 3L);
+      json.append(",\"score\":")
+          .append(record == mutatedRecord
+              ? 999999
+              : record * 3L);
       if (record % 5 != 0) {
         json.append(",\"ratio\":").append(record).append('.').append(record % 100);
       }
@@ -280,8 +280,8 @@ final class ParallelBulkProjectionEquivalenceTest {
   // ==== the slot-for-slot comparator ===========================================================
 
   /**
-   * Every persisted byte of one projection sub-tree, keyed by a human-readable slot name so a
-   * failure names the family that diverged.
+   * Every persisted byte of one projection sub-tree, keyed by a human-readable slot name so a failure
+   * names the family that diverged.
    */
   private record ProjectionStorageSnapshot(String rootPath, String[] fieldPaths, String[] fieldNames,
       byte[] columnKinds, int rowGroupCount, boolean stale, long[] valueDictionaryHeaderKeys,
@@ -322,8 +322,7 @@ final class ParallelBulkProjectionEquivalenceTest {
 
       // Bloom manifests + chunks, and set summaries, per column.
       for (int column = 0; column < columns; column++) {
-        put(slots, "bloomManifest[" + column + "]",
-            blob(storage, ProjectionIndexHOTStorage.bloomBlockSlotKey(column)));
+        put(slots, "bloomManifest[" + column + "]", blob(storage, ProjectionIndexHOTStorage.bloomBlockSlotKey(column)));
         put(slots, "setSummary[" + column + "]", blob(storage, ProjectionSetSummaryChunks.slotKey(column)));
         for (int chunk = 0; chunk < chunkSweep(rowGroups); chunk++) {
           put(slots, "bloomChunk[" + column + "][" + chunk + "]",
@@ -352,8 +351,8 @@ final class ParallelBulkProjectionEquivalenceTest {
       for (final long recordKey : recordKeys(wtx)) {
         final int locator = ProjectionRecordLocator.read(writer, INDEX_NUMBER, recordKey);
         if (locator != 0) {
-          slots.put("recordLocator[" + recordKey + "]", new byte[] { (byte) locator, (byte) (locator >>> 8),
-              (byte) (locator >>> 16), (byte) (locator >>> 24) });
+          slots.put("recordLocator[" + recordKey + "]",
+              new byte[] {(byte) locator, (byte) (locator >>> 8), (byte) (locator >>> 16), (byte) (locator >>> 24)});
         }
         put(slots, "structuralOrder[" + recordKey + "]",
             structuralOrderSlot(storage, ProjectionStructuralOrderDirectory.BASE + recordKey));
@@ -371,10 +370,10 @@ final class ParallelBulkProjectionEquivalenceTest {
   }
 
   /**
-   * A blob slot's bytes, or {@code null} when the slot holds nothing OR holds something that is not
-   * a blob. The sweep deliberately probes past the end of every family, and a slot key one past a
-   * family's last entry can land on an unrelated raw slot; that is "absent" for this comparison,
-   * and both arms are probed identically, so a real divergence still shows.
+   * A blob slot's bytes, or {@code null} when the slot holds nothing OR holds something that is not a
+   * blob. The sweep deliberately probes past the end of every family, and a slot key one past a
+   * family's last entry can land on an unrelated raw slot; that is "absent" for this comparison, and
+   * both arms are probed identically, so a real divergence still shows.
    */
   private static byte[] blob(final ProjectionIndexHOTStorage storage, final long slotKey) {
     try {
@@ -404,7 +403,7 @@ final class ParallelBulkProjectionEquivalenceTest {
     assertTrue(rtx.moveToFirstChild(), "the resource must expose its top-level array");
     final long arrayKey = rtx.getNodeKey();
     if (!rtx.moveToFirstChild()) {
-      return new long[] { arrayKey };
+      return new long[] {arrayKey};
     }
     final java.util.ArrayList<Long> keys = new java.util.ArrayList<>();
     keys.add(arrayKey);
@@ -453,7 +452,9 @@ final class ParallelBulkProjectionEquivalenceTest {
     final Map<String, Integer> census = new java.util.TreeMap<>();
     for (final String name : onePass.slots().keySet()) {
       final int bracket = name.indexOf('[');
-      census.merge(bracket < 0 ? name : name.substring(0, bracket), 1, Integer::sum);
+      census.merge(bracket < 0
+          ? name
+          : name.substring(0, bracket), 1, Integer::sum);
     }
     System.out.println("PROJECTION DIFFERENTIAL: " + onePass.slots().size() + " slots compared byte-for-byte across "
         + census.size() + " families " + census + "; rowGroups=" + onePass.rowGroupCount() + ", columnKinds="

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
@@ -34,15 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * BOTH-ARMS WITNESS for bulk slot accumulation (campaign #76 phase 2): the same operation
- * sequence runs once with accumulation engaged and once on the plain per-entry path; the two
- * storages must be READ-IDENTICAL (in-transaction and after a real commit) while their
- * construction counters prove the two arms genuinely took different routes.
+ * BOTH-ARMS WITNESS for bulk slot accumulation (campaign #76 phase 2): the same operation sequence
+ * runs once with accumulation engaged and once on the plain per-entry path; the two storages must
+ * be READ-IDENTICAL (in-transaction and after a real commit) while their construction counters
+ * prove the two arms genuinely took different routes.
  *
- * <p>Covers the contract corners individually: read-through of accumulated point keys,
- * last-writer-wins re-puts, tombstones, inline blobs, a REFERENCED blob whose side-page attach
- * is DEFERRED (read back through the pending map mid-accumulation, attached after the splice),
- * and the malformed-subtree oracle over the spliced tree.
+ * <p>
+ * Covers the contract corners individually: read-through of accumulated point keys,
+ * last-writer-wins re-puts, tombstones, inline blobs, a REFERENCED blob whose side-page attach is
+ * DEFERRED (read back through the pending map mid-accumulation, attached after the splice), and the
+ * malformed-subtree oracle over the spliced tree.
  */
 final class ProjectionBulkSlotAccumulationTest {
 
@@ -236,10 +237,10 @@ final class ProjectionBulkSlotAccumulationTest {
 
   /**
    * Regression: a payload landing EXACTLY on the 1 MiB block boundary followed by a zero-length
-   * (tombstone) payload. The block-full guard only rolled over when the next payload did not fit,
-   * and a zero-length one "fits" at offset 1048576 — so the entry was recorded at an offset that no
-   * longer fits the packed position's 20 offset bits and carried into the block INDEX, sending
-   * every later read one block past the end of the arena.
+   * (tombstone) payload. The block-full guard only rolled over when the next payload did not fit, and
+   * a zero-length one "fits" at offset 1048576 — so the entry was recorded at an offset that no
+   * longer fits the packed position's 20 offset bits and carried into the block INDEX, sending every
+   * later read one block past the end of the arena.
    */
   @Test
   void aZeroLengthPayloadOnTheBlockBoundaryStaysAddressable() {
@@ -269,7 +270,7 @@ final class ProjectionBulkSlotAccumulationTest {
 
     // And the arena keeps working: the next real payload is addressable too.
     final long afterKey = key;
-    final byte[] after = new byte[] { 7, 8, 9 };
+    final byte[] after = new byte[] {7, 8, 9};
     assertTrue(loader.tryAdd(afterKey, after));
     assertArrayEquals(after, loader.lastPayload(afterKey));
     if (remainder.length > 0) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.access.trx.page.HOTTrieReader;
+import io.sirix.index.hot.BulkSpliceTestBridge;
+import io.sirix.index.hot.HOTBulkSlotLoader;
+import io.sirix.index.hot.PathKeySerializer;
+import io.sirix.page.PageReference;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * BOTH-ARMS WITNESS for bulk slot accumulation (campaign #76 phase 2): the same operation
+ * sequence runs once with accumulation engaged and once on the plain per-entry path; the two
+ * storages must be READ-IDENTICAL (in-transaction and after a real commit) while their
+ * construction counters prove the two arms genuinely took different routes.
+ *
+ * <p>Covers the contract corners individually: read-through of accumulated point keys,
+ * last-writer-wins re-puts, tombstones, inline blobs, a REFERENCED blob whose side-page attach
+ * is DEFERRED (read back through the pending map mid-accumulation, attached after the splice),
+ * and the malformed-subtree oracle over the spliced tree.
+ */
+final class ProjectionBulkSlotAccumulationTest {
+
+  private static final String RESOURCE_NAME = "bulk-slot-accumulation";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  private static final long LABEL_BASE = 1L << 50;
+  private static final int LABELS = 50_000;
+  private static final long META_SLOT = 0L;
+  private static final long BIG_BLOB_SLOT = (1L << 42) + 7L;
+  private static final int BIG_BLOB_BYTES = 200_000;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE_NAME).build());
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void bothArmsProduceIdenticalState() {
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE_NAME)) {
+      try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+        final StorageEngineWriter sew = wtx.getStorageEngineWriter();
+        final ProjectionIndexHOTStorage bulkArm = new ProjectionIndexHOTStorage(sew, 0);
+        final ProjectionIndexHOTStorage plainArm = new ProjectionIndexHOTStorage(sew, 1);
+
+        bulkArm.beginBulkSlotAccumulation();
+        assertTrue(bulkArm.isBulkAccumulating(), "accumulation must engage on a virgin tree");
+
+        runSequence(bulkArm);
+        assertTrue(bulkArm.isBulkAccumulating(),
+            "no trip may fire in this sequence — the big blob's side page must be DEFERRED");
+        runSequence(plainArm);
+
+        // In-transaction equality BEFORE the splice: the bulk arm serves accumulated state
+        // read-through, so the two arms must already agree.
+        compareInTransaction(bulkArm, plainArm);
+
+        bulkArm.finalizeBulkSlotAccumulation();
+        assertFalse(bulkArm.isBulkAccumulating(), "finalize must leave accumulation mode");
+
+        // Witness that the arms took DIFFERENT construction routes.
+        // Distinct spliced entries: LABELS label slots (one of them tombstoned in place —
+        // still an entry) + the metadata blob + the big blob's marker.
+        assertEquals(LABELS + 2, bulkArm.bulkSplicedEntryCount(),
+            "bulk arm must have materialized exactly the accumulated distinct entries");
+        assertEquals(0, plainArm.bulkSplicedEntryCount(), "plain arm must never bulk-splice");
+
+        // Post-splice equality + structural oracle on both trees.
+        compareInTransaction(bulkArm, plainArm);
+        assertEquals(0, BulkSpliceTestBridge.malformedSubtreeCount(bulkArm), "bulk tree malformed");
+        assertEquals(0, BulkSpliceTestBridge.malformedSubtreeCount(plainArm), "plain tree malformed");
+
+        wtx.commit();
+      }
+
+      // Committed-state equality through the reader-side path — proves the spliced tree
+      // survives the real commit identically to the per-entry tree.
+      try (JsonNodeTrx probe = session.beginNodeTrx()) {
+        final StorageEngineReader reader = probe.getStorageEngineReader();
+        final Random sample = new Random(7L);
+        for (int i = 0; i < 500; i++) {
+          final long key = LABEL_BASE + sample.nextInt(LABELS);
+          final byte[] fromBulk = committedSlot(reader, 0, key);
+          final byte[] fromPlain = committedSlot(reader, 1, key);
+          if (fromPlain == null) {
+            assertNull(fromBulk, "committed presence mismatch at " + key);
+          } else {
+            assertArrayEquals(fromPlain, fromBulk, "committed payload mismatch at " + key);
+          }
+        }
+        final byte[] bigFromBulk = ProjectionIndexHOTStorage.readSegmentPageBytes(reader, 0, BIG_BLOB_SLOT, 0);
+        final byte[] bigFromPlain = ProjectionIndexHOTStorage.readSegmentPageBytes(reader, 1, BIG_BLOB_SLOT, 0);
+        assertArrayEquals(bigFromPlain, bigFromBulk, "committed big-blob side page mismatch");
+        assertArrayEquals(bigBlobPayload(), bigFromBulk, "committed big-blob content mismatch");
+      }
+    }
+  }
+
+  /** Committed raw-slot read via trie navigation ({@code null} when absent/tombstoned). */
+  private static byte @Nullable [] committedSlot(final StorageEngineReader reader, final int indexNumber,
+      final long slotKey) {
+    final PageReference root = ProjectionIndexHOTStorage.rootReference(reader, indexNumber);
+    if (root == null) {
+      return null;
+    }
+    final byte[] keyBytes = new byte[8];
+    PathKeySerializer.INSTANCE.serialize(slotKey, keyBytes, 0);
+    try (HOTTrieReader trieReader = new HOTTrieReader(reader)) {
+      final MemorySegment slice = trieReader.get(root, keyBytes);
+      return slice == null || slice.byteSize() == 0
+          ? null
+          : slice.toArray(ValueLayout.JAVA_BYTE);
+    }
+  }
+
+  /** The shared operation sequence — every storage-contract corner the accumulator touches. */
+  private static void runSequence(final ProjectionIndexHOTStorage storage) {
+    final byte[] payload = new byte[30];
+    for (int k = 0; k < LABELS; k++) {
+      fillLabel(payload, k);
+      storage.writeSlotValue(LABEL_BASE + k, payload);
+      if (k % 100 == 50) {
+        // Interleaved read of an earlier write — the order-label walk pattern (read-through).
+        final byte[] expected = new byte[30];
+        fillLabel(expected, k - 50);
+        assertArrayEquals(expected, storage.getRawSlot(LABEL_BASE + k - 50),
+            "mid-build read-back mismatch at " + (k - 50));
+      }
+    }
+    // Last-writer-wins re-put.
+    fillLabel(payload, 123_456);
+    storage.writeSlotValue(LABEL_BASE + 17, payload);
+    // Tombstone an accumulated label (write of the zero-length tombstone value).
+    storage.writeSlotValue(LABEL_BASE + 33, new byte[0]);
+    // Inline metadata blob.
+    storage.putBlob(META_SLOT, metaPayload());
+    // REFERENCED blob: marker in the slot, payload as a side OverflowPage (deferred while
+    // accumulating), read back immediately.
+    storage.putBlob(BIG_BLOB_SLOT, bigBlobPayload());
+    assertArrayEquals(bigBlobPayload(), storage.getBlob(BIG_BLOB_SLOT), "big blob read-back");
+  }
+
+  private static void compareInTransaction(final ProjectionIndexHOTStorage bulkArm,
+      final ProjectionIndexHOTStorage plainArm) {
+    for (int k = 0; k < LABELS; k += 7) {
+      final byte[] fromBulk = bulkArm.getRawSlot(LABEL_BASE + k);
+      final byte[] fromPlain = plainArm.getRawSlot(LABEL_BASE + k);
+      if (fromPlain == null) {
+        assertNull(fromBulk, "presence mismatch at label " + k);
+      } else {
+        assertArrayEquals(fromPlain, fromBulk, "payload mismatch at label " + k);
+      }
+    }
+    assertNull(bulkArm.getRawSlot(LABEL_BASE + 33), "tombstoned label must read absent (bulk)");
+    assertNull(plainArm.getRawSlot(LABEL_BASE + 33), "tombstoned label must read absent (plain)");
+    assertArrayEquals(plainArm.getBlob(META_SLOT), bulkArm.getBlob(META_SLOT), "metadata blob mismatch");
+    assertArrayEquals(plainArm.getBlob(BIG_BLOB_SLOT), bulkArm.getBlob(BIG_BLOB_SLOT), "big blob mismatch");
+  }
+
+  private static void fillLabel(final byte[] payload, final int k) {
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (k + i * 17);
+    }
+  }
+
+  private static byte[] metaPayload() {
+    final byte[] meta = new byte[100];
+    for (int i = 0; i < meta.length; i++) {
+      meta[i] = (byte) (i * 3);
+    }
+    return meta;
+  }
+
+  private static byte[] bigBlobPayload() {
+    final byte[] big = new byte[BIG_BLOB_BYTES];
+    for (int i = 0; i < big.length; i++) {
+      big[i] = (byte) (i * 7);
+    }
+    return big;
+  }
+
+  /** Loader-level capacity contract: refusal at the entry cap, replace and membership semantics. */
+  @Test
+  void loaderCapacityAndFoldSemantics() {
+    final HOTBulkSlotLoader loader = new HOTBulkSlotLoader(4, 1L << 20);
+    assertTrue(loader.tryAdd(1L, new byte[] {1}));
+    assertTrue(loader.tryAdd(2L, new byte[] {2}));
+    assertTrue(loader.tryAdd(1L, new byte[] {9}), "re-put of an accumulated key must accumulate");
+    assertTrue(loader.tryAdd(3L, new byte[0]), "zero-length (tombstone) payloads accumulate");
+    assertFalse(loader.tryAdd(4L, new byte[] {4}), "the 5th write must refuse at maxEntries=4");
+    assertTrue(loader.containsKey(1L));
+    assertFalse(loader.containsKey(4L));
+    assertArrayEquals(new byte[] {9}, loader.lastPayload(1L), "fold must keep the LAST payload");
+    assertArrayEquals(new byte[0], loader.lastPayload(3L));
+    assertNull(loader.lastPayload(4L), "a refused write must not be visible");
+    assertEquals(4, loader.size());
+    loader.clear();
+    assertTrue(loader.isEmpty());
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkSlotAccumulationTest.java
@@ -233,4 +233,48 @@ final class ProjectionBulkSlotAccumulationTest {
     loader.clear();
     assertTrue(loader.isEmpty());
   }
+
+  /**
+   * Regression: a payload landing EXACTLY on the 1 MiB block boundary followed by a zero-length
+   * (tombstone) payload. The block-full guard only rolled over when the next payload did not fit,
+   * and a zero-length one "fits" at offset 1048576 — so the entry was recorded at an offset that no
+   * longer fits the packed position's 20 offset bits and carried into the block INDEX, sending
+   * every later read one block past the end of the arena.
+   */
+  @Test
+  void aZeroLengthPayloadOnTheBlockBoundaryStaysAddressable() {
+    final int blockBytes = 1 << 20;
+    final int maxPayload = 65_535;
+    final HOTBulkSlotLoader loader = new HOTBulkSlotLoader(1024, 8L << 20);
+
+    // Fill the first block to EXACTLY its last byte.
+    int filled = 0;
+    long key = 0L;
+    while (blockBytes - filled > maxPayload) {
+      final byte[] payload = new byte[maxPayload];
+      payload[0] = (byte) key;
+      assertTrue(loader.tryAdd(key++, payload));
+      filled += maxPayload;
+    }
+    final byte[] remainder = new byte[blockBytes - filled];
+    if (remainder.length > 0) {
+      remainder[0] = 42;
+      assertTrue(loader.tryAdd(key++, remainder));
+    }
+
+    final long tombstoneKey = key++;
+    assertTrue(loader.tryAdd(tombstoneKey, new byte[0]), "a tombstone must accumulate on the boundary");
+    assertArrayEquals(new byte[0], loader.lastPayload(tombstoneKey),
+        "the boundary tombstone must read back as a zero-length payload");
+
+    // And the arena keeps working: the next real payload is addressable too.
+    final long afterKey = key;
+    final byte[] after = new byte[] { 7, 8, 9 };
+    assertTrue(loader.tryAdd(afterKey, after));
+    assertArrayEquals(after, loader.lastPayload(afterKey));
+    if (remainder.length > 0) {
+      assertArrayEquals(remainder, loader.lastPayload(afterKey - 2),
+          "the payload that exactly closed the block must still read back");
+    }
+  }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkVsPerEntryBench.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkVsPerEntryBench.java
@@ -28,27 +28,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * PHASE-2 PERF GATE (campaign #76): per-entry {@code writeSlotValue} vs the bulk
- * build-and-splice path for the two projection write shapes the campaign targets.
+ * PHASE-2 PERF GATE (campaign #76): per-entry {@code writeSlotValue} vs the bulk build-and-splice
+ * path for the two projection write shapes the campaign targets.
  *
  * <ul>
- * <li><b>label</b> — order-directory shape: strictly ascending {@code 2^50 + k}, ~30 B
- * payloads (one slot per record);</li>
- * <li><b>segslot</b> — column-segment shape: {@code (rowGroupId << 16) | slotKind} with ~200
- * slots per row group, ascending overall.</li>
+ * <li><b>label</b> — order-directory shape: strictly ascending {@code 2^50 + k}, ~30 B payloads
+ * (one slot per record);</li>
+ * <li><b>segslot</b> — column-segment shape: {@code (rowGroupId << 16) | slotKind} with ~200 slots
+ * per row group, ascending overall.</li>
  * </ul>
  *
- * <p>Both arms run the PRODUCTION paths inside a real transaction: per-entry =
- * {@link ProjectionIndexHOTStorage#writeSlotValue} (descent + dispatch + put + split cascade);
- * bulk = key serialization + entry-list assembly + {@code spliceBulkBuiltRoot} (via
+ * <p>
+ * Both arms run the PRODUCTION paths inside a real transaction: per-entry =
+ * {@link ProjectionIndexHOTStorage#writeSlotValue} (descent + dispatch + put + split cascade); bulk
+ * = key serialization + entry-list assembly + {@code spliceBulkBuiltRoot} (via
  * {@link BulkSpliceTestBridge}), i.e. everything a slot loader would do after accumulation.
  *
- * <p>Protocol: per shape and scale, a JIT warmup round of both arms (100 k), then interleaved
- * measured repetitions (per-entry, bulk, per-entry, bulk at 1 M; one repetition each at 10 M,
- * per-entry FIRST so any thermal drift penalizes the bulk arm — conservative for the claim under
- * test). Reported number = best repetition. Correctness witnesses run OUTSIDE the timed
- * regions: sampled read-back equality across arms and a zero-malformed-subtree check on the
- * bulk tree.
+ * <p>
+ * Protocol: per shape and scale, a JIT warmup round of both arms (100 k), then interleaved measured
+ * repetitions (per-entry, bulk, per-entry, bulk at 1 M; one repetition each at 10 M, per-entry
+ * FIRST so any thermal drift penalizes the bulk arm — conservative for the claim under test).
+ * Reported number = best repetition. Correctness witnesses run OUTSIDE the timed regions: sampled
+ * read-back equality across arms and a zero-malformed-subtree check on the bulk tree.
  */
 final class ProjectionBulkVsPerEntryBench {
 
@@ -124,10 +125,11 @@ final class ProjectionBulkVsPerEntryBench {
     }
   }
 
-  private record TimedStorage(long nanos, ProjectionIndexHOTStorage storage) {}
+  private record TimedStorage(long nanos, ProjectionIndexHOTStorage storage) {
+  }
 
-  private TimedStorage timePerEntry(final StorageEngineWriter sew, final int indexNumber,
-      final LongUnaryOperator keyOf, final int entries) {
+  private TimedStorage timePerEntry(final StorageEngineWriter sew, final int indexNumber, final LongUnaryOperator keyOf,
+      final int entries) {
     final long start = System.nanoTime();
     final ProjectionIndexHOTStorage storage = runPerEntry(sew, indexNumber, keyOf, entries);
     return new TimedStorage(System.nanoTime() - start, storage);
@@ -153,9 +155,9 @@ final class ProjectionBulkVsPerEntryBench {
   }
 
   /**
-   * Bulk arm: everything a slot loader does after accumulation — serialize each key
-   * (sign-flipped 8-byte BE), copy the payload, assemble the exact-size entry list, build and
-   * splice through the production {@code spliceBulkBuiltRoot}.
+   * Bulk arm: everything a slot loader does after accumulation — serialize each key (sign-flipped
+   * 8-byte BE), copy the payload, assemble the exact-size entry list, build and splice through the
+   * production {@code spliceBulkBuiltRoot}.
    */
   private ProjectionIndexHOTStorage runBulk(final StorageEngineWriter sew, final int indexNumber,
       final LongUnaryOperator keyOf, final int entries) {
@@ -208,7 +210,7 @@ final class ProjectionBulkVsPerEntryBench {
     final String ratioText = Double.isNaN(ratio)
         ? "-"
         : String.format("%.2fx", ratio);
-    System.out.printf("%-8s %-9d %-10s %13.1f %10.1f   %s%n", shape, entries, arm, nsPerEntry,
-        nanos / 1_000_000.0, ratioText);
+    System.out.printf("%-8s %-9d %-10s %13.1f %10.1f   %s%n", shape, entries, arm, nsPerEntry, nanos / 1_000_000.0,
+        ratioText);
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkVsPerEntryBench.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionBulkVsPerEntryBench.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineWriter;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.hot.BulkSpliceTestBridge;
+import io.sirix.index.hot.HOTBulkBuilder;
+import io.sirix.index.hot.PathKeySerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.LongUnaryOperator;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * PHASE-2 PERF GATE (campaign #76): per-entry {@code writeSlotValue} vs the bulk
+ * build-and-splice path for the two projection write shapes the campaign targets.
+ *
+ * <ul>
+ * <li><b>label</b> — order-directory shape: strictly ascending {@code 2^50 + k}, ~30 B
+ * payloads (one slot per record);</li>
+ * <li><b>segslot</b> — column-segment shape: {@code (rowGroupId << 16) | slotKind} with ~200
+ * slots per row group, ascending overall.</li>
+ * </ul>
+ *
+ * <p>Both arms run the PRODUCTION paths inside a real transaction: per-entry =
+ * {@link ProjectionIndexHOTStorage#writeSlotValue} (descent + dispatch + put + split cascade);
+ * bulk = key serialization + entry-list assembly + {@code spliceBulkBuiltRoot} (via
+ * {@link BulkSpliceTestBridge}), i.e. everything a slot loader would do after accumulation.
+ *
+ * <p>Protocol: per shape and scale, a JIT warmup round of both arms (100 k), then interleaved
+ * measured repetitions (per-entry, bulk, per-entry, bulk at 1 M; one repetition each at 10 M,
+ * per-entry FIRST so any thermal drift penalizes the bulk arm — conservative for the claim under
+ * test). Reported number = best repetition. Correctness witnesses run OUTSIDE the timed
+ * regions: sampled read-back equality across arms and a zero-malformed-subtree check on the
+ * bulk tree.
+ */
+final class ProjectionBulkVsPerEntryBench {
+
+  private static final String RESOURCE_NAME = "bulk-vs-perentry";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  private static final long LABEL_BASE = 1L << 50;
+  private static final int SLOTS_PER_ROW_GROUP = 200;
+  private static final int PAYLOAD_BYTES = 30;
+  private static final int WARMUP_ENTRIES = 100_000;
+  private static final int READBACK_SAMPLES = 1_000;
+
+  private static final LongUnaryOperator LABEL_KEYS = k -> LABEL_BASE + k;
+  private static final LongUnaryOperator SEGSLOT_KEYS =
+      k -> ((k / SLOTS_PER_ROW_GROUP) << 16) | (k % SLOTS_PER_ROW_GROUP);
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE_NAME).build());
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void perfGate() {
+    System.out.println("shape    scale     arm        best-ns/entry   total-ms   ratio(perEntry/bulk)");
+    runShape("label", LABEL_KEYS, 1_000_000, 2);
+    runShape("label", LABEL_KEYS, 10_000_000, 1);
+    runShape("segslot", SEGSLOT_KEYS, 1_000_000, 2);
+    runShape("segslot", SEGSLOT_KEYS, 10_000_000, 1);
+  }
+
+  private void runShape(final String shape, final LongUnaryOperator keyOf, final int entries, final int reps) {
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE_NAME);
+        JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final StorageEngineWriter sew = wtx.getStorageEngineWriter();
+      int nextIndexNumber = 0;
+
+      // JIT warmup — both arms, small scale, throwaway index numbers.
+      runPerEntry(sew, nextIndexNumber++, keyOf, WARMUP_ENTRIES);
+      runBulk(sew, nextIndexNumber++, keyOf, WARMUP_ENTRIES);
+
+      long bestPerEntryNanos = Long.MAX_VALUE;
+      long bestBulkNanos = Long.MAX_VALUE;
+      ProjectionIndexHOTStorage lastPerEntry = null;
+      ProjectionIndexHOTStorage lastBulk = null;
+      for (int rep = 0; rep < reps; rep++) {
+        final TimedStorage perEntry = timePerEntry(sew, nextIndexNumber++, keyOf, entries);
+        final TimedStorage bulk = timeBulk(sew, nextIndexNumber++, keyOf, entries);
+        bestPerEntryNanos = Math.min(bestPerEntryNanos, perEntry.nanos);
+        bestBulkNanos = Math.min(bestBulkNanos, bulk.nanos);
+        lastPerEntry = perEntry.storage;
+        lastBulk = bulk.storage;
+      }
+
+      // Witnesses (untimed): sampled read-back equality across arms; bulk tree detector-clean.
+      verifySampledEquality(lastPerEntry, lastBulk, keyOf, entries);
+      assertEquals(0, BulkSpliceTestBridge.malformedSubtreeCount(lastBulk),
+          shape + "/" + entries + ": bulk tree must be detector-clean");
+
+      final double ratio = (double) bestPerEntryNanos / (double) bestBulkNanos;
+      report(shape, entries, "perEntry", bestPerEntryNanos, Double.NaN);
+      report(shape, entries, "bulk", bestBulkNanos, ratio);
+    }
+  }
+
+  private record TimedStorage(long nanos, ProjectionIndexHOTStorage storage) {}
+
+  private TimedStorage timePerEntry(final StorageEngineWriter sew, final int indexNumber,
+      final LongUnaryOperator keyOf, final int entries) {
+    final long start = System.nanoTime();
+    final ProjectionIndexHOTStorage storage = runPerEntry(sew, indexNumber, keyOf, entries);
+    return new TimedStorage(System.nanoTime() - start, storage);
+  }
+
+  private TimedStorage timeBulk(final StorageEngineWriter sew, final int indexNumber, final LongUnaryOperator keyOf,
+      final int entries) {
+    final long start = System.nanoTime();
+    final ProjectionIndexHOTStorage storage = runBulk(sew, indexNumber, keyOf, entries);
+    return new TimedStorage(System.nanoTime() - start, storage);
+  }
+
+  /** Per-entry arm: one production {@code writeSlotValue} per slot. */
+  private ProjectionIndexHOTStorage runPerEntry(final StorageEngineWriter sew, final int indexNumber,
+      final LongUnaryOperator keyOf, final int entries) {
+    final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(sew, indexNumber);
+    final byte[] payload = new byte[PAYLOAD_BYTES];
+    for (long k = 0; k < entries; k++) {
+      fillPayload(payload, k);
+      storage.writeSlotValue(keyOf.applyAsLong(k), payload);
+    }
+    return storage;
+  }
+
+  /**
+   * Bulk arm: everything a slot loader does after accumulation — serialize each key
+   * (sign-flipped 8-byte BE), copy the payload, assemble the exact-size entry list, build and
+   * splice through the production {@code spliceBulkBuiltRoot}.
+   */
+  private ProjectionIndexHOTStorage runBulk(final StorageEngineWriter sew, final int indexNumber,
+      final LongUnaryOperator keyOf, final int entries) {
+    final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(sew, indexNumber);
+    final List<HOTBulkBuilder.Entry> list = new ArrayList<>(entries);
+    for (long k = 0; k < entries; k++) {
+      final byte[] key = new byte[8];
+      PathKeySerializer.INSTANCE.serialize(keyOf.applyAsLong(k), key, 0);
+      final byte[] payload = new byte[PAYLOAD_BYTES];
+      fillPayload(payload, k);
+      list.add(new HOTBulkBuilder.Entry(key, payload));
+    }
+    BulkSpliceTestBridge.spliceBulkBuiltRoot(storage, list);
+    return storage;
+  }
+
+  /** Deterministic ~30 B payload derived from the slot ordinal. */
+  private static void fillPayload(final byte[] payload, final long k) {
+    for (int i = 0; i < payload.length; i++) {
+      payload[i] = (byte) (k + i * 31);
+    }
+  }
+
+  private static void verifySampledEquality(final ProjectionIndexHOTStorage perEntry,
+      final ProjectionIndexHOTStorage bulk, final LongUnaryOperator keyOf, final int entries) {
+    assertNotNull(perEntry, "per-entry arm missing");
+    assertNotNull(bulk, "bulk arm missing");
+    final byte[] expected = new byte[PAYLOAD_BYTES];
+    final long step = Math.max(1L, (long) entries / READBACK_SAMPLES);
+    for (long k = 0; k < entries; k += step) {
+      final long slotKey = keyOf.applyAsLong(k);
+      fillPayload(expected, k);
+      final byte[] fromPerEntry = perEntry.getRawSlot(slotKey);
+      final byte[] fromBulk = bulk.getRawSlot(slotKey);
+      assertNotNull(fromPerEntry, "per-entry arm missing slot " + slotKey);
+      assertNotNull(fromBulk, "bulk arm missing slot " + slotKey);
+      assertArrayEquals(expected, fromPerEntry, "per-entry payload mismatch at slot " + slotKey);
+      assertArrayEquals(expected, fromBulk, "bulk payload mismatch at slot " + slotKey);
+    }
+    // The extremes are always checked.
+    final long last = entries - 1L;
+    fillPayload(expected, last);
+    assertArrayEquals(expected, perEntry.getRawSlot(keyOf.applyAsLong(last)), "per-entry last slot");
+    assertArrayEquals(expected, bulk.getRawSlot(keyOf.applyAsLong(last)), "bulk last slot");
+  }
+
+  private static void report(final String shape, final int entries, final String arm, final long nanos,
+      final double ratio) {
+    final double nsPerEntry = (double) nanos / (double) entries;
+    final String ratioText = Double.isNaN(ratio)
+        ? "-"
+        : String.format("%.2fx", ratio);
+    System.out.printf("%-8s %-9d %-10s %13.1f %10.1f   %s%n", shape, entries, arm, nsPerEntry,
+        nanos / 1_000_000.0, ratioText);
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
@@ -94,9 +94,21 @@ final class ProjectionDictionaryBudgetAbandonNoticeTest {
 
   private static final int TOTAL_DISTINCT = RECORDS / ROWS_PER_VALUE;
 
-  /** The notice as an operator reads it. Groups: index, column, retained, entries, budget, tail. */
+  /**
+   * The notice as an operator reads it. Groups: index, column, breaching bytes, the name of the term
+   * that breached, entries, budget, retained, tail.
+   *
+   * <p>
+   * The breaching quantity and the budget are BOTH in the line on purpose. Every byte-budget guard
+   * weighs retention plus a reservation, so a notice quoting retention alone printed a number below
+   * the budget it announced as exceeded — arithmetic an operator cannot reconcile, and no figure to
+   * raise the budget to. The loud arm asserts the printed relation, not merely the presence of
+   * numbers.
+   * </p>
+   */
   private static final Pattern NOTICE = Pattern.compile("^\\[proj] PROJECTION ABANDONED during the load: index (\\d+),"
-      + " column (\\d+) retained (\\d+) B over (\\d+) distinct values, past its (\\d+) B budget\\. (.*)$");
+      + " column (\\d+) needed (\\d+) B \\(([^)]+)\\) over (\\d+) distinct values, past its (\\d+) B budget"
+      + " \\((\\d+) B retained\\)\\. (.*)$");
 
   private String priorBudget;
 
@@ -148,13 +160,25 @@ final class ProjectionDictionaryBudgetAbandonNoticeTest {
     assertTrue(notice.startsWith("[proj] "),
         "the notice must reach stderr unprefixed, i.e. not through a log appender: " + notice);
     final Matcher parsed = NOTICE.matcher(notice);
-    assertTrue(parsed.matches(), "the notice no longer states index, column, retention and budget: " + notice);
+    assertTrue(parsed.matches(),
+        "the notice no longer states index, column, the breaching term and the budget: " + notice);
     assertEquals(INDEX_NUMBER, Integer.parseInt(parsed.group(1)), "the notice must name the abandoned index");
     assertEquals(0, Integer.parseInt(parsed.group(2)), "the notice must name the column whose dictionary breached");
-    assertTrue(Integer.parseInt(parsed.group(4)) > 0, "the notice must report how many values had been admitted");
-    assertEquals(budget, Long.parseLong(parsed.group(5)), "the notice must quote the budget that was breached");
-    assertTrue(parsed.group(6).contains("STALE") && parsed.group(6).contains("jn:create-projection-index"),
+    assertTrue(Integer.parseInt(parsed.group(5)) > 0, "the notice must report how many values had been admitted");
+    assertEquals(budget, Long.parseLong(parsed.group(6)), "the notice must quote the budget that was breached");
+    assertTrue(parsed.group(8).contains("STALE") && parsed.group(8).contains("jn:create-projection-index"),
         "the notice must say the projection is stale and name the call that rebuilds it: " + notice);
+
+    // THE POINT OF THE ARITHMETIC: the quantity the line announces as breaching must actually exceed
+    // the budget the same line quotes. Reporting retention instead put a smaller number on the left
+    // of a "past its ... budget" claim on every real breach.
+    final long breachingBytes = Long.parseLong(parsed.group(3));
+    final long retainedBytes = Long.parseLong(parsed.group(7));
+    assertTrue(breachingBytes > budget, "the notice announces a breach with a quantity that does NOT exceed the budget"
+        + " it quotes (" + breachingBytes + " B vs " + budget + " B): " + notice);
+    assertFalse(parsed.group(4).isBlank(), "the breaching quantity must be named, or it cannot be acted on: " + notice);
+    assertTrue(retainedBytes <= breachingBytes, "retention cannot exceed the retention-plus-reservation term that was"
+        + " weighed against the budget: " + notice);
 
     final ProjectionIndexMetadata metadata = metadata();
     assertNotNull(metadata, "the abandoned load must leave the tombstone behind, not an empty slot");

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
@@ -38,19 +38,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The one silent load-degradation that is not allowed to stay silent: a resource-wide value
- * dictionary that breaches its byte budget mid-load abandons the projection, and the operator has to
- * learn that from the process itself.
+ * dictionary that breaches its byte budget mid-load abandons the projection, and the operator has
+ * to learn that from the process itself.
  *
  * <h2>What is under test</h2>
  *
  * The stderr line emitted by {@code ProjectionIndexChangeListener#abandonForOversizedDictionary} is
  * an OPERATOR-FACING OUTPUT CONTRACT, not an implementation detail: the load goes on to report
- * success, so without the notice a projection that never finished is indistinguishable from one that
- * did, and a long benchmark run is silently measured on the generic pipeline. It is deliberately a
- * {@code System.err.println} rather than a log call, because the shipped logback configuration pins
- * the root logger to ERROR and would swallow the warning that accompanies it. The loud arm therefore
- * runs with the root logger switched OFF — if the notice travelled by any suppressible channel, that
- * arm would capture nothing.
+ * success, so without the notice a projection that never finished is indistinguishable from one
+ * that did, and a long benchmark run is silently measured on the generic pipeline. It is
+ * deliberately a {@code System.err.println} rather than a log call, because the shipped logback
+ * configuration pins the root logger to ERROR and would swallow the warning that accompanies it.
+ * The loud arm therefore runs with the root logger switched OFF — if the notice travelled by any
+ * suppressible channel, that arm would capture nothing.
  *
  * <h2>How the breach is reached (no fault injection)</h2>
  *
@@ -61,12 +61,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * every value {@link #ROWS_PER_VALUE} times, which is under the election's per-leaf deduplication
  * factor, so AUTO promotes the column to a resource-wide dictionary after the leading sample — the
  * control arm asserts exactly that by checking the published column kind. The load is armed with no
- * row-count hint ({@code -1}), the documented state in which the election-time decline cannot run and
- * "the writer's runtime cap is the only protection"; see the {@code expectedRows} contract on
- * {@link ProjectionIndexBuilder#setExpectedRows(long)}. The budget is CALIBRATED from the real writer
- * rather than hard-coded: it sits above what the sample's distinct values cost to flush and below
- * what the whole corpus costs, so the election succeeds and a later value breaches. Both ends of that
- * window are asserted before the load runs, so drift in the writer's arithmetic fails as a
+ * row-count hint ({@code -1}), the documented state in which the election-time decline cannot run
+ * and "the writer's runtime cap is the only protection"; see the {@code expectedRows} contract on
+ * {@link ProjectionIndexBuilder#setExpectedRows(long)}. The budget is CALIBRATED from the real
+ * writer rather than hard-coded: it sits above what the sample's distinct values cost to flush and
+ * below what the whole corpus costs, so the election succeeds and a later value breaches. Both ends
+ * of that window are asserted before the load runs, so drift in the writer's arithmetic fails as a
  * calibration error instead of quietly turning this into a test of nothing.
  */
 final class ProjectionDictionaryBudgetAbandonNoticeTest {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionDictionaryBudgetAbandonNoticeTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.Databases;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The one silent load-degradation that is not allowed to stay silent: a resource-wide value
+ * dictionary that breaches its byte budget mid-load abandons the projection, and the operator has to
+ * learn that from the process itself.
+ *
+ * <h2>What is under test</h2>
+ *
+ * The stderr line emitted by {@code ProjectionIndexChangeListener#abandonForOversizedDictionary} is
+ * an OPERATOR-FACING OUTPUT CONTRACT, not an implementation detail: the load goes on to report
+ * success, so without the notice a projection that never finished is indistinguishable from one that
+ * did, and a long benchmark run is silently measured on the generic pipeline. It is deliberately a
+ * {@code System.err.println} rather than a log call, because the shipped logback configuration pins
+ * the root logger to ERROR and would swallow the warning that accompanies it. The loud arm therefore
+ * runs with the root logger switched OFF — if the notice travelled by any suppressible channel, that
+ * arm would capture nothing.
+ *
+ * <h2>How the breach is reached (no fault injection)</h2>
+ *
+ * Both arms run the real load-time build over the same corpus through
+ * {@code createProjectionIndexAtLoadStart} plus the shredder, and differ only in the documented
+ * {@code -Dsirix.projection.globalDict.budgetBytes} ceiling, which
+ * {@link ProjectionIndexBuilder#globalDictionaryBudgetBytes()} reads per build. The corpus repeats
+ * every value {@link #ROWS_PER_VALUE} times, which is under the election's per-leaf deduplication
+ * factor, so AUTO promotes the column to a resource-wide dictionary after the leading sample — the
+ * control arm asserts exactly that by checking the published column kind. The load is armed with no
+ * row-count hint ({@code -1}), the documented state in which the election-time decline cannot run and
+ * "the writer's runtime cap is the only protection"; see the {@code expectedRows} contract on
+ * {@link ProjectionIndexBuilder#setExpectedRows(long)}. The budget is CALIBRATED from the real writer
+ * rather than hard-coded: it sits above what the sample's distinct values cost to flush and below
+ * what the whole corpus costs, so the election succeeds and a later value breaches. Both ends of that
+ * window are asserted before the load runs, so drift in the writer's arithmetic fails as a
+ * calibration error instead of quietly turning this into a test of nothing.
+ */
+final class ProjectionDictionaryBudgetAbandonNoticeTest {
+
+  private static final int INDEX_NUMBER = 0;
+
+  /** Enough row groups that the leading decision sample is only a fraction of the corpus. */
+  private static final int RECORDS = 30_000;
+
+  /**
+   * Rows per distinct value. Below the election's minimum per-leaf deduplication factor of 4, so a
+   * per-leaf dictionary is measured as "storing almost nothing twice" and the column goes global.
+   */
+  private static final int ROWS_PER_VALUE = 2;
+
+  private static final int VALUE_BYTES = 24;
+
+  /**
+   * Distinct values the election measures, give or take a partly-filled row group: the builder holds
+   * back 16 leading leaves of at most {@link ProjectionIndexRowGroupPage#MAX_ROWS} rows. Used only to
+   * calibrate the budget, whose margin absorbs the difference; the window assertions in
+   * {@link #calibratedBudget()} are what guarantee the calibration is usable.
+   */
+  private static final int SAMPLE_DISTINCT = 16 * ProjectionIndexRowGroupPage.MAX_ROWS / ROWS_PER_VALUE;
+
+  private static final int TOTAL_DISTINCT = RECORDS / ROWS_PER_VALUE;
+
+  /** The notice as an operator reads it. Groups: index, column, retained, entries, budget, tail. */
+  private static final Pattern NOTICE = Pattern.compile("^\\[proj] PROJECTION ABANDONED during the load: index (\\d+),"
+      + " column (\\d+) retained (\\d+) B over (\\d+) distinct values, past its (\\d+) B budget\\. (.*)$");
+
+  private String priorBudget;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    ProjectionBulkLoad.clearActive();
+    priorBudget = System.getProperty("sirix.projection.globalDict.budgetBytes");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (priorBudget == null) {
+      System.clearProperty("sirix.projection.globalDict.budgetBytes");
+    } else {
+      System.setProperty("sirix.projection.globalDict.budgetBytes", priorBudget);
+    }
+    ProjectionBulkLoad.clearActive();
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /**
+   * LOUD ARM. A dictionary that outgrows its budget after the election must announce the abandon on
+   * stderr with the logger switched off, tombstone the projection with a machine-readable reason, and
+   * let the load itself complete.
+   */
+  @Test
+  void aDictionaryBudgetBreachAnnouncesTheAbandonedProjectionEvenWithLoggingOff() {
+    final long budget = calibratedBudget();
+    System.setProperty("sirix.projection.globalDict.budgetBytes", Long.toString(budget));
+
+    final Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    final Level priorLevel = rootLogger.getLevel();
+    // Harsher than the shipped configuration's ERROR: nothing travelling by the logger can be
+    // observed from here, so whatever the capture below sees came through the unsuppressible channel.
+    rootLogger.setLevel(Level.OFF);
+    final Capture capture;
+    try {
+      capture = load();
+    } finally {
+      rootLogger.setLevel(priorLevel);
+    }
+
+    final List<String> notices = capture.linesContaining("PROJECTION ABANDONED");
+    assertEquals(1, notices.size(),
+        "the abandon must be announced exactly once; captured stderr was:\n" + capture.text());
+    final String notice = notices.getFirst();
+    assertTrue(notice.startsWith("[proj] "),
+        "the notice must reach stderr unprefixed, i.e. not through a log appender: " + notice);
+    final Matcher parsed = NOTICE.matcher(notice);
+    assertTrue(parsed.matches(), "the notice no longer states index, column, retention and budget: " + notice);
+    assertEquals(INDEX_NUMBER, Integer.parseInt(parsed.group(1)), "the notice must name the abandoned index");
+    assertEquals(0, Integer.parseInt(parsed.group(2)), "the notice must name the column whose dictionary breached");
+    assertTrue(Integer.parseInt(parsed.group(4)) > 0, "the notice must report how many values had been admitted");
+    assertEquals(budget, Long.parseLong(parsed.group(5)), "the notice must quote the budget that was breached");
+    assertTrue(parsed.group(6).contains("STALE") && parsed.group(6).contains("jn:create-projection-index"),
+        "the notice must say the projection is stale and name the call that rebuilds it: " + notice);
+
+    final ProjectionIndexMetadata metadata = metadata();
+    assertNotNull(metadata, "the abandoned load must leave the tombstone behind, not an empty slot");
+    assertTrue(metadata.isStale(), "an abandoned projection must not read as live");
+    assertEquals(ProjectionIndexMetadata.StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED, metadata.staleReason(),
+        "the tombstone must carry the machine-readable reason the notice describes");
+
+    // "The load completes" is the other half of the contract: the ingest must survive the decline.
+    assertEquals(RECORDS, committedRecordCount(), "the abandon must cost the projection, never the load");
+  }
+
+  /**
+   * CONTROL ARM. The same corpus with the aggregate budget disabled must publish a live resource-wide
+   * dictionary column and say nothing at all — which is what makes the loud arm a test of the BREACH
+   * rather than of a corpus that would have complained either way.
+   */
+  @Test
+  void aLoadThatStaysInsideItsBudgetPublishesTheGlobalColumnSilently() {
+    System.setProperty("sirix.projection.globalDict.budgetBytes", Long.toString(Long.MAX_VALUE));
+
+    final Capture capture = load();
+
+    assertTrue(capture.linesContaining("PROJECTION ABANDONED").isEmpty(),
+        "a healthy load must not announce an abandon; captured stderr was:\n" + capture.text());
+
+    final ProjectionIndexMetadata metadata = metadata();
+    assertNotNull(metadata, "the healthy load must publish metadata");
+    assertFalse(metadata.isStale(), "the healthy load must publish a live projection");
+    assertEquals(ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL, metadata.columnKinds()[0],
+        "the corpus must actually elect a resource-wide dictionary, or the loud arm's breach could never happen");
+    assertEquals(RECORDS, committedRecordCount(), "the healthy load must index every record");
+  }
+
+  /**
+   * A budget above the sample's flush peak and below the whole corpus's: the election admits the
+   * column, and a later value cannot fit. Measured on the real writer, so the window is expressed in
+   * the same arithmetic the load will use.
+   */
+  private static long calibratedBudget() {
+    final long samplePeak = flushPeakForDistinctValues(SAMPLE_DISTINCT);
+    final long corpusPeak = flushPeakForDistinctValues(TOTAL_DISTINCT);
+    final long budget = samplePeak * 5L / 4L;
+    assertTrue(budget >= GlobalValueDictionaryWriter.MINIMUM_BUDGET_BYTES,
+        "calibration produced a budget below what an empty dictionary already retains: " + budget);
+    assertTrue(corpusPeak > budget, "the corpus can no longer outgrow a budget the sample fits in (sample peak "
+        + samplePeak + " B, corpus peak " + corpusPeak + " B) — recalibrate the corpus, this test would prove nothing");
+    return budget;
+  }
+
+  /** What a dictionary holding the first {@code distinct} corpus values costs at flush time. */
+  private static long flushPeakForDistinctValues(final int distinct) {
+    final GlobalValueDictionaryWriter writer = new GlobalValueDictionaryWriter(0, Long.MAX_VALUE);
+    try {
+      for (int ordinal = 0; ordinal < distinct; ordinal++) {
+        writer.intern(value(ordinal));
+      }
+      return writer.estimatedFlushPeakBytes();
+    } finally {
+      writer.release();
+    }
+  }
+
+  /** One load-time build over the corpus, with everything the process wrote to stderr captured. */
+  private static Capture load() {
+    final PrintStream originalErr = System.err;
+    final ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    System.setErr(new PrintStream(new TeeOutputStream(originalErr, sink), true, StandardCharsets.UTF_8));
+    try {
+      final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+      try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+          final JsonNodeTrx wtx = session.beginNodeTrx()) {
+        final JsonIndexController controller =
+            (JsonIndexController) session.getWtxIndexController(wtx.getRevisionNumber());
+        // -1: no row-count hint, the documented state in which the election cannot decline up front.
+        controller.createProjectionIndexAtLoadStart(projectionDef(), wtx, -1L);
+        wtx.insertSubtreeAsFirstChild(JsonShredder.createStringReader(corpus()), JsonNodeTrx.Commit.NO);
+        wtx.commit();
+      }
+    } finally {
+      System.setErr(originalErr);
+    }
+    return new Capture(sink.toString(StandardCharsets.UTF_8));
+  }
+
+  /** Records in the committed resource — the load's own outcome, independent of the projection. */
+  private static long committedRecordCount() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final var rtx = session.beginNodeReadOnlyTrx()) {
+      rtx.moveToDocumentRoot();
+      assertTrue(rtx.moveToFirstChild(), "the committed revision must hold the imported array");
+      return rtx.getChildCount();
+    }
+  }
+
+  private static ProjectionIndexMetadata metadata() {
+    final var database = JsonTestHelper.getDatabase(JsonTestHelper.PATHS.PATH1.getFile());
+    try (final JsonResourceSession session = database.beginResourceSession(JsonTestHelper.RESOURCE);
+        final JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final byte[] raw = new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER).getBlob(0L);
+      return raw == null
+          ? null
+          : ProjectionIndexMetadata.parse(raw);
+    }
+  }
+
+  private static IndexDef projectionDef() {
+    return IndexDefs.createProjectionIdxDef(Path.parse("/[]", PathParser.Type.JSON),
+        List.of(Path.parse("/[]/code", PathParser.Type.JSON)), List.of(Type.STR), INDEX_NUMBER, IndexDef.DbType.JSON);
+  }
+
+  private static String corpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * (VALUE_BYTES + 16));
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"code\":\"").append(value(record / ROWS_PER_VALUE)).append("\"}");
+    }
+    return json.append(']').toString();
+  }
+
+  /** Fixed-width distinct values, so the dictionary's growth is a function of the ordinal alone. */
+  private static String value(final int ordinal) {
+    final StringBuilder text = new StringBuilder(VALUE_BYTES);
+    text.append('c').append(String.format("%08d", ordinal));
+    while (text.length() < VALUE_BYTES) {
+      text.append('x');
+    }
+    return text.toString();
+  }
+
+  /** Captured stderr, read as the lines an operator would see. */
+  private record Capture(String text) {
+    private List<String> linesContaining(final String needle) {
+      final List<String> matches = new ArrayList<>();
+      for (final String line : text.split("\\R")) {
+        if (line.contains(needle)) {
+          matches.add(line);
+        }
+      }
+      return matches;
+    }
+  }
+
+  /** Keeps the real stderr readable while an arm records what was written to it. */
+  private static final class TeeOutputStream extends OutputStream {
+    private final OutputStream first;
+    private final OutputStream second;
+
+    private TeeOutputStream(final OutputStream first, final OutputStream second) {
+      this.first = first;
+      this.second = second;
+    }
+
+    @Override
+    public void write(final int b) throws IOException {
+      first.write(b);
+      second.write(b);
+    }
+
+    @Override
+    public void write(final byte[] bytes, final int offset, final int length) throws IOException {
+      first.write(bytes, offset, length);
+      second.write(bytes, offset, length);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      first.flush();
+      second.flush();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionGlobalDictionaryGenerationRotationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionGlobalDictionaryGenerationRotationTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Witness for the structural defect the one-pass parallel load fixes: the post-pass build appends a
+ * resource-wide value dictionary as ONE generation, and a generation admits at most
+ * {@link GlobalValueDictionaryWriter#MAX_DISTINCT_ENTRIES_PER_APPEND} distinct entries. Any elected
+ * string column with more distinct values than that kills the build outright — the workaround being
+ * to turn the dictionary off entirely.
+ *
+ * <p>
+ * A load-time build has no such ceiling: it flushes a dictionary generation at every storage epoch,
+ * so generations rotate naturally with the load and the column's distinct count is bounded by the
+ * corpus rather than by one array's safe length.
+ *
+ * <p>
+ * Both arms run, because a fix needs a positive AND a negative witness: the same corpus and the same
+ * definition must SUCCEED one-pass and FAIL post-pass. A test that only ran the passing arm could not
+ * tell a fix from a corpus that never reached the ceiling.
+ */
+final class ProjectionGlobalDictionaryGenerationRotationTest {
+
+  private static final java.nio.file.Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+  private static final java.nio.file.Path POST_PASS_DATABASE_PATH = JsonTestHelper.PATHS.PATH2.getFile();
+  private static final int INDEX_NUMBER = 0;
+
+  /**
+   * Comfortably past the per-append ceiling, so neither arm can squeak under it on the WHOLE corpus.
+   */
+  private static final int DISTINCT_CODES = GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND * 2 + 4096;
+  /**
+   * Each code appears on {@link #CODE_RUN} consecutive records. This is what makes the test about
+   * generation ROTATION rather than about window size: the distinct values inside any one dictionary
+   * window stay well under the per-append ceiling, while the corpus as a whole is far past it. A
+   * column that is 100% distinct saturates a generation from its very first window and no rotation
+   * scheme can help it — that is a different (and honest) limit, not the one this test is about.
+   */
+  private static final int CODE_RUN = 4;
+
+  private static final int RECORDS = DISTINCT_CODES * CODE_RUN;
+
+  private String priorGlobalDictMode;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    JsonTestHelper.deleteEverything();
+    ProjectionBulkLoad.clearActive();
+    priorGlobalDictMode = System.getProperty("sirix.projection.globalDict");
+    // "allowed" in its strongest form: elect the dictionary regardless of the promotion heuristics,
+    // so the arms differ ONLY in how the elected dictionary's generations are appended.
+    System.setProperty("sirix.projection.globalDict", "always");
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    if (priorGlobalDictMode == null) {
+      System.clearProperty("sirix.projection.globalDict");
+    } else {
+      System.setProperty("sirix.projection.globalDict", priorGlobalDictMode);
+    }
+    ProjectionBulkLoad.clearActive();
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void aColumnPastThePerAppendCeilingBuildsOnePassAndBreaksThePostPass() throws Exception {
+    final byte[] corpus = corpus();
+
+    // POSITIVE witness: the load-time build rotates a generation per storage epoch and completes.
+    final ProjectionIndexMetadata onePass = loadOnePassParallel(corpus);
+    assertNotNull(onePass, "the one-pass load must publish metadata");
+    assertFalse(onePass.isStale(), "the one-pass build must not have abandoned the projection: a load that hits the "
+        + "dictionary ceiling aborts and leaves the stale tombstone behind, which looks like success from outside");
+    assertEquals(ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL, onePass.columnKinds()[0],
+        "the code column must actually have been built as a resource-wide dictionary column, or the ceiling was "
+            + "never approached and this test proves nothing");
+    final long[] dictionaryHeaderKeys = onePass.valueDictionaryHeaderKeys();
+    assertNotNull(dictionaryHeaderKeys, "an elected global-dictionary column must publish its dictionary header");
+    assertTrue(dictionaryHeaderKeys[0] > 0, "the code column's dictionary header key must be set");
+
+    // NEGATIVE witness: the same corpus and definition through the post-pass build.
+    Throwable postPassFailure = null;
+    ProjectionIndexMetadata postPass = null;
+    try {
+      postPass = loadParallelThenPostPass(corpus);
+    } catch (final Throwable failure) {
+      postPassFailure = failure;
+    }
+    System.out.println("#67 WITNESS: distinct=" + DISTINCT_CODES + " (ceiling "
+        + GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND + "), records=" + RECORDS
+        + " | ONE-PASS: stale=" + onePass.isStale() + " columnKind=" + onePass.columnKinds()[0] + " rowGroups="
+        + onePass.rowGroupCount() + " | POST-PASS: " + (postPassFailure == null
+            ? "no failure, stale=" + (postPass == null ? "?" : postPass.isStale()) + " columnKind="
+                + (postPass == null ? "?" : postPass.columnKinds()[0])
+            : "THREW " + postPassFailure.getClass().getSimpleName() + ": " + postPassFailure.getMessage()));
+    if (postPassFailure == null) {
+      assertNotNull(postPass, "the post-pass arm returned no metadata and no failure");
+      assertTrue(
+          postPass.isStale()
+              || postPass.columnKinds()[0] != ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL,
+          "the post-pass build was expected to die or decline the resource-wide dictionary for "
+              + DISTINCT_CODES + " distinct values (the per-append ceiling is "
+              + GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND + "), but it published a live "
+              + "STRING_GLOBAL column — the ceiling this test exists for is gone, and the test must be re-aimed");
+    } else {
+      assertTrue(mentionsTheCeiling(postPassFailure),
+          "the post-pass arm failed for an unrelated reason: " + postPassFailure);
+    }
+  }
+
+  private static boolean mentionsTheCeiling(final Throwable failure) {
+    for (Throwable cause = failure; cause != null; cause = cause.getCause() == cause
+        ? null
+        : cause.getCause()) {
+      final String message = cause.getMessage();
+      if (cause instanceof GlobalDictionaryBudgetExceededException
+          || (message != null && (message.contains("per-append limit") || message.contains("dictionary")))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // ==== arms ===================================================================================
+
+  private static ProjectionIndexMetadata loadOnePassParallel(final byte[] corpus) throws Exception {
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(2048, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          final JsonIndexController controller = session.getWtxIndexController(wtx.getRevisionNumber());
+          controller.createProjectionIndexAtLoadStart(projectionDef(), wtx, RECORDS);
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus), 1 << 20, 4);
+          wtx.commit();
+        }
+        return metadata(session);
+      }
+    }
+  }
+
+  private static ProjectionIndexMetadata loadParallelThenPostPass(final byte[] corpus) throws Exception {
+    Databases.createJsonDatabase(new DatabaseConfiguration(POST_PASS_DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(POST_PASS_DATABASE_PATH)) {
+      db.createResource(resourceConfig());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(2048, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+          ParallelBulkJsonImporter.assembleBytes(wtx, new ByteArrayInputStream(corpus), 1 << 20, 4);
+          wtx.commit();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        return metadata(session);
+      }
+    }
+  }
+
+  private static ProjectionIndexMetadata metadata(final JsonResourceSession session) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final byte[] raw =
+          new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER).getBlob(0L);
+      return raw == null
+          ? null
+          : ProjectionIndexMetadata.parse(raw);
+    }
+  }
+
+  private static ResourceConfiguration resourceConfig() {
+    return ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                .useDeweyIDs(false)
+                                .hashKind(HashType.NONE)
+                                .storeNodeHistory(false)
+                                .buildPathSummary(true)
+                                .build();
+  }
+
+  private static IndexDef projectionDef() {
+    final List<Path<QNm>> fieldPaths = List.of(Path.parse("/[]/code", PathParser.Type.JSON));
+    return IndexDefs.createProjectionIdxDef(Path.parse("/[]", PathParser.Type.JSON), fieldPaths, List.of(Type.STR),
+        INDEX_NUMBER, IndexDef.DbType.JSON);
+  }
+
+  private static byte[] corpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * 24);
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"code\":\"c").append(record / CODE_RUN).append("\"}");
+    }
+    json.append(']');
+    return json.toString().getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionGlobalDictionaryGenerationRotationTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionGlobalDictionaryGenerationRotationTest.java
@@ -48,9 +48,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * corpus rather than by one array's safe length.
  *
  * <p>
- * Both arms run, because a fix needs a positive AND a negative witness: the same corpus and the same
- * definition must SUCCEED one-pass and FAIL post-pass. A test that only ran the passing arm could not
- * tell a fix from a corpus that never reached the ceiling.
+ * Both arms run, because a fix needs a positive AND a negative witness: the same corpus and the
+ * same definition must SUCCEED one-pass and FAIL post-pass. A test that only ran the passing arm
+ * could not tell a fix from a corpus that never reached the ceiling.
  */
 final class ProjectionGlobalDictionaryGenerationRotationTest {
 
@@ -122,19 +122,22 @@ final class ProjectionGlobalDictionaryGenerationRotationTest {
       postPassFailure = failure;
     }
     System.out.println("#67 WITNESS: distinct=" + DISTINCT_CODES + " (ceiling "
-        + GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND + "), records=" + RECORDS
-        + " | ONE-PASS: stale=" + onePass.isStale() + " columnKind=" + onePass.columnKinds()[0] + " rowGroups="
-        + onePass.rowGroupCount() + " | POST-PASS: " + (postPassFailure == null
-            ? "no failure, stale=" + (postPass == null ? "?" : postPass.isStale()) + " columnKind="
-                + (postPass == null ? "?" : postPass.columnKinds()[0])
+        + GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND + "), records=" + RECORDS + " | ONE-PASS: stale="
+        + onePass.isStale() + " columnKind=" + onePass.columnKinds()[0] + " rowGroups=" + onePass.rowGroupCount()
+        + " | POST-PASS: " + (postPassFailure == null
+            ? "no failure, stale=" + (postPass == null
+                ? "?"
+                : postPass.isStale()) + " columnKind="
+                + (postPass == null
+                    ? "?"
+                    : postPass.columnKinds()[0])
             : "THREW " + postPassFailure.getClass().getSimpleName() + ": " + postPassFailure.getMessage()));
     if (postPassFailure == null) {
       assertNotNull(postPass, "the post-pass arm returned no metadata and no failure");
       assertTrue(
-          postPass.isStale()
-              || postPass.columnKinds()[0] != ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL,
-          "the post-pass build was expected to die or decline the resource-wide dictionary for "
-              + DISTINCT_CODES + " distinct values (the per-append ceiling is "
+          postPass.isStale() || postPass.columnKinds()[0] != ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL,
+          "the post-pass build was expected to die or decline the resource-wide dictionary for " + DISTINCT_CODES
+              + " distinct values (the per-append ceiling is "
               + GlobalValueDictionaryWriter.MAX_DISTINCT_ENTRIES_PER_APPEND + "), but it published a live "
               + "STRING_GLOBAL column — the ceiling this test exists for is gone, and the test must be re-aimed");
     } else {
@@ -194,8 +197,7 @@ final class ProjectionGlobalDictionaryGenerationRotationTest {
 
   private static ProjectionIndexMetadata metadata(final JsonResourceSession session) {
     try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-      final byte[] raw =
-          new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER).getBlob(0L);
+      final byte[] raw = new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), INDEX_NUMBER).getBlob(0L);
       return raw == null
           ? null
           : ProjectionIndexMetadata.parse(raw);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionPostPassBoundedRetentionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionPostPassBoundedRetentionTest.java
@@ -41,12 +41,16 @@ final class ProjectionPostPassBoundedRetentionTest {
 
   private static final String FLUSH_PROPERTY = "sirix.projection.buildIntermediateFlush";
 
-  /** 40 full row groups (1024 rows each) — enough leaves that an unbounded build's live intent-log
-   * entry count separates from the epoch bound by a wide, drift-tolerant margin. */
+  /**
+   * 40 full row groups (1024 rows each) — enough leaves that an unbounded build's live intent-log
+   * entry count separates from the epoch bound by a wide, drift-tolerant margin.
+   */
   private static final int COMMITTED_RECORD_COUNT = 40 * 1024;
 
-  /** Crosses the flush boundary dozens of times with full rotation+cleanup cycles, so the
-   * read-back-after-rotation contract is exercised for real, not just in the final epoch. */
+  /**
+   * Crosses the flush boundary dozens of times with full rotation+cleanup cycles, so the
+   * read-back-after-rotation contract is exercised for real, not just in the final epoch.
+   */
   private static final int UNCOMMITTED_RECORD_COUNT = 40 * 1024;
 
   @TempDir
@@ -124,8 +128,10 @@ final class ProjectionPostPassBoundedRetentionTest {
     }
   }
 
-  /** The checksum {@link #projectionRowsAndChecksum} computes, folded over the generated corpus
-   * directly: records carry {@code a = 0..n-1} in insertion order. */
+  /**
+   * The checksum {@link #projectionRowsAndChecksum} computes, folded over the generated corpus
+   * directly: records carry {@code a = 0..n-1} in insertion order.
+   */
   private static long expectedNumericChecksum(final int recordCount) {
     long checksum = 1469598103934665603L;
     for (long value = 0; value < recordCount; value++) {
@@ -134,8 +140,10 @@ final class ProjectionPostPassBoundedRetentionTest {
     return checksum;
   }
 
-  /** Shreds and commits the corpus into a fresh resource, then builds the projection in a new
-   * transaction, returning the intent log's live entry count captured right before the commit. */
+  /**
+   * Shreds and commits the corpus into a fresh resource, then builds the projection in a new
+   * transaction, returning the intent log's live entry count captured right before the commit.
+   */
   private int buildOverCommittedCorpus(final Database<JsonResourceSession> database, final String resource,
       final String flushProperty) throws Exception {
     createResource(database, resource);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionPostPassBoundedRetentionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionPostPassBoundedRetentionTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.io.StorageType;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JacksonJsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static io.brackit.query.util.path.Path.parse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Witnesses the explicit (post-pass) projection build's bounded-retention contract: the build rides
+ * async-flush epochs, so the transaction intent log holds one epoch of pages instead of the entire
+ * output. Without the intermediate flushes a 100M-row build pins ~20 GB of live frames and dies of
+ * arena exhaustion — the bound is the fix, and the inverted arm proves the witness can say no.
+ */
+final class ProjectionPostPassBoundedRetentionTest {
+
+  private static final String FLUSH_PROPERTY = "sirix.projection.buildIntermediateFlush";
+
+  /** 40 full row groups (1024 rows each) — enough leaves that an unbounded build's live intent-log
+   * entry count separates from the epoch bound by a wide, drift-tolerant margin. */
+  private static final int COMMITTED_RECORD_COUNT = 40 * 1024;
+
+  /** Crosses the flush boundary dozens of times with full rotation+cleanup cycles, so the
+   * read-back-after-rotation contract is exercised for real, not just in the final epoch. */
+  private static final int UNCOMMITTED_RECORD_COUNT = 40 * 1024;
+
+  @TempDir
+  Path temporaryDirectory;
+
+  private Path databasePath;
+
+  @BeforeEach
+  void setUp() {
+    databasePath = temporaryDirectory.resolve("database");
+    Databases.createJsonDatabase(new DatabaseConfiguration(databasePath));
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(FLUSH_PROPERTY);
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+    Databases.clearGlobalCaches();
+  }
+
+  @Test
+  void intermediateFlushesBoundTheIntentLogAndPreserveTheProjection() throws Exception {
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(databasePath)) {
+      final int boundedLive = buildOverCommittedCorpus(database, "bounded", null);
+      final int pinnedLive = buildOverCommittedCorpus(database, "pinned", "false");
+
+      // The absolute contract: with flushes on, the log never exceeds one epoch of pages plus the
+      // end-phase writes (Bloom/fence finish, header, dictionaries).
+      assertTrue(boundedLive <= 64,
+          "flushing build should retain at most one epoch of intent-log entries, held " + boundedLive);
+      // The inverted arm is the positive witness that the counter can say no: the legacy build
+      // pins every page it creates, so its live count must dwarf the flushing build's.
+      assertTrue(pinnedLive > boundedLive * 3,
+          "legacy build must pin the whole output (flushing=" + boundedLive + ", pinned=" + pinnedLive + ")");
+
+      // Both arms must describe the same projection: identical leaf structure and column content.
+      final long[] bounded = projectionRowsAndChecksum(database, "bounded");
+      final long[] pinned = projectionRowsAndChecksum(database, "pinned");
+      assertEquals(COMMITTED_RECORD_COUNT, bounded[0], "flushing build lost rows");
+      assertEquals(bounded[0], pinned[0], "arms disagree on row count");
+      assertEquals(bounded[1], pinned[1], "arms disagree on column content");
+    }
+  }
+
+  @Test
+  void buildInsideAMutatingTransactionFlushesAndKeepsEveryUncommittedRecord() throws Exception {
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(databasePath)) {
+      final String resource = "uncommitted";
+      createResource(database, resource);
+      try (JsonResourceSession session = database.beginResourceSession(resource);
+          JsonNodeTrx wtx = session.beginNodeTrx();
+          var parser = JacksonJsonShredder.createStringParser(corpusJson(UNCOMMITTED_RECORD_COUNT))) {
+        new JacksonJsonShredder.Builder(wtx, parser, InsertPosition.AS_FIRST_CHILD).build().call();
+        // The document records are still uncommitted and live in the intent log — and the build
+        // flushes anyway: a rotated-out page of the open revision resolves back from disk through
+        // the log's recorded offsets, so the extraction reads every record across rotations. This
+        // is the contract that lets a 100M build stay within one epoch of retained pages even
+        // inside a mutating transaction.
+        assertTrue(wtx.getStorageEngineWriter().getLog().liveEntryCount() > 0,
+            "precondition: the corpus must still live in the intent log");
+        final JsonIndexController controller =
+            (JsonIndexController) session.getWtxIndexController(wtx.getRevisionNumber());
+        controller.createIndexes(Set.of(projectionDefinition(0)), wtx);
+        final int liveEntries = wtx.getStorageEngineWriter().getLog().liveEntryCount();
+        assertTrue(liveEntries <= 64,
+            "the build must rotate the corpus and its own output out of the log, held " + liveEntries);
+        wtx.commit();
+      }
+      final long[] result = projectionRowsAndChecksum(database, resource);
+      assertEquals(UNCOMMITTED_RECORD_COUNT, result[0],
+          "build inside a mutating transaction must keep every uncommitted record");
+      assertEquals(expectedNumericChecksum(UNCOMMITTED_RECORD_COUNT), result[1],
+          "extracted column content must be exact across rotations");
+    }
+  }
+
+  /** The checksum {@link #projectionRowsAndChecksum} computes, folded over the generated corpus
+   * directly: records carry {@code a = 0..n-1} in insertion order. */
+  private static long expectedNumericChecksum(final int recordCount) {
+    long checksum = 1469598103934665603L;
+    for (long value = 0; value < recordCount; value++) {
+      checksum = (checksum ^ value) * 1099511628211L;
+    }
+    return checksum;
+  }
+
+  /** Shreds and commits the corpus into a fresh resource, then builds the projection in a new
+   * transaction, returning the intent log's live entry count captured right before the commit. */
+  private int buildOverCommittedCorpus(final Database<JsonResourceSession> database, final String resource,
+      final String flushProperty) throws Exception {
+    createResource(database, resource);
+    try (JsonResourceSession session = database.beginResourceSession(resource);
+        JsonNodeTrx wtx = session.beginNodeTrx();
+        var parser = JacksonJsonShredder.createStringParser(corpusJson(COMMITTED_RECORD_COUNT))) {
+      new JacksonJsonShredder.Builder(wtx, parser, InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+    }
+    if (flushProperty == null) {
+      System.clearProperty(FLUSH_PROPERTY);
+    } else {
+      System.setProperty(FLUSH_PROPERTY, flushProperty);
+    }
+    try (JsonResourceSession session = database.beginResourceSession(resource);
+        JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final JsonIndexController controller =
+          (JsonIndexController) session.getWtxIndexController(wtx.getRevisionNumber());
+      controller.createIndexes(Set.of(projectionDefinition(0)), wtx);
+      final int liveEntries = wtx.getStorageEngineWriter().getLog().liveEntryCount();
+      wtx.commit();
+      return liveEntries;
+    } finally {
+      System.clearProperty(FLUSH_PROPERTY);
+    }
+  }
+
+  /** Total row count and an order-sensitive checksum of the numeric column across every leaf. */
+  private long[] projectionRowsAndChecksum(final Database<JsonResourceSession> database, final String resource) {
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+    Databases.clearGlobalCaches();
+    try (JsonResourceSession session = database.beginResourceSession(resource);
+        var rtx = session.beginNodeReadOnlyTrx()) {
+      final IndexDef definition = projectionDefinition(0);
+      final ProjectionIndexRegistry.Handle handle =
+          ProjectionIndexCatalog.load(session, rtx.getRevisionNumber(), definition);
+      final List<byte[]> leaves = handle.rowGroupPayloads(ProjectionIndexCatalog.rowGroupMaterializer(session,
+          rtx.getRevisionNumber(), definition.getID(), handle.rowGroupCount()));
+      long rows = 0;
+      long checksum = 1469598103934665603L;
+      for (final byte[] payload : leaves) {
+        final ProjectionIndexRowGroupPage page = ProjectionIndexRowGroupPage.deserialize(payload);
+        rows += page.getRowCount();
+        final long[] column = page.numericColumn(0);
+        for (int row = 0; row < page.getRowCount(); row++) {
+          checksum = (checksum ^ column[row]) * 1099511628211L;
+        }
+      }
+      return new long[] {rows, checksum};
+    }
+  }
+
+  private static void createResource(final Database<JsonResourceSession> database, final String resource) {
+    assertTrue(database.createResource(ResourceConfiguration.newBuilder(resource)
+                                                            .storageType(StorageType.FILE_CHANNEL)
+                                                            .hashKind(HashType.NONE)
+                                                            .storeDiffs(false)
+                                                            .buildPathSummary(true)
+                                                            .buildPathStatistics(false)
+                                                            .useDeweyIDs(true)
+                                                            .build()));
+  }
+
+  private static IndexDef projectionDefinition(final int indexNumber) {
+    return IndexDefs.createProjectionIdxDef(parse("/[]", PathParser.Type.JSON),
+        List.of(parse("/[]/a", PathParser.Type.JSON), parse("/[]/b", PathParser.Type.JSON)),
+        List.of(Type.LON, Type.STR), indexNumber, IndexDef.DbType.JSON);
+  }
+
+  private static String corpusJson(final int recordCount) {
+    final StringBuilder json = new StringBuilder(recordCount * 32).append('[');
+    for (int i = 0; i < recordCount; i++) {
+      if (i > 0) {
+        json.append(',');
+      }
+      json.append("{\"a\":").append(i).append(",\"b\":\"s").append(i % 50).append("\"}");
+    }
+    return json.append(']').toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionSegmentResurrectionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionSegmentResurrectionTest.java
@@ -51,10 +51,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * waiting for an exception would pass straight through it.
  *
  * <p>
- * It lives in this package rather than beside the HOT-layer fixtures because the segment-slot API is
- * projection-internal. Strategy-matrix, eviction and historical-read coverage sit in
- * {@code io.sirix.page.HOTCompleteDumpMergeTest} and {@code io.sirix.page.HOTTombstoneEvictionTest},
- * at the layer where the merge itself lives.
+ * It lives in this package rather than beside the HOT-layer fixtures because the segment-slot API
+ * is projection-internal. Strategy-matrix, eviction and historical-read coverage sit in
+ * {@code io.sirix.page.HOTCompleteDumpMergeTest} and
+ * {@code io.sirix.page.HOTTombstoneEvictionTest}, at the layer where the merge itself lives.
  * </p>
  */
 final class ProjectionSegmentResurrectionTest {
@@ -75,8 +75,8 @@ final class ProjectionSegmentResurrectionTest {
     JsonTestHelper.deleteEverything();
     Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
     try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
-      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
-          .versioningApproach(VersioningType.SLIDING_SNAPSHOT).build());
+      db.createResource(
+          ResourceConfiguration.newBuilder(RESOURCE).versioningApproach(VersioningType.SLIDING_SNAPSHOT).build());
     }
     VersioningType.resetFragmentMergeCounters();
     HOTTrieWriter.resetInPlaceLeafSplits();
@@ -91,8 +91,8 @@ final class ProjectionSegmentResurrectionTest {
   /**
    * Named for what it PROVES, not for the defect it was written to hunt. The previous name —
    * {@code aResurrectedSegmentIsServedWithPreSplitBytesAndThrowsNothing} — asserted the opposite of
-   * the body, which requires {@code staleBytes == 0}; a reader scanning method names would have
-   * come away believing the resurrection was an established behaviour of this codebase.
+   * the body, which requires {@code staleBytes == 0}; a reader scanning method names would have come
+   * away believing the resurrection was an established behaviour of this codebase.
    */
   @Test
   void everySegmentServesItsLatestBytesAcrossASplit() throws IOException {
@@ -113,8 +113,7 @@ final class ProjectionSegmentResurrectionTest {
       // fragment chain reachable. Claiming split coverage in a COMMENT (as this class used to) is
       // exactly what HOTTrieWriter's own counter javadoc says not to do.
       assertTrue(HOTTrieWriter.inPlaceLeafSplits() > 0,
-          "no in-place leaf split ran, so this case covers nothing (splits="
-              + HOTTrieWriter.inPlaceLeafSplits() + ")");
+          "no in-place leaf split ran, so this case covers nothing (splits=" + HOTTrieWriter.inPlaceLeafSplits() + ")");
       assertTrue(VersioningType.multiFragmentMerges() > 0,
           "the merge path was never entered, so this case proves nothing (merges="
               + VersioningType.multiFragmentMerges() + ")");
@@ -127,7 +126,9 @@ final class ProjectionSegmentResurrectionTest {
           final byte[] got = ProjectionIndexHOTStorage.readColumnSegmentSlot(reader, 0,
               ProjectionIndexHOTStorage.columnSegmentSlotKey(rg, 0));
           // Row group 1 was rewritten by the last two commits; every other one last saw marker 2.
-          final byte expected = rg == 1 ? (byte) 4 : (byte) 2;
+          final byte expected = rg == 1
+              ? (byte) 4
+              : (byte) 2;
           if (got == null || got.length == 0) {
             missing++;
           } else if (got[0] != expected) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionSegmentResurrectionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionSegmentResurrectionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.page.HOTTrieWriter;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Task #57, THE QUIET ARM — asserted on BYTES, because the symptom it looks for would not throw.
+ *
+ * <h2>What is established here, and what is only predicted</h2>
+ *
+ * PREDICTED BY A CODE READING, NEVER OBSERVED: if a merge walked past a fragment that declared
+ * itself a complete dump, it could serve a row group's segment from a pre-split copy. The loud form
+ * of that would raise — {@code collectSlotsRange} finding two descriptor slots for one row group —
+ * but the column-segment side carries no duplicate check, so were the split point to fall in the
+ * composite key's low bits, a row group could keep a single descriptor while some SEGMENTS
+ * duplicated, and the store would simply answer with one of them.
+ *
+ * <p>
+ * NO EXECUTION HAS EVER PRODUCED EITHER FORM. This class passes against unmodified production code,
+ * as did every other probe run for task #57 — three strategies, six phases, three window widths,
+ * point reads, content bytes and a full range enumeration, with the vulnerable in-place split
+ * confirmed each time. What this class therefore IS is a pinned invariant rather than a regression
+ * test: if a future change makes the walk reachable, the byte comparison below fails instead of a
+ * database quietly serving stale segments.
+ * </p>
+ *
+ * <h2>Why bytes rather than an exception</h2>
+ *
+ * Nothing here is asserted via a throw. Every segment is read back and its CONTENT compared against
+ * what the most recent commit wrote, because the quiet form would produce no other signal — a test
+ * waiting for an exception would pass straight through it.
+ *
+ * <p>
+ * It lives in this package rather than beside the HOT-layer fixtures because the segment-slot API is
+ * projection-internal. Strategy-matrix, eviction and historical-read coverage sit in
+ * {@code io.sirix.page.HOTCompleteDumpMergeTest} and {@code io.sirix.page.HOTTombstoneEvictionTest},
+ * at the layer where the merge itself lives.
+ * </p>
+ */
+final class ProjectionSegmentResurrectionTest {
+
+  private static final String RESOURCE = "projection-segment-resurrection";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  /** Measured: the in-place leaf split first appears around this many row groups in this shape. */
+  private static final int ROW_GROUPS = 2000;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    // The witnesses below are gated behind -Dsirix.hot.mergeDiag; with the gate off they read zero
+    // and this class would fail confusingly rather than saying what is actually wrong.
+    assertTrue(VersioningType.hotMergeDiagEnabled(),
+        "HOT merge diagnostics are OFF, so the merge and split witnesses cannot fire. Run with "
+            + "-Dsirix.hot.mergeDiag=true (the gradle test configuration sets it).");
+    JsonTestHelper.deleteEverything();
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+          .versioningApproach(VersioningType.SLIDING_SNAPSHOT).build());
+    }
+    VersioningType.resetFragmentMergeCounters();
+    HOTTrieWriter.resetInPlaceLeafSplits();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /**
+   * Named for what it PROVES, not for the defect it was written to hunt. The previous name —
+   * {@code aResurrectedSegmentIsServedWithPreSplitBytesAndThrowsNothing} — asserted the opposite of
+   * the body, which requires {@code staleBytes == 0}; a reader scanning method names would have
+   * come away believing the resurrection was an established behaviour of this codebase.
+   */
+  @Test
+  void everySegmentServesItsLatestBytesAcrossASplit() throws IOException {
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      // Four commits: fill and split, then two that leave a SPARSE head fragment over the split
+      // leaf. Distinct markers per commit, because rewriting identical bytes does not dirty the
+      // page and then no fragment chain forms at all.
+      writeSegments(session, ROW_GROUPS, (byte) 1);
+      writeSegments(session, ROW_GROUPS, (byte) 2);
+      writeSegments(session, 1, (byte) 3);
+      writeSegments(session, 1, (byte) 4);
+
+      // TWO WITNESSES, both required before any absence assertion below means anything. The merge
+      // witness alone is insufficient: measured elsewhere, a shape can reconstruct fragments while
+      // never taking the in-place split, and the split is the only thing that makes a stale
+      // fragment chain reachable. Claiming split coverage in a COMMENT (as this class used to) is
+      // exactly what HOTTrieWriter's own counter javadoc says not to do.
+      assertTrue(HOTTrieWriter.inPlaceLeafSplits() > 0,
+          "no in-place leaf split ran, so this case covers nothing (splits="
+              + HOTTrieWriter.inPlaceLeafSplits() + ")");
+      assertTrue(VersioningType.multiFragmentMerges() > 0,
+          "the merge path was never entered, so this case proves nothing (merges="
+              + VersioningType.multiFragmentMerges() + ")");
+
+      try (JsonNodeTrx probe = session.beginNodeTrx()) {
+        final StorageEngineReader reader = probe.getStorageEngineReader();
+        int missing = 0;
+        int staleBytes = 0;
+        for (long rg = 1; rg <= ROW_GROUPS; rg++) {
+          final byte[] got = ProjectionIndexHOTStorage.readColumnSegmentSlot(reader, 0,
+              ProjectionIndexHOTStorage.columnSegmentSlotKey(rg, 0));
+          // Row group 1 was rewritten by the last two commits; every other one last saw marker 2.
+          final byte expected = rg == 1 ? (byte) 4 : (byte) 2;
+          if (got == null || got.length == 0) {
+            missing++;
+          } else if (got[0] != expected) {
+            staleBytes++;
+          }
+        }
+        assertEquals(0, missing, "no segment may be lost across the split");
+        assertEquals(0, staleBytes,
+            "a segment was served carrying bytes from before the split. This is the quiet arm of "
+                + "task #57: nothing throws, the store just answers with the wrong copy.");
+      }
+
+      assertEquals(0, VersioningType.completeDumpsWalkedPast(),
+          "the merge must not walk past a complete dump - the mechanism behind the stale bytes above");
+    }
+  }
+
+  /** One commit writing {@code count} single-column segments, each stamped with {@code marker}. */
+  private static void writeSegments(final JsonResourceSession session, final int count, final byte marker) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), 0);
+      for (long rg = 1; rg <= count; rg++) {
+        final byte[] segment = new byte[512];
+        segment[0] = marker;
+        segment[1] = (byte) rg;
+        storage.putColumnSegmentSlot(ProjectionIndexHOTStorage.columnSegmentSlotKey(rg, 0), segment);
+      }
+      wtx.commit();
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStaleReasonTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStaleReasonTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.index.projection.ProjectionIndexMetadata.StaleReason;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The durable stale-reason code: it must survive a serialize/parse round trip, stay compatible with
+ * tombstones written before reasons existed, and never turn an unknown future reason into a parse
+ * failure.
+ *
+ * <p>
+ * The reason exists because "stale" and "corrupt" are different claims and the difference was being
+ * lost (tasks #45, #50), and because #52 needs the same slot to say "still wanted, known
+ * incomplete" rather than "retired". Both are wire values now, so the encoding is what has to be
+ * pinned — a renumbering later would be a format migration.
+ * </p>
+ */
+final class ProjectionStaleReasonTest {
+
+  @Test
+  void everyReasonSurvivesARoundTrip() {
+    for (final StaleReason reason : StaleReason.values()) {
+      final byte[] wire = ProjectionIndexMetadata.staleTombstone(reason).serialize();
+      final ProjectionIndexMetadata parsed = ProjectionIndexMetadata.parse(wire);
+      assertTrue(parsed.isStale(), reason + " must still read as stale");
+      assertEquals(reason, parsed.staleReason(), reason + " must survive the round trip");
+    }
+  }
+
+  /**
+   * The bits carrying the reason were always zero before this existed, so an old tombstone must
+   * parse as UNSPECIFIED rather than as anything else — that is what makes the change additive and
+   * lets it skip a version bump.
+   */
+  @Test
+  void aReasonlessTombstoneReadsAsUnspecified() {
+    final ProjectionIndexMetadata parsed = ProjectionIndexMetadata.parse(ProjectionIndexMetadata.staleTombstone()
+        .serialize());
+    assertTrue(parsed.isStale());
+    assertEquals(StaleReason.UNSPECIFIED, parsed.staleReason());
+  }
+
+  /** Wire values are append-only: pin the ordinals so a reorder fails here rather than in the field. */
+  @Test
+  void ordinalsArePinnedBecauseTheyAreWireValues() {
+    assertEquals(0, StaleReason.UNSPECIFIED.ordinal());
+    assertEquals(1, StaleReason.GLOBAL_DICTIONARY_NOT_MAINTAINABLE.ordinal());
+    assertEquals(2, StaleReason.MAINTENANCE_FAILED.ordinal());
+    assertEquals(3, StaleReason.KIND_INCONSISTENT_STORE.ordinal());
+    assertEquals(4, StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED.ordinal());
+    assertEquals(5, StaleReason.REBUILD_PENDING.ordinal());
+    assertTrue(StaleReason.values().length <= 8, "only three flag bits carry the reason");
+  }
+
+  /**
+   * Every reason must name a remedy someone can run. "Rebuild required" in the abstract makes the
+   * operator rediscover what the writer already knew.
+   */
+  @Test
+  void everyReasonNamesARunnableRemedy() {
+    for (final StaleReason reason : StaleReason.values()) {
+      final String remedy = reason.remedy();
+      assertTrue(remedy.contains("jn:create-projection-index"),
+          reason + " must name the actual call, not describe it: " + remedy);
+    }
+    // The budget breach has a second, cheaper remedy than rebuilding blind, and should say so.
+    final String budget = StaleReason.GLOBAL_DICTIONARY_BUDGET_EXCEEDED.remedy();
+    assertTrue(budget.contains("hint"), "the budget breach should mention the row-count hint: " + budget);
+    assertNotEquals(StaleReason.MAINTENANCE_FAILED.remedy(), budget,
+        "a breach and a failure are different situations and should not give identical advice");
+  }
+
+  @Test
+  void aNullReasonIsRejectedRatherThanStoredAsZero() {
+    assertThrows(NullPointerException.class, () -> ProjectionIndexMetadata.staleTombstone(null));
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStaleReasonTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStaleReasonTest.java
@@ -36,19 +36,21 @@ final class ProjectionStaleReasonTest {
   }
 
   /**
-   * The bits carrying the reason were always zero before this existed, so an old tombstone must
-   * parse as UNSPECIFIED rather than as anything else — that is what makes the change additive and
-   * lets it skip a version bump.
+   * The bits carrying the reason were always zero before this existed, so an old tombstone must parse
+   * as UNSPECIFIED rather than as anything else — that is what makes the change additive and lets it
+   * skip a version bump.
    */
   @Test
   void aReasonlessTombstoneReadsAsUnspecified() {
-    final ProjectionIndexMetadata parsed = ProjectionIndexMetadata.parse(ProjectionIndexMetadata.staleTombstone()
-        .serialize());
+    final ProjectionIndexMetadata parsed =
+        ProjectionIndexMetadata.parse(ProjectionIndexMetadata.staleTombstone().serialize());
     assertTrue(parsed.isStale());
     assertEquals(StaleReason.UNSPECIFIED, parsed.staleReason());
   }
 
-  /** Wire values are append-only: pin the ordinals so a reorder fails here rather than in the field. */
+  /**
+   * Wire values are append-only: pin the ordinals so a reorder fails here rather than in the field.
+   */
   @Test
   void ordinalsArePinnedBecauseTheyAreWireValues() {
     assertEquals(0, StaleReason.UNSPECIFIED.ordinal());

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStoreKindConsistencyTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStoreKindConsistencyTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.sirix.index.projection.ProjectionIndexHOTStorage.RowGroupDirectory;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A projection store whose leaves disagree about a column's encoding must be REFUSED at
+ * construction, and refused as inconsistent rather than corrupt (tasks #45 and #50).
+ *
+ * <p>
+ * The store reads its column kinds from leaf 0 and dispatches every route on them, so a leaf that
+ * declares a different kind is not a bad column — it means the leaves no longer describe the same
+ * projection. Task #45's wrong answer was exactly this state, produced by commit-time maintenance,
+ * and it surfaced four rounds downstream as "known-corrupt BODY segment": the wrong component and
+ * the wrong problem, because nothing had ever compared the leaves.
+ * </p>
+ *
+ * <p>
+ * NON-VACUITY: {@link #anAgreeingStoreIsAccepted()} is the control — it builds leaves the same way
+ * and must construct cleanly, so a check that simply threw always would fail it. And the
+ * disagreement test asserts the message NAMES the offending leaf and column, which a blind throw
+ * could not produce. Both matter: this gate is one edit away from passing for the wrong reason.
+ * </p>
+ */
+final class ProjectionStoreKindConsistencyTest {
+
+  private static final byte[] KINDS = {ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG,
+      ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT, ProjectionIndexRowGroupPage.COLUMN_KIND_BOOLEAN};
+
+  @Test
+  void anAgreeingStoreIsAccepted() {
+    final ProjectionColumnStore store = new ProjectionColumnStore(List.of(directory(1, KINDS), directory(2, KINDS)));
+    assertEquals(KINDS.length, store.columnCount(), "the control must build a usable store");
+  }
+
+  @Test
+  void aLeafThatDisagreesAboutAColumnKindIsRefused() {
+    // Leaf 2 carries the resource-wide encoding for column 1 where leaf 1 carries the per-leaf one —
+    // the shape maintenance produced when it rebuilt a leaf from the DECLARED kinds.
+    final byte[] divergent = KINDS.clone();
+    divergent[1] = ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL;
+
+    final List<RowGroupDirectory> directories = List.of(directory(1, KINDS), directory(2, divergent));
+    final ProjectionStoreInconsistentException refused =
+        assertThrows(ProjectionStoreInconsistentException.class, () -> new ProjectionColumnStore(directories));
+
+    assertEquals(1, refused.leaf(), "the refusal must name WHICH leaf disagreed");
+    final String message = refused.getMessage();
+    assertTrue(message.contains("column 1"), "the refusal must name the column: " + message);
+    assertTrue(message.contains("INCONSISTENT"), "the refusal must not call this corruption: " + message);
+    assertFalse(message.toLowerCase(java.util.Locale.ROOT).contains("corrupt bytes"),
+        "the bytes decode fine — blaming them is what task #45 spent four rounds chasing: " + message);
+  }
+
+  @Test
+  void aSingleLeafStoreHasNothingToDisagreeWith() {
+    final ProjectionColumnStore store = new ProjectionColumnStore(List.of(directory(1, KINDS)));
+    assertEquals(KINDS.length, store.columnCount());
+  }
+
+  /** The typed refusal must remain catchable by handlers that only know the general failure. */
+  @Test
+  void theRefusalStaysCompatibleWithExistingHandlers() {
+    assertTrue(IllegalStateException.class.isAssignableFrom(ProjectionStoreInconsistentException.class),
+        "existing catch sites must keep degrading safely rather than seeing an unknown unchecked type");
+  }
+
+  private static RowGroupDirectory directory(final long rowGroupId, final byte[] kinds) {
+    final ProjectionIndexRowGroupPage page = new ProjectionIndexRowGroupPage(kinds);
+    // A STRING_GLOBAL column interns through a dictionary writer, so one has to exist for the leaf
+    // to be BUILDABLE at all. Using the real writer keeps the divergent leaf a genuine artifact
+    // rather than a hand-patched descriptor byte.
+    GlobalValueDictionaryWriter[] dictionaries = null;
+    for (int c = 0; c < kinds.length; c++) {
+      if (kinds[c] == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_GLOBAL) {
+        if (dictionaries == null) {
+          dictionaries = new GlobalValueDictionaryWriter[kinds.length];
+        }
+        dictionaries[c] = new GlobalValueDictionaryWriter();
+      }
+    }
+    if (dictionaries != null) {
+      page.setGlobalDictionaries(dictionaries);
+    }
+    final long[] longs = new long[kinds.length];
+    final boolean[] bools = new boolean[kinds.length];
+    final String[] strings = new String[kinds.length];
+    final boolean[] present = new boolean[kinds.length];
+    final boolean[] unrep = new boolean[kinds.length];
+    final boolean[] nonIntegral = new boolean[kinds.length];
+    final boolean[] nonDoubleSource = new boolean[kinds.length];
+    for (int row = 0; row < 4; row++) {
+      longs[0] = row;
+      strings[1] = "v" + row;
+      bools[2] = (row & 1) == 0;
+      for (int c = 0; c < kinds.length; c++) {
+        present[c] = true;
+      }
+      page.appendRow(rowGroupId * 1000 + row, longs, bools, strings, present, unrep, nonIntegral, nonDoubleSource);
+    }
+    final ProjectionIndexColumnSegmentCodec.EncodedRowGroup encoded =
+        ProjectionIndexColumnSegmentCodec.encode(page.serialize());
+    final int segments = encoded.columnSegmentIds().length;
+    final int[] ids = new int[segments];
+    final long[] offsets = new long[segments];
+    for (int i = 0; i < segments; i++) {
+      ids[i] = encoded.columnSegmentIds()[i] & 0xFF;
+      offsets[i] = 1_000L + i;
+    }
+    return new RowGroupDirectory(rowGroupId, encoded.descriptor(), ids, offsets);
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStreamingGlobalDictionaryTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionStreamingGlobalDictionaryTest.java
@@ -74,7 +74,11 @@ final class ProjectionStreamingGlobalDictionaryTest {
       for (int repeat = 0; repeat < 256; repeat++) {
         assertEquals(3, dictionary.intern("gamma"));
       }
-      assertEquals(2L, dictionary.persistentProbeCount());
+      // The resident probe front keeps every (value, id) of the load in memory across generation
+      // flushes, so re-interning a flushed value never walks the persistent radix. Zero probes IS
+      // the contract now — the old expectation of one probe per flushed value re-encounter was the
+      // ~5-page-decode-per-value regime this front exists to remove. The ids are the real pin.
+      assertEquals(0L, dictionary.persistentProbeCount());
       assertEquals(headerKey, dictionary.flush());
       storage.asyncFlush();
       storage.awaitPendingAsyncFlush();
@@ -89,7 +93,7 @@ final class ProjectionStreamingGlobalDictionaryTest {
       for (int repeat = 0; repeat < 256; repeat++) {
         assertEquals(4, dictionary.intern("delta"));
       }
-      assertEquals(5L, dictionary.persistentProbeCount());
+      assertEquals(0L, dictionary.persistentProbeCount());
       assertEquals(headerKey, dictionary.flush());
       wtx.commit();
     } finally {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -32,7 +32,10 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -243,6 +246,80 @@ final class ProjectionWindowedPayloadServeTest {
         "a 2-window resident cap over 8 windows must have re-materialized evicted windows; fetches=" + fetches.get());
     assertTrue(view.residentWindows() <= 3,
         "residency must stay near the cap (cap 2, plus one in-flight); resident=" + view.residentWindows());
+  }
+
+  @Test
+  void aWindowedViewIsNeverMemoizedOnTheSharedHandle() {
+    // A handle lives in the catalog's PROCESS-WIDE cache, keyed by (resource, def, build revision)
+    // and dropped only when the resource is removed — so anything it memoizes outlives every
+    // session that touched it. The eager list is inert bytes and is safe to share; a windowed view
+    // is not, because it fetches each window through the session its materializer was built from.
+    // Memoizing one would hand the NEXT session a view bound to a CLOSED one, so over budget the
+    // handle must consult every caller's own materializer and must keep reporting "not resident".
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        final IndexDef def = projectionDef();
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(def), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        final int rowGroupCount = rowGroupCount(session, revision);
+        priorWindowLeaves = ProjectionIndexCatalog.setWindowLeavesForTesting(TEST_WINDOW_LEAVES);
+        priorEagerBudget = ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(1L);
+
+        final ProjectionIndexRegistry.Handle handle = ProjectionIndexCatalog.load(session, revision, def);
+        assertNotNull(handle, "the persisted projection must load");
+        assertFalse(handle.payloadsMaterialized(), "a freshly loaded column-lazy handle holds no leaves");
+
+        final AtomicInteger consulted = new AtomicInteger();
+        final Supplier<List<byte[]>> callerMaterializer = () -> {
+          consulted.incrementAndGet();
+          return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20)
+                                       .get();
+        };
+
+        final List<byte[]> first = handle.rowGroupPayloads(callerMaterializer);
+        assertTrue(first instanceof ProjectionWindowedRowGroupPayloads,
+            "over budget the handle must serve the windowed view; got " + first.getClass().getSimpleName());
+        assertFalse(handle.payloadsMaterialized(),
+            "a windowed view is NOT resident — reporting it as materialized steers later queries off the "
+                + "sliced route and pins a session-bound view on the shared handle");
+
+        final List<byte[]> second = handle.rowGroupPayloads(callerMaterializer);
+        assertEquals(2, consulted.get(),
+            "each caller must build its view from ITS OWN live session; the handle memoized one instead");
+        assertNotSame(first, second, "the memoized view would be handed to the next session verbatim");
+        assertFalse(handle.payloadsMaterialized());
+
+        // Both views still answer the corpus arithmetic — the fix must not degrade serving.
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(first));
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(second));
+
+        // The eager arm is the contrast: under the budget the leaves ARE inert bytes, so the handle
+        // memoizes them and reports resident.
+        ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
+        final int consultedBeforeEager = consulted.get();
+        final List<byte[]> eager = handle.rowGroupPayloads(callerMaterializer);
+        assertFalse(eager instanceof ProjectionWindowedRowGroupPayloads);
+        assertTrue(handle.payloadsMaterialized(), "resident leaves must flip the predicate");
+        assertEquals(consultedBeforeEager + 1, consulted.get());
+        assertSame(eager, handle.rowGroupPayloads(callerMaterializer),
+            "resident leaves must be memoized and served without re-consulting the materializer");
+        assertEquals(consultedBeforeEager + 1, consulted.get());
+      }
+    }
   }
 
   private static int rowGroupCount(final JsonResourceSession session, final int revision) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -223,15 +224,26 @@ final class ProjectionWindowedPayloadServeTest {
     final int rowGroups = 16;
     final int windowSize = 2;
     final AtomicInteger fetches = new AtomicInteger();
+    final AtomicInteger sourcesSeen = new AtomicInteger();
     final ProjectionWindowedRowGroupPayloads view =
-        new ProjectionWindowedRowGroupPayloads(rowGroups, windowSize, 2, (from, toExclusive) -> {
+        new ProjectionWindowedRowGroupPayloads(rowGroups, windowSize, 2, (source, from, toExclusive) -> {
           fetches.incrementAndGet();
+          if (source != null) {
+            sourcesSeen.incrementAndGet();
+          }
           final byte[][] window = new byte[toExclusive - from][];
           for (int i = from; i < toExclusive; i++) {
             window[i - from] = new byte[] { (byte) i, (byte) (i >> 8) };
           }
           return window;
         });
+    // The view captures no session: consulting one before a source is bound is a programming error
+    // it must name, not a silent read through a stale binding.
+    final IllegalStateException unbound = assertThrows(IllegalStateException.class, () -> view.get(0));
+    assertTrue(unbound.getMessage().contains("reader source"), unbound.getMessage());
+    view.bindReaderSource(() -> {
+      throw new UnsupportedOperationException("the synthetic fetcher never opens a reader");
+    });
     assertEquals(rowGroups, view.size());
     assertEquals(8, view.windowCount());
     // Two full passes plus a scatter: every access must see its own row group's bytes.
@@ -246,17 +258,17 @@ final class ProjectionWindowedPayloadServeTest {
         "a 2-window resident cap over 8 windows must have re-materialized evicted windows; fetches=" + fetches.get());
     assertTrue(view.residentWindows() <= 3,
         "residency must stay near the cap (cap 2, plus one in-flight); resident=" + view.residentWindows());
+    assertEquals(fetches.get(), sourcesSeen.get(), "every fetch must be handed the bound reader source");
   }
 
   @Test
-  void aWindowedViewIsSessionScopedAndNeverPinnedOnTheSharedHandle() {
+  void aWindowedViewIsOwnedByTheHandleAndSurvivesTheBuildingSessionsClose() {
     // A handle lives in the catalog's PROCESS-WIDE cache, keyed by (resource, def, build revision)
-    // and dropped only when the resource is removed — so anything it memoizes outlives every
-    // session that touched it. The eager list is inert bytes and is safe to share; a windowed view
-    // is not, because it fetches each window through the session its materializer was built from.
-    // The view's owner is therefore the SESSION: not the handle (it would outlive the session and
-    // fetch through a closed one) and not the caller (N views over one session permit N times the
-    // residency each view's window cap was sized for).
+    // — which is exactly the identity of the leaves a windowed view reads, so the handle is the
+    // view's natural owner. What makes that safe is that the view captures NO session: each consult
+    // rebinds it to the CALLER's own live reader source. The property this pins is the one that
+    // originally forced the view off the handle: after the session that built it has closed, the
+    // very same memoized view still serves, through its successor's transactions.
     Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
     try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
       db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
@@ -302,30 +314,23 @@ final class ProjectionWindowedPayloadServeTest {
             "over budget the handle must serve the windowed view; got " + firstSessionView.getClass().getSimpleName());
         assertFalse(sharedHandle.payloadsMaterialized(),
             "a windowed view is NOT resident — reporting it as materialized steers later queries off the "
-                + "sliced route and pins a session-bound view on the shared handle");
+                + "sliced route into a byte-kernel scan that re-reads windows from disk");
 
-        // The handle re-consults every caller's own materializer (it memoizes nothing session-bound)
-        // and the SESSION hands back the one view it already owns.
+        // Memoized ON THE HANDLE: a second consult neither rebuilds the view nor re-walks the
+        // physical order, so the materializer is not consulted again.
         final List<byte[]> again = sharedHandle.rowGroupPayloads(callerMaterializer);
-        assertEquals(2, consulted.get(), "the handle must not memoize a session-bound view");
-        assertSame(firstSessionView, again, "one windowed view per session, not per consult");
+        assertEquals(1, consulted.get(), "a memoized view must not be rebuilt per consult");
+        assertSame(firstSessionView, again, "one windowed view per handle");
         assertFalse(sharedHandle.payloadsMaterialized());
-
-        // Two INDEPENDENT materializers — what two concurrent compile chains over one session build
-        // — must resolve to that same single view, or each brings its own resident-window budget.
-        final List<byte[]> chainA =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20).get();
-        final List<byte[]> chainB =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20).get();
-        assertSame(firstSessionView, chainA, "a second chain over the same session must reuse the session's view");
-        assertSame(chainA, chainB, "a third chain over the same session must reuse the session's view");
         assertEquals(1, ChunkedBodyConfig.lazyLoads(),
-            "the windowed route must be ENGAGED once per session, not once per caller");
+            "the windowed route must be ENGAGED once per handle, not once per caller");
 
         assertEquals(RECORDS, ProjectionIndexByteScan.countRows(firstSessionView));
       }
 
       // ==== the reported failure: a NEW session on the SAME cached handle ====
+      // The first session is closed. Its windows are evicted below the cap as the scan walks, so
+      // serving here REQUIRES opening fresh transactions — through the successor, never the corpse.
       try (JsonResourceSession reopened = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         final ProjectionIndexRegistry.Handle again = ProjectionIndexCatalog.load(reopened, revision, def);
         assertSame(sharedHandle, again, "the catalog's DATA cache must still serve the same handle instance");
@@ -333,20 +338,32 @@ final class ProjectionWindowedPayloadServeTest {
 
         final List<byte[]> reopenedView = again.rowGroupPayloads(
             ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20));
-        assertNotSame(firstSessionView, reopenedView,
-            "the closed session's view must not be handed to its successor");
+        assertSame(firstSessionView, reopenedView,
+            "the handle's memoized view is the successor's view too — it captured no session to go stale");
         assertEquals(RECORDS, ProjectionIndexByteScan.countRows(reopenedView),
             "the new session must serve its windows through ITS OWN live transactions");
 
-        // The eager arm is the contrast: under the budget the leaves ARE inert bytes, so the handle
-        // memoizes them and reports resident.
+        // A handle that went windowed STAYS windowed for its lifetime: raising the budget must not
+        // silently turn the next consult into the multi-GB materialization the handle was created
+        // to avoid. The promotion is a cache-lifetime decision, so it takes a fresh handle.
         ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
+        assertSame(firstSessionView,
+            again.rowGroupPayloads(
+                ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20)),
+            "a raised budget must not re-materialize a handle that is already serving windowed");
+        assertFalse(again.payloadsMaterialized());
+
+        // The eager arm is the contrast, on a handle that never went windowed: under the budget the
+        // leaves ARE inert bytes, so the handle memoizes them and reports resident.
+        ProjectionIndexCatalog.clearCache();
+        final ProjectionIndexRegistry.Handle fresh = ProjectionIndexCatalog.load(reopened, revision, def);
+        assertNotSame(sharedHandle, fresh, "clearCache must yield a handle that has served nothing yet");
         final Supplier<List<byte[]>> eagerMaterializer =
             ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
-        final List<byte[]> eager = again.rowGroupPayloads(eagerMaterializer);
+        final List<byte[]> eager = fresh.rowGroupPayloads(eagerMaterializer);
         assertFalse(eager instanceof ProjectionWindowedRowGroupPayloads);
-        assertTrue(again.payloadsMaterialized(), "resident leaves must flip the predicate");
-        assertSame(eager, again.rowGroupPayloads(eagerMaterializer),
+        assertTrue(fresh.payloadsMaterialized(), "resident leaves must flip the predicate");
+        assertSame(eager, fresh.rowGroupPayloads(eagerMaterializer),
             "resident leaves must be memoized and served without re-consulting the materializer");
       }
     }
@@ -395,10 +412,12 @@ final class ProjectionWindowedPayloadServeTest {
         assertSame(atBuild, atLater, "one handle, cached on the BUILD revision, serves both query revisions");
 
         final int rowGroupCount = atBuild.rowGroupCount();
-        final List<byte[]> viewAtBuild =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, buildRevision, atBuild, rowGroupCount).get();
-        final List<byte[]> viewAtLater =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, atLater, rowGroupCount).get();
+        final List<byte[]> viewAtBuild = atBuild.rowGroupPayloads(
+            ProjectionIndexCatalog.rowGroupMaterializer(session, buildRevision, INDEX_NUMBER, rowGroupCount,
+                1L << 20));
+        final List<byte[]> viewAtLater = atLater.rowGroupPayloads(
+            ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, INDEX_NUMBER, rowGroupCount,
+                1L << 20));
         assertTrue(viewAtBuild instanceof ProjectionWindowedRowGroupPayloads);
         assertSame(viewAtBuild, viewAtLater,
             "the memo owner is the HANDLE; a second query revision on the same handle must not build a second view");
@@ -456,6 +475,84 @@ final class ProjectionWindowedPayloadServeTest {
             assertFalse(store.columnFillable(nameColumn), "the whole-column fill is over budget here");
             assertTrue(store.columnIdentityFillable(nameColumn),
                 "the identity fill fits, so a distinct operand on this column is still route-viable");
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void aMaskedFillIsPricedByWhatTheMaskLeavesStanding() {
+    // The budget used to guard only the UNMASKED door. A keep mask returns non-null as soon as ONE
+    // leaf drops, so a prune that eliminates almost nothing still routed the whole multi-GB column
+    // through columnMasked — the residency the budget exists to refuse. Pricing has to follow the
+    // mask: a prune that proves the fetch small proceeds, one that does not declines through the
+    // same non-memoizing door.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int leaves = metadata.rowGroupCount();
+          assertTrue(leaves >= 3, "the corpus must span several leaves; got " + leaves);
+          final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
+          final ProjectionColumnStore store = new ProjectionColumnStore(
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
+                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int nameColumn = 0;
+
+          final long[] keepAll = new long[(leaves + 63) >>> 6];
+          for (int leaf = 0; leaf < leaves; leaf++) {
+            keepAll[leaf >>> 6] |= 1L << (leaf & 63);
+          }
+          final long[] keepOne = new long[(leaves + 63) >>> 6];
+          keepOne[0] |= 1L;
+
+          final long allBytes = store.projectedMaskedFillBytes(nameColumn, keepAll);
+          final long oneBytes = store.projectedMaskedFillBytes(nameColumn, keepOne);
+          assertEquals(store.projectedColumnFillBytes(nameColumn), allBytes,
+              "a mask that drops nothing must price exactly like the whole-column fill");
+          assertTrue(oneBytes > 0 && oneBytes < allBytes,
+              "a one-leaf mask must price strictly below the whole column: " + oneBytes + " vs " + allBytes);
+
+          // A budget the one-leaf prune fits and the keep-everything mask does not.
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(allBytes - 1);
+          try {
+            final ProjectionColumnStore.FillBudgetExceededException declined =
+                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
+                    () -> store.columnMasked(nameColumn, fetcher, keepAll));
+            assertTrue(declined.getMessage().contains("budget"), declined.getMessage());
+
+            // Same budget, a mask that proves the fetch small: it proceeds.
+            final ProjectionColumnStore.ColumnSlice[] pruned = store.columnMasked(nameColumn, fetcher, keepOne);
+            assertEquals(leaves, pruned.length, "a masked fill still yields one slice per leaf");
+
+            // The decline is NOT memoized as corruption: with the budget restored the same store
+            // fills the same mask.
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
+            assertEquals(leaves, store.columnMasked(nameColumn, fetcher, keepAll).length);
           } finally {
             ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
           }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -249,13 +249,14 @@ final class ProjectionWindowedPayloadServeTest {
   }
 
   @Test
-  void aWindowedViewIsNeverMemoizedOnTheSharedHandle() {
+  void aWindowedViewIsSessionScopedAndNeverPinnedOnTheSharedHandle() {
     // A handle lives in the catalog's PROCESS-WIDE cache, keyed by (resource, def, build revision)
     // and dropped only when the resource is removed — so anything it memoizes outlives every
     // session that touched it. The eager list is inert bytes and is safe to share; a windowed view
     // is not, because it fetches each window through the session its materializer was built from.
-    // Memoizing one would hand the NEXT session a view bound to a CLOSED one, so over budget the
-    // handle must consult every caller's own materializer and must keep reporting "not resident".
+    // The view's owner is therefore the SESSION: not the handle (it would outlive the session and
+    // fetch through a closed one) and not the caller (N views over one session permit N times the
+    // residency each view's window cap was sized for).
     Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
     try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
       db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
@@ -264,24 +265,30 @@ final class ProjectionWindowedPayloadServeTest {
                                              .storeNodeHistory(false)
                                              .buildPathSummary(true)
                                              .build());
+      final IndexDef def = projectionDef();
+      final int revision;
+      final int rowGroupCount;
+      final ProjectionIndexRegistry.Handle sharedHandle;
+      final List<byte[]> firstSessionView;
+
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
               .commitAfterwards().build().call();
         }
-        final IndexDef def = projectionDef();
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(def), wtx);
           wtx.commit();
         }
-        final int revision = session.getMostRecentRevisionNumber();
-        final int rowGroupCount = rowGroupCount(session, revision);
+        revision = session.getMostRecentRevisionNumber();
+        rowGroupCount = rowGroupCount(session, revision);
         priorWindowLeaves = ProjectionIndexCatalog.setWindowLeavesForTesting(TEST_WINDOW_LEAVES);
         priorEagerBudget = ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(1L);
+        ChunkedBodyConfig.resetDiag();
 
-        final ProjectionIndexRegistry.Handle handle = ProjectionIndexCatalog.load(session, revision, def);
-        assertNotNull(handle, "the persisted projection must load");
-        assertFalse(handle.payloadsMaterialized(), "a freshly loaded column-lazy handle holds no leaves");
+        sharedHandle = ProjectionIndexCatalog.load(session, revision, def);
+        assertNotNull(sharedHandle, "the persisted projection must load");
+        assertFalse(sharedHandle.payloadsMaterialized(), "a freshly loaded column-lazy handle holds no leaves");
 
         final AtomicInteger consulted = new AtomicInteger();
         final Supplier<List<byte[]>> callerMaterializer = () -> {
@@ -290,34 +297,57 @@ final class ProjectionWindowedPayloadServeTest {
                                        .get();
         };
 
-        final List<byte[]> first = handle.rowGroupPayloads(callerMaterializer);
-        assertTrue(first instanceof ProjectionWindowedRowGroupPayloads,
-            "over budget the handle must serve the windowed view; got " + first.getClass().getSimpleName());
-        assertFalse(handle.payloadsMaterialized(),
+        firstSessionView = sharedHandle.rowGroupPayloads(callerMaterializer);
+        assertTrue(firstSessionView instanceof ProjectionWindowedRowGroupPayloads,
+            "over budget the handle must serve the windowed view; got " + firstSessionView.getClass().getSimpleName());
+        assertFalse(sharedHandle.payloadsMaterialized(),
             "a windowed view is NOT resident — reporting it as materialized steers later queries off the "
                 + "sliced route and pins a session-bound view on the shared handle");
 
-        final List<byte[]> second = handle.rowGroupPayloads(callerMaterializer);
-        assertEquals(2, consulted.get(),
-            "each caller must build its view from ITS OWN live session; the handle memoized one instead");
-        assertNotSame(first, second, "the memoized view would be handed to the next session verbatim");
-        assertFalse(handle.payloadsMaterialized());
+        // The handle re-consults every caller's own materializer (it memoizes nothing session-bound)
+        // and the SESSION hands back the one view it already owns.
+        final List<byte[]> again = sharedHandle.rowGroupPayloads(callerMaterializer);
+        assertEquals(2, consulted.get(), "the handle must not memoize a session-bound view");
+        assertSame(firstSessionView, again, "one windowed view per session, not per consult");
+        assertFalse(sharedHandle.payloadsMaterialized());
 
-        // Both views still answer the corpus arithmetic — the fix must not degrade serving.
-        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(first));
-        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(second));
+        // Two INDEPENDENT materializers — what two concurrent compile chains over one session build
+        // — must resolve to that same single view, or each brings its own resident-window budget.
+        final List<byte[]> chainA =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20).get();
+        final List<byte[]> chainB =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20).get();
+        assertSame(firstSessionView, chainA, "a second chain over the same session must reuse the session's view");
+        assertSame(chainA, chainB, "a third chain over the same session must reuse the session's view");
+        assertEquals(1, ChunkedBodyConfig.lazyLoads(),
+            "the windowed route must be ENGAGED once per session, not once per caller");
+
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(firstSessionView));
+      }
+
+      // ==== the reported failure: a NEW session on the SAME cached handle ====
+      try (JsonResourceSession reopened = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        final ProjectionIndexRegistry.Handle again = ProjectionIndexCatalog.load(reopened, revision, def);
+        assertSame(sharedHandle, again, "the catalog's DATA cache must still serve the same handle instance");
+        assertFalse(again.payloadsMaterialized());
+
+        final List<byte[]> reopenedView = again.rowGroupPayloads(
+            ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20));
+        assertNotSame(firstSessionView, reopenedView,
+            "the closed session's view must not be handed to its successor");
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(reopenedView),
+            "the new session must serve its windows through ITS OWN live transactions");
 
         // The eager arm is the contrast: under the budget the leaves ARE inert bytes, so the handle
         // memoizes them and reports resident.
         ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
-        final int consultedBeforeEager = consulted.get();
-        final List<byte[]> eager = handle.rowGroupPayloads(callerMaterializer);
+        final Supplier<List<byte[]>> eagerMaterializer =
+            ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
+        final List<byte[]> eager = again.rowGroupPayloads(eagerMaterializer);
         assertFalse(eager instanceof ProjectionWindowedRowGroupPayloads);
-        assertTrue(handle.payloadsMaterialized(), "resident leaves must flip the predicate");
-        assertEquals(consultedBeforeEager + 1, consulted.get());
-        assertSame(eager, handle.rowGroupPayloads(callerMaterializer),
+        assertTrue(again.payloadsMaterialized(), "resident leaves must flip the predicate");
+        assertSame(eager, again.rowGroupPayloads(eagerMaterializer),
             "resident leaves must be memoized and served without re-consulting the materializer");
-        assertEquals(consultedBeforeEager + 1, consulted.get());
       }
     }
   }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.page.ChunkedBodyConfig;
+import io.sirix.service.InsertPosition;
+import io.sirix.service.json.shredder.JsonShredder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Task #78 gate: a projection whose whole-leaf materialization would exceed the eager budget is
+ * served through WINDOWED payload loads — and the windowed view answers byte-for-byte what the
+ * eager whole-column list answers.
+ *
+ * <p>
+ * Both arms run against the same persisted store, and the witness demands positives on each side
+ * (the guards-must-demand-a-positive-witness rule): the eager arm must record an eager
+ * materialization and no windowed engagement; the windowed arm must record the engagement and one
+ * materialization per window; and a kernel answer computed over each list must agree with the
+ * corpus arithmetic, not merely with the other arm.
+ */
+final class ProjectionWindowedPayloadServeTest {
+
+  private static final java.nio.file.Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+  private static final int INDEX_NUMBER = 0;
+  private static final int RECORDS = 4000;
+  /** Two leaves per window at 1024 rows per leaf and 4000 records: three windows, one partial. */
+  private static final int TEST_WINDOW_LEAVES = 2;
+
+  private long priorEagerBudget = -1;
+  private int priorWindowLeaves = -1;
+
+  @BeforeEach
+  void setUp() {
+    JsonTestHelper.deleteEverything();
+    ProjectionBulkLoad.clearActive();
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (priorEagerBudget >= 0) {
+      ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(priorEagerBudget);
+    }
+    if (priorWindowLeaves >= 0) {
+      ProjectionIndexCatalog.setWindowLeavesForTesting(priorWindowLeaves);
+    }
+    ProjectionBulkLoad.clearActive();
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  @Test
+  void aWindowedListAnswersExactlyLikeTheEagerList() {
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        final int rowGroupCount = rowGroupCount(session, revision);
+        assertTrue(rowGroupCount >= 3, "the corpus must span several leaves; got " + rowGroupCount);
+        final long projectedWeight = 1L << 20; // any positive figure routes; the budget decides
+
+        // ==== eager arm ====
+        priorEagerBudget = ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
+        priorWindowLeaves = ProjectionIndexCatalog.setWindowLeavesForTesting(TEST_WINDOW_LEAVES);
+        ChunkedBodyConfig.resetDiag();
+        final Supplier<List<byte[]>> eagerSupplier =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount,
+                projectedWeight);
+        final List<byte[]> eager = eagerSupplier.get();
+        assertEquals(rowGroupCount, eager.size());
+        assertEquals(0, ChunkedBodyConfig.lazyLoads(), "the eager arm must not engage the windowed route");
+        assertEquals(0, ChunkedBodyConfig.chunkMaterializations(), "the eager arm must materialize no windows");
+        assertEquals(1, ChunkedBodyConfig.eagerFallbacks(),
+            "a lazy handle materialized eagerly must record exactly one eager materialization");
+
+        // ==== windowed arm ====
+        ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(1L);
+        ChunkedBodyConfig.resetDiag();
+        final Supplier<List<byte[]>> windowedSupplier =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount,
+                projectedWeight);
+        final List<byte[]> windowed = windowedSupplier.get();
+        assertEquals(rowGroupCount, windowed.size());
+        assertTrue(windowed instanceof ProjectionWindowedRowGroupPayloads,
+            "over budget, the supplier must return the windowed view; got " + windowed.getClass().getSimpleName());
+
+        // Byte-for-byte identical payloads at every index — sequential AND shuffled access order,
+        // because the windowed view materializes and may evict as it goes.
+        for (int i = 0; i < rowGroupCount; i++) {
+          assertArrayEquals(eager.get(i), windowed.get(i), "payload of row group " + i + " differs");
+        }
+        for (int i = rowGroupCount - 1; i >= 0; i--) {
+          assertArrayEquals(eager.get(i), windowed.get(i), "payload of row group " + i + " differs on re-access");
+        }
+        assertEquals(1, ChunkedBodyConfig.lazyLoads(), "the windowed route must record its engagement");
+        final int expectedWindows = 1 + (rowGroupCount - 1) / TEST_WINDOW_LEAVES;
+        assertTrue(ChunkedBodyConfig.chunkMaterializations() >= expectedWindows,
+            "every window must have materialized at least once: " + ChunkedBodyConfig.chunkMaterializations() + " < "
+                + expectedWindows);
+        assertEquals(0, ChunkedBodyConfig.eagerFallbacks(), "the windowed arm must not fall back to eager");
+
+        // A real kernel answer over each list, checked against the corpus arithmetic — a defect
+        // that empties or inflates both arms identically cannot pass.
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(eager));
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(windowed));
+      }
+    }
+  }
+
+  @Test
+  void anOverBudgetColumnFillDeclinesWithoutMemoizingCorruption() {
+    // The second eager site of task #78: the sliced string-predicate route fills a WHOLE column's
+    // BODY+DICT segments at once. Over the budget it must decline through the established
+    // IllegalStateException door (callers fall back to the whole-leaf windowed route) — and the
+    // decline must NOT poison the store: with the budget restored, the very same store fills.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int[] physicalOrder =
+              ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, metadata.rowGroupCount());
+          final List<ProjectionIndexHOTStorage.RowGroupDirectory> directories =
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER,
+                  metadata.rowGroupCount(), physicalOrder, worker -> worker.accept(reader));
+          assertNotNull(directories, "the store must expose row-group directories");
+          final ProjectionColumnStore store = new ProjectionColumnStore(directories);
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int nameColumn = 0;
+          final long projected = store.projectedColumnFillBytes(nameColumn);
+          assertTrue(projected > 0, "the name column must project a positive fill size");
+
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(projected - 1);
+          try {
+            final IllegalStateException decline =
+                org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                    () -> store.column(nameColumn, fetcher));
+            assertTrue(decline.getMessage().contains("budget"),
+                "the decline must name the budget, got: " + decline.getMessage());
+            assertTrue(store.projectedColumnFillBytes(nameColumn) == projected,
+                "the projected size must be stable across declines");
+            // NOT memoized as corruption: restoring the budget lets the SAME store fill.
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
+            final ProjectionColumnStore.ColumnSlice[] slices = store.column(nameColumn, fetcher);
+            assertEquals(metadata.rowGroupCount(), slices.length);
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void theWindowedViewBoundsResidencyAndSurvivesEviction() {
+    // Direct unit coverage of the view: a synthetic fetcher, a tiny resident cap, and an access
+    // pattern that forces eviction and re-materialization. Content must stay stable and the
+    // resident count bounded.
+    final int rowGroups = 16;
+    final int windowSize = 2;
+    final AtomicInteger fetches = new AtomicInteger();
+    final ProjectionWindowedRowGroupPayloads view =
+        new ProjectionWindowedRowGroupPayloads(rowGroups, windowSize, 2, (from, toExclusive) -> {
+          fetches.incrementAndGet();
+          final byte[][] window = new byte[toExclusive - from][];
+          for (int i = from; i < toExclusive; i++) {
+            window[i - from] = new byte[] { (byte) i, (byte) (i >> 8) };
+          }
+          return window;
+        });
+    assertEquals(rowGroups, view.size());
+    assertEquals(8, view.windowCount());
+    // Two full passes plus a scatter: every access must see its own row group's bytes.
+    for (int pass = 0; pass < 2; pass++) {
+      for (int i = 0; i < rowGroups; i++) {
+        assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) }, view.get(i));
+      }
+    }
+    IntStream.of(15, 0, 7, 3, 12, 1, 14, 2).forEach(i -> assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) },
+        view.get(i)));
+    assertTrue(fetches.get() > view.windowCount(),
+        "a 2-window resident cap over 8 windows must have re-materialized evicted windows; fetches=" + fetches.get());
+    assertTrue(view.residentWindows() <= 3,
+        "residency must stay near the cap (cap 2, plus one in-flight); resident=" + view.residentWindows());
+  }
+
+  private static int rowGroupCount(final JsonResourceSession session, final int revision) {
+    try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+      final byte[] raw = ProjectionIndexHOTStorage.readBlob(rtx.getStorageEngineReader(), INDEX_NUMBER, 0L);
+      assertNotNull(raw, "the projection must have metadata at slot 0");
+      final ProjectionIndexMetadata metadata = ProjectionIndexMetadata.parse(raw);
+      assertNotNull(metadata);
+      return metadata.rowGroupCount();
+    }
+  }
+
+  private static IndexDef projectionDef() {
+    return IndexDefs.createProjectionIdxDef(Path.parse("/[]", PathParser.Type.JSON),
+        List.of(Path.parse("/[]/name", PathParser.Type.JSON), Path.parse("/[]/score", PathParser.Type.JSON)),
+        List.of(Type.STR, Type.LON), INDEX_NUMBER, IndexDef.DbType.JSON);
+  }
+
+  private static String corpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * 48);
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"name\":\"n").append(record).append("-").append("x".repeat(record % 13)).append('"');
+      json.append(",\"score\":").append(record * 3L).append('}');
+    }
+    return json.append(']').toString();
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -684,6 +684,72 @@ final class ProjectionWindowedPayloadServeTest {
     }
   }
 
+  @Test
+  void theRecordKeyFillIsPricedAndChargedLikeEveryOtherRetainedFill() {
+    // The KEYS chain is fetched unmasked across every leaf and DECODES into a long[] the store
+    // retains for its whole cache lifetime — 8 B/row, which at 100M rows is ~800 MB. The cache
+    // weigher's flat charge is justified by the cumulative ledger bounding every retained fill, so
+    // a door that retains a row-count-scaled array without pricing or charging it makes that
+    // justification false on exactly the workload the windowed route targets.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int leaves = metadata.rowGroupCount();
+          final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
+          final ProjectionColumnStore store = new ProjectionColumnStore(
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
+                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+
+          final long keysBytes = store.projectedRecordKeysFillBytes();
+          // The decoded long[] alone is 8 B per row, so the projection must exceed it — a figure
+          // that counted only the raw chain would leave the retained half unpriced.
+          assertTrue(keysBytes >= 8L * RECORDS,
+              "the projection must include the decoded 8 B/row keys: " + keysBytes + " for " + RECORDS + " rows");
+
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(keysBytes - 1);
+          try {
+            final ProjectionColumnStore.FillBudgetExceededException declined =
+                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
+                    () -> store.recordKeys(fetcher));
+            assertTrue(declined.getMessage().contains("record-key"), declined.getMessage());
+            assertEquals(0L, store.retainedFillBytes(), "a declined fill must charge nothing");
+
+            // With room, the fill proceeds AND is charged — the ledger is what the weigher's flat
+            // charge rests on, so an uncharged retained fill is the same defect as an unpriced one.
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
+            assertEquals(leaves, store.recordKeys(fetcher).length);
+            assertTrue(store.retainedFillBytes() >= keysBytes,
+                "a published record-key fill must be charged: " + store.retainedFillBytes() + " < " + keysBytes);
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
   /** Long, highly distinct names: the dictionary dwarfs the 8 B/entry hash chain beside it. */
   private static String fatDictionaryCorpus() {
     final StringBuilder json = new StringBuilder(RECORDS * 256);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -911,6 +911,62 @@ final class ProjectionWindowedPayloadServeTest {
     }
   }
 
+  @Test
+  void aBodyChainAlreadyRetainedIsNotChargedAgainstTheNextFillOfTheSameColumn() {
+    // The fused fold route fills a column's raw BODY bytes directly; a later query on the same
+    // cached handle takes the sliced route on that column. The gate priced the second fill at its
+    // GROSS projection against a ledger that already held those very body arrays, so it refused
+    // fills whose true residency fit the budget — and the group arms answer a refusal by re-entering
+    // whole-leaf, permanently steering a servable query off the sliced route for phantom bytes.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionColumnStore store = storeOf(reader);
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int scoreColumn = 1;
+          final long projected = store.projectedColumnFillBytes(scoreColumn);
+
+          // The fold route goes first, exactly as a plain sum() over this column would.
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(projected);
+          try {
+            store.columnBytes(scoreColumn, fetcher);
+            final long afterBody = store.retainedFillBytes();
+            assertTrue(afterBody > 0, "the raw BODY fill must be charged");
+            assertTrue(afterBody < projected, "the BODY chain alone must be cheaper than the whole fill");
+
+            // A budget that exactly fits the column's true residency. The slice fill reuses those
+            // very body arrays, so what it ADDS still fits — the gate must price the increment.
+            assertTrue(store.columnFillWithinBudget(scoreColumn),
+                "the planner predicate must price what the fill adds, not bytes already retained");
+            store.column(scoreColumn, fetcher);
+            assertEquals(projected, store.retainedFillBytes(),
+                "the store's residency is the column's projection — the body chain is one set of arrays");
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
   /** The store behind the fixture's persisted projection. */
   private static ProjectionColumnStore storeOf(final io.sirix.api.StorageEngineReader reader) {
     final ProjectionIndexMetadata metadata =

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -817,6 +817,125 @@ final class ProjectionWindowedPayloadServeTest {
     }
   }
 
+  @Test
+  void aStringColumnFillIsPricedForItsDecodedIdLane_NotOnlyItsSegmentBytes() {
+    // The shared pricing function priced STRING_DICT at zero decoded residency — the one kind the
+    // windowed route exists to serve. A filled string slice retains a 4 B/row id lane, presence
+    // words and a DECOMPRESSED dictionary; a low-cardinality column makes the id lane the dominant
+    // term, so a figure that counts only stored segment bytes falls far below what the fill holds.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(lowCardinalityCorpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final ProjectionColumnStore store = storeOf(rtx.getStorageEngineReader());
+          final int nameColumn = 0;
+          assertEquals(ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT, store.columnKind(nameColumn),
+              "the fixture's name column must be the dictionary-coded string kind this prices");
+
+          final long idLane = 4L * RECORDS;
+          assertTrue(store.projectedColumnFillBytes(nameColumn) >= idLane,
+              "a string fill must be priced for the 4 B/row ids it decodes into: "
+                  + store.projectedColumnFillBytes(nameColumn) + " < " + idLane);
+          // The identity mode retains the same id lane beside its hash chain — the arithmetic that
+          // used to contribute exactly zero for a column that is STRING_DICT by construction.
+          assertTrue(store.projectedColumnIdentityFillBytes(nameColumn) >= idLane,
+              "an identity fill must be priced for its id lane too: "
+                  + store.projectedColumnIdentityFillBytes(nameColumn) + " < " + idLane);
+        }
+      }
+    }
+  }
+
+  @Test
+  void aFilledColumnIsChargedToTheLedgerExactlyOnce() {
+    // A slice fill runs through the raw-BODY door, which prices and charges that chain on its own
+    // account. Charging the outer projection on top counted one retained copy of the BODY arrays
+    // twice, and the ledger is monotonic and feeds the decline predicates — so the over-charge
+    // steers later servable queries off the sliced route for residency that is not there.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionColumnStore store = storeOf(reader);
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int scoreColumn = 1;
+          final long projected = store.projectedColumnFillBytes(scoreColumn);
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
+          try {
+            assertEquals(0L, store.retainedFillBytes());
+            store.column(scoreColumn, fetcher);
+            assertEquals(projected, store.retainedFillBytes(),
+                "one fill must charge its projection exactly once, not once per door it passes through");
+
+            // Re-entering the inner raw-BODY door for the same column adds nothing: those bytes are
+            // already retained and already charged.
+            store.columnBytes(scoreColumn, fetcher);
+            assertEquals(projected, store.retainedFillBytes(), "an already-retained chain must not be charged again");
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
+  /** The store behind the fixture's persisted projection. */
+  private static ProjectionColumnStore storeOf(final io.sirix.api.StorageEngineReader reader) {
+    final ProjectionIndexMetadata metadata =
+        ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+    assertNotNull(metadata);
+    final int leaves = metadata.rowGroupCount();
+    final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
+    return new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader,
+        INDEX_NUMBER, leaves, physicalOrder, worker -> worker.accept(reader)));
+  }
+
+  /** THREE distinct names over every record: the decoded id lane dwarfs the stored dictionary. */
+  private static String lowCardinalityCorpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * 32);
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"name\":\"n").append(record % 3).append('"');
+      json.append(",\"score\":").append(record * 3L).append('}');
+    }
+    return json.append(']').toString();
+  }
+
   /** Long, highly distinct names: the dictionary dwarfs the 8 B/entry hash chain beside it. */
   private static String fatDictionaryCorpus() {
     final StringBuilder json = new StringBuilder(RECORDS * 256);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -127,8 +128,8 @@ final class ProjectionWindowedPayloadServeTest {
                 projectedWeight);
         final List<byte[]> windowed = windowedSupplier.get();
         assertEquals(rowGroupCount, windowed.size());
-        assertTrue(windowed instanceof ProjectionWindowedRowGroupPayloads,
-            "over budget, the supplier must return the windowed view; got " + windowed.getClass().getSimpleName());
+        assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(windowed),
+            "over budget, the supplier must return a windowed view; got " + windowed.getClass().getSimpleName());
 
         // Byte-for-byte identical payloads at every index — sequential AND shuffled access order,
         // because the windowed view materializes and may evict as it goes.
@@ -225,11 +226,20 @@ final class ProjectionWindowedPayloadServeTest {
     final int windowSize = 2;
     final AtomicInteger fetches = new AtomicInteger();
     final AtomicInteger sourcesSeen = new AtomicInteger();
-    final ProjectionWindowedRowGroupPayloads view =
+    final AtomicInteger sourcesA = new AtomicInteger();
+    final AtomicInteger sourcesB = new AtomicInteger();
+    final java.util.Set<ProjectionWindowedRowGroupPayloads.ReaderSource> sourcesOfA =
+        java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+    final ProjectionWindowedRowGroupPayloads cache =
         new ProjectionWindowedRowGroupPayloads(rowGroups, windowSize, 2, (source, from, toExclusive) -> {
           fetches.incrementAndGet();
           if (source != null) {
             sourcesSeen.incrementAndGet();
+            if (sourcesOfA.contains(source)) {
+              sourcesA.incrementAndGet();
+            } else {
+              sourcesB.incrementAndGet();
+            }
           }
           final byte[][] window = new byte[toExclusive - from][];
           for (int i = from; i < toExclusive; i++) {
@@ -237,28 +247,49 @@ final class ProjectionWindowedPayloadServeTest {
           }
           return window;
         });
-    // The view captures no session: consulting one before a source is bound is a programming error
-    // it must name, not a silent read through a stale binding.
-    final IllegalStateException unbound = assertThrows(IllegalStateException.class, () -> view.get(0));
-    assertTrue(unbound.getMessage().contains("reader source"), unbound.getMessage());
-    view.bindReaderSource(() -> {
+    assertEquals(rowGroups, cache.size());
+    assertEquals(8, cache.windowCount());
+
+    // TWO callers, each with its OWN source. A shared mutable source field would make every fetch
+    // use whichever caller bound last — the dead-session failure with the arrow reversed — so each
+    // view's fetches must arrive carrying that view's own source and no other.
+    final ProjectionWindowedRowGroupPayloads.ReaderSource sourceA = () -> {
       throw new UnsupportedOperationException("the synthetic fetcher never opens a reader");
-    });
-    assertEquals(rowGroups, view.size());
-    assertEquals(8, view.windowCount());
-    // Two full passes plus a scatter: every access must see its own row group's bytes.
+    };
+    sourcesOfA.add(sourceA);
+    final ProjectionWindowedRowGroupPayloads.ReaderSource sourceB = () -> {
+      throw new UnsupportedOperationException("the synthetic fetcher never opens a reader");
+    };
+    final List<byte[]> viewA = cache.boundTo(sourceA);
+    final List<byte[]> viewB = cache.boundTo(sourceB);
+    assertNotSame(viewA, viewB, "each consult gets its own thin view");
+    assertSame(cache, ProjectionWindowedRowGroupPayloads.cacheOf(viewA));
+    assertSame(cache, ProjectionWindowedRowGroupPayloads.cacheOf(viewB),
+        "both views must share ONE window cache, or the resident cap is multiplied");
+    assertSame(sourceA, ProjectionWindowedRowGroupPayloads.sourceOf(viewA));
+    assertSame(sourceB, ProjectionWindowedRowGroupPayloads.sourceOf(viewB));
+
+    // Two full passes plus a scatter: every access must see its own row group's bytes. The passes
+    // alternate views, so a shared-source implementation would be caught by the per-source tally.
     for (int pass = 0; pass < 2; pass++) {
+      final List<byte[]> view = pass == 0
+          ? viewA
+          : viewB;
       for (int i = 0; i < rowGroups; i++) {
         assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) }, view.get(i));
       }
     }
     IntStream.of(15, 0, 7, 3, 12, 1, 14, 2).forEach(i -> assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) },
-        view.get(i)));
-    assertTrue(fetches.get() > view.windowCount(),
+        viewA.get(i)));
+    assertTrue(fetches.get() > cache.windowCount(),
         "a 2-window resident cap over 8 windows must have re-materialized evicted windows; fetches=" + fetches.get());
-    assertTrue(view.residentWindows() <= 3,
-        "residency must stay near the cap (cap 2, plus one in-flight); resident=" + view.residentWindows());
-    assertEquals(fetches.get(), sourcesSeen.get(), "every fetch must be handed the bound reader source");
+    assertTrue(cache.residentWindows() <= 3,
+        "residency must stay near the cap (cap 2, plus one in-flight); resident=" + cache.residentWindows());
+    assertEquals(fetches.get(), sourcesSeen.get(), "every fetch must be handed a reader source");
+    assertTrue(sourcesA.get() > 0 && sourcesB.get() > 0,
+        "both callers' sources must have been used; A=" + sourcesA.get() + " B=" + sourcesB.get());
+    assertEquals(fetches.get(), sourcesA.get() + sourcesB.get(),
+        "every fetch must carry the source of the view that triggered it, never another caller's");
   }
 
   @Test
@@ -303,15 +334,25 @@ final class ProjectionWindowedPayloadServeTest {
         assertFalse(sharedHandle.payloadsMaterialized(), "a freshly loaded column-lazy handle holds no leaves");
 
         final AtomicInteger consulted = new AtomicInteger();
-        final Supplier<List<byte[]>> callerMaterializer = () -> {
-          consulted.incrementAndGet();
-          return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20)
-                                       .get();
-        };
+        final var delegate = (ProjectionWindowedRowGroupPayloads.BoundMaterializer) ProjectionIndexCatalog
+            .rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
+        final Supplier<List<byte[]>> callerMaterializer =
+            new ProjectionWindowedRowGroupPayloads.BoundMaterializer() {
+              @Override
+              public List<byte[]> get() {
+                consulted.incrementAndGet();
+                return delegate.get();
+              }
+
+              @Override
+              public ProjectionWindowedRowGroupPayloads.ReaderSource readerSource() {
+                return delegate.readerSource();
+              }
+            };
 
         firstSessionView = sharedHandle.rowGroupPayloads(callerMaterializer);
-        assertTrue(firstSessionView instanceof ProjectionWindowedRowGroupPayloads,
-            "over budget the handle must serve the windowed view; got " + firstSessionView.getClass().getSimpleName());
+        assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(firstSessionView),
+            "over budget the handle must serve a windowed view; got " + firstSessionView.getClass().getSimpleName());
         assertFalse(sharedHandle.payloadsMaterialized(),
             "a windowed view is NOT resident — reporting it as materialized steers later queries off the "
                 + "sliced route into a byte-kernel scan that re-reads windows from disk");
@@ -319,8 +360,10 @@ final class ProjectionWindowedPayloadServeTest {
         // Memoized ON THE HANDLE: a second consult neither rebuilds the view nor re-walks the
         // physical order, so the materializer is not consulted again.
         final List<byte[]> again = sharedHandle.rowGroupPayloads(callerMaterializer);
-        assertEquals(1, consulted.get(), "a memoized view must not be rebuilt per consult");
-        assertSame(firstSessionView, again, "one windowed view per handle");
+        assertEquals(1, consulted.get(), "a memoized cache must not be rebuilt per consult");
+        assertNotSame(firstSessionView, again, "each consult gets its OWN thin view, never a shared bound one");
+        assertSame(ProjectionWindowedRowGroupPayloads.cacheOf(firstSessionView),
+            ProjectionWindowedRowGroupPayloads.cacheOf(again), "one window cache per handle");
         assertFalse(sharedHandle.payloadsMaterialized());
         assertEquals(1, ChunkedBodyConfig.lazyLoads(),
             "the windowed route must be ENGAGED once per handle, not once per caller");
@@ -338,20 +381,24 @@ final class ProjectionWindowedPayloadServeTest {
 
         final List<byte[]> reopenedView = again.rowGroupPayloads(
             ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20));
-        assertSame(firstSessionView, reopenedView,
-            "the handle's memoized view is the successor's view too — it captured no session to go stale");
+        assertSame(ProjectionWindowedRowGroupPayloads.cacheOf(firstSessionView),
+            ProjectionWindowedRowGroupPayloads.cacheOf(reopenedView),
+            "the handle's memoized CACHE is the successor's too — it captured no session to go stale");
+        assertNotSame(firstSessionView, reopenedView, "the successor reads through its OWN source");
         assertEquals(RECORDS, ProjectionIndexByteScan.countRows(reopenedView),
             "the new session must serve its windows through ITS OWN live transactions");
 
-        // A handle that went windowed STAYS windowed for its lifetime: raising the budget must not
-        // silently turn the next consult into the multi-GB materialization the handle was created
-        // to avoid. The promotion is a cache-lifetime decision, so it takes a fresh handle.
-        ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
-        assertSame(firstSessionView,
-            again.rowGroupPayloads(
-                ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20)),
-            "a raised budget must not re-materialize a handle that is already serving windowed");
+        // A windowed handle keeps serving windowed while callers hand it windowed materializers.
+        // It is PROMOTED only when a caller's materializer actually produces resident leaves — the
+        // handle never decides on its own to pay for a whole-leaf materialization.
         assertFalse(again.payloadsMaterialized());
+        ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
+        final List<byte[]> promoted = again.rowGroupPayloads(
+            ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20));
+        assertNull(ProjectionWindowedRowGroupPayloads.cacheOf(promoted),
+            "a materializer that produced resident leaves must promote the handle off the windowed route");
+        assertTrue(again.payloadsMaterialized(), "promotion must flip the resident predicate");
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(promoted));
 
         // The eager arm is the contrast, on a handle that never went windowed: under the budget the
         // leaves ARE inert bytes, so the handle memoizes them and reports resident.
@@ -361,7 +408,7 @@ final class ProjectionWindowedPayloadServeTest {
         final Supplier<List<byte[]>> eagerMaterializer =
             ProjectionIndexCatalog.rowGroupMaterializer(reopened, revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
         final List<byte[]> eager = fresh.rowGroupPayloads(eagerMaterializer);
-        assertFalse(eager instanceof ProjectionWindowedRowGroupPayloads);
+        assertNull(ProjectionWindowedRowGroupPayloads.cacheOf(eager));
         assertTrue(fresh.payloadsMaterialized(), "resident leaves must flip the predicate");
         assertSame(eager, fresh.rowGroupPayloads(eagerMaterializer),
             "resident leaves must be memoized and served without re-consulting the materializer");
@@ -418,9 +465,10 @@ final class ProjectionWindowedPayloadServeTest {
         final List<byte[]> viewAtLater = atLater.rowGroupPayloads(
             ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, INDEX_NUMBER, rowGroupCount,
                 1L << 20));
-        assertTrue(viewAtBuild instanceof ProjectionWindowedRowGroupPayloads);
-        assertSame(viewAtBuild, viewAtLater,
-            "the memo owner is the HANDLE; a second query revision on the same handle must not build a second view");
+        assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(viewAtBuild));
+        assertSame(ProjectionWindowedRowGroupPayloads.cacheOf(viewAtBuild),
+            ProjectionWindowedRowGroupPayloads.cacheOf(viewAtLater),
+            "the memo owner is the HANDLE; a second query revision on the same handle must not build a second cache");
         assertEquals(1, ChunkedBodyConfig.lazyLoads(),
             "the windowed route must be ENGAGED once per handle, not once per query revision");
         assertEquals(RECORDS, ProjectionIndexByteScan.countRows(viewAtLater));
@@ -553,6 +601,81 @@ final class ProjectionWindowedPayloadServeTest {
             // fills the same mask.
             ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
             assertEquals(leaves, store.columnMasked(nameColumn, fetcher, keepAll).length);
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  void columnFillsArePricedCUMULATIVELY_NotOnePerColumn() {
+    // The fill budget is a per-column figure, but a published fill is RETAINED for the store's whole
+    // cache lifetime — so a handle's residency is the SUM over the columns a query mix touches. With
+    // only a per-column check, a projection whose columns each sit just under the budget retains
+    // several budgets' worth while the cache weigher charges one, and the 8 G envelope the windowed
+    // route exists to hold is gone.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int leaves = metadata.rowGroupCount();
+          final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
+          final ProjectionColumnStore store = new ProjectionColumnStore(
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
+                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int nameColumn = 0;
+          final int scoreColumn = 1;
+          final long nameBytes = store.projectedColumnFillBytes(nameColumn);
+          final long scoreBytes = store.projectedColumnFillBytes(scoreColumn);
+
+          // A budget each column fits ALONE but the two together do not.
+          final long budget = Math.max(nameBytes, scoreBytes) + Math.min(nameBytes, scoreBytes) / 2;
+          assertTrue(budget >= nameBytes && budget >= scoreBytes && budget < nameBytes + scoreBytes,
+              "the budget must admit either column alone and neither pair: " + budget + " vs " + nameBytes + "+"
+                  + scoreBytes);
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(budget);
+          try {
+            assertEquals(0L, store.retainedFillBytes(), "a fresh store retains nothing");
+            assertTrue(store.columnFillWithinBudget(nameColumn), "the first column alone must fit");
+            assertEquals(leaves, store.column(nameColumn, fetcher).length);
+            assertTrue(store.retainedFillBytes() >= nameBytes, "a published fill must be charged");
+
+            // The second column's OWN projection still fits the budget; what does not fit is the
+            // pair, and that is the question the store has to be asking.
+            assertTrue(scoreBytes <= budget, "the second column alone would fit");
+            assertFalse(store.columnFillWithinBudget(scoreColumn),
+                "beside what is already retained, the second column must not fit");
+            final ProjectionColumnStore.FillBudgetExceededException declined =
+                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
+                    () -> store.column(scoreColumn, fetcher));
+            assertTrue(declined.getMessage().contains("already retained"), declined.getMessage());
+
+            // Not memoized as corruption: with room restored the same store fills the same column.
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(Long.MAX_VALUE);
+            assertEquals(leaves, store.column(scoreColumn, fetcher).length);
           } finally {
             ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
           }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -94,8 +94,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -110,9 +110,8 @@ final class ProjectionWindowedPayloadServeTest {
         priorEagerBudget = ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(Long.MAX_VALUE);
         priorWindowLeaves = ProjectionIndexCatalog.setWindowLeavesForTesting(TEST_WINDOW_LEAVES);
         ChunkedBodyConfig.resetDiag();
-        final Supplier<List<byte[]>> eagerSupplier =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount,
-                projectedWeight);
+        final Supplier<List<byte[]>> eagerSupplier = ProjectionIndexCatalog.rowGroupMaterializer(session, revision,
+            INDEX_NUMBER, rowGroupCount, projectedWeight);
         final List<byte[]> eager = eagerSupplier.get();
         assertEquals(rowGroupCount, eager.size());
         assertEquals(0, ChunkedBodyConfig.lazyLoads(), "the eager arm must not engage the windowed route");
@@ -123,9 +122,8 @@ final class ProjectionWindowedPayloadServeTest {
         // ==== windowed arm ====
         ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(1L);
         ChunkedBodyConfig.resetDiag();
-        final Supplier<List<byte[]>> windowedSupplier =
-            ProjectionIndexCatalog.rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount,
-                projectedWeight);
+        final Supplier<List<byte[]>> windowedSupplier = ProjectionIndexCatalog.rowGroupMaterializer(session, revision,
+            INDEX_NUMBER, rowGroupCount, projectedWeight);
         final List<byte[]> windowed = windowedSupplier.get();
         assertEquals(rowGroupCount, windowed.size());
         assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(windowed),
@@ -170,8 +168,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -198,9 +196,8 @@ final class ProjectionWindowedPayloadServeTest {
 
           final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(projected - 1);
           try {
-            final IllegalStateException decline =
-                org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                    () -> store.column(nameColumn, fetcher));
+            final IllegalStateException decline = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalStateException.class, () -> store.column(nameColumn, fetcher));
             assertTrue(decline.getMessage().contains("budget"),
                 "the decline must name the budget, got: " + decline.getMessage());
             assertTrue(store.projectedColumnFillBytes(nameColumn) == projected,
@@ -243,7 +240,7 @@ final class ProjectionWindowedPayloadServeTest {
           }
           final byte[][] window = new byte[toExclusive - from][];
           for (int i = from; i < toExclusive; i++) {
-            window[i - from] = new byte[] { (byte) i, (byte) (i >> 8) };
+            window[i - from] = new byte[] {(byte) i, (byte) (i >> 8)};
           }
           return window;
         });
@@ -276,11 +273,11 @@ final class ProjectionWindowedPayloadServeTest {
           ? viewA
           : viewB;
       for (int i = 0; i < rowGroups; i++) {
-        assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) }, view.get(i));
+        assertArrayEquals(new byte[] {(byte) i, (byte) (i >> 8)}, view.get(i));
       }
     }
-    IntStream.of(15, 0, 7, 3, 12, 1, 14, 2).forEach(i -> assertArrayEquals(new byte[] { (byte) i, (byte) (i >> 8) },
-        viewA.get(i)));
+    IntStream.of(15, 0, 7, 3, 12, 1, 14, 2)
+             .forEach(i -> assertArrayEquals(new byte[] {(byte) i, (byte) (i >> 8)}, viewA.get(i)));
     assertTrue(fetches.get() > cache.windowCount(),
         "a 2-window resident cap over 8 windows must have re-materialized evicted windows; fetches=" + fetches.get());
     assertTrue(cache.residentWindows() <= 3,
@@ -316,8 +313,8 @@ final class ProjectionWindowedPayloadServeTest {
 
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(def), wtx);
@@ -334,21 +331,21 @@ final class ProjectionWindowedPayloadServeTest {
         assertFalse(sharedHandle.payloadsMaterialized(), "a freshly loaded column-lazy handle holds no leaves");
 
         final AtomicInteger consulted = new AtomicInteger();
-        final var delegate = (ProjectionWindowedRowGroupPayloads.BoundMaterializer) ProjectionIndexCatalog
-            .rowGroupMaterializer(session, revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
-        final Supplier<List<byte[]>> callerMaterializer =
-            new ProjectionWindowedRowGroupPayloads.BoundMaterializer() {
-              @Override
-              public List<byte[]> get() {
-                consulted.incrementAndGet();
-                return delegate.get();
-              }
+        final var delegate =
+            (ProjectionWindowedRowGroupPayloads.BoundMaterializer) ProjectionIndexCatalog.rowGroupMaterializer(session,
+                revision, INDEX_NUMBER, rowGroupCount, 1L << 20);
+        final Supplier<List<byte[]>> callerMaterializer = new ProjectionWindowedRowGroupPayloads.BoundMaterializer() {
+          @Override
+          public List<byte[]> get() {
+            consulted.incrementAndGet();
+            return delegate.get();
+          }
 
-              @Override
-              public ProjectionWindowedRowGroupPayloads.ReaderSource readerSource() {
-                return delegate.readerSource();
-              }
-            };
+          @Override
+          public ProjectionWindowedRowGroupPayloads.ReaderSource readerSource() {
+            return delegate.readerSource();
+          }
+        };
 
         firstSessionView = sharedHandle.rowGroupPayloads(callerMaterializer);
         assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(firstSessionView),
@@ -433,8 +430,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         final IndexDef def = projectionDef();
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
@@ -460,11 +457,9 @@ final class ProjectionWindowedPayloadServeTest {
 
         final int rowGroupCount = atBuild.rowGroupCount();
         final List<byte[]> viewAtBuild = atBuild.rowGroupPayloads(
-            ProjectionIndexCatalog.rowGroupMaterializer(session, buildRevision, INDEX_NUMBER, rowGroupCount,
-                1L << 20));
+            ProjectionIndexCatalog.rowGroupMaterializer(session, buildRevision, INDEX_NUMBER, rowGroupCount, 1L << 20));
         final List<byte[]> viewAtLater = atLater.rowGroupPayloads(
-            ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, INDEX_NUMBER, rowGroupCount,
-                1L << 20));
+            ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, INDEX_NUMBER, rowGroupCount, 1L << 20));
         assertNotNull(ProjectionWindowedRowGroupPayloads.cacheOf(viewAtBuild));
         assertSame(ProjectionWindowedRowGroupPayloads.cacheOf(viewAtBuild),
             ProjectionWindowedRowGroupPayloads.cacheOf(viewAtLater),
@@ -506,15 +501,14 @@ final class ProjectionWindowedPayloadServeTest {
           assertNotNull(metadata);
           final int[] physicalOrder =
               ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, metadata.rowGroupCount());
-          final ProjectionColumnStore store = new ProjectionColumnStore(
-              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER,
-                  metadata.rowGroupCount(), physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore store =
+              new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(
+                  reader, INDEX_NUMBER, metadata.rowGroupCount(), physicalOrder, worker -> worker.accept(reader)));
           final int nameColumn = 0;
           final long full = store.projectedColumnFillBytes(nameColumn);
           final long identity = store.projectedColumnIdentityFillBytes(nameColumn);
-          assertTrue(identity < full,
-              "a fat dictionary must project a SMALLER identity fill than a whole-column fill: " + identity + " vs "
-                  + full);
+          assertTrue(identity < full, "a fat dictionary must project a SMALLER identity fill than a whole-column fill: "
+              + identity + " vs " + full);
 
           // A budget between the two modes: the whole-column fill is refused, the identity fill is
           // affordable — so the route gate must disagree with itself across the two predicates.
@@ -548,8 +542,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -564,9 +558,9 @@ final class ProjectionWindowedPayloadServeTest {
           final int leaves = metadata.rowGroupCount();
           assertTrue(leaves >= 3, "the corpus must span several leaves; got " + leaves);
           final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
-          final ProjectionColumnStore store = new ProjectionColumnStore(
-              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
-                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore store =
+              new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(
+                  reader, INDEX_NUMBER, leaves, physicalOrder, worker -> worker.accept(reader)));
           final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
               offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
           final int nameColumn = 0;
@@ -626,8 +620,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -641,9 +635,9 @@ final class ProjectionWindowedPayloadServeTest {
           assertNotNull(metadata);
           final int leaves = metadata.rowGroupCount();
           final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
-          final ProjectionColumnStore store = new ProjectionColumnStore(
-              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
-                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore store =
+              new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(
+                  reader, INDEX_NUMBER, leaves, physicalOrder, worker -> worker.accept(reader)));
           final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
               offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
           final int nameColumn = 0;
@@ -668,9 +662,8 @@ final class ProjectionWindowedPayloadServeTest {
             assertTrue(scoreBytes <= budget, "the second column alone would fit");
             assertFalse(store.columnFillWithinBudget(scoreColumn),
                 "beside what is already retained, the second column must not fit");
-            final ProjectionColumnStore.FillBudgetExceededException declined =
-                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
-                    () -> store.column(scoreColumn, fetcher));
+            final ProjectionColumnStore.FillBudgetExceededException declined = assertThrows(
+                ProjectionColumnStore.FillBudgetExceededException.class, () -> store.column(scoreColumn, fetcher));
             assertTrue(declined.getMessage().contains("already retained"), declined.getMessage());
 
             // Not memoized as corruption: with room restored the same store fills the same column.
@@ -701,8 +694,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -716,9 +709,9 @@ final class ProjectionWindowedPayloadServeTest {
           assertNotNull(metadata);
           final int leaves = metadata.rowGroupCount();
           final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
-          final ProjectionColumnStore store = new ProjectionColumnStore(
-              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
-                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore store =
+              new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(
+                  reader, INDEX_NUMBER, leaves, physicalOrder, worker -> worker.accept(reader)));
           final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
               offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
 
@@ -731,8 +724,7 @@ final class ProjectionWindowedPayloadServeTest {
           final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(keysBytes - 1);
           try {
             final ProjectionColumnStore.FillBudgetExceededException declined =
-                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
-                    () -> store.recordKeys(fetcher));
+                assertThrows(ProjectionColumnStore.FillBudgetExceededException.class, () -> store.recordKeys(fetcher));
             assertTrue(declined.getMessage().contains("record-key"), declined.getMessage());
             assertEquals(0L, store.retainedFillBytes(), "a declined fill must charge nothing");
 
@@ -768,8 +760,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -783,9 +775,9 @@ final class ProjectionWindowedPayloadServeTest {
           assertNotNull(metadata);
           final int leaves = metadata.rowGroupCount();
           final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
-          final ProjectionColumnStore store = new ProjectionColumnStore(
-              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
-                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore store =
+              new ProjectionColumnStore(ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(
+                  reader, INDEX_NUMBER, leaves, physicalOrder, worker -> worker.accept(reader)));
           final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
               offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
           final int scoreColumn = 1;
@@ -877,8 +869,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
@@ -928,8 +920,8 @@ final class ProjectionWindowedPayloadServeTest {
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
-          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
-              .commitAfterwards().build().call();
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
         }
         try (JsonNodeTrx wtx = session.beginNodeTrx()) {
           session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -352,6 +352,132 @@ final class ProjectionWindowedPayloadServeTest {
     }
   }
 
+  @Test
+  void oneWindowedViewPerHANDLE_NotPerQueryRevision() {
+    // A handle is cached on the BUILD revision, so ONE handle serves every query revision since the
+    // build. Keying the session memo on the query revision instead builds a fresh view — its own
+    // resident-window cap, its own full physical-order walk — per revision, over byte-identical
+    // leaves. That is the exact multiplication the session memo exists to prevent, surviving along
+    // the revision axis.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        final IndexDef def = projectionDef();
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(def), wtx);
+          wtx.commit();
+        }
+        final int buildRevision = session.getMostRecentRevisionNumber();
+        // A later revision that does NOT rebuild the projection: the same handle must serve it.
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          wtx.commit();
+        }
+        final int laterRevision = session.getMostRecentRevisionNumber();
+        assertTrue(laterRevision > buildRevision, "the second commit must produce a later revision");
+
+        priorWindowLeaves = ProjectionIndexCatalog.setWindowLeavesForTesting(TEST_WINDOW_LEAVES);
+        priorEagerBudget = ProjectionIndexCatalog.setEagerMaterializeBytesForTesting(1L);
+        ChunkedBodyConfig.resetDiag();
+
+        final ProjectionIndexRegistry.Handle atBuild = ProjectionIndexCatalog.load(session, buildRevision, def);
+        final ProjectionIndexRegistry.Handle atLater = ProjectionIndexCatalog.load(session, laterRevision, def);
+        assertNotNull(atBuild);
+        assertSame(atBuild, atLater, "one handle, cached on the BUILD revision, serves both query revisions");
+
+        final int rowGroupCount = atBuild.rowGroupCount();
+        final List<byte[]> viewAtBuild =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, buildRevision, atBuild, rowGroupCount).get();
+        final List<byte[]> viewAtLater =
+            ProjectionIndexCatalog.rowGroupMaterializer(session, laterRevision, atLater, rowGroupCount).get();
+        assertTrue(viewAtBuild instanceof ProjectionWindowedRowGroupPayloads);
+        assertSame(viewAtBuild, viewAtLater,
+            "the memo owner is the HANDLE; a second query revision on the same handle must not build a second view");
+        assertEquals(1, ChunkedBodyConfig.lazyLoads(),
+            "the windowed route must be ENGAGED once per handle, not once per query revision");
+        assertEquals(RECORDS, ProjectionIndexByteScan.countRows(viewAtLater));
+      }
+    }
+  }
+
+  @Test
+  void aFatDictionaryColumnIsViableInDISTINCT_IDENTITYModeWhenItsFullFillIsNot() {
+    // The COUNT(DISTINCT) operand is filled in distinct-identity mode: BODY plus the ~8 B/entry
+    // hash chain, with NO dictionary bytes. Judging that operand by the whole-column projection
+    // (BODY + DICTIONARY) rejects the sliced arm over bytes its fill never fetches.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(fatDictionaryCorpus()),
+              InsertPosition.AS_FIRST_CHILD).commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int[] physicalOrder =
+              ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, metadata.rowGroupCount());
+          final ProjectionColumnStore store = new ProjectionColumnStore(
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER,
+                  metadata.rowGroupCount(), physicalOrder, worker -> worker.accept(reader)));
+          final int nameColumn = 0;
+          final long full = store.projectedColumnFillBytes(nameColumn);
+          final long identity = store.projectedColumnIdentityFillBytes(nameColumn);
+          assertTrue(identity < full,
+              "a fat dictionary must project a SMALLER identity fill than a whole-column fill: " + identity + " vs "
+                  + full);
+
+          // A budget between the two modes: the whole-column fill is refused, the identity fill is
+          // affordable — so the route gate must disagree with itself across the two predicates.
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(identity);
+          try {
+            assertFalse(store.columnFillable(nameColumn), "the whole-column fill is over budget here");
+            assertTrue(store.columnIdentityFillable(nameColumn),
+                "the identity fill fits, so a distinct operand on this column is still route-viable");
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
+  /** Long, highly distinct names: the dictionary dwarfs the 8 B/entry hash chain beside it. */
+  private static String fatDictionaryCorpus() {
+    final StringBuilder json = new StringBuilder(RECORDS * 256);
+    json.append('[');
+    for (int record = 0; record < RECORDS; record++) {
+      if (record > 0) {
+        json.append(',');
+      }
+      json.append("{\"name\":\"n").append(record).append('-').append("abcdefghij".repeat(20)).append('"');
+      json.append(",\"score\":").append(record * 3L).append('}');
+    }
+    return json.append(']').toString();
+  }
+
   private static int rowGroupCount(final JsonResourceSession session, final int revision) {
     try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
       final byte[] raw = ProjectionIndexHOTStorage.readBlob(rtx.getStorageEngineReader(), INDEX_NUMBER, 0L);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/ProjectionWindowedPayloadServeTest.java
@@ -750,6 +750,73 @@ final class ProjectionWindowedPayloadServeTest {
     }
   }
 
+  @Test
+  void aFillIsPricedByWhatItDECODESInto_NotOnlyItsPackedBytes() {
+    // One question — what does this column cost resident — used to have two answers: the cache
+    // weigher counted the decoded 8 B/row lane, the fill doors counted only packed segment bytes.
+    // A bit-packed NUMERIC_LONG column packs to a byte or two per row and decodes to eight, so a
+    // budget priced on packed bytes admits several times what it believes it is admitting. The two
+    // sides now share one pricing function, and the observable is that the door's own figure
+    // accounts for the lane it will decode into.
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(JsonTestHelper.RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(JsonTestHelper.RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          new JsonShredder.Builder(wtx, JsonShredder.createStringReader(corpus()), InsertPosition.AS_FIRST_CHILD)
+              .commitAfterwards().build().call();
+        }
+        try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+          session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(Set.of(projectionDef()), wtx);
+          wtx.commit();
+        }
+        final int revision = session.getMostRecentRevisionNumber();
+        try (var rtx = session.beginNodeReadOnlyTrx(revision)) {
+          final var reader = rtx.getStorageEngineReader();
+          final ProjectionIndexMetadata metadata =
+              ProjectionIndexMetadata.parse(ProjectionIndexHOTStorage.readBlob(reader, INDEX_NUMBER, 0L));
+          assertNotNull(metadata);
+          final int leaves = metadata.rowGroupCount();
+          final int[] physicalOrder = ProjectionIndexFences.readPhysicalOrder(reader, INDEX_NUMBER, leaves);
+          final ProjectionColumnStore store = new ProjectionColumnStore(
+              ProjectionIndexHOTStorage.readAllRowGroupDirectoriesFromColumnSegmentSlots(reader, INDEX_NUMBER, leaves,
+                  physicalOrder, worker -> worker.accept(reader)));
+          final ProjectionColumnStore.ColumnSegmentFetcher fetcher =
+              offsets -> ProjectionIndexHOTStorage.readSegmentBytesBatch(reader, offsets);
+          final int scoreColumn = 1;
+          assertEquals(ProjectionIndexRowGroupPage.COLUMN_KIND_NUMERIC_LONG, store.columnKind(scoreColumn),
+              "the fixture's score column must be the bit-packed long lane this prices");
+
+          final long decodedLane = 8L * RECORDS;
+          final long projected = store.projectedColumnFillBytes(scoreColumn);
+          assertTrue(projected >= decodedLane,
+              "a long-lane fill must be priced for the 8 B/row it decodes into: " + projected + " < " + decodedLane);
+
+          // And the figure is the one the DOOR enforces, not a number computed beside it: a budget
+          // just under it refuses the fill, and one at it admits.
+          final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(projected - 1);
+          try {
+            assertFalse(store.columnFillWithinBudget(scoreColumn));
+            assertThrows(ProjectionColumnStore.FillBudgetExceededException.class,
+                () -> store.column(scoreColumn, fetcher));
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(projected);
+            assertTrue(store.columnFillWithinBudget(scoreColumn));
+            assertEquals(leaves, store.column(scoreColumn, fetcher).length);
+            assertTrue(store.retainedFillBytes() >= decodedLane,
+                "the ledger must carry the decoded lane too: " + store.retainedFillBytes());
+          } finally {
+            ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+          }
+        }
+      }
+    }
+  }
+
   /** Long, highly distinct names: the dictionary dwarfs the 8 B/entry hash chain beside it. */
   private static String fatDictionaryCorpus() {
     final StringBuilder json = new StringBuilder(RECORDS * 256);

--- a/bundles/sirix-core/src/test/java/io/sirix/io/HashAccessesEquivalenceTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/io/HashAccessesEquivalenceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Random;
+import net.openhft.hashing.LongHashFunction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the FORMAT-STABILITY contract of {@link HashAccesses}: the Unsafe-free accesses must produce
+ * hashes bit-identical to the library's default access, because every checksum already persisted in
+ * a sirix data file was computed through that default. A single differing bit here means existing
+ * resources fail verification on open. The oracle is the library's own {@code hashBytes} (the
+ * Unsafe path), exercised across every length stripe the XXH3 implementation switches on (empty,
+ * &le;16, 17–128, 129–240, and long inputs spanning multiple blocks) plus unaligned offsets, and
+ * across byte[], heap-segment and native-segment shapes.
+ */
+final class HashAccessesEquivalenceTest {
+
+  private static final LongHashFunction XX3 = LongHashFunction.xx3();
+
+  /** Every XXH3 stripe boundary, its neighbours, and block-spanning sizes. */
+  private static final int[] LENGTHS = {0, 1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 175,
+      239, 240, 241, 511, 512, 1024, 1025, 4096, 65_536, 65_537, 1 << 20};
+
+  @Test
+  @DisplayName("byte[] hashes through the VarHandle access match the library default bit-for-bit")
+  void byteArrayAccessMatchesDefault() {
+    final Random random = new Random(0x5151C5_1EEDL);
+    for (final int length : LENGTHS) {
+      for (final int offset : new int[] {0, 1, 7, 13}) {
+        final byte[] buffer = new byte[offset + length + 3];
+        random.nextBytes(buffer);
+        final long expected = XX3.hashBytes(buffer, offset, length);
+        assertEquals(expected, XX3.hash(buffer, HashAccesses.BYTES, offset, length),
+            "length=" + length + " offset=" + offset);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("heap and native segment hashes match the byte[] hash of the same bytes")
+  void segmentAccessMatchesDefault() {
+    final Random random = new Random(0xD1C7_F007L);
+    try (Arena arena = Arena.ofConfined()) {
+      for (final int length : LENGTHS) {
+        final byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        final long expected = XX3.hashBytes(bytes);
+
+        final MemorySegment heap = MemorySegment.ofArray(bytes);
+        assertEquals(expected, XX3.hash(heap, HashAccesses.SEGMENT, 0, length), "heap length=" + length);
+
+        final MemorySegment nativeSegment = arena.allocate(Math.max(length, 1));
+        MemorySegment.copy(bytes, 0, nativeSegment, ValueLayout.JAVA_BYTE, 0, length);
+        assertEquals(expected, XX3.hash(nativeSegment.asSlice(0, length), HashAccesses.SEGMENT, 0, length),
+            "native length=" + length);
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("HashAlgorithm.XXH3 answers identically across all three input shapes")
+  void hashAlgorithmShapesAgree() {
+    final Random random = new Random(0xA1607_1774L);
+    try (Arena arena = Arena.ofConfined()) {
+      for (final int length : LENGTHS) {
+        final byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+        final long fromArray = HashAlgorithm.XXH3.computeHashLong(bytes);
+        assertEquals(XX3.hashBytes(bytes), fromArray, "array vs library, length=" + length);
+        assertEquals(fromArray, HashAlgorithm.XXH3.computeHashLong(MemorySegment.ofArray(bytes)),
+            "heap segment, length=" + length);
+        final MemorySegment nativeSegment = arena.allocate(Math.max(length, 1));
+        MemorySegment.copy(bytes, 0, nativeSegment, ValueLayout.JAVA_BYTE, 0, length);
+        assertEquals(fromArray, HashAlgorithm.XXH3.computeHashLong(nativeSegment.asSlice(0, length)),
+            "native segment, length=" + length);
+      }
+    }
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/HOTCompleteDumpMergeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/HOTCompleteDumpMergeTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.page.HOTTrieWriter;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.ProjectionIndexHOTStorage;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Task #57: pins the invariant that the HOT fragment merge never walks past a fragment declaring
+ * itself a complete dump.
+ *
+ * <h2>What this suite is, and what it is NOT</h2>
+ *
+ * It is NOT a regression test for a fixed defect — nothing was fixed, because nothing could be made
+ * to break. {@link HOTLeafPage#completeDump} exists to stop a merge pulling entries out of older
+ * fragments; its own javadoc names the failure it prevents — "entries that were moved to the
+ * right-half page during the split get resurrected from the base revision". On a plain reading,
+ * {@code mergeHOTFragmentsByKey} consults the flag for the NEWEST fragment only, and since {@code
+ * copy()} does not carry the flag forward, the commit after a split emits a sparse head, the head
+ * check stops firing, and the walk should run straight past the dump into pre-split fragments.
+ *
+ * <p>
+ * IT NEVER DOES. Across three versioning strategies, six commit phases, three window widths, point
+ * reads, content-byte comparison, occurrence counting and a full range enumeration over descriptor
+ * and column-segment slots — with the vulnerable in-place split confirmed to have run in every one
+ * — no merge has ever reached past a complete dump, and no key has ever been resurrected. Some
+ * guard upstream of the merge prevents it and has NOT been identified. The merge was therefore left
+ * exactly as it was: an unexplained absence is not a licence to change the storage layer.
+ * </p>
+ *
+ * <p>
+ * SO THIS SUITE PINS THE ABSENCE INSTEAD OF FIXING THE PRESENCE. Today every case passes against
+ * unmodified production code. If a future change removes or weakens whichever guard is doing the
+ * work, these assertions fire and point at this investigation, rather than at a corrupt database
+ * discovered months later. That is the whole value: a protected unknown beats an unprotected one.
+ * </p>
+ *
+ * <h2>Why these tests are shaped this way</h2>
+ *
+ * WITNESS BEFORE ASSERTION. Every case proves the merge path was ENTERED, via a counter, before it
+ * asserts anything about correctness. Running on a fragmenting strategy is not the same as
+ * reconstructing: measured on this codebase, a leaf is still served from a single fragment after
+ * one update commit and only merges from the second. A test that skipped the witness could pass
+ * while never reconstructing anything — which is exactly how an earlier versioned-merge test in
+ * this same area passed with its merge counters reading zero.
+ *
+ * NEVER FULL. {@link VersioningType#FULL} is immune by construction ({@code
+ * bumpHOTPageFragmentChain} returns false, so no chain exists), so a FULL arm would pass vacuously
+ * and prove nothing. The parameterised cases cover the three fragmenting strategies; FULL appears
+ * only in {@link #fullIsImmuneByConstruction()}, which asserts the immunity itself rather than
+ * borrowing it as coverage.
+ *
+ * THE CANARY IS THE SHARP ASSERTION. {@code completeDumpsWalkedPast()} counts merges that walked
+ * through a fragment declaring itself complete — the defect's PRECONDITION, independent of whether
+ * any particular key was visibly resurrected. Asserting on the mechanism rather than the symptom is
+ * what makes this a guard: a change that re-enables the walk trips it immediately, without needing
+ * a workload unlucky enough to expose a wrong answer.
+ *
+ * <p>
+ * AND THE SPLIT ITSELF IS ASSERTED. {@code IN_PLACE_LEAF_SPLITS} must be nonzero, because the whole
+ * scenario is only dangerous when the in-place split — the one path that reuses the original {@code
+ * PageReference} — actually ran. A refactor that routes leaf splits elsewhere would leave every
+ * assertion below trivially satisfied; without this check the suite would go on passing while
+ * silently covering nothing.
+ * </p>
+ */
+final class HOTCompleteDumpMergeTest {
+
+  private static final String RESOURCE = "hot-complete-dump";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  /**
+   * Enough distinct row groups with fat payloads to force at least one IN-PLACE leaf split.
+   *
+   * <p>
+   * MEASURED, and the number matters. At 400 nothing splits at all: the fixture ran clean and
+   * "passed" while covering nothing, which is the decoration these tests exist to avoid. A probe
+   * over 400 / 2000 / 8000 showed the in-place split first appears at 2000. Do not lower this
+   * without re-running that probe; the split, not the row count, is the trigger — and
+   * {@link #assertVulnerablePathRan} now enforces that mechanically rather than by comment.
+   * </p>
+   *
+   * <p>
+   * RETRACTED: an earlier revision of this comment also claimed the probe showed {@code
+   * completeDumpsWalkedPast=1} at 2000. It did not. That reading came from an over-broad counter
+   * that fired on ENCOUNTERING a complete dump anywhere in the chain, including as the last
+   * fragment, which is harmless. Under the counter's current (and correct) definition — fragments
+   * visited BEHIND one that declared the chain complete — the probe reads zero, as everything else
+   * has.
+   * </p>
+   */
+  private static final int ROW_GROUPS = 2000;
+
+  private static final int PAYLOAD_BYTES = 3 * 1024;
+
+  @BeforeEach
+  void setUp() {
+    // THE INSTRUMENT MUST BE LIVE, ASSERTED BEFORE ANYTHING ELSE. Every counter this class relies
+    // on is gated behind -Dsirix.hot.mergeDiag, because they sit on the default read and commit
+    // paths and cannot be always-on. With the gate off they all read zero — and "zero walked past a
+    // complete dump" from a DISABLED instrument is indistinguishable from the same reading from a
+    // healthy one, so the whole class would pass while measuring nothing. The build supplies the
+    // flag; this catches the run where it did not.
+    assertTrue(VersioningType.hotMergeDiagEnabled(),
+        "HOT merge diagnostics are OFF, so every counter reads zero and every assertion in this "
+            + "class would pass vacuously. Run with -Dsirix.hot.mergeDiag=true (the gradle test "
+            + "configuration sets it).");
+    JsonTestHelper.deleteEverything();
+    VersioningType.resetFragmentMergeCounters();
+    // MUST be reset per case: these are process-wide statics, and a split left over from the
+    // previous test would satisfy assertVulnerablePathRan for a case that never split at all.
+    HOTTrieWriter.resetInPlaceLeafSplits();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /**
+   * The four-commit minimum: create, fill to force a split, commit again so the head fragment is
+   * sparse, then read. This is the shape in which the code reading says the walk should run through
+   * the complete dump into pre-split fragments. It does not, on any of the three strategies.
+   */
+  @ParameterizedTest
+  @EnumSource(value = VersioningType.class, names = {"DIFFERENTIAL", "INCREMENTAL", "SLIDING_SNAPSHOT"})
+  void aReadAfterASplitMustNotWalkPastTheCompleteDump(final VersioningType versioning) throws IOException {
+    createResource(versioning);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      commit1_seed(session);
+      commit2_fillToForceSplit(session);
+      commit3_touchOneKey(session);
+      commit4_touchOneKey(session);
+
+      // NO counter reset here. Reconstruction happens on the read-modify-write COMMIT path, not on
+      // the blob reads below - measured: resetting before the read gives merges=0 and the witness
+      // fails even though the defect fired during the commits. The counters therefore span the
+      // whole scenario, reset once in setUp.
+      // NOTE: no clearAllCaches here - see the probe finding below.
+      final Set<Long> distinct = readAllRowGroups(session);
+
+      // WITNESS FIRST: without these the assertions below could pass on the single-fragment path,
+      // or on a run where no split ever happened.
+      assertVulnerablePathRan(versioning);
+      assertTrue(VersioningType.multiFragmentMerges() > 0,
+          versioning + ": the merge path was never entered, so this case proves nothing. " + counters());
+
+      // THE MECHANISM. Nonzero means the walk went through a fragment that declared itself the
+      // complete state of its page — the task #57 precondition, whether or not a key visibly changed.
+      assertEquals(0, VersioningType.completeDumpsWalkedPast(),
+          versioning + ": the merge walked past a complete dump, so pre-split fragments contributed "
+              + "entries the split had relocated");
+
+      // THE CONSEQUENCE, asserted separately so a failure says which layer broke.
+      assertEquals(ROW_GROUPS, distinct.size(),
+          versioning + ": every row group must be readable exactly once after the split");
+    }
+  }
+
+  /**
+   * The five-commit escalation, SLIDING_SNAPSHOT only. A fix that stops NEW resurrection but leaves
+   * entries the carry-forward already wrote into the head fragment would pass the four-commit case
+   * and still be wrong on a real database, because those entries can never age out again.
+   */
+  @Test
+  void slidingSnapshotMustNotMakeResurrectedEntriesPermanent() throws IOException {
+    createResource(VersioningType.SLIDING_SNAPSHOT);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      commit1_seed(session);
+      commit2_fillToForceSplit(session);
+      commit3_touchOneKey(session);
+      commit4_touchOneKey(session);
+      commit5_touchOneKey(session);
+
+      // NO counter reset here. Reconstruction happens on the read-modify-write COMMIT path, not on
+      // the blob reads below - measured: resetting before the read gives merges=0 and the witness
+      // fails even though the defect fired during the commits. The counters therefore span the
+      // whole scenario, reset once in setUp.
+      // NOTE: no clearAllCaches here - see the probe finding below.
+      final Set<Long> distinct = readAllRowGroups(session);
+
+      assertVulnerablePathRan(VersioningType.SLIDING_SNAPSHOT);
+      assertTrue(VersioningType.multiFragmentMerges() > 0, "the merge path must have been entered. " + counters());
+      assertEquals(0, VersioningType.completeDumpsWalkedPast(),
+          "after five commits the window has rotated; nothing may have walked behind a complete dump");
+      assertEquals(ROW_GROUPS, distinct.size(), "no row group may be lost or duplicated after rotation");
+    }
+  }
+
+  /**
+   * Historical reads are believed correct — at the split revision the newest fragment IS the dump,
+   * so the head check fires and the read is sound. Asserted rather than assumed, because it is
+   * precisely the property a careless fix could break.
+   */
+  @Test
+  void readingTheRevisionAtWhichTheSplitHappenedStaysCorrect() throws IOException {
+    createResource(VersioningType.SLIDING_SNAPSHOT);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      commit1_seed(session);
+      commit2_fillToForceSplit(session);
+      final int splitRevision = session.getMostRecentRevisionNumber();
+      commit3_touchOneKey(session);
+      commit4_touchOneKey(session);
+
+      // NO counter reset here. Reconstruction happens on the read-modify-write COMMIT path, not on
+      // the blob reads below - measured: resetting before the read gives merges=0 and the witness
+      // fails even though the merge ran during the commits. The counters therefore span the whole
+      // scenario, reset once in setUp.
+      assertVulnerablePathRan(VersioningType.SLIDING_SNAPSHOT);
+
+      // A HISTORICAL reader, opened AT the split revision. An earlier version of this case captured
+      // splitRevision and then read through a HEAD transaction, passing the revision to a helper
+      // that ignored the parameter entirely — so it re-read exactly what every other case reads and
+      // asserted nothing whatsoever about the split revision. The revision has to be bound to the
+      // READER, because readBlob takes no revision of its own.
+      try (JsonNodeReadOnlyTrx atSplitTrx = session.beginNodeReadOnlyTrx(splitRevision)) {
+        assertEquals(splitRevision, atSplitTrx.getRevisionNumber(),
+            "the probe must actually be positioned at the split revision, or this case is testing "
+                + "the head again");
+        final Set<Long> atSplit = readAllRowGroups(atSplitTrx.getStorageEngineReader());
+        assertEquals(ROW_GROUPS, atSplit.size(),
+            "the revision at which the split happened must read correctly — the head check fires there");
+      }
+    }
+  }
+
+  /** FULL has no fragment chain at all, so it cannot exhibit this defect — asserted, not assumed. */
+  @Test
+  void fullIsImmuneByConstruction() throws IOException {
+    createResource(VersioningType.FULL);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      commit1_seed(session);
+      commit2_fillToForceSplit(session);
+      commit3_touchOneKey(session);
+      commit4_touchOneKey(session);
+
+      // NO counter reset here. Reconstruction happens on the read-modify-write COMMIT path, not on
+      // the blob reads below - measured: resetting before the read gives merges=0 and the witness
+      // fails even though the defect fired during the commits. The counters therefore span the
+      // whole scenario, reset once in setUp.
+      // NOTE: no clearAllCaches here - see the probe finding below.
+      final Set<Long> distinct = readAllRowGroups(session);
+
+      // The immunity is only meaningful if FULL ran the SAME scenario — same split, same commits —
+      // and still kept no chain. Without this the arm could be immune merely by doing less.
+      assertVulnerablePathRan(VersioningType.FULL);
+      assertEquals(ROW_GROUPS, distinct.size(), "FULL must read every row group exactly once");
+      assertEquals(0, VersioningType.multiFragmentMerges(),
+          "FULL keeps no fragment chain, so nothing should ever reconstruct — this is WHY a FULL arm "
+              + "cannot serve as coverage for the other strategies");
+      assertEquals(0, VersioningType.completeDumpsWalkedPast());
+    }
+  }
+
+  /**
+   * The coverage guard: the in-place leaf split is the only split that reuses the original
+   * {@code PageReference}, and it is what makes a stale fragment chain reachable at all. If a
+   * refactor stops taking that path this fixture still passes every other assertion while
+   * exercising nothing — so the split is asserted, not assumed.
+   */
+  private static void assertVulnerablePathRan(final VersioningType versioning) {
+    assertTrue(HOTTrieWriter.inPlaceLeafSplits() > 0,
+        versioning + ": no in-place leaf split ran, so this case covers nothing — the scenario must be "
+            + "re-tuned (see ROW_GROUPS) before its other assertions mean anything. " + counters());
+  }
+
+  /** Every counter, because a single counter's zero is not a fact — the whole set triangulates. */
+  private static String counters() {
+    return "single=" + VersioningType.singleFragmentReads() + " merges=" + VersioningType.multiFragmentMerges()
+        + " walked=" + VersioningType.fragmentsWalked() + " shortCircuit=" + VersioningType.completeDumpShortCircuits()
+        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast()
+        + " inPlaceSplits=" + HOTTrieWriter.inPlaceLeafSplits()
+        + " carryFwd=" + VersioningType.carryForwardRotations();
+  }
+
+  /**
+   * INCREMENTAL is claimed to self-heal because its rotation resets the chain. Unasserted claims
+   * decay, so this pins it: after enough commits to rotate, the merge must stop reaching back.
+   */
+  @Test
+  void incrementalRotationResetsTheChain() throws IOException {
+    createResource(VersioningType.INCREMENTAL);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      commit1_seed(session);
+      commit2_fillToForceSplit(session);
+      for (int extra = 0; extra < 8; extra++) {
+        write(session, 0, 1, 10 + extra);
+      }
+
+      final Set<Long> distinct = readAllRowGroups(session);
+      assertVulnerablePathRan(VersioningType.INCREMENTAL);
+      assertTrue(VersioningType.multiFragmentMerges() > 0,
+          "the merge path must have been entered across the rotation. " + counters());
+      assertEquals(ROW_GROUPS, distinct.size(), "every row group readable after rotation");
+      assertEquals(0, VersioningType.completeDumpsWalkedPast(),
+          "INCREMENTAL must not walk past a complete dump either - its rotation shortens exposure, "
+              + "it does not make the walk correct");
+    }
+  }
+
+  // ---------------------------------------------------------------- fixture
+
+  private static void createResource(final VersioningType versioning) throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE).versioningApproach(versioning).build());
+    }
+  }
+
+  private static void commit1_seed(final JsonResourceSession session) {
+    write(session, 0, 8, 1);
+  }
+
+  /** The split: enough fat entries in one go that the leaf must divide. */
+  private static void commit2_fillToForceSplit(final JsonResourceSession session) {
+    write(session, 0, ROW_GROUPS, 2);
+  }
+
+  private static void commit3_touchOneKey(final JsonResourceSession session) {
+    write(session, 0, 1, 3);
+  }
+
+  // All three touch THE SAME slot, and that is the whole point: a fragment chain forms per LEAF, so
+  // successive commits must revisit the same leaf or every read stays single-fragment. Measured -
+  // with commits 3/4/5 touching slots 1/2/3 the fixture reported merges=0 while splits were
+  // happening, and the witness correctly refused to let it claim coverage.
+  private static void commit4_touchOneKey(final JsonResourceSession session) {
+    write(session, 0, 1, 4);
+  }
+
+  private static void commit5_touchOneKey(final JsonResourceSession session) {
+    write(session, 0, 1, 5);
+  }
+
+  private static void write(final JsonResourceSession session, final int from, final int toExclusive,
+      final int commitMarker) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), 0);
+      for (int i = from; i < toExclusive; i++) {
+        // A FRESH array per slot. Reusing one and mutating it stores a reference whose bytes then
+        // change under the already-computed hash, and every slot fails verification with a length
+        // that matches — which is what the FULL arm caught on the first run, doing exactly the job
+        // an immune control is for.
+        final byte[] payload = new byte[PAYLOAD_BYTES];
+        payload[0] = (byte) (i & 0xFF);
+        payload[1] = (byte) ((i >>> 8) & 0xFF);
+        // Distinct bytes per commit. Rewriting a slot with IDENTICAL content need not dirty the
+        // page, and then no new fragment forms and nothing ever reconstructs - measured: without
+        // this the fixture reported merges=0 while splits were happening.
+        payload[2] = (byte) commitMarker;
+        storage.putBlob(i + 1, payload);
+      }
+      wtx.commit();
+    }
+  }
+
+  private static Set<Long> readAllRowGroups(final JsonResourceSession session) {
+    try (JsonNodeTrx probe = session.beginNodeTrx()) {
+      return readAllRowGroups(probe.getStorageEngineReader());
+    }
+  }
+
+  /** Every slot that answers, collected as a SET so a duplicate shows up as a missing member. */
+  /**
+   * Read every row group and key the result on the CONTENT, not on the loop counter.
+   *
+   * <p>
+   * The earlier version added {@code i + 1} — the key it had just asked for — so the set counted
+   * "how many slots answered non-null" and nothing more. A slot returning some OTHER row group's
+   * payload was structurally invisible, which is precisely the failure this class exists to detect.
+   * The payload encodes its own row-group index in bytes 0..1 (see {@link #write}), so the identity
+   * is checked against the key that was requested and the set is built from what came back.
+   * </p>
+   *
+   * <p>
+   * SCOPE, stated because the earlier comment overclaimed: point reads cannot see DUPLICATION —
+   * two stored copies of one key still answer once. Duplicate detection needs the range enumeration
+   * over descriptor and column-segment slots, which lives outside this class.
+   * </p>
+   */
+  private static Set<Long> readAllRowGroups(final StorageEngineReader reader) {
+    final Set<Long> seen = new HashSet<>();
+    for (int i = 0; i < ROW_GROUPS; i++) {
+      final long requestedKey = (long) i + 1;
+      final byte[] blob = ProjectionIndexHOTStorage.readBlob(reader, 0, requestedKey);
+      if (blob != null && blob.length > 0) {
+        final long identityInPayload = ((blob[0] & 0xFFL) | ((blob[1] & 0xFFL) << 8)) + 1L;
+        assertEquals(requestedKey, identityInPayload,
+            "slot " + requestedKey + " answered with row group " + identityInPayload
+                + "'s payload — a wrong-content read, which keying on the loop counter would have "
+                + "hidden. " + counters());
+        seen.add(identityInPayload);
+      }
+    }
+    return seen;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/page/HOTCompleteDumpMergeTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/HOTCompleteDumpMergeTest.java
@@ -98,19 +98,18 @@ final class HOTCompleteDumpMergeTest {
    *
    * <p>
    * MEASURED, and the number matters. At 400 nothing splits at all: the fixture ran clean and
-   * "passed" while covering nothing, which is the decoration these tests exist to avoid. A probe
-   * over 400 / 2000 / 8000 showed the in-place split first appears at 2000. Do not lower this
-   * without re-running that probe; the split, not the row count, is the trigger — and
+   * "passed" while covering nothing, which is the decoration these tests exist to avoid. A probe over
+   * 400 / 2000 / 8000 showed the in-place split first appears at 2000. Do not lower this without
+   * re-running that probe; the split, not the row count, is the trigger — and
    * {@link #assertVulnerablePathRan} now enforces that mechanically rather than by comment.
    * </p>
    *
    * <p>
    * RETRACTED: an earlier revision of this comment also claimed the probe showed {@code
-   * completeDumpsWalkedPast=1} at 2000. It did not. That reading came from an over-broad counter
-   * that fired on ENCOUNTERING a complete dump anywhere in the chain, including as the last
-   * fragment, which is harmless. Under the counter's current (and correct) definition — fragments
-   * visited BEHIND one that declared the chain complete — the probe reads zero, as everything else
-   * has.
+   * completeDumpsWalkedPast=1} at 2000. It did not. That reading came from an over-broad counter that
+   * fired on ENCOUNTERING a complete dump anywhere in the chain, including as the last fragment,
+   * which is harmless. Under the counter's current (and correct) definition — fragments visited
+   * BEHIND one that declared the chain complete — the probe reads zero, as everything else has.
    * </p>
    */
   private static final int ROW_GROUPS = 2000;
@@ -217,9 +216,9 @@ final class HOTCompleteDumpMergeTest {
   }
 
   /**
-   * Historical reads are believed correct — at the split revision the newest fragment IS the dump,
-   * so the head check fires and the read is sound. Asserted rather than assumed, because it is
-   * precisely the property a careless fix could break.
+   * Historical reads are believed correct — at the split revision the newest fragment IS the dump, so
+   * the head check fires and the read is sound. Asserted rather than assumed, because it is precisely
+   * the property a careless fix could break.
    */
   @Test
   void readingTheRevisionAtWhichTheSplitHappenedStaysCorrect() throws IOException {
@@ -246,8 +245,7 @@ final class HOTCompleteDumpMergeTest {
       // READER, because readBlob takes no revision of its own.
       try (JsonNodeReadOnlyTrx atSplitTrx = session.beginNodeReadOnlyTrx(splitRevision)) {
         assertEquals(splitRevision, atSplitTrx.getRevisionNumber(),
-            "the probe must actually be positioned at the split revision, or this case is testing "
-                + "the head again");
+            "the probe must actually be positioned at the split revision, or this case is testing " + "the head again");
         final Set<Long> atSplit = readAllRowGroups(atSplitTrx.getStorageEngineReader());
         assertEquals(ROW_GROUPS, atSplit.size(),
             "the revision at which the split happened must read correctly — the head check fires there");
@@ -288,8 +286,8 @@ final class HOTCompleteDumpMergeTest {
   /**
    * The coverage guard: the in-place leaf split is the only split that reuses the original
    * {@code PageReference}, and it is what makes a stale fragment chain reachable at all. If a
-   * refactor stops taking that path this fixture still passes every other assertion while
-   * exercising nothing — so the split is asserted, not assumed.
+   * refactor stops taking that path this fixture still passes every other assertion while exercising
+   * nothing — so the split is asserted, not assumed.
    */
   private static void assertVulnerablePathRan(final VersioningType versioning) {
     assertTrue(HOTTrieWriter.inPlaceLeafSplits() > 0,
@@ -301,9 +299,8 @@ final class HOTCompleteDumpMergeTest {
   private static String counters() {
     return "single=" + VersioningType.singleFragmentReads() + " merges=" + VersioningType.multiFragmentMerges()
         + " walked=" + VersioningType.fragmentsWalked() + " shortCircuit=" + VersioningType.completeDumpShortCircuits()
-        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast()
-        + " inPlaceSplits=" + HOTTrieWriter.inPlaceLeafSplits()
-        + " carryFwd=" + VersioningType.carryForwardRotations();
+        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast() + " inPlaceSplits="
+        + HOTTrieWriter.inPlaceLeafSplits() + " carryFwd=" + VersioningType.carryForwardRotations();
   }
 
   /**
@@ -400,17 +397,17 @@ final class HOTCompleteDumpMergeTest {
    * Read every row group and key the result on the CONTENT, not on the loop counter.
    *
    * <p>
-   * The earlier version added {@code i + 1} — the key it had just asked for — so the set counted
-   * "how many slots answered non-null" and nothing more. A slot returning some OTHER row group's
-   * payload was structurally invisible, which is precisely the failure this class exists to detect.
-   * The payload encodes its own row-group index in bytes 0..1 (see {@link #write}), so the identity
-   * is checked against the key that was requested and the set is built from what came back.
+   * The earlier version added {@code i + 1} — the key it had just asked for — so the set counted "how
+   * many slots answered non-null" and nothing more. A slot returning some OTHER row group's payload
+   * was structurally invisible, which is precisely the failure this class exists to detect. The
+   * payload encodes its own row-group index in bytes 0..1 (see {@link #write}), so the identity is
+   * checked against the key that was requested and the set is built from what came back.
    * </p>
    *
    * <p>
-   * SCOPE, stated because the earlier comment overclaimed: point reads cannot see DUPLICATION —
-   * two stored copies of one key still answer once. Duplicate detection needs the range enumeration
-   * over descriptor and column-segment slots, which lives outside this class.
+   * SCOPE, stated because the earlier comment overclaimed: point reads cannot see DUPLICATION — two
+   * stored copies of one key still answer once. Duplicate detection needs the range enumeration over
+   * descriptor and column-segment slots, which lives outside this class.
    * </p>
    */
   private static Set<Long> readAllRowGroups(final StorageEngineReader reader) {
@@ -422,8 +419,8 @@ final class HOTCompleteDumpMergeTest {
         final long identityInPayload = ((blob[0] & 0xFFL) | ((blob[1] & 0xFFL) << 8)) + 1L;
         assertEquals(requestedKey, identityInPayload,
             "slot " + requestedKey + " answered with row group " + identityInPayload
-                + "'s payload — a wrong-content read, which keying on the loop counter would have "
-                + "hidden. " + counters());
+                + "'s payload — a wrong-content read, which keying on the loop counter would have " + "hidden. "
+                + counters());
         seen.add(identityInPayload);
       }
     }

--- a/bundles/sirix-core/src/test/java/io/sirix/page/HOTTombstoneEvictionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/HOTTombstoneEvictionTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <h2>Why this exists separately from {@link HOTCompleteDumpMergeTest}</h2>
  *
- * Every probe in the task #57 investigation WROTE or UPDATED slots; not one ever DELETED one. So two
- * surfaces went entirely unexercised: tombstones, and the eviction path
+ * Every probe in the task #57 investigation WROTE or UPDATED slots; not one ever DELETED one. So
+ * two surfaces went entirely unexercised: tombstones, and the eviction path
  * ({@code carryForwardAgingHOTEntries}) which is a different method from the merge walk. The
- * dangerous case is their interaction — if the carry-forward re-emitted the live value of a key that
- * a newer fragment had tombstoned, a deleted row would come back and be written into the HEAD
- * fragment, where it can never age out again. That is the same resurrection shape as #57 but through
- * eviction rather than merge, and it would be a wrong answer on the shipping default
+ * dangerous case is their interaction — if the carry-forward re-emitted the live value of a key
+ * that a newer fragment had tombstoned, a deleted row would come back and be written into the HEAD
+ * fragment, where it can never age out again. That is the same resurrection shape as #57 but
+ * through eviction rather than merge, and it would be a wrong answer on the shipping default
  * (SLIDING_SNAPSHOT, {@code revisionsToRestore = 3}).
  *
  * <h2>The witness is the specific mechanism, not "something ran"</h2>
@@ -208,8 +208,8 @@ final class HOTTombstoneEvictionTest {
       assertNull(ProjectionIndexHOTStorage.readBlob(reader, 0, DELETED_KEY),
           where + ": the deleted key came back. " + counters());
       assertNotNull(ProjectionIndexHOTStorage.readBlob(reader, 0, UNTOUCHED_KEY),
-          where + ": an untouched live key was LOST, so the absence above is not evidence of "
-              + "correct deletion. " + counters());
+          where + ": an untouched live key was LOST, so the absence above is not evidence of " + "correct deletion. "
+              + counters());
       assertNotNull(ProjectionIndexHOTStorage.readBlob(reader, 0, CHURN_KEY),
           where + ": the churned key was lost. " + counters());
     }
@@ -218,9 +218,8 @@ final class HOTTombstoneEvictionTest {
   private static String counters() {
     return "single=" + VersioningType.singleFragmentReads() + " merges=" + VersioningType.multiFragmentMerges()
         + " walked=" + VersioningType.fragmentsWalked() + " shortCircuit=" + VersioningType.completeDumpShortCircuits()
-        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast()
-        + " inPlaceSplits=" + HOTTrieWriter.inPlaceLeafSplits()
-        + " carryFwdRotations=" + VersioningType.carryForwardRotations()
+        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast() + " inPlaceSplits="
+        + HOTTrieWriter.inPlaceLeafSplits() + " carryFwdRotations=" + VersioningType.carryForwardRotations()
         + " carryFwdReemitted=" + VersioningType.carryForwardEntriesReemitted();
   }
 

--- a/bundles/sirix-core/src/test/java/io/sirix/page/HOTTombstoneEvictionTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/page/HOTTombstoneEvictionTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.page;
+
+import io.sirix.JsonTestHelper;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.page.HOTTrieWriter;
+import io.sirix.api.Database;
+import io.sirix.api.StorageEngineReader;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.ProjectionIndexHOTStorage;
+import io.sirix.settings.VersioningType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * DELETIONS across the sliding window: a tombstoned key must stay deleted through fragment
+ * reconstruction, through window eviction, and through a leaf split — including after the tombstone
+ * itself has aged out of the window.
+ *
+ * <h2>Why this exists separately from {@link HOTCompleteDumpMergeTest}</h2>
+ *
+ * Every probe in the task #57 investigation WROTE or UPDATED slots; not one ever DELETED one. So two
+ * surfaces went entirely unexercised: tombstones, and the eviction path
+ * ({@code carryForwardAgingHOTEntries}) which is a different method from the merge walk. The
+ * dangerous case is their interaction — if the carry-forward re-emitted the live value of a key that
+ * a newer fragment had tombstoned, a deleted row would come back and be written into the HEAD
+ * fragment, where it can never age out again. That is the same resurrection shape as #57 but through
+ * eviction rather than merge, and it would be a wrong answer on the shipping default
+ * (SLIDING_SNAPSHOT, {@code revisionsToRestore = 3}).
+ *
+ * <h2>The witness is the specific mechanism, not "something ran"</h2>
+ *
+ * Asserting "the deleted key is absent" is trivially satisfied by a run where no eviction ever
+ * happened — the empty-enumeration mistake. Each case therefore asserts the counter for the
+ * mechanism it is actually about, BEFORE its absence assertion: merge cases assert
+ * {@code multiFragmentMerges > 0}, eviction cases assert {@code carryForwardRotations > 0}, and the
+ * split case asserts {@code IN_PLACE_LEAF_SPLITS > 0}. "A merge ran" is NOT a witness that an
+ * eviction ran, and the two are different code paths.
+ *
+ * <h2>Window arithmetic, so the commit counts are not folklore</h2>
+ *
+ * {@code hotSlidingSnapshotEvicts} uses {@code chainCap = revisionsToRestore - 1 = 2}, and evicts
+ * once {@code fragments.size() + 1 > chainCap}. So eviction begins as soon as two on-disk fragments
+ * exist — from roughly the third commit on a given leaf — and every later commit evicts again. The
+ * sweep below therefore runs well past that point and asserts after EVERY commit, which also covers
+ * the phase at which the tombstone itself is the entry being dropped.
+ */
+final class HOTTombstoneEvictionTest {
+
+  private static final String RESOURCE = "hot-tombstone";
+  private static final Path DATABASE_PATH = JsonTestHelper.PATHS.PATH1.getFile();
+
+  /** Small, per the reproducer's brief — these cases are about deletion, not about splitting. */
+  private static final int KEYS = 8;
+
+  /** The key that gets deleted and must never come back. */
+  private static final long DELETED_KEY = 3L;
+
+  /** A key that is never touched after seeding — it must survive every eviction. */
+  private static final long UNTOUCHED_KEY = 5L;
+
+  /** The key rewritten on every commit, to keep producing fragments. */
+  private static final long CHURN_KEY = 1L;
+
+  private static final int PAYLOAD_BYTES = 3 * 1024;
+
+  /** Matches {@link HOTCompleteDumpMergeTest}: the row count at which an in-place split appears. */
+  private static final int SPLIT_KEYS = 2000;
+
+  @BeforeEach
+  void setUp() {
+    // The rotation and split witnesses are gated behind -Dsirix.hot.mergeDiag (these counters sit
+    // on the default commit path and cannot be always-on). With the gate off they read zero, so the
+    // witnesses would fail — correctly, but confusingly. Say plainly what is wrong instead.
+    assertTrue(VersioningType.hotMergeDiagEnabled(),
+        "HOT merge diagnostics are OFF, so the rotation and split witnesses cannot fire. Run with "
+            + "-Dsirix.hot.mergeDiag=true (the gradle test configuration sets it).");
+    JsonTestHelper.deleteEverything();
+    VersioningType.resetFragmentMergeCounters();
+    HOTTrieWriter.resetInPlaceLeafSplits();
+  }
+
+  @AfterEach
+  void tearDown() {
+    JsonTestHelper.deleteEverything();
+    Databases.getGlobalBufferManager().clearAllCaches();
+  }
+
+  /**
+   * CASE 1 — tombstone through a MERGE. The live value sits in an older in-window fragment and the
+   * tombstone in a newer one, so reconstruction must let the tombstone shadow it.
+   */
+  @ParameterizedTest
+  @EnumSource(value = VersioningType.class, names = {"DIFFERENTIAL", "INCREMENTAL", "SLIDING_SNAPSHOT"})
+  void aTombstoneMustShadowALiveValueInAnOlderFragment(final VersioningType versioning) throws IOException {
+    createResource(versioning);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      seed(session);
+      churn(session, 2);
+      delete(session, DELETED_KEY);
+      churn(session, 4);
+
+      assertTrue(VersioningType.multiFragmentMerges() > 0,
+          versioning + ": no reconstruction happened, so this case proves nothing. " + counters());
+      assertDeletedStaysDeleted(session, versioning + " after merge");
+    }
+  }
+
+  /**
+   * CASE 2 and CASE 4 — tombstone through EVICTION, asserted at every phase.
+   *
+   * <p>
+   * Running the assertion after every commit is what covers case 4 (the tombstone itself aging out)
+   * without guessing which commit that happens on: whichever phase drops it, the very next check
+   * catches a resurrection, and the failure message names the phase. Cheaper and less fragile than
+   * computing the eviction phase and asserting only there.
+   * </p>
+   */
+  @Test
+  void aDeletedKeyMustNotReturnWhenItsFragmentsAgeOutOfTheWindow() throws IOException {
+    createResource(VersioningType.SLIDING_SNAPSHOT);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      seed(session);
+      delete(session, DELETED_KEY);
+
+      long rotationsFirstSeenAtPhase = -1;
+      for (int phase = 0; phase < 8; phase++) {
+        churn(session, 10 + phase);
+        if (rotationsFirstSeenAtPhase < 0 && VersioningType.carryForwardRotations() > 0) {
+          rotationsFirstSeenAtPhase = phase;
+        }
+        assertDeletedStaysDeleted(session, "phase " + phase);
+      }
+
+      // THE WITNESS, and it is the whole point of this case: without a rotation the absence above
+      // is an absence of eviction, not a property of eviction.
+      assertTrue(VersioningType.carryForwardRotations() > 0,
+          "no fragment ever aged out, so this case says nothing about eviction. " + counters());
+      assertTrue(rotationsFirstSeenAtPhase >= 0, "rotation phase not observed. " + counters());
+    }
+  }
+
+  /**
+   * CASE 3 — the full composition: a tombstone, an IN-PLACE SPLIT that relocates entries around it,
+   * and then enough commits that the window ROTATES on the split leaf.
+   *
+   * <p>
+   * The first version of this case asserted only the split and measured {@code rotations=0} — it
+   * composed a tombstone with a split but never evicted anything, so the interaction the reproducer
+   * was asked for was still untested. It now asserts BOTH mechanisms fired, which is the difference
+   * between "these two features were present" and "these two features interacted".
+   * </p>
+   */
+  @Test
+  void deletedKeysMustNotReturnWhenASplitRelocatesThemAndTheWindowThenRotates() throws IOException {
+    createResource(VersioningType.SLIDING_SNAPSHOT);
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH);
+        JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+
+      // Seed a small prefix, delete inside it, THEN grow the leaf until it splits, so the split
+      // relocates entries across keys that are already tombstoned.
+      writeRange(session, 0, 64, 1);
+      delete(session, DELETED_KEY);
+      writeRange(session, 64, SPLIT_KEYS, 2);
+
+      // Now churn past the window cap so the post-split fragments age out underneath the tombstone.
+      for (int phase = 0; phase < 6; phase++) {
+        writeRange(session, 0, 1, 20 + phase);
+        assertDeletedStaysDeleted(session, "post-split phase " + phase);
+      }
+
+      assertTrue(HOTTrieWriter.inPlaceLeafSplits() > 0,
+          "no in-place leaf split ran, so the split half of this case is not covered. " + counters());
+      assertTrue(VersioningType.carryForwardRotations() > 0,
+          "the window never rotated, so this case is a split test, not an interaction test. " + counters());
+      assertDeletedStaysDeleted(session, "after split and rotation");
+    }
+  }
+
+  // ---------------------------------------------------------------- assertions
+
+  /**
+   * The deleted key must be gone AND its neighbours must still be there. Asserting only the absence
+   * would pass on a store that lost everything, which is the twin every decline arm needs.
+   */
+  private static void assertDeletedStaysDeleted(final JsonResourceSession session, final String where) {
+    try (JsonNodeTrx probe = session.beginNodeTrx()) {
+      final StorageEngineReader reader = probe.getStorageEngineReader();
+      assertNull(ProjectionIndexHOTStorage.readBlob(reader, 0, DELETED_KEY),
+          where + ": the deleted key came back. " + counters());
+      assertNotNull(ProjectionIndexHOTStorage.readBlob(reader, 0, UNTOUCHED_KEY),
+          where + ": an untouched live key was LOST, so the absence above is not evidence of "
+              + "correct deletion. " + counters());
+      assertNotNull(ProjectionIndexHOTStorage.readBlob(reader, 0, CHURN_KEY),
+          where + ": the churned key was lost. " + counters());
+    }
+  }
+
+  private static String counters() {
+    return "single=" + VersioningType.singleFragmentReads() + " merges=" + VersioningType.multiFragmentMerges()
+        + " walked=" + VersioningType.fragmentsWalked() + " shortCircuit=" + VersioningType.completeDumpShortCircuits()
+        + " walkedPastDump=" + VersioningType.completeDumpsWalkedPast()
+        + " inPlaceSplits=" + HOTTrieWriter.inPlaceLeafSplits()
+        + " carryFwdRotations=" + VersioningType.carryForwardRotations()
+        + " carryFwdReemitted=" + VersioningType.carryForwardEntriesReemitted();
+  }
+
+  // ---------------------------------------------------------------- fixture
+
+  private static void createResource(final VersioningType versioning) throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(DATABASE_PATH));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(DATABASE_PATH)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE).versioningApproach(versioning).build());
+    }
+  }
+
+  private static void seed(final JsonResourceSession session) {
+    writeRange(session, 0, KEYS, 1);
+  }
+
+  /** Rewrite only the churn key, with fresh content so the page actually dirties. */
+  private static void churn(final JsonResourceSession session, final int marker) {
+    writeRange(session, (int) CHURN_KEY - 1, (int) CHURN_KEY, marker);
+  }
+
+  private static void writeRange(final JsonResourceSession session, final int from, final int toExclusive,
+      final int commitMarker) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      final ProjectionIndexHOTStorage storage = new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), 0);
+      for (int i = from; i < toExclusive; i++) {
+        // A FRESH array per slot — a reused, mutated buffer changes bytes under an already-computed
+        // content hash and every slot then fails verification (measured in the sibling fixture).
+        final byte[] payload = new byte[PAYLOAD_BYTES];
+        payload[0] = (byte) (i & 0xFF);
+        payload[1] = (byte) ((i >>> 8) & 0xFF);
+        // Distinct per commit: rewriting a slot with IDENTICAL content need not dirty the page, and
+        // then no fragment forms and nothing evicts or reconstructs.
+        payload[2] = (byte) commitMarker;
+        storage.putBlob(i + 1, payload);
+      }
+      wtx.commit();
+    }
+  }
+
+  private static void delete(final JsonResourceSession session, final long slotKey) {
+    try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+      new ProjectionIndexHOTStorage(wtx.getStorageEngineWriter(), 0).tombstoneRowGroup(slotKey);
+      wtx.commit();
+    }
+  }
+}

--- a/bundles/sirix-query/build.gradle
+++ b/bundles/sirix-query/build.gradle
@@ -194,33 +194,8 @@ jar {
     }
 }
 
-// ProjectionRefusalPathTest needs the incremental-patch ceiling lowered to 1, so that two dirty
-// records exceed it and the refusal path is actually reached. The ceiling is read ONCE into a
-// static final, so it has to arrive as a JVM flag rather than something the test can set — and it
-// must NOT apply to the rest of the suite, where forcing every update into a refusal would silently
-// change what dozens of other projection tests exercise. Hence a dedicated fork for that one class,
-// excluded from the main `test` task below.
-//
-// The test also ASSERTS the property is set rather than skipping when it is absent. Assert AND
-// provide: this task makes the ordinary `gradle test` run correct, and the assertion catches a run
-// configured some other way — where a skip would look indistinguishable from a pass.
-tasks.register('projectionRefusalTest', Test) {
-    description = 'Projection refusal-path fixture; needs a lowered incremental-patch ceiling.'
-    group = 'verification'
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    useJUnitPlatform()
-    include '**/ProjectionRefusalPathTest.class'
-    systemProperty 'sirix.projection.maxIncrementalRecords', '1'
-}
-
-tasks.named('check') { dependsOn 'projectionRefusalTest' }
-
 test {
     useJUnitPlatform()
-    // Runs in its own fork (above) with the ceiling lowered. Including it here would run it without
-    // the property and trip its own configuration assertion.
-    exclude '**/ProjectionRefusalPathTest.class'
     systemProperty "io.brackit.query.debug", System.getProperty("io.brackit.query.debug")
     systemProperty "io.brackit.query.debugDir", System.getProperty("io.brackit.query.debugDir")
     systemProperty "sirix.projDiag", System.getProperty("sirix.projDiag")

--- a/bundles/sirix-query/build.gradle
+++ b/bundles/sirix-query/build.gradle
@@ -194,8 +194,33 @@ jar {
     }
 }
 
+// ProjectionRefusalPathTest needs the incremental-patch ceiling lowered to 1, so that two dirty
+// records exceed it and the refusal path is actually reached. The ceiling is read ONCE into a
+// static final, so it has to arrive as a JVM flag rather than something the test can set — and it
+// must NOT apply to the rest of the suite, where forcing every update into a refusal would silently
+// change what dozens of other projection tests exercise. Hence a dedicated fork for that one class,
+// excluded from the main `test` task below.
+//
+// The test also ASSERTS the property is set rather than skipping when it is absent. Assert AND
+// provide: this task makes the ordinary `gradle test` run correct, and the assertion catches a run
+// configured some other way — where a skip would look indistinguishable from a pass.
+tasks.register('projectionRefusalTest', Test) {
+    description = 'Projection refusal-path fixture; needs a lowered incremental-patch ceiling.'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    useJUnitPlatform()
+    include '**/ProjectionRefusalPathTest.class'
+    systemProperty 'sirix.projection.maxIncrementalRecords', '1'
+}
+
+tasks.named('check') { dependsOn 'projectionRefusalTest' }
+
 test {
     useJUnitPlatform()
+    // Runs in its own fork (above) with the ceiling lowered. Including it here would run it without
+    // the property and trip its own configuration assertion.
+    exclude '**/ProjectionRefusalPathTest.class'
     systemProperty "io.brackit.query.debug", System.getProperty("io.brackit.query.debug")
     systemProperty "io.brackit.query.debugDir", System.getProperty("io.brackit.query.debugDir")
     systemProperty "sirix.projDiag", System.getProperty("sirix.projDiag")

--- a/bundles/sirix-query/src/main/java/io/sirix/query/SirixCompileChain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/SirixCompileChain.java
@@ -603,7 +603,10 @@ public final class SirixCompileChain extends CompileChain implements AutoCloseab
       return;
     }
     try {
-      executor.retire();
+      // Async join: retirement can sit behind an uncancellable multi-GB warm-up read, and every
+      // compile on this chain would serialize behind it. The drain/shutdown half still runs
+      // synchronously inside retireAsync().
+      executor.retireAsync();
     } catch (final Exception ignored) {
       // Retirement must not mask compilation. Terminal chain close still owns the shared fence.
     }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/StoreBoundExecutorCache.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/StoreBoundExecutorCache.java
@@ -263,7 +263,9 @@ final class StoreBoundExecutorCache implements AutoCloseable {
       return;
     }
     try {
-      executor.retire();
+      // Async join — an LRU eviction retires an executor for a DIFFERENT resource on the
+      // resolving thread; it must not block behind that executor's uncancellable warm-up read.
+      executor.retireAsync();
     } catch (final Exception ignored) {
       // Best-effort: the chain-wide terminal fence remains authoritative at final close.
     }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeDifferentialMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeDifferentialMain.java
@@ -1,0 +1,282 @@
+package io.sirix.query.bench.clickbench;
+
+import io.brackit.query.Query;
+import io.brackit.query.jdm.Item;
+import io.brackit.query.jdm.Iter;
+import io.brackit.query.jdm.Sequence;
+import io.brackit.query.util.serialize.StringSerializer;
+import io.sirix.cache.Allocators;
+import io.sirix.query.SirixCompileChain;
+import io.sirix.query.SirixQueryContext;
+import io.sirix.query.json.BasicJsonDBStore;
+import io.sirix.query.scan.SirixVectorizedExecutor;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Differential gate for the partition-decomposed ClickBench queries: proves, for each of the 43
+ * queries, that the composite (partitioned) formulation computes exactly the single-resource
+ * answer.
+ *
+ * <p>
+ * Three arms per query, all compared as ORDER-INSENSITIVE multisets of serialized items (full
+ * lists, no order/limit — comparing every group and every aggregate validates the merge algebra
+ * completely while sidestepping top-k boundary-tie nondeterminism):
+ * <ol>
+ * <li>ORIGINAL: the production query text minus its {@code subsequence} wrapper, on the
+ * single-resource corpus — the ground truth.</li>
+ * <li>SPEC-SINGLE (spec-generated queries only): the spec's own single-resource formulation. A
+ * mismatch against (1) means the spec mis-models the query — without this arm a modeling error
+ * shared by both generated texts would pass silently.</li>
+ * <li>COMPOSITE: the merged partitioned formulation on the partitioned corpus.</li>
+ * </ol>
+ *
+ * <p>
+ * Usage: {@code ClickBenchCompositeDifferentialMain <location> <singleDb> <singleResource>
+ * <compositeDb> <partitions>} — both databases must hold the SAME rows (same generator seed) and
+ * are opened through one store rooted at {@code location}. Also times the composite PRODUCTION
+ * texts (2 tries) and reports the served-counter delta, because a decomposition that answers
+ * correctly from the generic pipeline is a correctness success and a performance failure.
+ */
+public final class ClickBenchCompositeDifferentialMain {
+
+  private ClickBenchCompositeDifferentialMain() {
+  }
+
+  public static void main(final String[] args) {
+    if (args.length != 5
+        && !(args.length == 6 && ("--timings-only".equals(args[5]) || "--union".equals(args[5])))) {
+      System.err.println("usage: ClickBenchCompositeDifferentialMain <location> <singleDb> <singleResource>"
+          + " <compositeDb> <partitions> [--timings-only|--union]");
+      System.exit(2);
+    }
+    final boolean timingsOnly = args.length == 6 && "--timings-only".equals(args[5]);
+    // --union: arm C is the ORIGINAL query text against the LOGICAL UNION resource of the
+    // partitioned database (catalog-resolved), not the decomposed composite texts — the gate for
+    // the engine-side union that makes a partitioned load protocol-legitimate.
+    final boolean unionMode = args.length == 6 && "--union".equals(args[5]);
+    final Path location = Path.of(args[0]);
+    final String singleDb = args[1];
+    final String singleResource = args[2];
+    final String compositeDb = args[3];
+    final int partitions = Integer.parseInt(args[4]);
+    // The store would otherwise size its off-heap arenas from the shipped default (24 GiB), which
+    // together with the comparison heap got the first run of this main OOM-killed at Q24.
+    Allocators.getInstance().init(Long.parseLong(System.getProperty("sirix.offheap.bytes", String.valueOf(6L << 30))));
+
+    final List<ClickBenchCompositeQueries.CompositeQuery> composites =
+        ClickBenchCompositeQueries.all(compositeDb, "hits", partitions, singleDb, singleResource);
+    final List<ClickBenchQueries.Query> originals = ClickBenchQueries.all();
+
+    int failures = 0;
+    try (final BasicJsonDBStore store = BasicJsonDBStore.newBuilder().location(location).build();
+        final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+        final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      System.out.printf("%-4s | %7s | %9s | %s%n", "q", "rows", "verdict", "note");
+      for (int q = 0; timingsOnly
+          ? false
+          : q < 43; q++) {
+        final ClickBenchCompositeQueries.CompositeQuery composite = composites.get(q);
+        String note = "";
+        String verdict;
+        int rows = -1;
+        try {
+          final String originalFull = ClickBenchQueries.wrap(singleDb, singleResource,
+              stripSubsequence(originals.get(q).jsoniq(0)));
+          final ArmDigest truth = items(chain, ctx, originalFull);
+          rows = (int) truth.count();
+          if (!unionMode && composite.singleFull() != null) {
+            final ArmDigest specSingle = items(chain, ctx, composite.singleFull());
+            final String specDiff = diff(truth, specSingle);
+            if (specDiff != null) {
+              verdict = "SPEC-FAIL";
+              note = specDiff;
+              failures++;
+              System.out.printf("%-4d | %7d | %9s | %s%n", q, rows, verdict, note);
+              continue;
+            }
+          }
+          final ArmDigest merged = items(chain, ctx, unionMode
+              ? ClickBenchQueries.wrap(compositeDb, "hits", stripSubsequence(originals.get(q).jsoniq(0)))
+              : composite.compositeFull());
+          final String mergeDiff = diff(truth, merged);
+          if (mergeDiff != null) {
+            verdict = "FAIL";
+            note = mergeDiff;
+            failures++;
+          } else {
+            verdict = "PASS";
+          }
+        } catch (final RuntimeException e) {
+          verdict = "ERROR";
+          note = e.getClass().getSimpleName() + ": " + firstLine(e.getMessage());
+          failures++;
+        }
+        System.out.printf("%-4d | %7d | %9s | %s%n", q, rows, verdict, note);
+      }
+
+      if (unionMode) {
+        System.out.println(failures == 0
+            ? "UNION DIFFERENTIAL PASS: 43/43"
+            : "UNION DIFFERENTIAL FAIL: " + failures + " of 43");
+        System.exit(failures == 0
+            ? 0
+            : 1);
+      }
+      System.out.println();
+      System.out.println("# composite production timings (2 tries each):");
+      final long served0 = servedTotal();
+      System.out.printf("%-4s | %10s | %10s | %6s%n", "q", "try1(s)", "try2(s)", "served");
+      for (int q = 0; q < 43; q++) {
+        final String text = composites.get(q).compositeProduction();
+        final long servedBefore = servedTotal();
+        double t1 = -1;
+        double t2 = -1;
+        String note = "";
+        try {
+          t1 = timeOnce(chain, ctx, text);
+          t2 = timeOnce(chain, ctx, text);
+        } catch (final RuntimeException e) {
+          note = e.getClass().getSimpleName() + ": " + firstLine(e.getMessage());
+        }
+        System.out.printf(Locale.ROOT, "%-4d | %10.3f | %10.3f | %6d %s%n", q, t1, t2,
+            servedTotal() - servedBefore, note);
+      }
+      System.out.printf("# production served delta: %d (43 queries x %d legs x 2 tries = %d max)%n",
+          servedTotal() - served0, partitions, 43 * partitions * 2);
+    }
+    System.out.println(failures == 0
+        ? "DIFFERENTIAL PASS: 43/43"
+        : "DIFFERENTIAL FAIL: " + failures + " of 43");
+    System.exit(failures == 0
+        ? 0
+        : 1);
+  }
+
+  /**
+   * Streamed order-insensitive multiset digest of a result. Small results additionally keep the
+   * serialized rows so a mismatch can name its first difference; large results are compared by
+   * {@code (count, ΣhashA, ΣhashB)} alone — two independent 64-bit per-item hashes summed, which is
+   * multiset-invariant and holds nothing in memory (the first run of this gate was OOM-killed
+   * holding 147k serialized rows per arm).
+   */
+  private record ArmDigest(long count, long sumA, long sumB, List<String> rows) {
+  }
+
+  /** Full lists (with diff detail) are kept only below this row count. */
+  private static final int DETAIL_ROWS = 100_000;
+
+  private static ArmDigest items(final SirixCompileChain chain, final SirixQueryContext ctx, final String text) {
+    final Sequence result = new Query(chain, text).execute(ctx);
+    long count = 0;
+    long sumA = 0;
+    long sumB = 0;
+    List<String> rows = new ArrayList<>(1024);
+    if (result != null) {
+      try (final Iter iter = result.iterate()) {
+        Item item;
+        while ((item = iter.next()) != null) {
+          final StringWriter buffer = new StringWriter(128);
+          try (PrintWriter writer = new PrintWriter(buffer)) {
+            new StringSerializer(writer).serialize(item);
+          }
+          final String row = buffer.toString().strip();
+          count++;
+          sumA += row.hashCode();
+          sumB += fnv1a64(row);
+          if (rows != null) {
+            rows.add(row);
+            if (rows.size() > DETAIL_ROWS) {
+              rows = null;
+            }
+          }
+        }
+      }
+    }
+    return new ArmDigest(count, sumA, sumB, rows);
+  }
+
+  private static long fnv1a64(final String value) {
+    long hash = 0xcbf29ce484222325L;
+    for (int i = 0; i < value.length(); i++) {
+      hash = (hash ^ value.charAt(i)) * 0x100000001b3L;
+    }
+    return hash;
+  }
+
+  /** Order-insensitive multiset comparison; null when equal, else a compact first-difference note. */
+  private static String diff(final ArmDigest expected, final ArmDigest actual) {
+    if (expected.count() != actual.count()) {
+      return "row count " + actual.count() + " != expected " + expected.count();
+    }
+    if (expected.rows() != null && actual.rows() != null) {
+      final List<String> left = new ArrayList<>(expected.rows());
+      final List<String> right = new ArrayList<>(actual.rows());
+      Collections.sort(left);
+      Collections.sort(right);
+      for (int i = 0; i < left.size(); i++) {
+        if (!left.get(i).equals(right.get(i))) {
+          return "first diff at sorted row " + i + ": expected " + clip(left.get(i)) + " got " + clip(right.get(i));
+        }
+      }
+      return null;
+    }
+    if (expected.sumA() != actual.sumA() || expected.sumB() != actual.sumB()) {
+      return "multiset hash mismatch over " + actual.count() + " rows (rerun with detail for the rows)";
+    }
+    return null;
+  }
+
+  private static double timeOnce(final SirixCompileChain chain, final SirixQueryContext ctx, final String text) {
+    final long start = System.nanoTime();
+    final Sequence result = new Query(chain, text).execute(ctx);
+    if (result != null) {
+      try (final Iter iter = result.iterate()) {
+        while (iter.next() != null) {
+          // Materialize fully; timing must include the work, not just plan construction.
+        }
+      }
+    }
+    return (System.nanoTime() - start) / 1e9;
+  }
+
+  /** Unwraps the outermost {@code subsequence(BODY, o, n)} so the full list is compared. */
+  private static String stripSubsequence(final String body) {
+    final String trimmed = body.strip();
+    if (!trimmed.startsWith("subsequence(")) {
+      return trimmed;
+    }
+    final int close = trimmed.lastIndexOf(')');
+    final int secondComma = trimmed.lastIndexOf(',', trimmed.lastIndexOf(',', close) - 1);
+    return trimmed.substring("subsequence(".length(), secondComma).strip();
+  }
+
+  private static long servedTotal() {
+    return SirixVectorizedExecutor.projectionCountsServed() + SirixVectorizedExecutor.groupAggServedCount()
+        + SirixVectorizedExecutor.numericGroupByServedCount() + SirixVectorizedExecutor.groupAggSlicedServedCount()
+        + SirixVectorizedExecutor.sortedScanServedCount() + SirixVectorizedExecutor.predicateScanServedCount()
+        + SirixVectorizedExecutor.predicateValueEmissionsServedCount();
+  }
+
+  private static String firstLine(final String message) {
+    if (message == null) {
+      return "";
+    }
+    final int newline = message.indexOf('\n');
+    return newline < 0
+        ? message
+        : message.substring(0, newline);
+  }
+
+  private static String clip(final String value) {
+    return value.length() > 120
+        ? value.substring(0, 120) + "…"
+        : value;
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeDifferentialMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeDifferentialMain.java
@@ -46,12 +46,10 @@ import java.util.Locale;
  */
 public final class ClickBenchCompositeDifferentialMain {
 
-  private ClickBenchCompositeDifferentialMain() {
-  }
+  private ClickBenchCompositeDifferentialMain() {}
 
   public static void main(final String[] args) {
-    if (args.length != 5
-        && !(args.length == 6 && ("--timings-only".equals(args[5]) || "--union".equals(args[5])))) {
+    if (args.length != 5 && !(args.length == 6 && ("--timings-only".equals(args[5]) || "--union".equals(args[5])))) {
       System.err.println("usage: ClickBenchCompositeDifferentialMain <location> <singleDb> <singleResource>"
           + " <compositeDb> <partitions> [--timings-only|--union]");
       System.exit(2);
@@ -87,8 +85,8 @@ public final class ClickBenchCompositeDifferentialMain {
         String verdict;
         int rows = -1;
         try {
-          final String originalFull = ClickBenchQueries.wrap(singleDb, singleResource,
-              stripSubsequence(originals.get(q).jsoniq(0)));
+          final String originalFull =
+              ClickBenchQueries.wrap(singleDb, singleResource, stripSubsequence(originals.get(q).jsoniq(0)));
           final ArmDigest truth = items(chain, ctx, originalFull);
           rows = (int) truth.count();
           if (!unionMode && composite.singleFull() != null) {
@@ -145,8 +143,8 @@ public final class ClickBenchCompositeDifferentialMain {
         } catch (final RuntimeException e) {
           note = e.getClass().getSimpleName() + ": " + firstLine(e.getMessage());
         }
-        System.out.printf(Locale.ROOT, "%-4d | %10.3f | %10.3f | %6d %s%n", q, t1, t2,
-            servedTotal() - servedBefore, note);
+        System.out.printf(Locale.ROOT, "%-4d | %10.3f | %10.3f | %6d %s%n", q, t1, t2, servedTotal() - servedBefore,
+            note);
       }
       System.out.printf("# production served delta: %d (43 queries x %d legs x 2 tries = %d max)%n",
           servedTotal() - served0, partitions, 43 * partitions * 2);
@@ -163,8 +161,8 @@ public final class ClickBenchCompositeDifferentialMain {
    * Streamed order-insensitive multiset digest of a result. Small results additionally keep the
    * serialized rows so a mismatch can name its first difference; large results are compared by
    * {@code (count, ΣhashA, ΣhashB)} alone — two independent 64-bit per-item hashes summed, which is
-   * multiset-invariant and holds nothing in memory (the first run of this gate was OOM-killed
-   * holding 147k serialized rows per arm).
+   * multiset-invariant and holds nothing in memory (the first run of this gate was OOM-killed holding
+   * 147k serialized rows per arm).
    */
   private record ArmDigest(long count, long sumA, long sumB, List<String> rows) {
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeQueries.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeQueries.java
@@ -1,0 +1,566 @@
+package io.sirix.query.bench.clickbench;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Partition-decomposed ("composite") formulations of the 43 ClickBench queries for a corpus loaded
+ * as {@code N} partitioned resources ({@code hits-0 … hits-(N-1)}) instead of one resource.
+ *
+ * <p>
+ * Every partition leg is emitted as a literal {@code let $hits := jn:doc('db','hits-i') return
+ * (…)} sub-expression — the shape the analytical fast paths detect — so each leg resolves its own
+ * vectorized executor through the per-source hook and is served from that partition's projection.
+ * A single {@code let $hits := (docA, docB, …)} binding would compile and answer correctly while
+ * silently dropping every query onto the generic pipeline; gate any change here on the
+ * {@code # served:} counters, never on timings.
+ *
+ * <h2>Decomposition algebra</h2>
+ * <ul>
+ * <li>{@code COUNT → sum} of per-partition counts, {@code SUM → sum} of sums, {@code MIN/MAX} of
+ * per-partition minima/maxima.</li>
+ * <li>{@code AVG} decomposes to {@code (sum, count)} partials combined as
+ * {@code xs:double(Σsum div Σcount)} — averaging averages would weight partitions, not rows. The
+ * denominator is the group's row count, which equals the value count because ClickBench columns
+ * are dense (NOT NULL); a nullable column would need its own value-count partial.</li>
+ * <li>{@code COUNT(DISTINCT x)} is NOT decomposable over counts — each partition ships its
+ * per-group DISTINCT VALUE LIST (as an array field) and the merge counts distinct over the union
+ * of the lists.</li>
+ * <li>{@code HAVING} and {@code OFFSET/LIMIT} apply only at the merge: a partition-local filter or
+ * cut would discard groups/rows that survive globally.</li>
+ * <li>Raw-row top-k (no grouping) merges per-partition top-k lists: top-k of a union equals top-k
+ * of the concatenated per-partition top-ks, with sort keys riding along when the output column
+ * differs from the sort column.</li>
+ * </ul>
+ *
+ * <p>
+ * For each query this class provides the PRODUCTION text (original order/limit semantics) and a
+ * FULL-LIST text (no order, no limit, HAVING kept) whose result is compared order-insensitively
+ * against the single-resource answer by {@code ClickBenchCompositeDifferentialMain} — comparing
+ * complete group lists validates the merge algebra for every group and every aggregate while
+ * sidestepping top-k boundary-tie nondeterminism. For spec-generated queries it also provides the
+ * spec's single-resource full-list text, which the differential pins against the ORIGINAL query
+ * text so a spec that mis-models a query cannot pass by both arms sharing the error.
+ */
+public final class ClickBenchCompositeQueries {
+
+  /**
+   * One query's composite texts. {@code singleFull} is {@code null} where the composite legs embed
+   * the original body verbatim (scalars, row-top-k) and the spec-fidelity arm would be identical to
+   * the original by construction.
+   */
+  public record CompositeQuery(int index, String compositeFull, String compositeProduction, String singleFull) {
+  }
+
+  private ClickBenchCompositeQueries() {
+  }
+
+  /** All 43 queries decomposed over {@code partitions} resources {@code prefix-0 … prefix-(n-1)}. */
+  public static List<CompositeQuery> all(final String database, final String prefix, final int partitions,
+      final String singleDatabase, final String singleResource) {
+    if (partitions < 1) {
+      throw new IllegalArgumentException("partitions must be >= 1, got " + partitions);
+    }
+    final List<CompositeQuery> out = new ArrayList<>(43);
+    for (int q = 0; q < 43; q++) {
+      out.add(build(q, database, prefix, partitions, singleDatabase, singleResource));
+    }
+    return out;
+  }
+
+  // ==== per-query construction ==================================================================
+
+  private static CompositeQuery build(final int q, final String db, final String prefix, final int n,
+      final String sdb, final String sres) {
+    return switch (q) {
+      // -- scalar aggregates ---------------------------------------------------------------------
+      case 0 -> scalarSum(q, db, prefix, n, "count($hits[])");
+      case 1 -> scalarSum(q, db, prefix, n, "count(for $h in $hits[] where $h.AdvEngineID != 0 return $h)");
+      case 2 -> {
+        final String leg = """
+            {"s": sum(for $h in $hits[] return $h.AdvEngineID),
+             "c": count($hits[]),
+             "r": sum(for $h in $hits[] return $h.ResolutionWidth)}""";
+        final String outer = "let $ps := (\n" + legs(db, prefix, n, leg, ",\n") + "\n)\n"
+            + "return {\"sum_AdvEngineID\": sum($ps.s), \"count\": sum($ps.c), "
+            + "\"avg_ResolutionWidth\": xs:double(sum($ps.r) div sum($ps.c))}";
+        yield new CompositeQuery(q, outer, outer, null);
+      }
+      case 3 -> {
+        final String leg = "{\"s\": sum(for $h in $hits[] return $h.UserID), \"c\": count($hits[])}";
+        final String outer = "let $ps := (\n" + legs(db, prefix, n, leg, ",\n") + "\n)\n"
+            + "return xs:double(sum($ps.s) div sum($ps.c))";
+        yield new CompositeQuery(q, outer, outer, null);
+      }
+      case 4 -> distinctCount(q, db, prefix, n, "$h.UserID");
+      case 5 -> distinctCount(q, db, prefix, n, "$h.SearchPhrase");
+      case 6 -> {
+        final String leg = """
+            {"mn": min(for $h in $hits[] return $h.EventDate),
+             "mx": max(for $h in $hits[] return $h.EventDate)}""";
+        final String outer = "let $ps := (\n" + legs(db, prefix, n, leg, ",\n") + "\n)\n"
+            + "return {\"min_EventDate\": min($ps.mn), \"max_EventDate\": max($ps.mx)}";
+        yield new CompositeQuery(q, outer, outer, null);
+      }
+      case 19 -> {
+        final String leg = "for $h in $hits[] where $h.UserID = 435090932899640449 return $h.UserID";
+        final String outer = "(\n" + legs(db, prefix, n, leg, ",\n") + "\n)";
+        yield new CompositeQuery(q, outer, outer, null);
+      }
+      case 20 -> scalarSum(q, db, prefix, n, "count(for $h in $hits[] where contains($h.URL, \"google\") return $h)");
+      case 29 -> ninetySums(q, db, prefix, n);
+
+      // -- raw-row top-k -------------------------------------------------------------------------
+      case 23 -> {
+        final String prodLeg = "subsequence(for $h in $hits[] where contains($h.URL, \"google\") "
+            + "order by $h.EventTime return $h, 1, 10)";
+        final String prod =
+            "subsequence(for $r in (\n" + legs(db, prefix, n, prodLeg, ",\n") + "\n) order by $r.EventTime return $r, 1, 10)";
+        final String full = "(\n"
+            + legs(db, prefix, n, "for $h in $hits[] where contains($h.URL, \"google\") return $h", ",\n") + "\n)";
+        yield new CompositeQuery(q, full, prod, null);
+      }
+      case 24 -> topKPhrase(q, db, prefix, n, "order by $h.EventTime",
+          "{\"t\": $h.EventTime, \"v\": $h.SearchPhrase}", "order by $r.t return $r.v");
+      case 25 -> topKPhrase(q, db, prefix, n, "order by $h.SearchPhrase", "$h.SearchPhrase",
+          "order by $r return $r");
+      case 26 -> topKPhrase(q, db, prefix, n, "order by $h.EventTime, $h.SearchPhrase",
+          "{\"t\": $h.EventTime, \"s\": $h.SearchPhrase}", "order by $r.t, $r.s return $r.s");
+
+      // -- grouped aggregations (spec-generated) -------------------------------------------------
+      default -> grouped(spec(q), db, prefix, n, sdb, sres);
+    };
+  }
+
+  private static CompositeQuery scalarSum(final int q, final String db, final String prefix, final int n,
+      final String legBody) {
+    final String text = legs(db, prefix, n, legBody, "\n+ ");
+    return new CompositeQuery(q, text, text, null);
+  }
+
+  private static CompositeQuery distinctCount(final int q, final String db, final String prefix, final int n,
+      final String src) {
+    final String leg = "distinct-values(for $h in $hits[] return " + src + ")";
+    final String text = "count(distinct-values((\n" + legs(db, prefix, n, leg, ",\n") + "\n)))";
+    return new CompositeQuery(q, text, text, null);
+  }
+
+  private static CompositeQuery topKPhrase(final int q, final String db, final String prefix, final int n,
+      final String innerOrder, final String innerReturn, final String outerOrderReturn) {
+    final String prodLeg = "subsequence(for $h in $hits[] where $h.SearchPhrase != \"\" " + innerOrder + " return "
+        + innerReturn + ", 1, 10)";
+    final String prod =
+        "subsequence(for $r in (\n" + legs(db, prefix, n, prodLeg, ",\n") + "\n) " + outerOrderReturn + ", 1, 10)";
+    final String full = "(\n"
+        + legs(db, prefix, n, "for $h in $hits[] where $h.SearchPhrase != \"\" return $h.SearchPhrase", ",\n") + "\n)";
+    return new CompositeQuery(q, full, prod, null);
+  }
+
+  private static CompositeQuery ninetySums(final int q, final String db, final String prefix, final int n) {
+    final StringBuilder leg = new StringBuilder(8192).append("for $h in $hits[]\nlet $g := 1");
+    for (int i = 0; i <= 89; i++) {
+      leg.append(", $w").append(i).append(" := $h.ResolutionWidth");
+      if (i > 0) {
+        leg.append(" + ").append(i);
+      }
+    }
+    leg.append("\ngroup by $g\nreturn {");
+    for (int i = 0; i <= 89; i++) {
+      if (i > 0) {
+        leg.append(", ");
+      }
+      leg.append("\"s").append(i).append("\": sum($w").append(i).append(')');
+    }
+    leg.append('}');
+    final StringBuilder outer = new StringBuilder(16384).append("let $ps := (\n")
+                                                        .append(legs(db, prefix, n, leg.toString(), ",\n"))
+                                                        .append("\n)\nreturn {");
+    for (int i = 0; i <= 89; i++) {
+      if (i > 0) {
+        outer.append(", ");
+      }
+      outer.append("\"s").append(i).append("\": sum($ps.s").append(i).append(')');
+    }
+    final String text = outer.append('}').toString();
+    return new CompositeQuery(q, text, text, null);
+  }
+
+  // ==== grouped-aggregation spec model ==========================================================
+
+  private enum Kind {
+    COUNT, SUM, AVG, MIN, COUNT_DISTINCT
+  }
+
+  /** One output aggregate: its result-object field name, kind, and grouped source expression. */
+  private record Agg(String out, Kind kind, String src) {
+  }
+
+  /** One group key: result-object field name, per-record expression, optional return expression. */
+  private record Key(String out, String expr, String retExpr) {
+    Key(final String out, final String expr) {
+      this(out, expr, null);
+    }
+  }
+
+  /**
+   * A grouped ClickBench query in decomposable form. {@code lets} are pre-group computed bindings
+   * (referenced by aggregate sources), {@code havingCountAbove} filters on the COUNT aggregate at
+   * the merge, {@code orderRef} names the output field ordered on ({@code null} = unordered),
+   * {@code offset/limit} are the subsequence bounds ({@code -1} = none).
+   */
+  private record GroupSpec(int index, String where, String lets, List<Key> keys, List<Agg> aggs,
+      long havingCountAbove, String orderRef, boolean orderDesc, int offset, int limit, List<String> returnOrder) {
+  }
+
+  private static final String JULY_2013 =
+      "$h.CounterID = 62 and $h.EventDate >= \"2013-07-01\" and $h.EventDate <= \"2013-07-31\"";
+
+  private static GroupSpec spec(final int q) {
+    return switch (q) {
+      case 7 -> new GroupSpec(q, "$h.AdvEngineID != 0", null, List.of(new Key("AdvEngineID", "$h.AdvEngineID")),
+          List.of(new Agg("count", Kind.COUNT, null)), -1, "count", true, -1, -1, List.of("AdvEngineID", "count"));
+      case 8 -> new GroupSpec(q, null, null, List.of(new Key("RegionID", "$h.RegionID")),
+          List.of(new Agg("u", Kind.COUNT_DISTINCT, "$h.UserID")), -1, "u", true, 1, 10, List.of("RegionID", "u"));
+      case 9 -> new GroupSpec(q, null, null, List.of(new Key("RegionID", "$h.RegionID")),
+          List.of(new Agg("sum_AdvEngineID", Kind.SUM, "$h.AdvEngineID"), new Agg("c", Kind.COUNT, null),
+              new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth"),
+              new Agg("uniq_UserID", Kind.COUNT_DISTINCT, "$h.UserID")),
+          -1, "c", true, 1, 10, List.of("RegionID", "sum_AdvEngineID", "c", "avg_ResolutionWidth", "uniq_UserID"));
+      case 10 -> new GroupSpec(q, "$h.MobilePhoneModel != \"\"", null,
+          List.of(new Key("MobilePhoneModel", "$h.MobilePhoneModel")),
+          List.of(new Agg("u", Kind.COUNT_DISTINCT, "$h.UserID")), -1, "u", true, 1, 10,
+          List.of("MobilePhoneModel", "u"));
+      case 11 -> new GroupSpec(q, "$h.MobilePhoneModel != \"\"", null,
+          List.of(new Key("MobilePhone", "$h.MobilePhone"), new Key("MobilePhoneModel", "$h.MobilePhoneModel")),
+          List.of(new Agg("u", Kind.COUNT_DISTINCT, "$h.UserID")), -1, "u", true, 1, 10,
+          List.of("MobilePhone", "MobilePhoneModel", "u"));
+      case 12 -> new GroupSpec(q, "$h.SearchPhrase != \"\"", null, List.of(new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("SearchPhrase", "c"));
+      case 13 -> new GroupSpec(q, "$h.SearchPhrase != \"\"", null, List.of(new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("u", Kind.COUNT_DISTINCT, "$h.UserID")), -1, "u", true, 1, 10, List.of("SearchPhrase", "u"));
+      case 14 -> new GroupSpec(q, "$h.SearchPhrase != \"\"", null,
+          List.of(new Key("SearchEngineID", "$h.SearchEngineID"), new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10,
+          List.of("SearchEngineID", "SearchPhrase", "c"));
+      case 15 -> new GroupSpec(q, null, null, List.of(new Key("UserID", "$h.UserID")),
+          List.of(new Agg("count", Kind.COUNT, null)), -1, "count", true, 1, 10, List.of("UserID", "count"));
+      case 16 -> new GroupSpec(q, null, null,
+          List.of(new Key("UserID", "$h.UserID"), new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("count", Kind.COUNT, null)), -1, "count", true, 1, 10,
+          List.of("UserID", "SearchPhrase", "count"));
+      case 17 -> new GroupSpec(q, null, null,
+          List.of(new Key("UserID", "$h.UserID"), new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("count", Kind.COUNT, null)), -1, null, false, 1, 10,
+          List.of("UserID", "SearchPhrase", "count"));
+      case 18 -> new GroupSpec(q, null, null,
+          List.of(new Key("UserID", "$h.UserID"), new Key("m", "xs:integer(substring($h.EventTime, 15, 2))"),
+              new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("count", Kind.COUNT, null)), -1, "count", true, 1, 10,
+          List.of("UserID", "m", "SearchPhrase", "count"));
+      case 21 -> new GroupSpec(q, "contains($h.URL, \"google\") and $h.SearchPhrase != \"\"", null,
+          List.of(new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("min_URL", Kind.MIN, "$h.URL"), new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10,
+          List.of("SearchPhrase", "min_URL", "c"));
+      case 22 -> new GroupSpec(q,
+          "contains($h.Title, \"Google\") and not(contains($h.URL, \".google.\")) and $h.SearchPhrase != \"\"", null,
+          List.of(new Key("SearchPhrase", "$h.SearchPhrase")),
+          List.of(new Agg("min_URL", Kind.MIN, "$h.URL"), new Agg("min_Title", Kind.MIN, "$h.Title"),
+              new Agg("c", Kind.COUNT, null), new Agg("uniq_UserID", Kind.COUNT_DISTINCT, "$h.UserID")),
+          -1, "c", true, 1, 10, List.of("SearchPhrase", "min_URL", "min_Title", "c", "uniq_UserID"));
+      case 27 -> new GroupSpec(q, "$h.URL != \"\"", "$len := string-length($h.URL)",
+          List.of(new Key("CounterID", "$h.CounterID")),
+          List.of(new Agg("l", Kind.AVG, "$len"), new Agg("c", Kind.COUNT, null)), 100000, "l", true, 1, 25,
+          List.of("CounterID", "l", "c"));
+      case 28 -> new GroupSpec(q, "$h.Referer != \"\"", "$len := string-length($h.Referer)",
+          List.of(new Key("k", "replace($h.Referer, '^https?://(www\\.)?([^/]+)/.*$', '$2')")),
+          List.of(new Agg("l", Kind.AVG, "$len"), new Agg("c", Kind.COUNT, null),
+              new Agg("min_Referer", Kind.MIN, "$h.Referer")),
+          100000, "l", true, 1, 25, List.of("k", "l", "c", "min_Referer"));
+      case 30 -> new GroupSpec(q, "$h.SearchPhrase != \"\"", null,
+          List.of(new Key("SearchEngineID", "$h.SearchEngineID"), new Key("ClientIP", "$h.ClientIP")),
+          List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
+              new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
+          -1, "c", true, 1, 10, List.of("SearchEngineID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
+      case 31 -> new GroupSpec(q, "$h.SearchPhrase != \"\"", null,
+          List.of(new Key("WatchID", "$h.WatchID"), new Key("ClientIP", "$h.ClientIP")),
+          List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
+              new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
+          -1, "c", true, 1, 10, List.of("WatchID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
+      case 32 -> new GroupSpec(q, null, null,
+          List.of(new Key("WatchID", "$h.WatchID"), new Key("ClientIP", "$h.ClientIP")),
+          List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
+              new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
+          -1, "c", true, 1, 10, List.of("WatchID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
+      case 33 -> new GroupSpec(q, null, null, List.of(new Key("URL", "$h.URL")),
+          List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("URL", "c"));
+      case 34 -> new GroupSpec(q, null, null, List.of(new Key("one", "1"), new Key("URL", "$h.URL")),
+          List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("one", "URL", "c"));
+      case 35 -> new GroupSpec(q, null, null,
+          List.of(new Key("ClientIP", "$h.ClientIP"), new Key("m1", "$h.ClientIP - 1"),
+              new Key("m2", "$h.ClientIP - 2"), new Key("m3", "$h.ClientIP - 3")),
+          List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("ClientIP", "m1", "m2", "m3", "c"));
+      case 36 -> new GroupSpec(q,
+          JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.URL != \"\"", null,
+          List.of(new Key("URL", "$h.URL")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true, 1,
+          10, List.of("URL", "PageViews"));
+      case 37 -> new GroupSpec(q,
+          JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.Title != \"\"", null,
+          List.of(new Key("Title", "$h.Title")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews",
+          true, 1, 10, List.of("Title", "PageViews"));
+      case 38 -> new GroupSpec(q,
+          JULY_2013 + " and $h.IsRefresh = 0 and $h.IsLink != 0 and $h.IsDownload = 0", null,
+          List.of(new Key("URL", "$h.URL")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true,
+          1001, 10, List.of("URL", "PageViews"));
+      case 39 -> new GroupSpec(q, JULY_2013 + " and $h.IsRefresh = 0", null,
+          List.of(new Key("TraficSourceID", "$h.TraficSourceID"), new Key("SearchEngineID", "$h.SearchEngineID"),
+              new Key("AdvEngineID", "$h.AdvEngineID"),
+              new Key("Src", "(if ($h.SearchEngineID = 0 and $h.AdvEngineID = 0) then $h.Referer else \"\")"),
+              new Key("Dst", "$h.URL")),
+          List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true, 1001, 10,
+          List.of("TraficSourceID", "SearchEngineID", "AdvEngineID", "Src", "Dst", "PageViews"));
+      case 40 -> new GroupSpec(q,
+          JULY_2013 + " and $h.IsRefresh = 0 and $h.TraficSourceID = (-1, 6) and $h.RefererHash = 3594120000172545465",
+          null, List.of(new Key("URLHash", "$h.URLHash"), new Key("EventDate", "$h.EventDate")),
+          List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true, 101, 10,
+          List.of("URLHash", "EventDate", "PageViews"));
+      case 41 -> new GroupSpec(q,
+          JULY_2013 + " and $h.IsRefresh = 0 and $h.DontCountHits = 0 and $h.URLHash = 2868770270353813622", null,
+          List.of(new Key("WindowClientWidth", "$h.WindowClientWidth"),
+              new Key("WindowClientHeight", "$h.WindowClientHeight")),
+          List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true, 10001, 10,
+          List.of("WindowClientWidth", "WindowClientHeight", "PageViews"));
+      case 42 -> new GroupSpec(q,
+          "$h.CounterID = 62 and $h.EventDate >= \"2013-07-14\" and $h.EventDate <= \"2013-07-15\""
+              + " and $h.IsRefresh = 0 and $h.DontCountHits = 0",
+          null, List.of(new Key("M", "substring($h.EventTime, 1, 16)", "concat($g0, \":00\")")),
+          List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "M", false, 1001, 10, List.of("M", "PageViews"));
+      default -> throw new IllegalArgumentException("query " + q + " is not spec-shaped");
+    };
+  }
+
+  // ==== grouped-aggregation text generation =====================================================
+
+  private static CompositeQuery grouped(final GroupSpec spec, final String db, final String prefix, final int n,
+      final String sdb, final String sres) {
+    final String inner = innerPartial(spec);
+    final String outerCore = outerCore(spec, legs(db, prefix, n, inner, ",\n"));
+    final String full = outerCore;
+    final String production = productionWrap(spec, outerCore);
+    final String singleFull = "let $hits := jn:doc('" + sdb + "','" + sres + "')\nreturn (\n" + singleFullBody(spec)
+        + "\n)";
+    return new CompositeQuery(spec.index(), full, production, singleFull);
+  }
+
+  /** The per-partition leg: same scan/group as the original, partial aggregates, no order/limit. */
+  private static String innerPartial(final GroupSpec spec) {
+    final StringBuilder sb = new StringBuilder(512).append("for $h in $hits[]\n");
+    if (spec.where() != null) {
+      sb.append("where ").append(spec.where()).append('\n');
+    }
+    sb.append("let ");
+    if (spec.lets() != null) {
+      sb.append(spec.lets()).append(", ");
+    }
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i).append(" := ").append(spec.keys().get(i).expr());
+    }
+    sb.append("\ngroup by ");
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i);
+    }
+    sb.append("\nreturn {");
+    for (int i = 0; i < spec.keys().size(); i++) {
+      sb.append("\"g").append(i).append("\": $g").append(i).append(", ");
+    }
+    final List<Agg> aggs = spec.aggs();
+    for (int i = 0; i < aggs.size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      final Agg agg = aggs.get(i);
+      sb.append("\"p").append(i).append("\": ").append(switch (agg.kind()) {
+        case COUNT -> "count($h)";
+        case SUM, AVG -> "sum(" + agg.src() + ")";
+        case MIN -> "min(" + agg.src() + ")";
+        case COUNT_DISTINCT -> "[distinct-values(" + agg.src() + ")]";
+      });
+    }
+    // AVG needs a row-count denominator at the merge; emit one even when the query has no COUNT.
+    if (countAggIndex(spec) < 0 && aggs.stream().anyMatch(a -> a.kind() == Kind.AVG)) {
+      sb.append(", \"pc\": count($h)");
+    }
+    return sb.append('}').toString();
+  }
+
+  /** The merge: regroup the concatenated partials, combine, HAVING — no order, no subsequence. */
+  private static String outerCore(final GroupSpec spec, final String legsText) {
+    final StringBuilder sb = new StringBuilder(1024).append("for $p in (\n").append(legsText).append("\n)\nlet ");
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i).append(" := $p.g").append(i);
+    }
+    sb.append("\ngroup by ");
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i);
+    }
+    final int countIdx = countAggIndex(spec);
+    final String countRef = countIdx >= 0
+        ? "$f" + countIdx
+        : "sum($p.pc)";
+    sb.append('\n');
+    // COUNT first so AVG combiners can reference it.
+    if (countIdx >= 0) {
+      sb.append("let $f").append(countIdx).append(" := sum($p.p").append(countIdx).append(")\n");
+    }
+    final List<Agg> aggs = spec.aggs();
+    for (int i = 0; i < aggs.size(); i++) {
+      if (i == countIdx) {
+        continue;
+      }
+      final Agg agg = aggs.get(i);
+      sb.append("let $f").append(i).append(" := ").append(switch (agg.kind()) {
+        case COUNT -> throw new IllegalStateException("second COUNT aggregate in query " + spec.index());
+        case SUM -> "sum($p.p" + i + ")";
+        case AVG -> "xs:double(sum($p.p" + i + ") div " + countRef + ")";
+        case MIN -> "min($p.p" + i + ")";
+        case COUNT_DISTINCT -> "count(distinct-values(for $q in $p.p" + i + " return $q[]))";
+      }).append('\n');
+    }
+    if (spec.havingCountAbove() >= 0) {
+      sb.append("where ").append(countRef).append(" > ").append(spec.havingCountAbove()).append('\n');
+    }
+    return sb.append(returnClause(spec)).toString();
+  }
+
+  /** Adds the original order-by and subsequence on top of the merge core. */
+  private static String productionWrap(final GroupSpec spec, final String core) {
+    String text = core;
+    if (spec.orderRef() != null) {
+      final String orderVar = refVar(spec, spec.orderRef());
+      final int returnAt = text.lastIndexOf("return {");
+      text = text.substring(0, returnAt) + "order by " + orderVar + (spec.orderDesc()
+          ? " descending"
+          : "") + '\n' + text.substring(returnAt);
+    }
+    if (spec.offset() >= 0) {
+      text = "subsequence(\n" + text + ", " + spec.offset() + ", " + spec.limit() + ')';
+    }
+    return text;
+  }
+
+  /** The spec's single-resource formulation with final aggregates — full list, HAVING kept. */
+  private static String singleFullBody(final GroupSpec spec) {
+    final StringBuilder sb = new StringBuilder(512).append("for $h in $hits[]\n");
+    if (spec.where() != null) {
+      sb.append("where ").append(spec.where()).append('\n');
+    }
+    sb.append("let ");
+    if (spec.lets() != null) {
+      sb.append(spec.lets()).append(", ");
+    }
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i).append(" := ").append(spec.keys().get(i).expr());
+    }
+    sb.append("\ngroup by ");
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("$g").append(i);
+    }
+    sb.append('\n');
+    final List<Agg> aggs = spec.aggs();
+    for (int i = 0; i < aggs.size(); i++) {
+      final Agg agg = aggs.get(i);
+      sb.append("let $f").append(i).append(" := ").append(switch (agg.kind()) {
+        case COUNT -> "count($h)";
+        case SUM -> "sum(" + agg.src() + ")";
+        case AVG -> "xs:double(avg(" + agg.src() + "))";
+        case MIN -> "min(" + agg.src() + ")";
+        case COUNT_DISTINCT -> "count(distinct-values(" + agg.src() + "))";
+      }).append('\n');
+    }
+    if (spec.havingCountAbove() >= 0) {
+      sb.append("where $f").append(countAggIndex(spec)).append(" > ").append(spec.havingCountAbove()).append('\n');
+    }
+    return sb.append(returnClause(spec)).toString();
+  }
+
+  private static String returnClause(final GroupSpec spec) {
+    final StringBuilder sb = new StringBuilder(128).append("return {");
+    boolean first = true;
+    for (final String out : spec.returnOrder()) {
+      if (!first) {
+        sb.append(", ");
+      }
+      first = false;
+      sb.append('"').append(out).append("\": ").append(refExpr(spec, out));
+    }
+    return sb.append('}').toString();
+  }
+
+  /** The value expression for an output field: a key's return expression/var or an aggregate var. */
+  private static String refExpr(final GroupSpec spec, final String out) {
+    for (int i = 0; i < spec.keys().size(); i++) {
+      final Key key = spec.keys().get(i);
+      if (key.out().equals(out)) {
+        return key.retExpr() != null
+            ? key.retExpr()
+            : "$g" + i;
+      }
+    }
+    return refVar(spec, out);
+  }
+
+  /** The variable an output field is bound to (order-by needs the var, not a return expression). */
+  private static String refVar(final GroupSpec spec, final String out) {
+    for (int i = 0; i < spec.keys().size(); i++) {
+      if (spec.keys().get(i).out().equals(out)) {
+        return "$g" + i;
+      }
+    }
+    for (int i = 0; i < spec.aggs().size(); i++) {
+      if (spec.aggs().get(i).out().equals(out)) {
+        return "$f" + i;
+      }
+    }
+    throw new IllegalArgumentException("query " + spec.index() + " references unknown output '" + out + "'");
+  }
+
+  private static int countAggIndex(final GroupSpec spec) {
+    for (int i = 0; i < spec.aggs().size(); i++) {
+      if (spec.aggs().get(i).kind() == Kind.COUNT) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** Partition legs, each a literal {@code jn:doc} let-binding (the fast-path shape), joined. */
+  private static String legs(final String database, final String prefix, final int partitions, final String innerBody,
+      final String join) {
+    final StringBuilder sb = new StringBuilder(partitions * (innerBody.length() + 64));
+    for (int i = 0; i < partitions; i++) {
+      if (i > 0) {
+        sb.append(join);
+      }
+      sb.append("(let $hits := jn:doc('").append(database).append("','").append(prefix).append('-').append(i)
+        .append("')\nreturn (").append(innerBody).append("))");
+    }
+    return sb.toString();
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeQueries.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchCompositeQueries.java
@@ -10,8 +10,8 @@ import java.util.List;
  * <p>
  * Every partition leg is emitted as a literal {@code let $hits := jn:doc('db','hits-i') return
  * (…)} sub-expression — the shape the analytical fast paths detect — so each leg resolves its own
- * vectorized executor through the per-source hook and is served from that partition's projection.
- * A single {@code let $hits := (docA, docB, …)} binding would compile and answer correctly while
+ * vectorized executor through the per-source hook and is served from that partition's projection. A
+ * single {@code let $hits := (docA, docB, …)} binding would compile and answer correctly while
  * silently dropping every query onto the generic pipeline; gate any change here on the
  * {@code # served:} counters, never on timings.
  *
@@ -21,11 +21,11 @@ import java.util.List;
  * per-partition minima/maxima.</li>
  * <li>{@code AVG} decomposes to {@code (sum, count)} partials combined as
  * {@code xs:double(Σsum div Σcount)} — averaging averages would weight partitions, not rows. The
- * denominator is the group's row count, which equals the value count because ClickBench columns
- * are dense (NOT NULL); a nullable column would need its own value-count partial.</li>
+ * denominator is the group's row count, which equals the value count because ClickBench columns are
+ * dense (NOT NULL); a nullable column would need its own value-count partial.</li>
  * <li>{@code COUNT(DISTINCT x)} is NOT decomposable over counts — each partition ships its
- * per-group DISTINCT VALUE LIST (as an array field) and the merge counts distinct over the union
- * of the lists.</li>
+ * per-group DISTINCT VALUE LIST (as an array field) and the merge counts distinct over the union of
+ * the lists.</li>
  * <li>{@code HAVING} and {@code OFFSET/LIMIT} apply only at the merge: a partition-local filter or
  * cut would discard groups/rows that survive globally.</li>
  * <li>Raw-row top-k (no grouping) merges per-partition top-k lists: top-k of a union equals top-k
@@ -52,8 +52,7 @@ public final class ClickBenchCompositeQueries {
   public record CompositeQuery(int index, String compositeFull, String compositeProduction, String singleFull) {
   }
 
-  private ClickBenchCompositeQueries() {
-  }
+  private ClickBenchCompositeQueries() {}
 
   /** All 43 queries decomposed over {@code partitions} resources {@code prefix-0 … prefix-(n-1)}. */
   public static List<CompositeQuery> all(final String database, final String prefix, final int partitions,
@@ -70,8 +69,8 @@ public final class ClickBenchCompositeQueries {
 
   // ==== per-query construction ==================================================================
 
-  private static CompositeQuery build(final int q, final String db, final String prefix, final int n,
-      final String sdb, final String sres) {
+  private static CompositeQuery build(final int q, final String db, final String prefix, final int n, final String sdb,
+      final String sres) {
     return switch (q) {
       // -- scalar aggregates ---------------------------------------------------------------------
       case 0 -> scalarSum(q, db, prefix, n, "count($hits[])");
@@ -114,16 +113,15 @@ public final class ClickBenchCompositeQueries {
       case 23 -> {
         final String prodLeg = "subsequence(for $h in $hits[] where contains($h.URL, \"google\") "
             + "order by $h.EventTime return $h, 1, 10)";
-        final String prod =
-            "subsequence(for $r in (\n" + legs(db, prefix, n, prodLeg, ",\n") + "\n) order by $r.EventTime return $r, 1, 10)";
+        final String prod = "subsequence(for $r in (\n" + legs(db, prefix, n, prodLeg, ",\n")
+            + "\n) order by $r.EventTime return $r, 1, 10)";
         final String full = "(\n"
             + legs(db, prefix, n, "for $h in $hits[] where contains($h.URL, \"google\") return $h", ",\n") + "\n)";
         yield new CompositeQuery(q, full, prod, null);
       }
-      case 24 -> topKPhrase(q, db, prefix, n, "order by $h.EventTime",
-          "{\"t\": $h.EventTime, \"v\": $h.SearchPhrase}", "order by $r.t return $r.v");
-      case 25 -> topKPhrase(q, db, prefix, n, "order by $h.SearchPhrase", "$h.SearchPhrase",
-          "order by $r return $r");
+      case 24 -> topKPhrase(q, db, prefix, n, "order by $h.EventTime", "{\"t\": $h.EventTime, \"v\": $h.SearchPhrase}",
+          "order by $r.t return $r.v");
+      case 25 -> topKPhrase(q, db, prefix, n, "order by $h.SearchPhrase", "$h.SearchPhrase", "order by $r return $r");
       case 26 -> topKPhrase(q, db, prefix, n, "order by $h.EventTime, $h.SearchPhrase",
           "{\"t\": $h.EventTime, \"s\": $h.SearchPhrase}", "order by $r.t, $r.s return $r.s");
 
@@ -204,12 +202,12 @@ public final class ClickBenchCompositeQueries {
 
   /**
    * A grouped ClickBench query in decomposable form. {@code lets} are pre-group computed bindings
-   * (referenced by aggregate sources), {@code havingCountAbove} filters on the COUNT aggregate at
-   * the merge, {@code orderRef} names the output field ordered on ({@code null} = unordered),
+   * (referenced by aggregate sources), {@code havingCountAbove} filters on the COUNT aggregate at the
+   * merge, {@code orderRef} names the output field ordered on ({@code null} = unordered),
    * {@code offset/limit} are the subsequence bounds ({@code -1} = none).
    */
-  private record GroupSpec(int index, String where, String lets, List<Key> keys, List<Agg> aggs,
-      long havingCountAbove, String orderRef, boolean orderDesc, int offset, int limit, List<String> returnOrder) {
+  private record GroupSpec(int index, String where, String lets, List<Key> keys, List<Agg> aggs, long havingCountAbove,
+      String orderRef, boolean orderDesc, int offset, int limit, List<String> returnOrder) {
   }
 
   private static final String JULY_2013 =
@@ -286,11 +284,11 @@ public final class ClickBenchCompositeQueries {
           List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
               new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
           -1, "c", true, 1, 10, List.of("WatchID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
-      case 32 -> new GroupSpec(q, null, null,
-          List.of(new Key("WatchID", "$h.WatchID"), new Key("ClientIP", "$h.ClientIP")),
-          List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
-              new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
-          -1, "c", true, 1, 10, List.of("WatchID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
+      case 32 ->
+        new GroupSpec(q, null, null, List.of(new Key("WatchID", "$h.WatchID"), new Key("ClientIP", "$h.ClientIP")),
+            List.of(new Agg("c", Kind.COUNT, null), new Agg("sum_IsRefresh", Kind.SUM, "$h.IsRefresh"),
+                new Agg("avg_ResolutionWidth", Kind.AVG, "$h.ResolutionWidth")),
+            -1, "c", true, 1, 10, List.of("WatchID", "ClientIP", "c", "sum_IsRefresh", "avg_ResolutionWidth"));
       case 33 -> new GroupSpec(q, null, null, List.of(new Key("URL", "$h.URL")),
           List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("URL", "c"));
       case 34 -> new GroupSpec(q, null, null, List.of(new Key("one", "1"), new Key("URL", "$h.URL")),
@@ -299,16 +297,13 @@ public final class ClickBenchCompositeQueries {
           List.of(new Key("ClientIP", "$h.ClientIP"), new Key("m1", "$h.ClientIP - 1"),
               new Key("m2", "$h.ClientIP - 2"), new Key("m3", "$h.ClientIP - 3")),
           List.of(new Agg("c", Kind.COUNT, null)), -1, "c", true, 1, 10, List.of("ClientIP", "m1", "m2", "m3", "c"));
-      case 36 -> new GroupSpec(q,
-          JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.URL != \"\"", null,
+      case 36 -> new GroupSpec(q, JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.URL != \"\"", null,
           List.of(new Key("URL", "$h.URL")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true, 1,
           10, List.of("URL", "PageViews"));
-      case 37 -> new GroupSpec(q,
-          JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.Title != \"\"", null,
-          List.of(new Key("Title", "$h.Title")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews",
+      case 37 -> new GroupSpec(q, JULY_2013 + " and $h.DontCountHits = 0 and $h.IsRefresh = 0 and $h.Title != \"\"",
+          null, List.of(new Key("Title", "$h.Title")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews",
           true, 1, 10, List.of("Title", "PageViews"));
-      case 38 -> new GroupSpec(q,
-          JULY_2013 + " and $h.IsRefresh = 0 and $h.IsLink != 0 and $h.IsDownload = 0", null,
+      case 38 -> new GroupSpec(q, JULY_2013 + " and $h.IsRefresh = 0 and $h.IsLink != 0 and $h.IsDownload = 0", null,
           List.of(new Key("URL", "$h.URL")), List.of(new Agg("PageViews", Kind.COUNT, null)), -1, "PageViews", true,
           1001, 10, List.of("URL", "PageViews"));
       case 39 -> new GroupSpec(q, JULY_2013 + " and $h.IsRefresh = 0", null,
@@ -346,8 +341,8 @@ public final class ClickBenchCompositeQueries {
     final String outerCore = outerCore(spec, legs(db, prefix, n, inner, ",\n"));
     final String full = outerCore;
     final String production = productionWrap(spec, outerCore);
-    final String singleFull = "let $hits := jn:doc('" + sdb + "','" + sres + "')\nreturn (\n" + singleFullBody(spec)
-        + "\n)";
+    final String singleFull =
+        "let $hits := jn:doc('" + sdb + "','" + sres + "')\nreturn (\n" + singleFullBody(spec) + "\n)";
     return new CompositeQuery(spec.index(), full, production, singleFull);
   }
 
@@ -558,8 +553,15 @@ public final class ClickBenchCompositeQueries {
       if (i > 0) {
         sb.append(join);
       }
-      sb.append("(let $hits := jn:doc('").append(database).append("','").append(prefix).append('-').append(i)
-        .append("')\nreturn (").append(innerBody).append("))");
+      sb.append("(let $hits := jn:doc('")
+        .append(database)
+        .append("','")
+        .append(prefix)
+        .append('-')
+        .append(i)
+        .append("')\nreturn (")
+        .append(innerBody)
+        .append("))");
     }
     return sb.toString();
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchLoadMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchLoadMain.java
@@ -11,6 +11,7 @@ import io.brackit.query.util.serialize.StringSerializer;
 import io.sirix.access.trx.node.AfterCommitState;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.cache.Allocators;
+import io.sirix.index.projection.ProjectionIndexBuilder;
 import io.sirix.io.SharedArenas;
 import io.sirix.io.StorageType;
 import io.sirix.query.SirixCompileChain;
@@ -259,8 +260,14 @@ public final class ClickBenchLoadMain {
     if (!projection) {
       System.out.println("# projection: DISABLED (-Dclickbench.projection=false) — nothing will be served");
     } else if (incrementalProjection) {
-      System.out.printf("# projection: columns=%d built DURING the shred (one pass)%n",
-          ClickBenchProjection.PROJECTED_COLUMNS.size());
+      // dictProbes is the intern-table retention witness: a one-pass load keeps its dictionary
+      // tables in memory until finalize, so interning can never reach the persistent radix and this
+      // must print 0. A non-zero figure means the per-value durable-read regime is back — the shape
+      // measured at ~85% of load CPU before the retention fix.
+      System.out.printf(
+          "# projection: columns=%d globalDictColumns=%d dictProbes=%d built DURING the shred (one pass)%n",
+          ClickBenchProjection.PROJECTED_COLUMNS.size(), ProjectionIndexBuilder.globalDictionaryColumnsBuilt(),
+          ProjectionIndexBuilder.persistentDictionaryProbesReported());
     } else {
       final double projectionSeconds = ClickBenchProjection.create(dbDir);
       System.out.printf("# projection: columns=%d built in %.3f s by a second pass%n",

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchLoadMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchLoadMain.java
@@ -264,8 +264,15 @@ public final class ClickBenchLoadMain {
       // tables in memory until finalize, so interning can never reach the persistent radix and this
       // must print 0. A non-zero figure means the per-value durable-read regime is back — the shape
       // measured at ~85% of load CPU before the retention fix.
+      //
+      // This banner is NOT a success claim for the projection itself (task #55): the one way a
+      // one-pass build fails while the LOAD still succeeds — a global dictionary breaching its byte
+      // cap abandons the projection — used to report only through a LOGGER.warn the shipped
+      // root=ERROR logback discards. The abandonment now ALSO prints '[proj] PROJECTION ABANDONED'
+      // on stderr, which the banner names so a guard knows what to scan for.
       System.out.printf(
-          "# projection: columns=%d globalDictColumns=%d dictProbes=%d built DURING the shred (one pass)%n",
+          "# projection: columns=%d globalDictColumns=%d dictProbes=%d built DURING the shred (one pass);"
+              + " an abandonment prints '[proj] PROJECTION ABANDONED' on stderr%n",
           ClickBenchProjection.PROJECTED_COLUMNS.size(), ProjectionIndexBuilder.globalDictionaryColumnsBuilt(),
           ProjectionIndexBuilder.persistentDictionaryProbesReported());
     } else {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelLoadProbe.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelLoadProbe.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.bench.clickbench;
+
+import com.google.gson.stream.JsonReader;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.access.trx.node.json.BulkJsonTreeAssembler;
+import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.cache.Allocators;
+import io.sirix.io.StorageType;
+import io.sirix.service.json.shredder.ParallelJsonShredder;
+import io.sirix.settings.VersioningType;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * MEASUREMENT PROBE, not a shipping loader: how does the existing partitioned parallel ingest
+ * ({@link ParallelJsonShredder}, one writer per partition-resource) scale with partition count on
+ * the ClickBench hits shape?
+ *
+ * <p>
+ * This is the load-bearing question for reaching Umbra-ballpark ingestion: the tuned single-writer
+ * path tops out around ~10k rows/s because one thread does everything, while ClickBench-class
+ * systems ingest 100M rows in minutes by using every core. Before designing a partitioned
+ * production load (query-side union, per-partition projections), this probe answers whether the
+ * storage engine's shared substrate — global page caches, the off-heap frame allocator, the IO
+ * layer — lets N independent writers actually run at N× or serializes them.
+ *
+ * <p>
+ * The generator emits byte-identical disjoint slices for disjoint {@code (firstRow, rowCount)}
+ * ranges under one seed, so the SAME total dataset is ingested regardless of partition count; only
+ * the framing brackets per slice differ. Partitions land in resources {@code hits-0 … hits-(p-1)}.
+ * No projection is armed — the probe measures the document-store substrate; per-partition
+ * projections are a later design step.
+ *
+ * <p>
+ * Usage: {@code ClickBenchParallelLoadProbe <dbDir> <totalRows> <partitions> [maxConcurrency]}
+ */
+public final class ClickBenchParallelLoadProbe {
+
+  private ClickBenchParallelLoadProbe() {
+    throw new AssertionError("no instances");
+  }
+
+  public static void main(final String[] args) throws Exception {
+    if (args.length < 3 || args.length > 4) {
+      System.err.println("Usage: ClickBenchParallelLoadProbe <dbDir> <totalRows> <partitions> [maxConcurrency]");
+      System.exit(2);
+      return;
+    }
+    final Path dbDir = Path.of(args[0]);
+    final long totalRows = Long.parseLong(args[1]);
+    final int partitions = Integer.parseInt(args[2]);
+    final int maxConcurrency = args.length == 4
+        ? Integer.parseInt(args[3])
+        : partitions;
+    if (totalRows <= 0 || partitions <= 0 || totalRows < partitions) {
+      System.err.println("need totalRows >= partitions > 0");
+      System.exit(2);
+      return;
+    }
+
+    final long offheap = Long.parseLong(System.getProperty("sirix.offheap.bytes", String.valueOf(24L << 30)));
+    Allocators.getInstance().init(offheap);
+    final int autoCommit = Integer.parseInt(System.getProperty("sirix.autoCommit.nodes", "1048576"));
+    final StorageType storageType =
+        StorageType.fromString(System.getProperty("storageType", StorageType.FILE_CHANNEL.name()));
+    final VersioningType versioningType =
+        VersioningType.fromString(System.getProperty("versioningType", VersioningType.FULL.name()));
+    final boolean pathSummary = Boolean.parseBoolean(System.getProperty("buildPathSummary", "true"));
+    final long seed = Long.parseLong(System.getProperty("clickbench.seed", "42"));
+
+    Files.createDirectories(dbDir);
+    final DatabaseConfiguration dbConfig = new DatabaseConfiguration(dbDir);
+    Databases.createJsonDatabase(dbConfig);
+
+    System.out.printf(Locale.ROOT,
+        "# parallel-load probe: rows=%d partitions=%d concurrency=%d offheap=%d MB "
+            + "autoCommit=%d storage=%s versioning=%s pathSummary=%s%n",
+        totalRows, partitions, maxConcurrency, offheap / (1L << 20), autoCommit, storageType, versioningType,
+        pathSummary);
+
+    // -Dprobe.writeFile=<path>: emit the generated dataset to a file once and exit — the
+    // file-based arms then measure the SHIPPING shape (real loads read files; the in-process
+    // generator's char-production cost is benchmark-rig-only and inflates both arms).
+    final String writeFile = System.getProperty("probe.writeFile");
+    if (writeFile != null) {
+      try (Reader generated = new ClickBenchHitsGenerator(0, totalRows, seed);
+          Writer sink = Files.newBufferedWriter(Path.of(writeFile), java.nio.charset.StandardCharsets.UTF_8)) {
+        generated.transferTo(sink);
+      }
+      System.out.printf(Locale.ROOT, "Wrote %d rows to %s (%d bytes)%n", totalRows, writeFile,
+          Files.size(Path.of(writeFile)));
+      return;
+    }
+    // -Dprobe.file=<path>: read the dataset from a file instead of generating in-process.
+    // Single-partition only — partitioned file splitting is a later step.
+    final String sourceFile = System.getProperty("probe.file");
+    if (sourceFile != null && partitions != 1) {
+      System.err.println("probe.file supports partitions=1 only");
+      System.exit(2);
+      return;
+    }
+
+    // Raw generator readers; the CURSOR arm wraps each in Gson at its use site, the BULK arm's
+    // scanner consumes the chars directly — the tokenizer difference is part of what the A/B
+    // measures.
+    final List<Callable<Reader>> slices = new ArrayList<>(partitions);
+    final long rowsPerPartition = totalRows / partitions;
+    for (int i = 0; i < partitions; i++) {
+      final long firstRow = i * rowsPerPartition;
+      final long rowCount = i == partitions - 1
+          ? totalRows - firstRow
+          : rowsPerPartition;
+      slices.add(sourceFile != null
+          ? () -> Files.newBufferedReader(Path.of(sourceFile), java.nio.charset.StandardCharsets.UTF_8)
+          : () -> new ClickBenchHitsGenerator(firstRow, rowCount, seed));
+    }
+
+    final boolean bulkAssembly = Boolean.getBoolean("probe.bulk");
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(dbDir)) {
+      final long start = System.nanoTime();
+      final int resourceCount;
+      if (bulkAssembly) {
+        // Same partitioning, resource configs, auto-commit cadence and concurrency as the cursor
+        // arm — the ONLY difference is the tree BUILDER, which is exactly what the A/B measures.
+        resourceCount = loadPartitionsViaBulkAssembly(database, slices, storageType, versioningType, pathSummary,
+            autoCommit, maxConcurrency);
+      } else {
+        final List<Callable<JsonReader>> gsonSlices = new ArrayList<>(slices.size());
+        for (final Callable<Reader> slice : slices) {
+          gsonSlices.add(() -> new JsonReader(slice.call()));
+        }
+        resourceCount = ParallelJsonShredder
+                                            .shredPartitioned(database, gsonSlices, "hits",
+                                                name -> resourceConfig(name, storageType, versioningType, pathSummary),
+                                                autoCommit, maxConcurrency, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)
+                                            .size();
+      }
+      final double seconds = (System.nanoTime() - start) / 1_000_000_000.0;
+      System.out.printf(Locale.ROOT, "Parallel load time: %.3f s (%d resources, %.0f rows/s, builder=%s)%n", seconds,
+          resourceCount, totalRows / seconds, bulkAssembly
+              ? "bulk-assembly"
+              : "cursor");
+    }
+    // Structural witness for cross-builder comparisons: node counts are dense keys, so identical
+    // maxNodeKey + root child count across arms rules out dropped or duplicated records regardless
+    // of how the FILE size differs (page re-touch patterns legitimately differ per builder).
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(dbDir)) {
+      long maxKeySum = 0;
+      long rootChildSum = 0;
+      for (final String name : database.listResources()
+                                       .stream()
+                                       .map(java.nio.file.Path::getFileName)
+                                       .map(Object::toString)
+                                       .sorted()
+                                       .toList()) {
+        try (JsonResourceSession session = database.beginResourceSession(name);
+            var rtx = session.beginNodeReadOnlyTrx()) {
+          maxKeySum += rtx.getMaxNodeKey();
+          rtx.moveToDocumentRoot();
+          rtx.moveToFirstChild();
+          rootChildSum += rtx.getChildCount();
+        }
+      }
+      System.out.printf(Locale.ROOT, "Structure: maxNodeKeySum=%d rootChildSum=%d%n", maxKeySum, rootChildSum);
+    }
+    try (var files = Files.walk(dbDir)) {
+      final long bytes = files.filter(Files::isRegularFile).mapToLong(file -> {
+        try {
+          return Files.size(file);
+        } catch (final IOException e) {
+          return 0L;
+        }
+      }).sum();
+      System.out.printf(Locale.ROOT, "Data size: %d%n", bytes);
+    }
+    if (Boolean.getBoolean("probe.projection")) {
+      projectPartitions(dbDir);
+    }
+  }
+
+  /**
+   * Post-pass per-partition projection build: one {@code jn:create-projection-index} + commit per
+   * resource, run sequentially so each number is an uncontended single-partition cost. Prints
+   * per-partition seconds plus total and max — max approximates the parallel-build wall floor.
+   */
+  private static void projectPartitions(final Path dbDir) {
+    final Path location = dbDir.toAbsolutePath().getParent();
+    final String databaseName = dbDir.getFileName().toString();
+    final List<String> resources;
+    try (Database<JsonResourceSession> database = Databases.openJsonDatabase(dbDir)) {
+      resources = database.listResources().stream().map(Path::getFileName).map(Object::toString).sorted().toList();
+    }
+    if (Boolean.getBoolean("probe.projectionParallel")) {
+      final long start = System.nanoTime();
+      final ExecutorService pool =
+          Executors.newFixedThreadPool(Math.min(resources.size(), Runtime.getRuntime().availableProcessors()));
+      try {
+        final List<Future<Double>> builds = new ArrayList<>(resources.size());
+        for (final String resource : resources) {
+          builds.add(pool.submit(() -> ClickBenchProjection.create(location, databaseName, resource)));
+        }
+        for (int i = 0; i < resources.size(); i++) {
+          System.out.printf(Locale.ROOT, "Projection %s: %.3f s%n", resources.get(i), builds.get(i).get());
+        }
+      } catch (final InterruptedException | java.util.concurrent.ExecutionException e) {
+        throw new IllegalStateException("parallel projection build failed", e);
+      } finally {
+        pool.shutdown();
+      }
+      System.out.printf(Locale.ROOT, "Projection wall (parallel): %.3f s (%d partitions)%n",
+          (System.nanoTime() - start) / 1e9, resources.size());
+      return;
+    }
+    double total = 0;
+    double max = 0;
+    for (final String resource : resources) {
+      final double seconds = ClickBenchProjection.create(location, databaseName, resource);
+      total += seconds;
+      max = Math.max(max, seconds);
+      System.out.printf(Locale.ROOT, "Projection %s: %.3f s%n", resource, seconds);
+    }
+    System.out.printf(Locale.ROOT, "Projection total: %.3f s (max %.3f s, %d partitions)%n", total, max,
+        resources.size());
+  }
+
+  private static ResourceConfiguration resourceConfig(final String name, final StorageType storageType,
+      final VersioningType versioningType, final boolean pathSummary) {
+    return new ResourceConfiguration.Builder(name).storageType(storageType)
+                                                  .versioningApproach(versioningType)
+                                                  .buildPathSummary(pathSummary)
+                                                  .hashKind(HashType.NONE)
+                                                  .storeNodeHistory(false)
+                                                  .useDeweyIDs(false)
+                                                  .build();
+  }
+
+  /**
+   * One writer per partition-resource, bulk-assembly builder, cursor-arm-identical everything else.
+   */
+  private static int loadPartitionsViaBulkAssembly(final Database<JsonResourceSession> database,
+      final List<Callable<Reader>> slices, final StorageType storageType, final VersioningType versioningType,
+      final boolean pathSummary, final int autoCommit, final int maxConcurrency) throws Exception {
+    final ExecutorService pool = Executors.newFixedThreadPool(Math.max(1, Math.min(maxConcurrency, slices.size())));
+    try {
+      final List<Future<?>> shards = new ArrayList<>(slices.size());
+      for (int i = 0; i < slices.size(); i++) {
+        final String name = "hits-" + i;
+        final Callable<Reader> slice = slices.get(i);
+        database.createResource(resourceConfig(name, storageType, versioningType, pathSummary));
+        shards.add(pool.submit(() -> {
+          try (JsonResourceSession session = database.beginResourceSession(name);
+              JsonNodeTrx wtx = session.beginNodeTrx(autoCommit, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+            // The scanner consumes the generator's char stream DIRECTLY — no Gson tokenizer in the
+            // bulk arm; the cursor arm keeps Gson, which is part of what the A/B measures.
+            // -Dprobe.parallelImport=true routes through the chunked coordinator/worker pipeline
+            // (P=1 in M2); default stays the sequential assembler.
+            if (Boolean.getBoolean("probe.parallelImport")) {
+              final String file = System.getProperty("probe.file");
+              if (file != null) {
+                // Byte entry: the coordinator slices/scans raw UTF-8; workers decode their own
+                // chunks — the shipping shape for file loads. .gz streams decompress on the
+                // feeder path; NDJSON corpora ride the array adapter, optionally row-limited.
+                java.io.InputStream fileBytes =
+                    new java.io.BufferedInputStream(java.nio.file.Files.newInputStream(java.nio.file.Path.of(file)),
+                        1 << 20);
+                if (file.endsWith(".gz")) {
+                  fileBytes = new java.util.zip.GZIPInputStream(fileBytes, 1 << 16);
+                }
+                if (Boolean.getBoolean("probe.ndjson")) {
+                  final long rowLimit = Long.getLong("probe.rowLimit", Long.MAX_VALUE);
+                  fileBytes = new io.sirix.access.trx.node.json.NdjsonAsArrayInputStream(fileBytes, rowLimit);
+                }
+                try (java.io.InputStream input = fileBytes) {
+                  ParallelBulkJsonImporter.assemble(wtx, input);
+                }
+              } else {
+                ParallelBulkJsonImporter.assemble(wtx, slice.call());
+              }
+            } else {
+              BulkJsonTreeAssembler.assemble(wtx, slice.call());
+            }
+            wtx.commit();
+          }
+          return null;
+        }));
+      }
+      for (final Future<?> shard : shards) {
+        shard.get();
+      }
+      return slices.size();
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelLoadProbe.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelLoadProbe.java
@@ -11,6 +11,7 @@ import io.sirix.access.trx.node.AfterCommitState;
 import io.sirix.access.trx.node.HashType;
 import io.sirix.api.json.JsonNodeTrx;
 import io.sirix.access.trx.node.json.BulkJsonTreeAssembler;
+import io.sirix.access.trx.node.json.NdjsonAsArrayInputStream;
 import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
 import io.sirix.api.Database;
 import io.sirix.api.json.JsonResourceSession;
@@ -19,18 +20,23 @@ import io.sirix.io.StorageType;
 import io.sirix.service.json.shredder.ParallelJsonShredder;
 import io.sirix.settings.VersioningType;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.zip.GZIPInputStream;
 
 /**
  * MEASUREMENT PROBE, not a shipping loader: how does the existing partitioned parallel ingest
@@ -105,7 +111,7 @@ public final class ClickBenchParallelLoadProbe {
     final String writeFile = System.getProperty("probe.writeFile");
     if (writeFile != null) {
       try (Reader generated = new ClickBenchHitsGenerator(0, totalRows, seed);
-          Writer sink = Files.newBufferedWriter(Path.of(writeFile), java.nio.charset.StandardCharsets.UTF_8)) {
+          Writer sink = Files.newBufferedWriter(Path.of(writeFile), StandardCharsets.UTF_8)) {
         generated.transferTo(sink);
       }
       System.out.printf(Locale.ROOT, "Wrote %d rows to %s (%d bytes)%n", totalRows, writeFile,
@@ -132,7 +138,7 @@ public final class ClickBenchParallelLoadProbe {
           ? totalRows - firstRow
           : rowsPerPartition;
       slices.add(sourceFile != null
-          ? () -> Files.newBufferedReader(Path.of(sourceFile), java.nio.charset.StandardCharsets.UTF_8)
+          ? () -> Files.newBufferedReader(Path.of(sourceFile), StandardCharsets.UTF_8)
           : () -> new ClickBenchHitsGenerator(firstRow, rowCount, seed));
     }
 
@@ -170,7 +176,7 @@ public final class ClickBenchParallelLoadProbe {
       long rootChildSum = 0;
       for (final String name : database.listResources()
                                        .stream()
-                                       .map(java.nio.file.Path::getFileName)
+                                       .map(Path::getFileName)
                                        .map(Object::toString)
                                        .sorted()
                                        .toList()) {
@@ -223,7 +229,7 @@ public final class ClickBenchParallelLoadProbe {
         for (int i = 0; i < resources.size(); i++) {
           System.out.printf(Locale.ROOT, "Projection %s: %.3f s%n", resources.get(i), builds.get(i).get());
         }
-      } catch (final InterruptedException | java.util.concurrent.ExecutionException e) {
+      } catch (final InterruptedException | ExecutionException e) {
         throw new IllegalStateException("parallel projection build failed", e);
       } finally {
         pool.shutdown();
@@ -281,17 +287,15 @@ public final class ClickBenchParallelLoadProbe {
                 // Byte entry: the coordinator slices/scans raw UTF-8; workers decode their own
                 // chunks — the shipping shape for file loads. .gz streams decompress on the
                 // feeder path; NDJSON corpora ride the array adapter, optionally row-limited.
-                java.io.InputStream fileBytes =
-                    new java.io.BufferedInputStream(java.nio.file.Files.newInputStream(java.nio.file.Path.of(file)),
-                        1 << 20);
+                InputStream fileBytes = new BufferedInputStream(Files.newInputStream(Path.of(file)), 1 << 20);
                 if (file.endsWith(".gz")) {
-                  fileBytes = new java.util.zip.GZIPInputStream(fileBytes, 1 << 16);
+                  fileBytes = new GZIPInputStream(fileBytes, 1 << 16);
                 }
                 if (Boolean.getBoolean("probe.ndjson")) {
                   final long rowLimit = Long.getLong("probe.rowLimit", Long.MAX_VALUE);
-                  fileBytes = new io.sirix.access.trx.node.json.NdjsonAsArrayInputStream(fileBytes, rowLimit);
+                  fileBytes = new NdjsonAsArrayInputStream(fileBytes, rowLimit);
                 }
-                try (java.io.InputStream input = fileBytes) {
+                try (InputStream input = fileBytes) {
                   ParallelBulkJsonImporter.assemble(wtx, input);
                 }
               } else {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelProjectionCostMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelProjectionCostMain.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.bench.clickbench;
+
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeReadOnlyTrx;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.projection.ProjectionIndexHOTStorage;
+import io.sirix.index.projection.ProjectionIndexMetadata;
+import io.sirix.query.json.ProjectionSpec;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Three-arm cost measurement for the parallel importer's one-pass projection build:
+ *
+ * <ol>
+ * <li><b>bare</b> — parallel import, no projection;</li>
+ * <li><b>onepass</b> — parallel import with the projection armed before the data;</li>
+ * <li><b>postpass</b> — parallel import bare, then {@code createIndexes} over the finished
+ * resource.</li>
+ * </ol>
+ *
+ * Arms are INTERLEAVED (bare, onepass, postpass, bare, onepass, ...) rather than run in blocks, so a
+ * machine whose clock or background load drifts over the session penalises every arm equally. The
+ * reported figure per arm is the MINIMUM over repetitions, which is the least noise-contaminated
+ * estimator available when the box is shared.
+ *
+ * <pre>
+ * java ... io.sirix.query.bench.clickbench.ClickBenchParallelProjectionCostMain &lt;corpus.json&gt; &lt;workDir&gt; [reps]
+ * </pre>
+ */
+public final class ClickBenchParallelProjectionCostMain {
+
+  private static final String RESOURCE = "res.jn";
+  private static final int PROJECTION_INDEX_NUMBER = 0;
+  /** The import transaction's node bound; matches the shipping bulk-import guidance. */
+  private static final int NODES_BEFORE_EPOCH_ROTATION = 262144;
+
+  private ClickBenchParallelProjectionCostMain() {
+    throw new AssertionError("no instances");
+  }
+
+  private enum Arm {
+    BARE, ONEPASS, POSTPASS
+  }
+
+  public static void main(final String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println("usage: <corpus.json> <workDir> [reps]");
+      System.exit(2);
+    }
+    final Path corpus = Path.of(args[0]);
+    final Path workDir = Path.of(args[1]);
+    final int reps = args.length > 2
+        ? Integer.parseInt(args[2])
+        : 3;
+    if (!Files.isRegularFile(corpus)) {
+      throw new IllegalArgumentException("corpus not found: " + corpus);
+    }
+    final long expectedRows = Long.getLong("cost.expectedRows", -1L);
+
+    final List<double[]> samples = new ArrayList<>();
+    for (final Arm ignored : Arm.values()) {
+      samples.add(new double[reps]);
+    }
+    for (int rep = 0; rep < reps; rep++) {
+      for (final Arm arm : Arm.values()) {
+        final Path dbPath = workDir.resolve("cost-" + arm.name().toLowerCase(Locale.ROOT));
+        deleteRecursively(dbPath);
+        final long nanos = System.nanoTime();
+        final long rows = runArm(arm, corpus, dbPath, expectedRows);
+        final double seconds = (System.nanoTime() - nanos) / 1e9;
+        samples.get(arm.ordinal())[rep] = seconds;
+        System.out.printf(Locale.ROOT, "rep %d  %-8s  %8.3f s   rows=%d%n", rep + 1, arm.name().toLowerCase(Locale.ROOT),
+            seconds, rows);
+        System.out.flush();
+        deleteRecursively(dbPath);
+      }
+    }
+
+    System.out.println();
+    System.out.printf(Locale.ROOT, "%-8s %10s %10s%n", "arm", "min(s)", "median(s)");
+    final double[] mins = new double[Arm.values().length];
+    for (final Arm arm : Arm.values()) {
+      final double[] armSamples = samples.get(arm.ordinal()).clone();
+      java.util.Arrays.sort(armSamples);
+      mins[arm.ordinal()] = armSamples[0];
+      System.out.printf(Locale.ROOT, "%-8s %10.3f %10.3f%n", arm.name().toLowerCase(Locale.ROOT), armSamples[0],
+          armSamples[armSamples.length / 2]);
+    }
+    final double bare = mins[Arm.BARE.ordinal()];
+    final double onePass = mins[Arm.ONEPASS.ordinal()];
+    final double postPass = mins[Arm.POSTPASS.ordinal()];
+    System.out.printf(Locale.ROOT, "%nONE-PASS OVERHEAD over bare: %+.3f s (%+.1f%%)%n", onePass - bare,
+        100.0 * (onePass - bare) / bare);
+    System.out.printf(Locale.ROOT, "ONE-PASS vs BARE+POST-PASS:  %+.3f s (%.2fx)%n", onePass - postPass,
+        postPass / onePass);
+  }
+
+  private static long runArm(final Arm arm, final Path corpus, final Path dbPath, final long expectedRows)
+      throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION,
+            AfterCommitState.KEEP_OPEN_ASYNC_FLUSH); InputStream in = openCorpus(corpus)) {
+          if (arm == Arm.ONEPASS) {
+            final JsonIndexController controller = session.getWtxIndexController(wtx.getRevisionNumber());
+            controller.createProjectionIndexAtLoadStart(projectionDef(expectedRows), wtx, expectedRows);
+          }
+          ParallelBulkJsonImporter.assemble(wtx, in);
+          wtx.commit();
+        }
+        if (arm == Arm.POSTPASS) {
+          try (JsonNodeTrx wtx = session.beginNodeTrx()) {
+            session.getWtxIndexController(wtx.getRevisionNumber())
+                   .createIndexes(Set.of(projectionDef(expectedRows)), wtx);
+            wtx.commit();
+          }
+        }
+        return verify(session, arm);
+      }
+    }
+  }
+
+  /**
+   * Read the result back so an arm that quietly produced nothing cannot post the best time. For the
+   * projection arms this additionally asserts the index is LIVE: an abandoned build leaves the stale
+   * tombstone behind and would otherwise look like the fastest way to build an index.
+   */
+  private static long verify(final JsonResourceSession session, final Arm arm) {
+    try (JsonNodeReadOnlyTrx rtx = session.beginNodeReadOnlyTrx(session.getMostRecentRevisionNumber())) {
+      rtx.moveToDocumentRoot();
+      if (!rtx.moveToFirstChild()) {
+        throw new IllegalStateException(arm + " produced no top-level array");
+      }
+      final long rows = rtx.getChildCount();
+      if (rows == 0) {
+        throw new IllegalStateException(arm + " produced an empty record set");
+      }
+      if (arm != Arm.BARE) {
+        final byte[] raw = ProjectionIndexHOTStorage.readBlob(rtx.getStorageEngineReader(), PROJECTION_INDEX_NUMBER, 0L);
+        if (raw == null) {
+          throw new IllegalStateException(arm + " published no projection metadata");
+        }
+        final ProjectionIndexMetadata metadata = ProjectionIndexMetadata.parse(raw);
+        if (metadata.isStale()) {
+          throw new IllegalStateException(arm + " ABANDONED its projection — the tombstone is still in slot 0");
+        }
+        System.out.printf(Locale.ROOT, "        (%s projection: %d row groups)%n", arm.name().toLowerCase(Locale.ROOT),
+            metadata.rowGroupCount());
+      }
+      return rows;
+    }
+  }
+
+  private static IndexDef projectionDef(final long expectedRows) {
+    final ProjectionSpec spec = ClickBenchProjection.spec(expectedRows);
+    return spec.toIndexDef();
+  }
+
+  private static InputStream openCorpus(final Path corpus) throws IOException {
+    return new BufferedInputStream(Files.newInputStream(corpus), 1 << 20);
+  }
+
+  private static void deleteRecursively(final Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (var walk = Files.walk(path)) {
+      final List<Path> entries = walk.sorted(Comparator.reverseOrder()).toList();
+      for (final Path entry : entries) {
+        Files.deleteIfExists(entry);
+      }
+    }
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelProjectionCostMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchParallelProjectionCostMain.java
@@ -40,8 +40,8 @@ import java.util.Set;
  * resource.</li>
  * </ol>
  *
- * Arms are INTERLEAVED (bare, onepass, postpass, bare, onepass, ...) rather than run in blocks, so a
- * machine whose clock or background load drifts over the session penalises every arm equally. The
+ * Arms are INTERLEAVED (bare, onepass, postpass, bare, onepass, ...) rather than run in blocks, so
+ * a machine whose clock or background load drifts over the session penalises every arm equally. The
  * reported figure per arm is the MINIMUM over repetitions, which is the least noise-contaminated
  * estimator available when the box is shared.
  *
@@ -91,8 +91,8 @@ public final class ClickBenchParallelProjectionCostMain {
         final long rows = runArm(arm, corpus, dbPath, expectedRows);
         final double seconds = (System.nanoTime() - nanos) / 1e9;
         samples.get(arm.ordinal())[rep] = seconds;
-        System.out.printf(Locale.ROOT, "rep %d  %-8s  %8.3f s   rows=%d%n", rep + 1, arm.name().toLowerCase(Locale.ROOT),
-            seconds, rows);
+        System.out.printf(Locale.ROOT, "rep %d  %-8s  %8.3f s   rows=%d%n", rep + 1,
+            arm.name().toLowerCase(Locale.ROOT), seconds, rows);
         System.out.flush();
         deleteRecursively(dbPath);
       }
@@ -128,8 +128,9 @@ public final class ClickBenchParallelProjectionCostMain {
                                              .buildPathSummary(true)
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
-        try (JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION,
-            AfterCommitState.KEEP_OPEN_ASYNC_FLUSH); InputStream in = openCorpus(corpus)) {
+        try (
+            JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH);
+            InputStream in = openCorpus(corpus)) {
           if (arm == Arm.ONEPASS) {
             final JsonIndexController controller = session.getWtxIndexController(wtx.getRevisionNumber());
             controller.createProjectionIndexAtLoadStart(projectionDef(expectedRows), wtx, expectedRows);
@@ -165,7 +166,8 @@ public final class ClickBenchParallelProjectionCostMain {
         throw new IllegalStateException(arm + " produced an empty record set");
       }
       if (arm != Arm.BARE) {
-        final byte[] raw = ProjectionIndexHOTStorage.readBlob(rtx.getStorageEngineReader(), PROJECTION_INDEX_NUMBER, 0L);
+        final byte[] raw =
+            ProjectionIndexHOTStorage.readBlob(rtx.getStorageEngineReader(), PROJECTION_INDEX_NUMBER, 0L);
         if (raw == null) {
           throw new IllegalStateException(arm + " published no projection metadata");
         }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchPrimitiveIndexImportCostMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchPrimitiveIndexImportCostMain.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.query.bench.clickbench;
+
+import io.brackit.query.atomic.QNm;
+import io.brackit.query.jdm.Type;
+import io.brackit.query.util.path.Path;
+import io.brackit.query.util.path.PathParser;
+import io.sirix.access.DatabaseConfiguration;
+import io.sirix.access.Databases;
+import io.sirix.access.ResourceConfiguration;
+import io.sirix.access.trx.node.AfterCommitState;
+import io.sirix.access.trx.node.HashType;
+import io.sirix.access.trx.node.json.JsonIndexController;
+import io.sirix.access.trx.node.json.ParallelBulkJsonImporter;
+import io.sirix.api.Database;
+import io.sirix.api.json.JsonNodeTrx;
+import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.IndexDef;
+import io.sirix.index.IndexDefs;
+import io.sirix.index.IndexType;
+import io.sirix.index.redblacktree.keyvalue.NodeReferences;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Two-arm cost measurement for the parallel importer's PATH/CAS/NAME maintenance:
+ *
+ * <ol>
+ * <li><b>bare</b> — parallel import, no indexes;</li>
+ * <li><b>indexed</b> — the same import with one PATH, one NAME and two CAS definitions catalogued,
+ * maintained by the workers' tuple collection and the coordinator drain.</li>
+ * </ol>
+ *
+ * Arms are interleaved per rep; the reported figure per arm is the minimum over repetitions.
+ *
+ * <pre>
+ * java ... io.sirix.query.bench.clickbench.ClickBenchPrimitiveIndexImportCostMain &lt;corpus.json&gt; &lt;workDir&gt; [reps]
+ * </pre>
+ */
+public final class ClickBenchPrimitiveIndexImportCostMain {
+
+  private static final String RESOURCE = "res.jn";
+  private static final int NODES_BEFORE_EPOCH_ROTATION = 262144;
+
+  private ClickBenchPrimitiveIndexImportCostMain() {
+    throw new AssertionError("no instances");
+  }
+
+  private enum Arm {
+    BARE, INDEXED
+  }
+
+  public static void main(final String[] args) throws Exception {
+    if (args.length < 2) {
+      System.err.println("usage: <corpus.json> <workDir> [reps]");
+      System.exit(2);
+    }
+    final java.nio.file.Path corpus = java.nio.file.Path.of(args[0]);
+    final java.nio.file.Path workDir = java.nio.file.Path.of(args[1]);
+    final int reps = args.length > 2
+        ? Integer.parseInt(args[2])
+        : 3;
+    if (!Files.isRegularFile(corpus)) {
+      throw new IllegalArgumentException("corpus not found: " + corpus);
+    }
+
+    final double[][] samples = new double[Arm.values().length][reps];
+    for (int rep = 0; rep < reps; rep++) {
+      for (final Arm arm : Arm.values()) {
+        final java.nio.file.Path dbPath = workDir.resolve("idxcost-" + arm.name().toLowerCase(Locale.ROOT));
+        deleteRecursively(dbPath);
+        final long nanos = System.nanoTime();
+        final long rows = runArm(arm, corpus, dbPath);
+        final double seconds = (System.nanoTime() - nanos) / 1e9;
+        samples[arm.ordinal()][rep] = seconds;
+        System.out.printf(Locale.ROOT, "rep %d  %-8s %8.3f s   rows=%d%n", rep + 1,
+            arm.name().toLowerCase(Locale.ROOT), seconds, rows);
+        System.out.flush();
+        deleteRecursively(dbPath);
+      }
+    }
+
+    System.out.println();
+    System.out.printf(Locale.ROOT, "%-8s %10s %10s%n", "arm", "min(s)", "median(s)");
+    final double[] mins = new double[Arm.values().length];
+    for (final Arm arm : Arm.values()) {
+      final double[] armSamples = samples[arm.ordinal()].clone();
+      java.util.Arrays.sort(armSamples);
+      mins[arm.ordinal()] = armSamples[0];
+      System.out.printf(Locale.ROOT, "%-8s %10.3f %10.3f%n", arm.name().toLowerCase(Locale.ROOT), armSamples[0],
+          armSamples[armSamples.length / 2]);
+    }
+    final double bare = mins[Arm.BARE.ordinal()];
+    final double indexed = mins[Arm.INDEXED.ordinal()];
+    System.out.printf(Locale.ROOT, "%nPATH+CAS+NAME MAINTENANCE over bare: %+.3f s (%+.1f%%)%n", indexed - bare,
+        100.0 * (indexed - bare) / bare);
+  }
+
+  private static long runArm(final Arm arm, final java.nio.file.Path corpus, final java.nio.file.Path dbPath)
+      throws IOException {
+    Databases.createJsonDatabase(new DatabaseConfiguration(dbPath));
+    try (Database<JsonResourceSession> db = Databases.openJsonDatabase(dbPath)) {
+      db.createResource(ResourceConfiguration.newBuilder(RESOURCE)
+                                             .useDeweyIDs(false)
+                                             .hashKind(HashType.NONE)
+                                             .storeNodeHistory(false)
+                                             .buildPathSummary(true)
+                                             .build());
+      try (JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
+        try (JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION,
+            AfterCommitState.KEEP_OPEN_ASYNC_FLUSH); InputStream in = openCorpus(corpus)) {
+          if (arm == Arm.INDEXED) {
+            session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(indexDefs(), wtx);
+          }
+          ParallelBulkJsonImporter.assemble(wtx, in);
+          wtx.commit();
+        }
+        return verify(session, arm);
+      }
+    }
+  }
+
+  /** Read the result back so an arm that quietly produced nothing cannot post the best time. */
+  private static long verify(final JsonResourceSession session, final Arm arm) {
+    try (JsonNodeTrx trx = session.beginNodeTrx()) {
+      trx.moveToDocumentRoot();
+      if (!trx.moveToFirstChild()) {
+        throw new IllegalStateException(arm + " produced no top-level array");
+      }
+      final long rows = trx.getChildCount();
+      if (arm == Arm.INDEXED) {
+        final JsonIndexController controller = session.getWtxIndexController(trx.getRevisionNumber());
+        final IndexDef pathDef = controller.getIndexes().getIndexDef(0, IndexType.PATH);
+        final long pathEntries = countPostings(controller.openPathIndex(trx.getStorageEngineReader(), pathDef,
+            controller.createPathFilter(Set.of("/[]/URL"), trx)));
+        final IndexDef nameDef =
+            controller.getIndexes().getIndexDef(IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON).getID(),
+                IndexType.NAME);
+        final long nameEntries = countPostings(controller.openNameIndex(trx.getStorageEngineReader(), nameDef,
+            controller.createNameFilter(Set.of("URL"))));
+        if (pathEntries != rows || nameEntries != rows) {
+          throw new IllegalStateException("indexed arm read back path=" + pathEntries + " name=" + nameEntries
+              + " postings for " + rows + " rows — the indexes are short");
+        }
+        System.out.printf(Locale.ROOT, "        (indexed: URL path postings=%d, URL name postings=%d)%n", pathEntries,
+            nameEntries);
+      }
+      return rows;
+    }
+  }
+
+  private static long countPostings(final Iterator<NodeReferences> hits) {
+    long count = 0;
+    while (hits.hasNext()) {
+      count += hits.next().getNodeKeys().getLongCardinality();
+    }
+    return count;
+  }
+
+  private static Set<IndexDef> indexDefs() {
+    return Set.of(
+        IndexDefs.createPathIdxDef(Set.of(Path.parse("/[]/URL", PathParser.Type.JSON),
+            Path.parse("/[]/EventTime", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON),
+        IndexDefs.createSelectiveNameIdxDef(
+            Set.of(new QNm("URL"), new QNm("EventTime"), new QNm("CounterID")), 0, IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.LON, Set.of(Path.parse("/[]/CounterID", PathParser.Type.JSON)), 0,
+            IndexDef.DbType.JSON),
+        IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/URL", PathParser.Type.JSON)), 1,
+            IndexDef.DbType.JSON));
+  }
+
+  private static InputStream openCorpus(final java.nio.file.Path corpus) throws IOException {
+    return new BufferedInputStream(Files.newInputStream(corpus), 1 << 20);
+  }
+
+  private static void deleteRecursively(final java.nio.file.Path path) throws IOException {
+    if (!Files.exists(path)) {
+      return;
+    }
+    try (var walk = Files.walk(path)) {
+      final List<java.nio.file.Path> entries = walk.sorted(Comparator.reverseOrder()).toList();
+      for (final java.nio.file.Path entry : entries) {
+        Files.deleteIfExists(entry);
+      }
+    }
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchPrimitiveIndexImportCostMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchPrimitiveIndexImportCostMain.java
@@ -83,8 +83,8 @@ public final class ClickBenchPrimitiveIndexImportCostMain {
         final long rows = runArm(arm, corpus, dbPath);
         final double seconds = (System.nanoTime() - nanos) / 1e9;
         samples[arm.ordinal()][rep] = seconds;
-        System.out.printf(Locale.ROOT, "rep %d  %-8s %8.3f s   rows=%d%n", rep + 1,
-            arm.name().toLowerCase(Locale.ROOT), seconds, rows);
+        System.out.printf(Locale.ROOT, "rep %d  %-8s %8.3f s   rows=%d%n", rep + 1, arm.name().toLowerCase(Locale.ROOT),
+            seconds, rows);
         System.out.flush();
         deleteRecursively(dbPath);
       }
@@ -117,8 +117,9 @@ public final class ClickBenchPrimitiveIndexImportCostMain {
                                              .buildPathSummary(true)
                                              .build());
       try (JsonResourceSession session = db.beginResourceSession(RESOURCE)) {
-        try (JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION,
-            AfterCommitState.KEEP_OPEN_ASYNC_FLUSH); InputStream in = openCorpus(corpus)) {
+        try (
+            JsonNodeTrx wtx = session.beginNodeTrx(NODES_BEFORE_EPOCH_ROTATION, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH);
+            InputStream in = openCorpus(corpus)) {
           if (arm == Arm.INDEXED) {
             session.getWtxIndexController(wtx.getRevisionNumber()).createIndexes(indexDefs(), wtx);
           }
@@ -144,8 +145,8 @@ public final class ClickBenchPrimitiveIndexImportCostMain {
         final long pathEntries = countPostings(controller.openPathIndex(trx.getStorageEngineReader(), pathDef,
             controller.createPathFilter(Set.of("/[]/URL"), trx)));
         final IndexDef nameDef =
-            controller.getIndexes().getIndexDef(IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON).getID(),
-                IndexType.NAME);
+            controller.getIndexes()
+                      .getIndexDef(IndexDefs.createNameIdxDef(0, IndexDef.DbType.JSON).getID(), IndexType.NAME);
         final long nameEntries = countPostings(controller.openNameIndex(trx.getStorageEngineReader(), nameDef,
             controller.createNameFilter(Set.of("URL"))));
         if (pathEntries != rows || nameEntries != rows) {
@@ -169,10 +170,11 @@ public final class ClickBenchPrimitiveIndexImportCostMain {
 
   private static Set<IndexDef> indexDefs() {
     return Set.of(
-        IndexDefs.createPathIdxDef(Set.of(Path.parse("/[]/URL", PathParser.Type.JSON),
-            Path.parse("/[]/EventTime", PathParser.Type.JSON)), 0, IndexDef.DbType.JSON),
-        IndexDefs.createSelectiveNameIdxDef(
-            Set.of(new QNm("URL"), new QNm("EventTime"), new QNm("CounterID")), 0, IndexDef.DbType.JSON),
+        IndexDefs.createPathIdxDef(
+            Set.of(Path.parse("/[]/URL", PathParser.Type.JSON), Path.parse("/[]/EventTime", PathParser.Type.JSON)), 0,
+            IndexDef.DbType.JSON),
+        IndexDefs.createSelectiveNameIdxDef(Set.of(new QNm("URL"), new QNm("EventTime"), new QNm("CounterID")), 0,
+            IndexDef.DbType.JSON),
         IndexDefs.createCASIdxDef(false, Type.LON, Set.of(Path.parse("/[]/CounterID", PathParser.Type.JSON)), 0,
             IndexDef.DbType.JSON),
         IndexDefs.createCASIdxDef(false, Type.STR, Set.of(Path.parse("/[]/URL", PathParser.Type.JSON)), 1,

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchProjection.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/clickbench/ClickBenchProjection.java
@@ -106,6 +106,11 @@ public final class ClickBenchProjection {
 
   /** The {@code jn:create-projection-index} call for the projected columns. */
   public static String createQuery() {
+    return createQuery(ClickBenchSchema.DATABASE, ClickBenchSchema.RESOURCE);
+  }
+
+  /** Same call against an explicit database/resource — the per-partition composite entry point. */
+  public static String createQuery(final String database, final String resource) {
     final StringBuilder paths = new StringBuilder(PROJECTED_COLUMNS.size() * 24);
     final StringBuilder types = new StringBuilder(PROJECTED_COLUMNS.size() * 10);
     for (int i = 0; i < PROJECTED_COLUMNS.size(); i++) {
@@ -117,7 +122,7 @@ public final class ClickBenchProjection {
       paths.append('\'').append(ROOT_PATH).append('/').append(column).append('\'');
       types.append('\'').append(projectionType(column)).append('\'');
     }
-    return "let $doc := jn:doc('" + ClickBenchSchema.DATABASE + "','" + ClickBenchSchema.RESOURCE + "')\n"
+    return "let $doc := jn:doc('" + database + "','" + resource + "')\n"
         + "let $stats := jn:create-projection-index($doc, '" + ROOT_PATH + "',\n" + "    (" + paths + "),\n" + "    ("
         + types + "))\n" + "return {\"revision\": sdb:commit($doc)}";
   }
@@ -129,11 +134,24 @@ public final class ClickBenchProjection {
    * @return wall-clock seconds spent building and committing
    */
   public static double create(final Path dbDir) {
+    return create(dbDir, ClickBenchSchema.DATABASE, ClickBenchSchema.RESOURCE);
+  }
+
+  /**
+   * Build and persist the projection for one explicit database/resource pair — the per-partition
+   * entry point for partitioned (composite) corpora.
+   *
+   * @param location the store location holding {@code <database>/<resource>}
+   * @param database the database directory name under {@code location}
+   * @param resource the resource to project
+   * @return wall-clock seconds spent building and committing
+   */
+  public static double create(final Path location, final String database, final String resource) {
     final long start = System.nanoTime();
-    try (final BasicJsonDBStore store = BasicJsonDBStore.newBuilder().location(dbDir).build();
+    try (final BasicJsonDBStore store = BasicJsonDBStore.newBuilder().location(location).build();
         final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
         final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
-      new Query(chain, createQuery()).evaluate(ctx);
+      new Query(chain, createQuery(database, resource)).evaluate(ctx);
     }
     return (System.nanoTime() - start) / 1e9;
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/bench/jsonbench/JsonBenchLoadMain.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/bench/jsonbench/JsonBenchLoadMain.java
@@ -138,8 +138,12 @@ public final class JsonBenchLoadMain {
     // or group-by kernel.
     if (projection && incrementalProjection) {
       // Built by the shred itself — its cost is already inside the load time reported above.
-      System.out.printf("# projection: columns=%d globalDictColumns=%d built DURING the shred (one pass)%n",
-          JsonBenchProjection.COLUMN_PATHS.size(), ProjectionIndexBuilder.globalDictionaryColumnsBuilt());
+      // dictProbes must be 0 on a one-pass load: retained intern tables mean interning never
+      // reaches the persistent radix (non-zero = the per-value durable-read regime is back).
+      System.out.printf(
+          "# projection: columns=%d globalDictColumns=%d dictProbes=%d built DURING the shred (one pass)%n",
+          JsonBenchProjection.COLUMN_PATHS.size(), ProjectionIndexBuilder.globalDictionaryColumnsBuilt(),
+          ProjectionIndexBuilder.persistentDictionaryProbesReported());
     } else if (projection) {
       try {
         final double projectionSeconds = JsonBenchProjection.create(dbDir);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -8052,7 +8052,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // Budget-aware: a handle whose worst-case resident bytes exceed the eager budget is served by
     // the windowed payload view — the route that lets fat string columns answer whole-leaf query
     // shapes (LIKE, distinct) at 100M instead of OOMing the whole-column materialization.
-    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle, store.rowGroupCount());
+    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount(),
+        handle.projectedWeightBytes());
   }
 
   /** The write transaction's index controller (wtx mode only). */
@@ -13093,6 +13094,14 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
         System.err.println("[proj] groupAgg overflow at " + firstSirixFrame(overflow));
       }
       return declineGroupAgg("per-group sum overflowed a long");
+    } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
+      // Expected decline, not a defect: the store priced a column fill this arm would have needed
+      // and refused it, so the whole-leaf windowed route serves instead. Counting it would put a
+      // permanent false corruption signal under every query on a fat string column.
+      if (PROJ_DIAG) {
+        System.err.println("[proj] groupAgg sliced fill declined by budget: " + declined.getMessage());
+      }
+      return null;
     } catch (final RuntimeException e) {
       // Fail soft — the compiled generic pipeline answers correctly. But an EXCEPTION
       // here (unlike a gate decline) means a defect or corruption, and a silent 100%
@@ -13332,6 +13341,13 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     } catch (final ArithmeticException overflow) {
       // Expected decline: an overflowing sum or shift routes to the interpreter's
       // decimal-promoting arithmetic via the generic pipeline.
+      return null;
+    } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
+      // Expected decline: the store refused a priced column fill; the whole-leaf windowed route
+      // serves instead, and no defect counter ticks.
+      if (PROJ_DIAG) {
+        System.err.println("[proj] const-groupAgg sliced fill declined by budget: " + declined.getMessage());
+      }
       return null;
     } catch (final RuntimeException e) {
       GROUP_AGG_FAILED.increment();

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -8003,9 +8003,27 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // Budget-aware: a handle whose worst-case resident bytes exceed the eager budget is served by
     // the windowed payload view — the route that lets fat string columns answer whole-leaf query
     // shapes (LIKE, distinct) at 100M instead of OOMing the whole-column materialization.
-    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount(),
-        handle.projectedWeightBytes());
+    final Supplier<List<byte[]>> materializer = ProjectionIndexCatalog.rowGroupMaterializer(session, revision,
+        handle.defId(), store.rowGroupCount(), handle.projectedWeightBytes());
+    if (!ProjectionIndexCatalog.servesWindowedPayloads(handle.projectedWeightBytes())) {
+      return materializer;
+    }
+    // The shared handle deliberately does not memoize a windowed view (it would outlive this
+    // session and fetch through a closed one), so THIS executor memoizes it for its own lifetime —
+    // the exact lifetime of the session the view's fetcher is bound to. Without it every consult
+    // would redo the physical-order read and start from a cold window set.
+    return () -> windowedPayloadViews.computeIfAbsent(handle, memoized -> materializer.get());
   }
+
+  /**
+   * Per-executor memo of the WINDOWED whole-leaf views, keyed by handle IDENTITY (a handle carries
+   * no value equality) — see {@link #rowGroupMaterializer(ProjectionIndexRegistry.Handle)}. Bounded
+   * by the number of projection handles this executor's queries touch, and dropped with the
+   * executor, so it holds nothing past its session. Only windowed views land here; an eager handle
+   * memoizes its own resident leaves and never consults the materializer again.
+   */
+  private final ConcurrentHashMap<ProjectionIndexRegistry.Handle, List<byte[]>> windowedPayloadViews =
+      new ConcurrentHashMap<>();
 
   /** The write transaction's index controller (wtx mode only). */
   private JsonIndexController wtxIndexController() {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -759,7 +759,10 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SirixVectorizedExecutor.class);
 
-  /** Shared daemon reaper joining retired executors' pools off the compile path — see {@link #retireAsync()}. */
+  /**
+   * Shared daemon reaper joining retired executors' pools off the compile path — see
+   * {@link #retireAsync()}.
+   */
   private static final ExecutorService RETIREMENT_REAPER = Executors.newSingleThreadExecutor(r -> {
     final Thread thread = new Thread(r, "sirix-executor-retirement");
     thread.setDaemon(true);
@@ -1064,14 +1067,14 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   /**
-   * Retire without blocking the caller. {@link #retire()} joins the warm-up and worker pools, and
-   * a running whole-leaf warm-up materialization is uncancellable (its parallel arm runs through
+   * Retire without blocking the caller. {@link #retire()} joins the warm-up and worker pools, and a
+   * running whole-leaf warm-up materialization is uncancellable (its parallel arm runs through
    * {@code ForkJoinTask.invoke}, which ignores interrupts) — retiring synchronously on the compile
    * path serialized every compile of the chain, and every executor-cache overflow, behind a
    * potentially multi-GB read. The queue drain and shutdown still run HERE, synchronously (see
-   * {@link #initiatePoolShutdown}); only the join moves to the shared reaper. The caller has
-   * already unpublished this executor, so no new work reaches it, and in-flight scans complete
-   * exactly as under a synchronous retire.
+   * {@link #initiatePoolShutdown}); only the join moves to the shared reaper. The caller has already
+   * unpublished this executor, so no new work reaches it, and in-flight scans complete exactly as
+   * under a synchronous retire.
    */
   public void retireAsync() {
     initiatePoolShutdown(false);
@@ -1120,8 +1123,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   /**
    * The non-blocking half of a shutdown: reject new work, drain queued warm-ups, and run their
    * cancellation hooks. Runs synchronously in every retirement flavour — queued warm-ups carry
-   * cancellation hooks whose one-shot latches in-flight readers may await, so this must never
-   * queue behind another executor's slow termination.
+   * cancellation hooks whose one-shot latches in-flight readers may await, so this must never queue
+   * behind another executor's slow termination.
    */
   private void initiatePoolShutdown(final boolean terminal) {
     synchronized (workerPoolLifecycleLock) {
@@ -2686,8 +2689,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    * Every listed column servable by a WHOLE-COLUMN slice fill (fail-closed gate for the sliced group
    * route) — viability, not just kind: an over-budget column's fill declines inside the store, so
    * gating on {@link ProjectionColumnStore#columnFillable} keeps this route from selecting an arm
-   * that cannot complete. Only for columns that reach {@code store.column(...)}; a column filled in
-   * a cheaper mode has its own gate.
+   * that cannot complete. Only for columns that reach {@code store.column(...)}; a column filled in a
+   * cheaper mode has its own gate.
    */
   private static boolean allColumnsSliceable(final ProjectionColumnStore store, final int[] cols) {
     for (final int col : cols) {
@@ -2699,8 +2702,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   /**
-   * The aggregate columns' gate, asking each column about the mode it will ACTUALLY be filled in:
-   * the {@code COUNT(DISTINCT)} operand at {@code identityOperandIndex} goes through
+   * The aggregate columns' gate, asking each column about the mode it will ACTUALLY be filled in: the
+   * {@code COUNT(DISTINCT)} operand at {@code identityOperandIndex} goes through
    * {@link ProjectionColumnStore#columnDistinctIdentity} (BODY + the ~8 B/entry hash chain, no
    * dictionary), every other lane through a whole-column fill. Judging the operand by the
    * whole-column projection rejects a fat dictionary column on bytes its fill never fetches.
@@ -11727,8 +11730,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       return null;
     }
     return groupByAggregate(ctx, sourcePath, predicateOrNull, groupFields, keyNames, funcs, aggFields, outNames,
-        orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits,
-        keyCondElse, keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, false);
+        orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits, keyCondElse,
+        keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, false);
   }
 
   /**
@@ -11736,20 +11739,19 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    *
    * <p>
    * {@code wholeLeafOnly} exists for ONE transition: a column fill the store refuses on budget. The
-   * sliced arm cannot complete without those bytes, but the whole-leaf arm right beside it can —
-   * over an over-budget handle that arm IS the windowed byte-kernel scan the budget declined toward.
+   * sliced arm cannot complete without those bytes, but the whole-leaf arm right beside it can — over
+   * an over-budget handle that arm IS the windowed byte-kernel scan the budget declined toward.
    * Re-entering with the arm suppressed takes it, instead of dropping a query that has a viable
    * projection route in hand all the way to the generic navigational pipeline.
    * </p>
    */
   private ServedGroups groupByAggregate(final QueryContext ctx, final String[] sourcePath,
-      final PredicateNode predicateOrNull, final String[] groupFields, final String[] keyNames,
-      final String[] funcs, final String[] aggFields, final String[] outNames, final int[] orderIndexes,
-      final boolean[] orderAsc, final boolean[] orderEmptyLeast, final long limit, final long[] keyOffsets,
-      final int[] keySubstr, final String[] keyCondFields, final long[] keyCondLits,
-      final String[] keyCondElse, final String[] keyRegexPattern, final String[] keyRegexRepl,
-      final long[] keyDivMod, final boolean[] keyStringify, final long[] having,
-      final boolean wholeLeafOnly) {
+      final PredicateNode predicateOrNull, final String[] groupFields, final String[] keyNames, final String[] funcs,
+      final String[] aggFields, final String[] outNames, final int[] orderIndexes, final boolean[] orderAsc,
+      final boolean[] orderEmptyLeast, final long limit, final long[] keyOffsets, final int[] keySubstr,
+      final String[] keyCondFields, final long[] keyCondLits, final String[] keyCondElse,
+      final String[] keyRegexPattern, final String[] keyRegexRepl, final long[] keyDivMod, final boolean[] keyStringify,
+      final long[] having, final boolean wholeLeafOnly) {
     try {
       if (projectionRegistryKey == null || !anyProjectionAvailable()) {
         return declineGroupAgg("no projection available");
@@ -12109,8 +12111,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // background assembly landing between the kick and the re-read, demoting the very query that
       // triggered it — did not reproduce even at -Dsirix.projection.slicedPromoteAfter=1.
       final boolean groupSliced = GROUP_SLICED_ENABLED && !wholeLeafOnly && groupStore != null
-          && !handle.payloadsMaterialized()
-          && (tree == null
+          && !handle.payloadsMaterialized() && (tree == null
               ? predsSliceable(groupStore, preds)
               : treeSliceable(groupStore, tree))
           && allColumnsSliceable(groupStore, groupCols) && aggColumnsFillable(groupStore, aggColsFlat, cdStringDict
@@ -13131,8 +13132,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
         return declineGroupAgg("column fill over budget on the whole-leaf route too");
       }
       return groupByAggregate(ctx, sourcePath, predicateOrNull, groupFields, keyNames, funcs, aggFields, outNames,
-        orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits,
-        keyCondElse, keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, true);
+          orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits,
+          keyCondElse, keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, true);
     } catch (final RuntimeException e) {
       // Fail soft — the compiled generic pipeline answers correctly. But an EXCEPTION
       // here (unlike a gate decline) means a defect or corruption, and a silent 100%
@@ -13162,8 +13163,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
 
   /**
    * The const-group twin of {@link #declineGroupAgg}: a decline that falls to the generic pipeline
-   * must move a counter, or a route that stopped serving reads exactly like one that was never
-   * asked. Shares {@code GROUP_AGG_DECLINED} because both arms answer the same question.
+   * must move a counter, or a route that stopped serving reads exactly like one that was never asked.
+   * Shares {@code GROUP_AGG_DECLINED} because both arms answer the same question.
    *
    * @param reason names the gate; keep it stable and cheap
    * @return {@code null}, always — the caller's decline value
@@ -13282,9 +13283,9 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // conditions (and in the very order) it always did, while the route itself is latched before
       // the kick so "keep serving sliced until it lands" is enforced by the code and not only
       // promised by a comment. Hardening; the suspected intra-query demotion did not reproduce.
-      final boolean constPromoteNow = GROUP_SLICED_ENABLED && !wholeLeafOnly && constStore != null
-          && !handle.payloadsMaterialized() && !projectionWarmupPool.isShutdown()
-          && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
+      final boolean constPromoteNow =
+          GROUP_SLICED_ENABLED && !wholeLeafOnly && constStore != null && !handle.payloadsMaterialized()
+              && !projectionWarmupPool.isShutdown() && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
       final boolean constSliced = GROUP_SLICED_ENABLED && !wholeLeafOnly && constStore != null && !anyStrlenAgg
           && !handle.payloadsMaterialized() && predsSliceable(constStore, preds)
           && allColumnsSliceable(constStore, aggCols);

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -13158,6 +13158,22 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       Long.getLong("sirix.projection.groupDistinct.maxValues", 1L << 24);
 
   /** Constant-key group-bys served in one scalar pass (test oracle, same doctrine as the rest). */
+  /**
+   * The const-group twin of {@link #declineGroupAgg}: a decline that falls to the generic pipeline
+   * must move a counter, or a route that stopped serving reads exactly like one that was never
+   * asked. Shares {@code GROUP_AGG_DECLINED} because both arms answer the same question.
+   *
+   * @param reason names the gate; keep it stable and cheap
+   * @return {@code null}, always — the caller's decline value
+   */
+  private static @Nullable Sequence declineConstGroupAgg(final String reason) {
+    GROUP_AGG_DECLINED.increment();
+    if (PROJ_DIAG) {
+      System.err.println("[proj] const-groupAgg decline: " + reason);
+    }
+    return null;
+  }
+
   private static final LongAdder CONST_GROUP_AGG_SERVED = new LongAdder();
 
   /** Test observability for {@link #CONST_GROUP_AGG_SERVED}. */
@@ -13388,7 +13404,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
         System.err.println("[proj] const-groupAgg sliced fill declined by budget: " + declined.getMessage());
       }
       if (wholeLeafOnly) {
-        return null;
+        return declineConstGroupAgg("column fill over budget on the whole-leaf route too");
       }
       return constGroupAggregate(ctx, sourcePath, predicateOrNull, funcs, aggFields, offsets, outNames, true);
     } catch (final RuntimeException e) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -2316,7 +2316,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       }
       preds = fuseRangePredicates(extracted);
     }
-    if (store != null && predsSliceable(store, preds)) {
+    if (store != null && predsFillable(store, preds)) {
       try {
         return sliceAggregateParallel(store, preds, col, fetcher, aggMask);
       } catch (final IllegalStateException ise) {
@@ -2393,7 +2393,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // SLICED first: only the aggregate + predicate columns' segments are read — the whole-leaf
     // materialization below is the cold-start whale and exists only as the fallback.
     final ProjectionColumnStore store = handle.columnStoreOrNull();
-    if (store != null && store.columnFillable(col) && predsSliceable(store, preds)) {
+    if (store != null && store.columnFillable(col) && predsFillable(store, preds)) {
       try {
         final int rgc = store.rowGroupCount();
         final int effS = Math.min(threads, Math.max(1, (rgc + 63) / 64));
@@ -2683,14 +2683,58 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   private static final int SLICED_PROMOTE_AFTER = Integer.getInteger("sirix.projection.slicedPromoteAfter", 2);
 
   /**
-   * Every listed column servable from slices (fail-closed gate for the sliced group route) —
-   * viability, not just kind: an over-budget column's fill declines inside the store, so gating on
-   * {@link ProjectionColumnStore#columnFillable} keeps this route from selecting an arm that cannot
-   * complete.
+   * Every listed column servable by a WHOLE-COLUMN slice fill (fail-closed gate for the sliced group
+   * route) — viability, not just kind: an over-budget column's fill declines inside the store, so
+   * gating on {@link ProjectionColumnStore#columnFillable} keeps this route from selecting an arm
+   * that cannot complete. Only for columns that reach {@code store.column(...)}; a column filled in
+   * a cheaper mode has its own gate.
    */
   private static boolean allColumnsSliceable(final ProjectionColumnStore store, final int[] cols) {
     for (final int col : cols) {
       if (!store.columnFillable(col)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * The aggregate columns' gate, asking each column about the mode it will ACTUALLY be filled in:
+   * the {@code COUNT(DISTINCT)} operand at {@code identityOperandIndex} goes through
+   * {@link ProjectionColumnStore#columnDistinctIdentity} (BODY + the ~8 B/entry hash chain, no
+   * dictionary), every other lane through a whole-column fill. Judging the operand by the
+   * whole-column projection rejects a fat dictionary column on bytes its fill never fetches.
+   *
+   * @param identityOperandIndex index into {@code cols} of the distinct-identity operand, or
+   *        {@code -1} when no lane is filled in that mode
+   */
+  private static boolean aggColumnsFillable(final ProjectionColumnStore store, final int[] cols,
+      final int identityOperandIndex) {
+    for (int i = 0; i < cols.length; i++) {
+      final boolean viable = i == identityOperandIndex
+          ? store.columnIdentityFillable(cols[i])
+          : store.columnFillable(cols[i]);
+      if (!viable) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Every predicate column sliceable AND affordable as a whole-column fill. The strict twin of
+   * {@link #predsSliceable}, for the routes that PREFILL every predicate column
+   * ({@link #prefillColumns}, {@link #resolveTreeCols}) rather than fetching it masked — a masked
+   * fetch after a keep-mask prune reads a fraction of the column, so judging it by the whole-column
+   * projection turns a bloom-pruned point lookup into a full navigational fallback.
+   */
+  private static boolean predsFillable(final ProjectionColumnStore store,
+      final ProjectionIndexScan.ColumnPredicate[] preds) {
+    if (!predsSliceable(store, preds)) {
+      return false;
+    }
+    for (final ProjectionIndexScan.ColumnPredicate p : preds) {
+      if (!store.columnFillable(p.column)) {
         return false;
       }
     }
@@ -2703,7 +2747,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    */
   private static boolean treeSliceable(final ProjectionColumnStore store,
       final ProjectionIndexScan.PredicateTree tree) {
-    if (!predsSliceable(store, tree.leaves)) {
+    if (!predsFillable(store, tree.leaves)) {
       return false;
     }
     for (final ProjectionIndexScan.ColumnPredicate leaf : tree.leaves) {
@@ -2744,7 +2788,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   private static boolean predsSliceable(final ProjectionColumnStore store,
       final ProjectionIndexScan.ColumnPredicate[] preds) {
     for (final ProjectionIndexScan.ColumnPredicate p : preds) {
-      if (!store.columnFillable(p.column)) {
+      if (!store.columnSliceable(p.column)) {
         return false;
       }
       // A SET column takes a string literal too — membership. Left out, it fell to the
@@ -8008,8 +8052,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // Budget-aware: a handle whose worst-case resident bytes exceed the eager budget is served by
     // the windowed payload view — the route that lets fat string columns answer whole-leaf query
     // shapes (LIKE, distinct) at 100M instead of OOMing the whole-column materialization.
-    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount(),
-        handle.projectedWeightBytes());
+    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle, store.rowGroupCount());
   }
 
   /** The write transaction's index controller (wtx mode only). */
@@ -12045,7 +12088,9 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
           && (tree == null
               ? predsSliceable(groupStore, preds)
               : treeSliceable(groupStore, tree))
-          && allColumnsSliceable(groupStore, groupCols) && allColumnsSliceable(groupStore, aggColsFlat);
+          && allColumnsSliceable(groupStore, groupCols) && aggColumnsFillable(groupStore, aggColsFlat, cdStringDict
+              ? cdBlock
+              : -1);
       if (promoteNow && !projectionWarmupPool.isShutdown()) {
         // ASYNC promotion: materialize on the owned warm-up lane while THIS query still serves
         // sliced — the synchronous form stalled the promoting query for the whole assembly

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -2393,7 +2393,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // SLICED first: only the aggregate + predicate columns' segments are read — the whole-leaf
     // materialization below is the cold-start whale and exists only as the fallback.
     final ProjectionColumnStore store = handle.columnStoreOrNull();
-    if (store != null && store.columnSliceable(col) && predsSliceable(store, preds)) {
+    if (store != null && store.columnFillable(col) && predsSliceable(store, preds)) {
       try {
         final int rgc = store.rowGroupCount();
         final int effS = Math.min(threads, Math.max(1, (rgc + 63) / 64));
@@ -2682,10 +2682,15 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    */
   private static final int SLICED_PROMOTE_AFTER = Integer.getInteger("sirix.projection.slicedPromoteAfter", 2);
 
-  /** Every listed column servable from slices (fail-closed gate for the sliced group route). */
+  /**
+   * Every listed column servable from slices (fail-closed gate for the sliced group route) —
+   * viability, not just kind: an over-budget column's fill declines inside the store, so gating on
+   * {@link ProjectionColumnStore#columnFillable} keeps this route from selecting an arm that cannot
+   * complete.
+   */
   private static boolean allColumnsSliceable(final ProjectionColumnStore store, final int[] cols) {
     for (final int col : cols) {
-      if (!store.columnSliceable(col)) {
+      if (!store.columnFillable(col)) {
         return false;
       }
     }
@@ -2739,7 +2744,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   private static boolean predsSliceable(final ProjectionColumnStore store,
       final ProjectionIndexScan.ColumnPredicate[] preds) {
     for (final ProjectionIndexScan.ColumnPredicate p : preds) {
-      if (!store.columnSliceable(p.column)) {
+      if (!store.columnFillable(p.column)) {
         return false;
       }
       // A SET column takes a string literal too — membership. Left out, it fell to the
@@ -3442,7 +3447,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // SLICED first (regime-gated): the payload route hydrates every column of every leaf to
       // read ONE dict column's entries — a first-touch materializer in a fresh process (Q6).
       final ProjectionColumnStore mmStore = handle.columnStoreOrNull();
-      if (mmStore != null && !handle.payloadsMaterialized() && mmStore.columnSliceable(col)) {
+      if (mmStore != null && !handle.payloadsMaterialized() && mmStore.columnFillable(col)) {
         try {
           final ProjectionColumnStore.ColumnSlice[] mmSlices = mmStore.column(col, fetcher);
           final int n = mmStore.rowGroupCount();
@@ -8003,27 +8008,9 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // Budget-aware: a handle whose worst-case resident bytes exceed the eager budget is served by
     // the windowed payload view — the route that lets fat string columns answer whole-leaf query
     // shapes (LIKE, distinct) at 100M instead of OOMing the whole-column materialization.
-    final Supplier<List<byte[]>> materializer = ProjectionIndexCatalog.rowGroupMaterializer(session, revision,
-        handle.defId(), store.rowGroupCount(), handle.projectedWeightBytes());
-    if (!ProjectionIndexCatalog.servesWindowedPayloads(handle.projectedWeightBytes())) {
-      return materializer;
-    }
-    // The shared handle deliberately does not memoize a windowed view (it would outlive this
-    // session and fetch through a closed one), so THIS executor memoizes it for its own lifetime —
-    // the exact lifetime of the session the view's fetcher is bound to. Without it every consult
-    // would redo the physical-order read and start from a cold window set.
-    return () -> windowedPayloadViews.computeIfAbsent(handle, memoized -> materializer.get());
+    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount(),
+        handle.projectedWeightBytes());
   }
-
-  /**
-   * Per-executor memo of the WINDOWED whole-leaf views, keyed by handle IDENTITY (a handle carries
-   * no value equality) — see {@link #rowGroupMaterializer(ProjectionIndexRegistry.Handle)}. Bounded
-   * by the number of projection handles this executor's queries touch, and dropped with the
-   * executor, so it holds nothing past its session. Only windowed views land here; an eager handle
-   * memoizes its own resident leaves and never consults the materializer again.
-   */
-  private final ConcurrentHashMap<ProjectionIndexRegistry.Handle, List<byte[]>> windowedPayloadViews =
-      new ConcurrentHashMap<>();
 
   /** The write transaction's index controller (wtx mode only). */
   private JsonIndexController wtxIndexController() {
@@ -10885,7 +10872,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     // SLICED first (regime-gated like the group kernels): the payload route hydrates every
     // column of every leaf to read ONE dict — the suite's first cold materializer (Q5).
     final ProjectionColumnStore cdStore = handle.columnStoreOrNull();
-    if (cdStore != null && !handle.payloadsMaterialized() && cdStore.columnSliceable(groupColumn)
+    if (cdStore != null && !handle.payloadsMaterialized() && cdStore.columnFillable(groupColumn)
         && cdStore.columnKind(groupColumn) == ProjectionIndexRowGroupPage.COLUMN_KIND_STRING_DICT) {
       try {
         final ProjectionColumnStore.ColumnSlice[] cdSlices = cdStore.column(groupColumn, columnFetcher());

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -11726,7 +11726,30 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     if (!sourcePathIsPresent(sourcePath)) {
       return null;
     }
+    return groupByAggregate(ctx, sourcePath, predicateOrNull, groupFields, keyNames, funcs, aggFields, outNames,
+        orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits,
+        keyCondElse, keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, false);
+  }
 
+  /**
+   * The group-aggregate body, with the sliced arm suppressible.
+   *
+   * <p>
+   * {@code wholeLeafOnly} exists for ONE transition: a column fill the store refuses on budget. The
+   * sliced arm cannot complete without those bytes, but the whole-leaf arm right beside it can —
+   * over an over-budget handle that arm IS the windowed byte-kernel scan the budget declined toward.
+   * Re-entering with the arm suppressed takes it, instead of dropping a query that has a viable
+   * projection route in hand all the way to the generic navigational pipeline.
+   * </p>
+   */
+  private ServedGroups groupByAggregate(final QueryContext ctx, final String[] sourcePath,
+      final PredicateNode predicateOrNull, final String[] groupFields, final String[] keyNames,
+      final String[] funcs, final String[] aggFields, final String[] outNames, final int[] orderIndexes,
+      final boolean[] orderAsc, final boolean[] orderEmptyLeast, final long limit, final long[] keyOffsets,
+      final int[] keySubstr, final String[] keyCondFields, final long[] keyCondLits,
+      final String[] keyCondElse, final String[] keyRegexPattern, final String[] keyRegexRepl,
+      final long[] keyDivMod, final boolean[] keyStringify, final long[] having,
+      final boolean wholeLeafOnly) {
     try {
       if (projectionRegistryKey == null || !anyProjectionAvailable()) {
         return declineGroupAgg("no projection available");
@@ -12077,15 +12100,16 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // ticking only on a successful slice would move the trigger point. What must not lie about
       // real serves is a different instrument: GROUP_AGG_SLICED_SERVED, ticked at the kernels
       // themselves and read by groupAggSlicedServedCount().
-      final boolean promoteNow = GROUP_SLICED_ENABLED && groupStore != null && !handle.payloadsMaterialized()
-          && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
+      final boolean promoteNow = GROUP_SLICED_ENABLED && !wholeLeafOnly && groupStore != null
+          && !handle.payloadsMaterialized() && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
       // Latch the ROUTE before the promotion is kicked, so the code enforces the invariant the
       // comment below states ("KEEP SERVING SLICED until it lands") rather than re-deriving it from
       // payloadsMaterialized() after the kick. This is hardening of a documented-but-unenforced
       // guarantee, NOT the fix for a reproducing race: the suspected intra-query window — the
       // background assembly landing between the kick and the re-read, demoting the very query that
       // triggered it — did not reproduce even at -Dsirix.projection.slicedPromoteAfter=1.
-      final boolean groupSliced = GROUP_SLICED_ENABLED && groupStore != null && !handle.payloadsMaterialized()
+      final boolean groupSliced = GROUP_SLICED_ENABLED && !wholeLeafOnly && groupStore != null
+          && !handle.payloadsMaterialized()
           && (tree == null
               ? predsSliceable(groupStore, preds)
               : treeSliceable(groupStore, tree))
@@ -13095,13 +13119,20 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       }
       return declineGroupAgg("per-group sum overflowed a long");
     } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
-      // Expected decline, not a defect: the store priced a column fill this arm would have needed
-      // and refused it, so the whole-leaf windowed route serves instead. Counting it would put a
-      // permanent false corruption signal under every query on a fat string column.
+      // Expected decline, not a defect: the store priced a column fill this arm needed and refused
+      // it. Counting it would put a permanent false corruption signal under every query on a fat
+      // string column. Re-enter over the WHOLE-LEAF arm, which for such a handle is the windowed
+      // byte-kernel scan — returning null here would hand a servable query to the generic
+      // navigational pipeline instead.
       if (PROJ_DIAG) {
         System.err.println("[proj] groupAgg sliced fill declined by budget: " + declined.getMessage());
       }
-      return null;
+      if (wholeLeafOnly) {
+        return declineGroupAgg("column fill over budget on the whole-leaf route too");
+      }
+      return groupByAggregate(ctx, sourcePath, predicateOrNull, groupFields, keyNames, funcs, aggFields, outNames,
+        orderIndexes, orderAsc, orderEmptyLeast, limit, keyOffsets, keySubstr, keyCondFields, keyCondLits,
+        keyCondElse, keyRegexPattern, keyRegexRepl, keyDivMod, keyStringify, having, true);
     } catch (final RuntimeException e) {
       // Fail soft — the compiled generic pipeline answers correctly. But an EXCEPTION
       // here (unlike a gate decline) means a defect or corruption, and a silent 100%
@@ -13154,7 +13185,13 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     if (!sourcePathIsPresent(sourcePath)) {
       return null;
     }
+    return constGroupAggregate(ctx, sourcePath, predicateOrNull, funcs, aggFields, offsets, outNames, false);
+  }
 
+  /** As above, with the sliced arm suppressible — see {@link #groupByAggregate}. */
+  private Sequence constGroupAggregate(final QueryContext ctx, final String[] sourcePath,
+      final PredicateNode predicateOrNull, final String[] funcs, final String[] aggFields, final long[] offsets,
+      final String[] outNames, final boolean wholeLeafOnly) {
     try {
       if (projectionRegistryKey == null || !anyProjectionAvailable()) {
         return null;
@@ -13229,11 +13266,12 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // conditions (and in the very order) it always did, while the route itself is latched before
       // the kick so "keep serving sliced until it lands" is enforced by the code and not only
       // promised by a comment. Hardening; the suspected intra-query demotion did not reproduce.
-      final boolean constPromoteNow = GROUP_SLICED_ENABLED && constStore != null && !handle.payloadsMaterialized()
-          && !projectionWarmupPool.isShutdown() && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
-      final boolean constSliced =
-          GROUP_SLICED_ENABLED && constStore != null && !anyStrlenAgg && !handle.payloadsMaterialized()
-              && predsSliceable(constStore, preds) && allColumnsSliceable(constStore, aggCols);
+      final boolean constPromoteNow = GROUP_SLICED_ENABLED && !wholeLeafOnly && constStore != null
+          && !handle.payloadsMaterialized() && !projectionWarmupPool.isShutdown()
+          && handle.slicedRouteTick() >= SLICED_PROMOTE_AFTER;
+      final boolean constSliced = GROUP_SLICED_ENABLED && !wholeLeafOnly && constStore != null && !anyStrlenAgg
+          && !handle.payloadsMaterialized() && predsSliceable(constStore, preds)
+          && allColumnsSliceable(constStore, aggCols);
       if (constPromoteNow) {
         handle.promoteInBackground(projectionWarmupPool, rowGroupMaterializer(handle));
       }
@@ -13343,12 +13381,16 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // decimal-promoting arithmetic via the generic pipeline.
       return null;
     } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
-      // Expected decline: the store refused a priced column fill; the whole-leaf windowed route
-      // serves instead, and no defect counter ticks.
+      // Expected decline: the store refused a priced column fill. Re-enter over the whole-leaf arm
+      // (the windowed byte-kernel scan for such a handle) rather than dropping to the generic
+      // pipeline, and tick no defect counter.
       if (PROJ_DIAG) {
         System.err.println("[proj] const-groupAgg sliced fill declined by budget: " + declined.getMessage());
       }
-      return null;
+      if (wholeLeafOnly) {
+        return null;
+      }
+      return constGroupAggregate(ctx, sourcePath, predicateOrNull, funcs, aggFields, offsets, outNames, true);
     } catch (final RuntimeException e) {
       GROUP_AGG_FAILED.increment();
       if (PROJ_DIAG) {

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -137,9 +137,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
@@ -754,6 +757,15 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   /** Cached field-name → int nameKey resolution. Keyed once per executor lifetime. */
   private final ConcurrentHashMap<String, Integer> fieldKeyCache = new ConcurrentHashMap<>();
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SirixVectorizedExecutor.class);
+
+  /** Shared daemon reaper joining retired executors' pools off the compile path — see {@link #retireAsync()}. */
+  private static final ExecutorService RETIREMENT_REAPER = Executors.newSingleThreadExecutor(r -> {
+    final Thread thread = new Thread(r, "sirix-executor-retirement");
+    thread.setDaemon(true);
+    return thread;
+  });
+
   /**
    * Per-field cache of the {@code {count, sum, min, max}} tuple produced by
    * {@link #parallelAggregate(String)}. The executor is scoped to a single (session, revision), so
@@ -1052,6 +1064,38 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   /**
+   * Retire without blocking the caller. {@link #retire()} joins the warm-up and worker pools, and
+   * a running whole-leaf warm-up materialization is uncancellable (its parallel arm runs through
+   * {@code ForkJoinTask.invoke}, which ignores interrupts) — retiring synchronously on the compile
+   * path serialized every compile of the chain, and every executor-cache overflow, behind a
+   * potentially multi-GB read. The queue drain and shutdown still run HERE, synchronously (see
+   * {@link #initiatePoolShutdown}); only the join moves to the shared reaper. The caller has
+   * already unpublished this executor, so no new work reaches it, and in-flight scans complete
+   * exactly as under a synchronous retire.
+   */
+  public void retireAsync() {
+    initiatePoolShutdown(false);
+    try {
+      RETIREMENT_REAPER.execute(() -> {
+        try {
+          awaitPoolTermination(false);
+        } catch (final RuntimeException | Error failure) {
+          LOGGER.warn("Background executor retirement failed", failure);
+        } finally {
+          executionLifecycle.unregister(this);
+        }
+      });
+    } catch (final RejectedExecutionException reaperGone) {
+      // JVM shutdown took the reaper: fall back to the synchronous join.
+      try {
+        awaitPoolTermination(false);
+      } finally {
+        executionLifecycle.unregister(this);
+      }
+    }
+  }
+
+  /**
    * Terminally close this executor. Later parallel work is rejected and every locally accepted call
    * is drained. A standalone executor also closes its private execution lifetime; chain-owned
    * executors share a lifetime which {@link io.sirix.query.SirixCompileChain} closes once for all
@@ -1069,7 +1113,17 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   private void shutdownPoolsAndAwait(final boolean terminal) {
-    boolean interrupted = false;
+    initiatePoolShutdown(terminal);
+    awaitPoolTermination(terminal);
+  }
+
+  /**
+   * The non-blocking half of a shutdown: reject new work, drain queued warm-ups, and run their
+   * cancellation hooks. Runs synchronously in every retirement flavour — queued warm-ups carry
+   * cancellation hooks whose one-shot latches in-flight readers may await, so this must never
+   * queue behind another executor's slow termination.
+   */
+  private void initiatePoolShutdown(final boolean terminal) {
     synchronized (workerPoolLifecycleLock) {
       if (terminal) {
         terminallyClosed = true;
@@ -1096,6 +1150,11 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       }
       workerPool.shutdown();
     }
+  }
+
+  /** The blocking half: join both pools, release the worker cursors, and terminally drain calls. */
+  private void awaitPoolTermination(final boolean terminal) {
+    boolean interrupted = false;
 
     // A private lifetime has no sibling executors, so terminal close owns its admission fence and
     // detached cursors. A chain closes its shared lifetime before closing the cached executors.
@@ -7941,7 +8000,11 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     if (store == null) {
       return null;
     }
-    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount());
+    // Budget-aware: a handle whose worst-case resident bytes exceed the eager budget is served by
+    // the windowed payload view — the route that lets fat string columns answer whole-leaf query
+    // shapes (LIKE, distinct) at 100M instead of OOMing the whole-column materialization.
+    return ProjectionIndexCatalog.rowGroupMaterializer(session, revision, handle.defId(), store.rowGroupCount(),
+        handle.projectedWeightBytes());
   }
 
   /** The write transaction's index controller (wtx mode only). */

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -14568,6 +14568,16 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
         }
       }
       return new ItemSequence(items.toArray(new Item[0]));
+    } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
+      // The store priced a fill this route needed and refused it. This route has no whole-leaf
+      // twin — it exists to skip the keys/records/deref tail — so the caller's record path answers.
+      // Countable as a DECLINE: ticking the defect counter would put a permanent false corruption
+      // signal under every value emission on a fat string column.
+      PREDICATE_VALUE_EMISSION_DECLINED.increment();
+      if (PROJ_DIAG) {
+        System.err.println("[proj] predicate value emission declined by budget: " + declined.getMessage());
+      }
+      return null;
     } catch (final RuntimeException e) {
       PREDICATE_VALUE_EMISSION_FAILED.increment();
       if (PROJ_DIAG) {
@@ -14579,6 +14589,17 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
 
   public long[] sortedScanRecordKeys(final String[] sourcePath, final PredicateNode predicateOrNull,
       final String[] orderFields, final boolean[] descending, final long limit) {
+    return sortedScanRecordKeys(sourcePath, predicateOrNull, orderFields, descending, limit, false);
+  }
+
+  /**
+   * The sorted-scan body, with the sliced arm suppressible — the same one transition the group arms
+   * make. A column fill the store refuses on budget cannot be served sliced, but the whole-leaf
+   * branch below (over windowed payloads for an over-budget handle) can, so the decline re-enters
+   * there instead of dropping a servable query to the generic navigational pipeline.
+   */
+  private long[] sortedScanRecordKeys(final String[] sourcePath, final PredicateNode predicateOrNull,
+      final String[] orderFields, final boolean[] descending, final long limit, final boolean wholeLeafOnly) {
     try {
       if (projectionRegistryKey == null || !anyProjectionAvailable()) {
         return null;
@@ -14634,7 +14655,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       // the KEYS chain — never a whole leaf — and for a LIMIT the bounded heap prunes leaves
       // by zone bounds DURING collection, the R2 "heap over zone-map-pruned leaves" shape.
       final ProjectionColumnStore store = handle.columnStoreOrNull();
-      final boolean sliced = store != null && predsSliceable(store, preds);
+      final boolean sliced = !wholeLeafOnly && store != null && predsSliceable(store, preds);
       if (anyStringKey && !(sliced && limit >= 0)) {
         return null;
       }
@@ -14731,6 +14752,17 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       for (int i = 0; i < n; i++)
         out[i] = keys.getLong(order[i]);
       return out;
+    } catch (final ProjectionColumnStore.FillBudgetExceededException declined) {
+      // Expected decline, not a defect: the store refused a priced fill. Re-enter over the
+      // whole-leaf arm, which for an over-budget handle is the windowed byte-kernel scan.
+      if (PROJ_DIAG) {
+        System.err.println("[proj] sorted-scan sliced fill declined by budget: " + declined.getMessage());
+      }
+      if (wholeLeafOnly) {
+        SORTED_SCAN_DECLINED.increment();
+        return null;
+      }
+      return sortedScanRecordKeys(sourcePath, predicateOrNull, orderFields, descending, limit, true);
     } catch (final RuntimeException e) {
       SORTED_SCAN_FAILED.increment();
       if (PROJ_DIAG) {
@@ -14795,6 +14827,14 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   /** Sorted-scan serving attempts that FAILED with an exception (not gate declines). */
+  /** Sorted scans that declined on a priced fill BOTH sliced and whole-leaf — a route decision. */
+  private static final LongAdder SORTED_SCAN_DECLINED = new LongAdder();
+
+  /** Test/ops observability for {@link #SORTED_SCAN_DECLINED}. */
+  public static long sortedScanDeclinedCount() {
+    return SORTED_SCAN_DECLINED.sum();
+  }
+
   private static final LongAdder SORTED_SCAN_FAILED = new LongAdder();
 
   /** Test/ops observability for {@link #SORTED_SCAN_FAILED}. */
@@ -14825,6 +14865,14 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   }
 
   /** Value-emission attempts that FAILED with an exception (not gate declines). */
+  /** Value emissions that declined on a priced fill — a route decision, not corruption. */
+  private static final LongAdder PREDICATE_VALUE_EMISSION_DECLINED = new LongAdder();
+
+  /** Test/ops observability for {@link #PREDICATE_VALUE_EMISSION_DECLINED}. */
+  public static long predicateValueEmissionDeclinedCount() {
+    return PREDICATE_VALUE_EMISSION_DECLINED.sum();
+  }
+
   private static final LongAdder PREDICATE_VALUE_EMISSION_FAILED = new LongAdder();
 
   /** Test/ops observability for {@link #PREDICATE_VALUE_EMISSION_FAILED}. */

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -13158,6 +13158,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
       Long.getLong("sirix.projection.groupDistinct.maxValues", 1L << 24);
 
   /** Constant-key group-bys served in one scalar pass (test oracle, same doctrine as the rest). */
+  private static final LongAdder CONST_GROUP_AGG_SERVED = new LongAdder();
+
   /**
    * The const-group twin of {@link #declineGroupAgg}: a decline that falls to the generic pipeline
    * must move a counter, or a route that stopped serving reads exactly like one that was never
@@ -13173,8 +13175,6 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     }
     return null;
   }
-
-  private static final LongAdder CONST_GROUP_AGG_SERVED = new LongAdder();
 
   /** Test observability for {@link #CONST_GROUP_AGG_SERVED}. */
   public static long constGroupAggServedCount() {

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -1050,8 +1050,7 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
-  public void anOverBudgetColumnRoutesToTheWholeLeafKernelInsteadOfDecliningIntoTheSlicedArm()
-      throws IOException {
+  public void anOverBudgetColumnRoutesToTheWholeLeafKernelInsteadOfDecliningIntoTheSlicedArm() throws IOException {
     // A whole-column slice fill declines through the store's budget door. Kind-sliceability knows
     // nothing about that budget, so a planner gating on kind alone selects the sliced arm, the fill
     // then throws, and the exception lands in the group route's fail-soft catch — which increments
@@ -2301,8 +2300,8 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
         """);
     ProjectionIndexRegistry.clear();
     ProjectionIndexCatalog.clearCache();
-    final String sortedQuery = "let $doc := jn:doc('json-path1','budgetsorted.jn')\n"
-        + "for $r in $doc[] order by $r.age return $r";
+    final String sortedQuery =
+        "let $doc := jn:doc('json-path1','budgetsorted.jn')\n" + "for $r in $doc[] order by $r.age return $r";
     try (
         final BasicJsonDBStore store =
             BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
@@ -2314,8 +2313,8 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       final long ageBytes;
       try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
         final ProjectionIndexRegistry.Handle handle =
-            session.getRtxIndexController(revision).openProjectionIndex(rtx.getStorageEngineReader(),
-                new String[] {"[]"}, new String[] {"age", "tag"});
+            session.getRtxIndexController(revision)
+                   .openProjectionIndex(rtx.getStorageEngineReader(), new String[] {"[]"}, new String[] {"age", "tag"});
         Assertions.assertNotNull(handle, "the projection must be servable");
         final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
         Assertions.assertNotNull(columnStore);
@@ -2362,8 +2361,15 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       }
       // A SHORT group key beside a LONG predicate column, so one column's fill fits a budget the
       // other's does not — which is the whole point: the arm is selected, then the door refuses.
-      corpus.append("{\"dept\":\"d").append(i % 4).append("\",\"age\":").append(20 + i)
-            .append(",\"city\":\"").append("metropolis-").append("qwertyuiop".repeat(12)).append(i).append("\"}");
+      corpus.append("{\"dept\":\"d")
+            .append(i % 4)
+            .append("\",\"age\":")
+            .append(20 + i)
+            .append(",\"city\":\"")
+            .append("metropolis-")
+            .append("qwertyuiop".repeat(12))
+            .append(i)
+            .append("\"}");
     }
     query("jn:store('json-path1','budgetcontains.jn','" + corpus.append(']') + "')");
     query("""
@@ -2395,10 +2401,10 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       final long deptBytes;
       final long cityBytes;
       try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
-        final ProjectionIndexRegistry.Handle handle = session.getRtxIndexController(revision)
-                                                             .openProjectionIndex(rtx.getStorageEngineReader(),
-                                                                 new String[] {"[]"},
-                                                                 new String[] {"dept", "age", "city"});
+        final ProjectionIndexRegistry.Handle handle =
+            session.getRtxIndexController(revision)
+                   .openProjectionIndex(rtx.getStorageEngineReader(), new String[] {"[]"},
+                       new String[] {"dept", "age", "city"});
         Assertions.assertNotNull(handle, "the projection must be servable");
         final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
         Assertions.assertNotNull(columnStore, "the handle must be column-lazy for this test to price columns");
@@ -2456,8 +2462,16 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       if (i > 0) {
         predCorpus.append(',');
       }
-      predCorpus.append("{\"uid\":").append(i % 3 == 0 ? 7 : 3).append(",\"name\":\"n").append(i)
-                .append("\",\"grp\":\"").append("groupvalue-".repeat(24)).append(i % 3).append("\"}");
+      predCorpus.append("{\"uid\":")
+                .append(i % 3 == 0
+                    ? 7
+                    : 3)
+                .append(",\"name\":\"n")
+                .append(i)
+                .append("\",\"grp\":\"")
+                .append("groupvalue-".repeat(24))
+                .append(i % 3)
+                .append("\"}");
     }
     query("jn:store('json-path1','budgetpredscan.jn','" + predCorpus.append(']') + "')");
     query("""
@@ -2472,8 +2486,8 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
     // An ABSENT literal: every leaf's fingerprint misses, so the prune drops them all and the
     // masked fetch reads no segment at all — the cheapest possible serve, and the one the
     // whole-column budget was rejecting.
-    final String absentLookup =
-        "let $doc := jn:doc('json-path1','budgetpredscan.jn')\n" + "for $r in $doc[] where $r.grp = \"nowhere\" return $r";
+    final String absentLookup = "let $doc := jn:doc('json-path1','budgetpredscan.jn')\n"
+        + "for $r in $doc[] where $r.grp = \"nowhere\" return $r";
     try (
         final BasicJsonDBStore store =
             BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
@@ -2488,10 +2502,10 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       final long grpBytes;
       final long keysBytes;
       try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
-        final ProjectionIndexRegistry.Handle handle = session.getRtxIndexController(revision)
-                                                             .openProjectionIndex(rtx.getStorageEngineReader(),
-                                                                 new String[] {"[]"},
-                                                                 new String[] {"uid", "name", "grp"});
+        final ProjectionIndexRegistry.Handle handle =
+            session.getRtxIndexController(revision)
+                   .openProjectionIndex(rtx.getStorageEngineReader(), new String[] {"[]"},
+                       new String[] {"uid", "name", "grp"});
         Assertions.assertNotNull(handle, "the projection must be servable");
         final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
         Assertions.assertNotNull(columnStore);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -2378,16 +2378,17 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
     // fill projection therefore refuses a point lookup that would have read almost nothing, and the
     // query falls all the way to the generic navigational pipeline. The route gate has to ask about
     // the fill the route will actually perform.
-    query("""
-          jn:store('json-path1','budgetpredscan.jn','[
-            {"uid": 7, "name": "a", "grp": "x"},
-            {"uid": 3, "name": "b", "grp": "y"},
-            {"uid": 7, "name": "c", "grp": "x"},
-            {"uid": 9, "name": "d"},
-            {"uid": 7, "name": "e", "grp": "z"},
-            {"uid": 3, "name": "f", "grp": "x"}
-          ]')
-        """);
+    // LONG grp values: the point of the budget here is that the whole-COLUMN fill is refused while
+    // the pruned fetch is not, so the column has to be the expensive thing in the store.
+    final StringBuilder predCorpus = new StringBuilder(4096).append('[');
+    for (int i = 0; i < 6; i++) {
+      if (i > 0) {
+        predCorpus.append(',');
+      }
+      predCorpus.append("{\"uid\":").append(i % 3 == 0 ? 7 : 3).append(",\"name\":\"n").append(i)
+                .append("\",\"grp\":\"").append("groupvalue-".repeat(24)).append(i % 3).append("\"}");
+    }
+    query("jn:store('json-path1','budgetpredscan.jn','" + predCorpus.append(']') + "')");
     query("""
           let $doc := jn:doc('json-path1','budgetpredscan.jn')
           let $stats := jn:create-projection-index($doc, '/[]',
@@ -2409,12 +2410,30 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
         final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
       final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
       final JsonResourceSession session = collection.getDatabase().beginResourceSession("budgetpredscan.jn");
+      final int revision = session.getMostRecentRevisionNumber();
+      // A budget that refuses the WHOLE-COLUMN fill of the predicate column but admits the route's
+      // own record-key fill. Budgeting below the keys too would refuse the route for a reason that
+      // has nothing to do with the pruning under test — the keys are its result, not its cost.
+      final long grpBytes;
+      final long keysBytes;
+      try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
+        final ProjectionIndexRegistry.Handle handle = session.getRtxIndexController(revision)
+                                                             .openProjectionIndex(rtx.getStorageEngineReader(),
+                                                                 new String[] {"[]"},
+                                                                 new String[] {"uid", "name", "grp"});
+        Assertions.assertNotNull(handle, "the projection must be servable");
+        final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
+        Assertions.assertNotNull(columnStore);
+        grpBytes = columnStore.projectedColumnFillBytes(handle.columnOf("grp"));
+        keysBytes = columnStore.projectedRecordKeysFillBytes();
+      }
+      Assertions.assertTrue(keysBytes < grpBytes,
+          "the record keys must be cheaper than the whole predicate column: " + keysBytes + " vs " + grpBytes);
       final SirixCompileChain genericChain = SirixCompileChain.createWithJsonStoreWithoutAutoWiring(store);
       final String generic = evaluateQuery(genericChain, ctx, absentLookup);
-      final SirixVectorizedExecutor executor =
-          new SirixVectorizedExecutor(session, session.getMostRecentRevisionNumber(), 2);
+      final SirixVectorizedExecutor executor = new SirixVectorizedExecutor(session, revision, 2);
       SequentialPipelineStrategy.setVectorizedExecutor(executor);
-      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(1L);
+      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(grpBytes - 1);
       try {
         final long servedBefore = SirixVectorizedExecutor.predicateScanServedCount();
         Assertions.assertEquals(generic, evaluateQuery(chain, ctx, absentLookup),

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -2347,10 +2347,22 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
       try {
         Assertions.assertTrue(deptBytes <= cityBytes - 1, "the group key must stay within the chosen budget");
         final long failedBefore = SirixVectorizedExecutor.groupAggFailedCount();
+        final long declinedBefore = SirixVectorizedExecutor.groupAggregateDeclinedCount();
+        final long servedBefore = SirixVectorizedExecutor.groupAggServedCount();
+        final long slicedBefore = SirixVectorizedExecutor.groupAggSlicedServedCount();
         Assertions.assertEquals(generic, evaluateQuery(chain, ctx, containsGroupBy),
             "the answer must not change with the fill budget");
         Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggFailedCount() - failedBefore,
             "a priced fill refusal is a routing decision, not a corruption signal");
+        // The refusal must land on the WHOLE-LEAF arm, which for this handle is the byte-kernel
+        // scan over projection leaves — not on the generic navigational pipeline. Returning null
+        // here would leave both of these flat and walk every record instead.
+        Assertions.assertEquals(1L, SirixVectorizedExecutor.groupAggServedCount() - servedBefore,
+            "the query must still be SERVED from the projection, by the whole-leaf arm");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggSlicedServedCount() - slicedBefore,
+            "the sliced arm cannot serve a column whose fill the store refuses");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggregateDeclinedCount() - declinedBefore,
+            "a decline that re-routes successfully must not count as a route decline");
       } finally {
         ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
         SequentialPipelineStrategy.setVectorizedExecutor(null);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -1050,6 +1050,81 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
+  public void anOverBudgetColumnRoutesToTheWholeLeafKernelInsteadOfDecliningIntoTheSlicedArm()
+      throws IOException {
+    // A whole-column slice fill declines through the store's budget door. Kind-sliceability knows
+    // nothing about that budget, so a planner gating on kind alone selects the sliced arm, the fill
+    // then throws, and the exception lands in the group route's fail-soft catch — which increments
+    // GROUP_AGG_FAILED (documented to mean a defect or corruption) and drops the query to the
+    // GENERIC pipeline, the slowest route there is. The route must be chosen on VIABILITY, so an
+    // over-budget column goes to the whole-leaf byte kernel, still served from the projection.
+    query("""
+          jn:store('json-path1','budgetgroupstr.jn','[
+            {"dept": "Eng",   "age": 30, "city": "Berlin"},
+            {"dept": "Eng",   "age": 45, "city": "Muc"},
+            {"dept": "Sales", "age": 50, "city": "Ulm"},
+            {"age": 99, "city": "Bonn"},
+            {"dept": "HR",    "age": 23},
+            {"dept": "Eng",   "age": 4,  "city": "X"}
+          ]')
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','budgetgroupstr.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/dept', '/[]/age', '/[]/city'),
+              ('string', 'long', 'string'))
+          return {"revision": sdb:commit($doc)}
+        """);
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+
+    final String topKQuery = """
+          subsequence(
+            for $r in jn:doc('json-path1','budgetgroupstr.jn')[]
+            where $r.age gt 5
+            let $d := $r.dept, $len := fn:string-length($r.city)
+            group by $d
+            let $c := count($r)
+            order by $c descending
+            return {"d": $d, "c": $c, "total": sum($r.age),
+                    "slen": sum($len)}, 1, 3)
+        """;
+    try (
+        final BasicJsonDBStore store =
+            BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
+        final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+        final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
+      final JsonResourceSession session = collection.getDatabase().beginResourceSession("budgetgroupstr.jn");
+      // Oracle on a NON-auto-wiring chain, computed BEFORE the budget is shrunk — see the string
+      // twin above for the full reasoning.
+      final SirixCompileChain genericChain = SirixCompileChain.createWithJsonStoreWithoutAutoWiring(store);
+      final String generic = evaluateQuery(genericChain, ctx, topKQuery);
+      final SirixVectorizedExecutor executor =
+          new SirixVectorizedExecutor(session, session.getMostRecentRevisionNumber(), 2);
+      SequentialPipelineStrategy.setVectorizedExecutor(executor);
+      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(1L);
+      try {
+        final long aggBefore = SirixVectorizedExecutor.groupAggServedCount();
+        final long slicedBefore = SirixVectorizedExecutor.groupAggSlicedServedCount();
+        final long failedBefore = SirixVectorizedExecutor.groupAggFailedCount();
+        final String served = evaluateQuery(chain, ctx, topKQuery);
+        Assertions.assertEquals(generic, served, "the answer must not change with the fill budget");
+        Assertions.assertEquals(1L, SirixVectorizedExecutor.groupAggServedCount() - aggBefore,
+            "an over-budget column must still be SERVED from the projection, by the whole-leaf kernel");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggSlicedServedCount() - slicedBefore,
+            "the sliced arm cannot serve a column whose fill the store refuses");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggFailedCount() - failedBefore,
+            "routing into a fill that declines raises a false defect signal");
+      } finally {
+        ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+        SequentialPipelineStrategy.setVectorizedExecutor(null);
+        executor.close();
+      }
+    }
+  }
+
+  @Test
   public void compositeTopKGroupAggregatesServeFromColumnSlices() throws IOException {
     // Unit 4 twin: the COMPOSITE flat arm (Q11 shape — numeric + string 2-key, COUNT(DISTINCT),
     // ordered + capped) must serve from column slices. The record missing `model` exercises the

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -2278,6 +2278,77 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
+  public void anOverBudgetSortedScanReEntersTheWholeLeafArmInsteadOfCountingAsCorruption() throws IOException {
+    // The sorted scan performs an unmasked whole-column fill of its ORDER columns, so an
+    // over-budget column reaches the store's decline door. That decline used to escape to the
+    // route's generic RuntimeException handler, which ticks SORTED_SCAN_FAILED — a defect signal —
+    // and dropped the query to the generic navigational pipeline, even though the route has a
+    // whole-leaf byte-scan arm right beside the sliced one.
+    final StringBuilder corpus = new StringBuilder(4096).append('[');
+    for (int i = 0; i < 64; i++) {
+      if (i > 0) {
+        corpus.append(',');
+      }
+      corpus.append("{\"age\":").append((i * 37) % 101).append(",\"tag\":\"t").append(i % 5).append("\"}");
+    }
+    query("jn:store('json-path1','budgetsorted.jn','" + corpus.append(']') + "')");
+    query("""
+          let $doc := jn:doc('json-path1','budgetsorted.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/age', '/[]/tag'),
+              ('long', 'string'))
+          return {"revision": sdb:commit($doc)}
+        """);
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+    final String sortedQuery = "let $doc := jn:doc('json-path1','budgetsorted.jn')\n"
+        + "for $r in $doc[] order by $r.age return $r";
+    try (
+        final BasicJsonDBStore store =
+            BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
+        final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+        final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
+      final JsonResourceSession session = collection.getDatabase().beginResourceSession("budgetsorted.jn");
+      final int revision = session.getMostRecentRevisionNumber();
+      final long ageBytes;
+      try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
+        final ProjectionIndexRegistry.Handle handle =
+            session.getRtxIndexController(revision).openProjectionIndex(rtx.getStorageEngineReader(),
+                new String[] {"[]"}, new String[] {"age", "tag"});
+        Assertions.assertNotNull(handle, "the projection must be servable");
+        final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
+        Assertions.assertNotNull(columnStore);
+        ageBytes = columnStore.projectedColumnFillBytes(handle.columnOf("age"));
+      }
+      final SirixCompileChain genericChain = SirixCompileChain.createWithJsonStoreWithoutAutoWiring(store);
+      final String generic = evaluateQuery(genericChain, ctx, sortedQuery);
+      final SirixVectorizedExecutor executor = new SirixVectorizedExecutor(session, revision, 2);
+      SequentialPipelineStrategy.setVectorizedExecutor(executor);
+      // Just under the ORDER column's own projection: the sliced arm cannot fill it, the whole-leaf
+      // arm can.
+      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(ageBytes - 1);
+      try {
+        final long failedBefore = SirixVectorizedExecutor.sortedScanFailedCount();
+        final long declinedBefore = SirixVectorizedExecutor.sortedScanDeclinedCount();
+        final long servedBefore = SirixVectorizedExecutor.sortedScanServedCount();
+        Assertions.assertEquals(generic, evaluateQuery(chain, ctx, sortedQuery),
+            "the answer must not change with the fill budget");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.sortedScanFailedCount() - failedBefore,
+            "a priced fill refusal is a routing decision, not a corruption signal");
+        Assertions.assertEquals(1L, SirixVectorizedExecutor.sortedScanServedCount() - servedBefore,
+            "the sorted scan must still be SERVED, by the whole-leaf arm it already has");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.sortedScanDeclinedCount() - declinedBefore,
+            "a decline that re-routes successfully must not count as a route decline");
+      } finally {
+        ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+        SequentialPipelineStrategy.setVectorizedExecutor(null);
+        executor.close();
+      }
+    }
+  }
+
+  @Test
   public void anOverBudgetPredicateColumnDeclinesQuietlyInsteadOfCountingAsCorruption() throws IOException {
     // A CONTAINS literal cannot be bloom-pruned (fingerprints hash whole values), so the predicate
     // column takes the UNMASKED door and the store prices it against the fill budget. That decline

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -2278,6 +2278,88 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
+  public void anOverBudgetPredicateColumnDeclinesQuietlyInsteadOfCountingAsCorruption() throws IOException {
+    // A CONTAINS literal cannot be bloom-pruned (fingerprints hash whole values), so the predicate
+    // column takes the UNMASKED door and the store prices it against the fill budget. That decline
+    // used to land in the group arm's generic RuntimeException handler, whose own comment says an
+    // exception there "means a defect or corruption": every such query ticked GROUP_AGG_FAILED. A
+    // priced refusal is a routing decision, not a defect, and must be distinguishable from one.
+    final StringBuilder corpus = new StringBuilder(4096).append('[');
+    for (int i = 0; i < 64; i++) {
+      if (i > 0) {
+        corpus.append(',');
+      }
+      // A SHORT group key beside a LONG predicate column, so one column's fill fits a budget the
+      // other's does not — which is the whole point: the arm is selected, then the door refuses.
+      corpus.append("{\"dept\":\"d").append(i % 4).append("\",\"age\":").append(20 + i)
+            .append(",\"city\":\"").append("metropolis-").append("qwertyuiop".repeat(12)).append(i).append("\"}");
+    }
+    query("jn:store('json-path1','budgetcontains.jn','" + corpus.append(']') + "')");
+    query("""
+          let $doc := jn:doc('json-path1','budgetcontains.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/dept', '/[]/age', '/[]/city'),
+              ('string', 'long', 'string'))
+          return {"revision": sdb:commit($doc)}
+        """);
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+    final String containsGroupBy = """
+          for $r in jn:doc('json-path1','budgetcontains.jn')[]
+          where contains($r.city, "metropolis")
+          let $d := $r.dept
+          group by $d
+          let $c := count($r)
+          order by $c descending
+          return {"d": $d, "c": $c, "total": sum($r.age)}
+        """;
+    try (
+        final BasicJsonDBStore store =
+            BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
+        final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+        final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
+      final JsonResourceSession session = collection.getDatabase().beginResourceSession("budgetcontains.jn");
+      final int revision = session.getMostRecentRevisionNumber();
+      final long deptBytes;
+      final long cityBytes;
+      try (final var rtx = session.beginNodeReadOnlyTrx(revision)) {
+        final ProjectionIndexRegistry.Handle handle = session.getRtxIndexController(revision)
+                                                             .openProjectionIndex(rtx.getStorageEngineReader(),
+                                                                 new String[] {"[]"},
+                                                                 new String[] {"dept", "age", "city"});
+        Assertions.assertNotNull(handle, "the projection must be servable");
+        final ProjectionColumnStore columnStore = handle.columnStoreOrNull();
+        Assertions.assertNotNull(columnStore, "the handle must be column-lazy for this test to price columns");
+        deptBytes = columnStore.projectedColumnFillBytes(handle.columnOf("dept"));
+        cityBytes = columnStore.projectedColumnFillBytes(handle.columnOf("city"));
+      }
+      Assertions.assertTrue(cityBytes > deptBytes,
+          "the predicate column must project larger than the group key: " + cityBytes + " vs " + deptBytes);
+
+      final SirixCompileChain genericChain = SirixCompileChain.createWithJsonStoreWithoutAutoWiring(store);
+      final String generic = evaluateQuery(genericChain, ctx, containsGroupBy);
+      final SirixVectorizedExecutor executor = new SirixVectorizedExecutor(session, revision, 2);
+      SequentialPipelineStrategy.setVectorizedExecutor(executor);
+      // Between the two: the group key's fill is affordable so the sliced arm IS selected, and the
+      // predicate column's fill is not so the store refuses it once the arm is under way.
+      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(cityBytes - 1);
+      try {
+        Assertions.assertTrue(deptBytes <= cityBytes - 1, "the group key must stay within the chosen budget");
+        final long failedBefore = SirixVectorizedExecutor.groupAggFailedCount();
+        Assertions.assertEquals(generic, evaluateQuery(chain, ctx, containsGroupBy),
+            "the answer must not change with the fill budget");
+        Assertions.assertEquals(0L, SirixVectorizedExecutor.groupAggFailedCount() - failedBefore,
+            "a priced fill refusal is a routing decision, not a corruption signal");
+      } finally {
+        ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+        SequentialPipelineStrategy.setVectorizedExecutor(null);
+        executor.close();
+      }
+    }
+  }
+
+  @Test
   public void aBloomPrunedPointLookupStillServesWhenTheWholeColumnFillIsOverBudget() throws IOException {
     // A predicate column is fetched MASKED once the bloom fingerprints prune leaves — a fraction of
     // the column, and no budget door stands in front of it. Gating that route on the WHOLE-column

--- a/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/ProjectionIndexCatalogServingTest.java
@@ -2278,6 +2278,64 @@ public final class ProjectionIndexCatalogServingTest extends AbstractJsonTest {
   }
 
   @Test
+  public void aBloomPrunedPointLookupStillServesWhenTheWholeColumnFillIsOverBudget() throws IOException {
+    // A predicate column is fetched MASKED once the bloom fingerprints prune leaves — a fraction of
+    // the column, and no budget door stands in front of it. Gating that route on the WHOLE-column
+    // fill projection therefore refuses a point lookup that would have read almost nothing, and the
+    // query falls all the way to the generic navigational pipeline. The route gate has to ask about
+    // the fill the route will actually perform.
+    query("""
+          jn:store('json-path1','budgetpredscan.jn','[
+            {"uid": 7, "name": "a", "grp": "x"},
+            {"uid": 3, "name": "b", "grp": "y"},
+            {"uid": 7, "name": "c", "grp": "x"},
+            {"uid": 9, "name": "d"},
+            {"uid": 7, "name": "e", "grp": "z"},
+            {"uid": 3, "name": "f", "grp": "x"}
+          ]')
+        """);
+    query("""
+          let $doc := jn:doc('json-path1','budgetpredscan.jn')
+          let $stats := jn:create-projection-index($doc, '/[]',
+              ('/[]/uid', '/[]/name', '/[]/grp'),
+              ('long', 'string', 'string'))
+          return {"revision": sdb:commit($doc)}
+        """);
+    ProjectionIndexRegistry.clear();
+    ProjectionIndexCatalog.clearCache();
+    // An ABSENT literal: every leaf's fingerprint misses, so the prune drops them all and the
+    // masked fetch reads no segment at all — the cheapest possible serve, and the one the
+    // whole-column budget was rejecting.
+    final String absentLookup =
+        "let $doc := jn:doc('json-path1','budgetpredscan.jn')\n" + "for $r in $doc[] where $r.grp = \"nowhere\" return $r";
+    try (
+        final BasicJsonDBStore store =
+            BasicJsonDBStore.newBuilder().location(JsonTestHelper.PATHS.PATH1.getFile().getParent()).build();
+        final SirixQueryContext ctx = SirixQueryContext.createWithJsonStore(store);
+        final SirixCompileChain chain = SirixCompileChain.createWithJsonStore(store)) {
+      final JsonDBCollection collection = (JsonDBCollection) store.lookup("json-path1");
+      final JsonResourceSession session = collection.getDatabase().beginResourceSession("budgetpredscan.jn");
+      final SirixCompileChain genericChain = SirixCompileChain.createWithJsonStoreWithoutAutoWiring(store);
+      final String generic = evaluateQuery(genericChain, ctx, absentLookup);
+      final SirixVectorizedExecutor executor =
+          new SirixVectorizedExecutor(session, session.getMostRecentRevisionNumber(), 2);
+      SequentialPipelineStrategy.setVectorizedExecutor(executor);
+      final long priorBudget = ProjectionColumnStore.setColumnFillBudgetBytesForTesting(1L);
+      try {
+        final long servedBefore = SirixVectorizedExecutor.predicateScanServedCount();
+        Assertions.assertEquals(generic, evaluateQuery(chain, ctx, absentLookup),
+            "the answer must not change with the fill budget");
+        Assertions.assertEquals(1L, SirixVectorizedExecutor.predicateScanServedCount() - servedBefore,
+            "a bloom-pruned point lookup must still be SERVED by the predicate-scan route");
+      } finally {
+        ProjectionColumnStore.setColumnFillBudgetBytesForTesting(priorBudget);
+        SequentialPipelineStrategy.setVectorizedExecutor(null);
+        executor.close();
+      }
+    }
+  }
+
+  @Test
   public void predicateScansServeFilteredRowsInDocumentOrder() throws IOException {
     // Stage 7d: `for $r in P where p return $r [.field]` — record keys straight from the
     // predicate mask, materialized per record. Document order is the contract; multi-match

--- a/docs/BENCHMARK_CAMPAIGNS.md
+++ b/docs/BENCHMARK_CAMPAIGNS.md
@@ -152,9 +152,11 @@ suite 2.79× → 2.63×. Corpus grows +7 % on disk.
 ### 4.3 Async promotion of the projection payloads
 
 The projection can serve two ways: *sliced* (decode per-column segments on demand — wins
-cold, because it reads only what the query needs) and *byte-kernel* (operate on fully
-materialized row-group payloads — wins hot). Originally a query that noticed the hot
-regime *synchronously* materialized all payloads, stalling that query 150–250 ms.
+cold, because it reads only what the query needs) and *byte-kernel* (operate on materialized
+row-group payloads — wins hot; a projection too large for the eager budget materializes
+those payloads in bounded windows instead, see `PROJECTION_INDEXES.md`). Originally a query
+that noticed the hot regime *synchronously* materialized all payloads, stalling that query
+150–250 ms.
 Promotion now happens on a background daemon thread after the second sliced serve; the
 serving path flips over only when materialization has finished (fail-soft: if it fails,
 sliced serving continues). Nothing ever waits.

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -77,10 +77,17 @@ existing resources remains the cursor's job.
 |---|---|---|
 | 1M ClickBench-shaped rows (2.0 GB JSON) | 30.4 s | **12.1 s** |
 | 10M real ClickBench rows (gz-streamed NDJSON) | — | **119.6 s** (12.0 s/1M, linear) |
+| 100M real ClickBench rows (full 23 GB `hits.json.gz`) | — | **1145.2 s** (11.5 s/1M, 87.3k rows/s) |
 
-GC profile under the parallel importer: zero full collections; chunk buffers and decode scratch
-are pooled, so no humongous-allocation-triggered cycles. Peak RSS for the 10M import: 3.5 GB
-(heap 10 GB budgeted, off-heap capped at 8 GB).
+The 100M run is the full official corpus streamed through the NDJSON adapter: 99,997,497 records
+(the corpus's exact row count) verified by post-commit read-back, ~10.6 billion nodes minted,
+119.4 GiB on disk — scaling stays linear and per-row cost actually improves slightly as epochs
+amortize.
+
+GC profile under the parallel importer: zero full collections at every scale; chunk buffers and
+decode scratch are pooled, so no humongous-allocation-triggered cycles. Peak RSS for the 10M
+import: 3.5 GB (heap 10 GB budgeted, off-heap capped at 8 GB). At 100M: 3,953 young pauses
+totaling 4.4 s of a 1,145 s wall (0.38%), max single pause 3.7 ms.
 
 ### Known limits and roadmap
 

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -1,0 +1,89 @@
+# Bulk JSON Import
+
+SirixDB ships two bulk loaders for building a **fresh resource** from JSON input, both producing
+trees structurally identical to cursor-based insertion — same node keys, kinds, names, values,
+pointers, child counts, path summary and reference counts. Equivalence is enforced by a
+full-field differential test (`BulkAssemblyEquivalenceOracleTest`), not assumed.
+
+## Sequential: `BulkJsonTreeAssembler`
+
+```java
+try (var session = database.beginResourceSession(name);
+     var wtx = session.beginNodeTrx(autoCommitNodes, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+  BulkJsonTreeAssembler.assemble(wtx, reader);
+  wtx.commit();
+}
+```
+
+Append-only page assembly: every pointer is computed from a container stack *before* a record is
+written, so leaves are created with final pointers and each container takes exactly one in-place
+fixup at close. Node keys are predicted and asserted at every mint — a violated prediction is a
+hard error, never a silent mis-pointer.
+
+## Parallel: `ParallelBulkJsonImporter`
+
+```java
+ParallelBulkJsonImporter.assemble(wtx, inputStream);          // raw UTF-8 bytes (preferred)
+ParallelBulkJsonImporter.assemble(wtx, reader);               // char sources (bridged)
+```
+
+For inputs whose **top level is a large array** — the shape of every bulk corpus — members are
+independent subtrees, so the importer parallelizes: a writer-free feeder thread slices the raw
+byte stream into member-aligned chunks and scans their metadata in one pass; the coordinator
+resolves names and path-summary steps in document order, reserves each chunk's exact contiguous
+node-key range, and dispatches builds to a bounded pool; workers emit **final record bytes** into
+standalone pages (records are delta-encoded against their own key, so pre-reserved ranges need no
+rebasing); the coordinator stitches page-sharing chunk boundaries and adopts whole pages into the
+transaction. Any other input shape falls back to the sequential assembler automatically.
+
+NDJSON (one JSON value per line) rides an exact adapter:
+
+```java
+ParallelBulkJsonImporter.assemble(wtx, new NdjsonAsArrayInputStream(inputStream));
+// bounded prefix of a large corpus:
+new NdjsonAsArrayInputStream(inputStream, recordLimit)
+```
+
+### Scope (v1)
+
+Both loaders refuse, up front, configurations they do not faithfully reproduce: `hashType` other
+than `NONE`, stored DeweyIDs, node history, path statistics, a non-empty target document. The
+parallel importer additionally refuses primitive-index maintenance during the load. Mutating
+existing resources remains the cursor's job.
+
+### Verification guarantees
+
+- Per-chunk builds verify their reserved range exactly (final minted key == range end AND
+  populated slots == reserved count) — a count/build divergence refuses loudly per chunk.
+- The equivalence oracle compares parallel imports against sequential loads field-by-field,
+  including path-summary reference counts, across adversarial chunkings (one-member chunks,
+  boundaries mid-page, names first appearing in late chunks).
+
+### Tuning
+
+| Property | Default | Meaning |
+|---|---|---|
+| `sirix.parallelImport.builders` | `cores/4` | Build threads. Builds are cheap relative to the flush pipeline's parallel serialization — an oversized build pool *starves* it. |
+| `sirix.parallelImport.chunkBytes` | `4 MiB` | Chunk size. Larger chunks reduce pipeline overlap; 4 MiB measured best. |
+| `sirix.asyncFlush.maxLogEntries` | `16` | Intent-log entries per flush epoch. Bulk imports benefit from `128`–`256` (fewer epoch round-trips); the default is tuned for interactive writers. |
+| `sirix.asyncFlush.maxNodeCount` | `16384` | Record-count epoch bound; raise together with `maxLogEntries` (e.g. `262144` with `256`). |
+| `sirix.offheap.bytes` | `24 GiB` | Off-heap arena budget. **Cap this on smaller machines for large imports** (e.g. `8g` on a 32 GB box) — the default assumes a query-serving footprint. |
+
+### Measured (20-core box, NVMe)
+
+| Corpus | Sequential | Parallel |
+|---|---|---|
+| 1M ClickBench-shaped rows (2.0 GB JSON) | 30.4 s | **12.1 s** |
+| 10M real ClickBench rows (gz-streamed NDJSON) | — | **119.6 s** (12.0 s/1M, linear) |
+
+GC profile under the parallel importer: zero full collections; chunk buffers and decode scratch
+are pooled, so no humongous-allocation-triggered cycles. Peak RSS for the 10M import: 3.5 GB
+(heap 10 GB budgeted, off-heap capped at 8 GB).
+
+### Known limits and roadmap
+
+- The remaining wall is the flush pipeline's depth-1 epoch chain (serialize and append of
+  consecutive epochs never overlap); a two-generation intent-log pipeline is designed but not
+  built.
+- XML bulk import and projection maintenance riding the parallel load are planned follow-ups.
+- Import into existing resources is out of scope for both loaders.

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -47,11 +47,17 @@ new NdjsonAsArrayInputStream(inputStream, recordLimit)
 ### Scope
 
 Both loaders refuse, up front, configurations they do not faithfully reproduce: `hashType` other
-than `NONE`, stored DeweyIDs, node history, path statistics, a non-empty target document. The
-parallel importer additionally refuses **path, CAS, name and valid-time** index maintenance during
-the load — those families are fed by per-node change notifications, and its workers mint records off
-the transaction entirely, so no notification exists to feed them. **Projection indexes are
-supported** (see below). Mutating existing resources remains the cursor's job.
+than `NONE`, stored DeweyIDs, node history, path statistics, a non-empty target document.
+
+The parallel importer **maintains PATH, CAS and NAME** index definitions during the load: each
+chunk's build worker collects that family's tuples from the primitives it already holds, the
+coordinator drains them per chunk into the families' ordinary bulk loaders, and one flush per family
+materialises each trie before the caller's commit — the same entries the sequential path's per-node
+change notifications produce, byte-identical against a sequential oracle across 20 probes, at a
+measured +10.2% import cost for four real definitions. **Projection indexes are supported** too (see
+below). Only **valid-time** interval maintenance is still refused, and the refusal is def-based with
+an exact-family message: that family is resolved by a configured-path visitor over whole records,
+which has no chunk-local equivalent yet. Mutating existing resources remains the cursor's job.
 
 ### One-pass projections riding chunks
 
@@ -203,6 +209,6 @@ totaling 4.4 s of a 1,145 s wall (0.38%), max single pause 3.7 ms.
   the default 9 despite strictly less worker time. A multi-generation intent log aims at the same
   23%, against a class that has twice produced silent cross-generation use-after-free bugs; the
   serialize stage is where the load's throughput actually lives.
-- XML bulk import is a planned follow-up. Projection maintenance riding the parallel load has
-  landed (see above); the other index families still refuse.
+- XML bulk import is a planned follow-up. Projection, PATH, CAS and NAME maintenance riding the
+  parallel load has landed (see above); valid-time is the one family that still refuses.
 - Import into existing resources is out of scope for both loaders.

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -53,8 +53,11 @@ The parallel importer **maintains PATH, CAS and NAME** index definitions during 
 chunk's build worker collects that family's tuples from the primitives it already holds, the
 coordinator drains them per chunk into the families' ordinary bulk loaders, and one flush per family
 materialises each trie before the caller's commit — the same entries the sequential path's per-node
-change notifications produce, byte-identical against a sequential oracle across 20 probes, at a
-measured +10.2% import cost for four real definitions. **Projection indexes are supported** too (see
+change notifications produce, matching a sequential oracle's postings exactly across 20 probes, at a
+measured +10.2% import cost for four real definitions. The gate is postings equality rather than
+byte equality on purpose: a bulk-built trie is canonical while an incrementally built one is
+insertion-order-dependent, so the two are read-equivalent but not structurally equal — see
+[`HOT_BULK_BUILD.md`](HOT_BULK_BUILD.md) §1. **Projection indexes are supported** too (see
 below). Only **valid-time** interval maintenance is still refused, and the refusal is def-based with
 an exact-family message: that family is resolved by a configured-path visitor over whole records,
 which has no chunk-local equivalent yet. Mutating existing resources remains the cursor's job.
@@ -209,6 +212,13 @@ totaling 4.4 s of a 1,145 s wall (0.38%), max single pause 3.7 ms.
   the default 9 despite strictly less worker time. A multi-generation intent log aims at the same
   23%, against a class that has twice produced silent cross-generation use-after-free bugs; the
   serialize stage is where the load's throughput actually lives.
+- PATH/CAS/NAME maintenance is **not streaming**: each family's bulk loader keeps its whole entry
+  set resident (roughly `key bytes + 20` per indexed node) until the single flush at load end —
+  the price of building each trie in one canonical pass. Selective definitions like the four
+  measured above are cheap at any scale; a definition that indexes *every* node of a 100M-row
+  corpus has no bound, and the flush cannot be split because a family is one tree. Budget for it
+  or build that family afterwards. The unbuilt options are in
+  [`HOT_BULK_BUILD.md`](HOT_BULK_BUILD.md) §3.
 - XML bulk import is a planned follow-up. Projection, PATH, CAS and NAME maintenance riding the
   parallel load has landed (see above); valid-time is the one family that still refuses.
 - Import into existing resources is out of scope for both loaders.

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -67,6 +67,8 @@ existing resources remains the cursor's job.
 | `sirix.parallelImport.chunkBytes` | `4 MiB` | Chunk size. Larger chunks reduce pipeline overlap; 4 MiB measured best. |
 | `sirix.asyncFlush.maxLogEntries` | `16` | Intent-log entries per flush epoch. Bulk imports benefit from `128`–`256` (fewer epoch round-trips); the default is tuned for interactive writers. |
 | `sirix.asyncFlush.maxNodeCount` | `16384` | Record-count epoch bound; raise together with `maxLogEntries` (e.g. `262144` with `256`). |
+| `sirix.asyncFlush.parallelism` | `cores/2 - 1` | Serialize-pool width, shared JVM-wide. This is the load's throughput limit (see roadmap), but it is already at its optimum: on a 20-core box, 4 measured 15.2 s and 14 measured 14.0 s against 13.1 s at the default, because serializers past that point take cores from the insert threads. |
+| `sirix.hft.telemetry` | `false` | Print per-run flush phase totals (`serializeJoinWaitTotalNs`, `kvlAppendTotalNs`, permit waits) at writer close. Off by default; the counters are the only honest way to attribute an import's wall between insert and flush. |
 | `sirix.offheap.bytes` | `24 GiB` | Off-heap arena budget. **Cap this on smaller machines for large imports** (e.g. `8g` on a 32 GB box) — the default assumes a query-serving footprint. |
 
 ### Measured (20-core box, NVMe)
@@ -82,8 +84,23 @@ are pooled, so no humongous-allocation-triggered cycles. Peak RSS for the 10M im
 
 ### Known limits and roadmap
 
-- The remaining wall is the flush pipeline's depth-1 epoch chain (serialize and append of
-  consecutive epochs never overlap); a two-generation intent-log pipeline is designed but not
-  built.
+- The remaining wall is the flush's **parallel page serialization**, not the pipeline's depth.
+  The depth-1 reading is accurate — consecutive epochs' serialize and append never overlap, and
+  the insert side really does park on the flush permit for most of a load (8.8 s of a 12.1 s 1M
+  import) — but the overlap that a two-generation intent log would buy is worth far less than
+  that number suggests. Run with `-Dsirix.hft.telemetry=true` and the per-run phase totals say
+  why: of 10.9 s of worker time across 395 epochs, **8.4 s is stalled on the serialize pool and
+  2.5 s is the append**, and only the append is strictly serialized per writer. Overlapping the
+  append is the entire prize.
+  That prize was collected the cheap way to price it. The flush's sliding window already
+  double-buffers serialize against append and simply never gets to, because its width is defined
+  as the epoch size — one window per epoch. Sizing it independently pipelines several windows per
+  epoch: the stall fell to 6.8 s and worker time to 9.7 s, and **wall time did not follow**
+  (interleaved min-of-3: 12.047 s at one window per epoch, 12.412 s at four, 13.8 s at
+  seventeen). Freed flush capacity goes straight back into contention with the insert threads —
+  the same reason raising `sirix.asyncFlush.parallelism` to 14 measured slower end to end than
+  the default 9 despite strictly less worker time. A multi-generation intent log aims at the same
+  23%, against a class that has twice produced silent cross-generation use-after-free bugs; the
+  serialize stage is where the load's throughput actually lives.
 - XML bulk import and projection maintenance riding the parallel load are planned follow-ups.
 - Import into existing resources is out of scope for both loaders.

--- a/docs/BULK_IMPORT.md
+++ b/docs/BULK_IMPORT.md
@@ -44,17 +44,111 @@ ParallelBulkJsonImporter.assemble(wtx, new NdjsonAsArrayInputStream(inputStream)
 new NdjsonAsArrayInputStream(inputStream, recordLimit)
 ```
 
-### Scope (v1)
+### Scope
 
 Both loaders refuse, up front, configurations they do not faithfully reproduce: `hashType` other
 than `NONE`, stored DeweyIDs, node history, path statistics, a non-empty target document. The
-parallel importer additionally refuses primitive-index maintenance during the load. Mutating
-existing resources remains the cursor's job.
+parallel importer additionally refuses **path, CAS, name and valid-time** index maintenance during
+the load — those families are fed by per-node change notifications, and its workers mint records off
+the transaction entirely, so no notification exists to feed them. **Projection indexes are
+supported** (see below). Mutating existing resources remains the cursor's job.
+
+### One-pass projections riding chunks
+
+A projection index declared BEFORE the data is built by the parallel load itself, in the same single
+pass, instead of by a second full walk of the finished resource. One pass is also the FASTER route
+(see the cost section below), and the index is byte-identical either way.
+
+```java
+try (var wtx = session.beginNodeTrx(nodes, AfterCommitState.KEEP_OPEN_ASYNC_FLUSH)) {
+  session.getWtxIndexController(wtx.getRevisionNumber())
+         .createProjectionIndexAtLoadStart(projectionDef, wtx, expectedRows);
+  ParallelBulkJsonImporter.assemble(wtx, inputStream);
+  wtx.commit();   // the final commit closes the build: dictionaries, fences, metadata
+}
+```
+
+Rows are extracted WHERE THE DATA IS: each chunk's build worker fills a columnar row batch
+(`ProjectionChunkRowBatch`) from the same primitives it writes into page bytes — field matching by
+path class, cell classification by the row extractor's own shared helpers — so extraction costs one
+hook per node instead of a per-record re-read through the transaction. The coordinator replays the
+batches into the armed build in document order at adoption, and mints each record's structural-order
+label through the directory's in-order append lane, which is pure label algebra: no document lookup
+anywhere on the feed path. The rows are then PACKED by exactly the machinery the post-pass build
+uses — leaves, dictionary election, fences, Bloom chunks, metadata — which is what makes the two
+indexes identical rather than merely equivalent: `ParallelBulkProjectionEquivalenceTest` compares
+them slot for slot (row-group descriptors and leaves, fence chunks and the physical-order header,
+per-column Bloom manifests and chunks, set-summary chunks, the record locator, the structural-order
+directory and the dictionary blobs) and fails on a single differing byte.
+
+Under the async-flush pipeline, a record's row is fed only once its whole subtree has entered the
+intent log — the chunk's tail page is deliberately held out of the log until its successor's head
+merges into it, and the feed drains against that adopted-key watermark. The batch rows themselves
+read nothing back, so the feed discipline exists to keep document order and to land each row's
+dictionary interns in the storage epoch its record was adopted in, not to keep pages readable; the
+old design's second invariant — withholding the epoch's record accounting while a record straddled
+the held tail page — is gone with the re-read that needed it.
+
+Arming is optional and changes nothing when absent: an unarmed parallel import runs the same code
+path as before, and the feeder does not even collect per-member node counts. A projection that is
+catalogued but has NO load-time build armed for the transaction is refused rather than silently left
+unmaintained.
+
+The load-time build is **append-only**: rows are appended in document order exactly once, so an
+update that reaches back into an already-indexed record fails loudly. Build the index with
+`jn:create-projection-index` afterwards if the write order is not document order.
+
+One reproduction caveat, deliberate and narrow: the read-back extractor's work-list visits nested
+sibling subtrees in reverse order, while a worker streams document order. For any field matched at
+most once per record — every gate corpus, and ClickBench — the two are indistinguishable. A
+duplicate match poisons the cell identically in both orders; only the residual value bytes of such a
+poisoned cell (and the element order of a set column fed by several arrays of one record) can
+differ, and no consumer reads through a poisoned cell.
+
+#### Cost: measured — one pass beats bare-then-post-pass by 2.8×
+
+Three arms over the first 1M REAL ClickBench hits rows (2.36 GB JSON, array-wrapped), interleaved
+bare/onepass/postpass per rep, minimum of 3, `-Dsirix.projection.globalDict=never`,
+`-Xmx6g`:
+
+| Arm | min | median | vs bare |
+|---|---|---|---|
+| parallel import, no projection | **12.54 s** | 12.88 s | — |
+| parallel import, projection armed one-pass | **23.77 s** | 24.47 s | +11.2 s (+89.5%) |
+| parallel import bare, then post-pass build | **66.98 s** | 67.42 s | +54.4 s |
+
+Both projection arms produce the identical index — 977 row groups, live metadata, verified per rep.
+**One pass is 2.82× faster end to end than loading bare and building afterwards**, at 1.9× the bare
+import's wall. The previous design — the coordinator re-reading every record through the write
+transaction at drain time — measured 497 s one-pass on this workload's synthetic twin, ~8× SLOWER
+than the post-pass; moving extraction into the build workers and order labels onto the in-order
+append lane removed the entire regression (the rotation witness's 147k-record one-pass arm fell
+from 67 s to 3 s in the same change).
+
+#### Why one pass also lifts a hard ceiling
+
+A resource-wide value dictionary is appended in generations, and one generation admits at most
+16,384 distinct entries. The post-pass build appends the whole corpus as a SINGLE generation, so any
+elected string column with more distinct values than that kills the build outright — the standing
+workaround being `-Dsirix.projection.globalDict=never`. A load-time build flushes a generation per
+storage epoch, so generations rotate with the load. Measured on one corpus of 147,456 records with
+36,864 distinct values in the elected column: the one-pass parallel load publishes a live
+`STRING_GLOBAL` column over 144 row groups, while the post-pass build on the same data dies with
+`append entry 16,385 exceeds the safe per-append limit of 16,384`.
+
+This raises the ceiling from "the whole corpus" to "one storage epoch"; it does not remove it. A
+column that is ~100% distinct still saturates a generation inside the dictionary's own 16-leaf
+sample window, whatever the epoch size.
 
 ### Verification guarantees
 
 - Per-chunk builds verify their reserved range exactly (final minted key == range end AND
   populated slots == reserved count) — a count/build divergence refuses loudly per chunk.
+- With a projection armed, THREE independent derivations of the record roots must agree: the
+  feeder's per-member node counts, the range arithmetic that names the chunk's last member, and the
+  build worker's own parent-key record detection (checked per row at feed time). The build's
+  end-of-load check additionally compares rows emitted against the record-set array's child count —
+  so a load that mis-attributes records refuses instead of publishing a short index.
 - The equivalence oracle compares parallel imports against sequential loads field-by-field,
   including path-summary reference counts, across adversarial chunkings (one-member chunks,
   boundaries mid-page, names first appearing in late chunks).
@@ -109,5 +203,6 @@ totaling 4.4 s of a 1,145 s wall (0.38%), max single pause 3.7 ms.
   the default 9 despite strictly less worker time. A multi-generation intent log aims at the same
   23%, against a class that has twice produced silent cross-generation use-after-free bugs; the
   serialize stage is where the load's throughput actually lives.
-- XML bulk import and projection maintenance riding the parallel load are planned follow-ups.
+- XML bulk import is a planned follow-up. Projection maintenance riding the parallel load has
+  landed (see above); the other index families still refuse.
 - Import into existing resources is out of scope for both loaders.

--- a/docs/DISK_FORMAT.md
+++ b/docs/DISK_FORMAT.md
@@ -348,6 +348,12 @@ RevisionRootPage → ProjectionIndexPage (PageKind 16) → per-definition HOT su
                                          int buildRevision; rootPath; columns[];
                                          setSummaryCapabilityColumns[]; dictionaryAnchors[] }
                                          (a few hundred B → inline; no metadata page on open).
+                                         flags: bit0 = STALE; bits1-3 = the StaleReason ordinal
+                                         (WIRE VALUES — append only, never renumber; an ordinal
+                                         this build does not know reads as UNSPECIFIED and the
+                                         entry stays stale). The reason bits are additive: they
+                                         were always zero before, so a tombstone written without
+                                         them parses identically and ver stays 0.
                                          ver=0 is the ONLY supported version: any other value
                                          parses to null → "no metadata" → fail-closed decline.
     slotKind 0: PIXD descriptor, a PIXB blob whose payload is

--- a/docs/HOT_BULK_BUILD.md
+++ b/docs/HOT_BULK_BUILD.md
@@ -1,554 +1,172 @@
-# HOT Bulk Construction for Secondary Structures — Design (Campaign #76, Phase 1)
+# HOT Bulk Construction — the reasoning record
 
-**Status:** design record — the v1 design and the measured evidence behind it. It has since
-LANDED: the §2.1 leaf-packing fix, Seam 1 (the importer now maintains PATH/CAS/NAME during the
-load), and Seam 2's slot accumulator (`HOTBulkSlotLoader`, engaged by the post-pass
-`ProjectionIndexBuilder`; the load-time rider still writes per entry — see Seam 2b). What the
-shipped loaders actually do, refuse and cost is owned by
-[`BULK_IMPORT.md`](BULK_IMPORT.md); read this one for WHY. Every "today"/"currently"/"this
-worktree" statement below describes the tree at `226ceaac8`, the base this design was written
-against. Companion probe:
+Why the HOT bulk path is shaped the way it is: the canonicity verdict that decides how bulk
+construction can be gated, the memory arithmetic that decided how the projection slot sink
+persists, and the designs deliberately left for a v2. This document holds only reasoning that
+has no other owner — an argument a future reader or implementer needs and that the source
+cannot carry.
+
+It does **not** describe shipped behavior:
+
+- Which index families the parallel load maintains, what it refuses, and what that costs:
+  [`BULK_IMPORT.md`](BULK_IMPORT.md).
+- The post-pass projection build's write path, including the bulk slot sink it engages:
+  [`PROJECTION_INDEX_DEEP_DIVE.md`](PROJECTION_INDEX_DEEP_DIVE.md) §6.
+- Local safety invariants of the mechanisms below — the leaf-fit bound's overflow argument
+  (`HOTBulkBuilder.fitsLeafPage`), the fresh-subtree registration contract
+  (`AbstractHOTIndexWriter.registerFreshSubtree`), and the epoch transplant's
+  tree-state-independence (`ProjectionIndexHOTStorage.adoptBulkSlotAccumulation`): the class
+  javadoc owns each, and is the copy to trust.
+
+Evidence probe for §1:
 `bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java`.
 
-**Scope v1:** fresh subtrees only — no merge into populated trees, no tombstone
-migration, no cross-revision fragment interplay beyond what `registerFreshSubtree`
-already guarantees.
+---
+
+## 1. Shape canonicity — bulk output is canonical, the incremental trie is not
+
+This is the finding that determines what a bulk-construction gate is allowed to assert.
+
+- **`HOTBulkBuilder.build(S)` is deterministic in the key set.** Same sorted entries in, same
+  structure out, regardless of the order the pairs were fed to the loader — verified empirically
+  (`shape bulk==bulk2 (determinism): true` for both probe key patterns) and by code: a pure
+  two-phase recursion whose only inputs are the sorted arrays. With a fixed page-key allocator
+  start, page keys are deterministic too (allocation order is the DFS order of construction).
+  **Byte-identity between two bulk builds of the same entries is therefore a valid gate.**
+- **The live incremental trie is neither canonical nor order-independent.** The same 20 000-key
+  set through the production `doIndex` in ascending vs descending order: 40 leaves / 3 indirects
+  / height 2 vs 40 leaves / 20 indirects (a 6-deep chain); every shape pair unequal except
+  asc == shuffled, a post-consolidation coincidence. The code says so itself — the periodic
+  consolidation sweep exists because incremental insertion over-partitions into under-full frozen
+  leaves an insert never re-routes to, and it packs only toward `CONSOLIDATION_TARGET`
+  (¾ of `HOTLeafPage.MAX_ENTRIES`), not toward the bulk cut.
+- **Consequence — a bulk-vs-incremental gate must be semantic, never byte-identity.** Byte
+  identity is reserved for bulk-vs-bulk reproducibility. Equivalence against the incremental
+  result is asserted as identical point reads, identical range-cursor sequences, and — for the
+  projection — the census differential (`readAllRowGroupsFromColumnSegmentSlots` validates the
+  exact ordered descriptor set and every segment hash, so a lost, duplicated or misplaced slot
+  fails loudly), plus zero findings from the invariant oracle `HOTMalformedSubtreeDetector`,
+  which both construction routes must pass.
+- **The sharp form of the question** — does `spliceBulkBuiltRoot` produce trees byte-identical to
+  incremental insertion of the same keys, and do its existing users prove that or merely tolerate
+  divergence? **No, and they tolerate it.** The probe drove the real
+  `createBulkLoader → flush → spliceBulkBuiltRoot` path against the real `doIndex` on identical
+  key sets: interior structure differs even with canonical leaf packing (bulk 40 leaves /
+  9 indirects vs incremental-ascending 40 / 3 — an SMHP fanout-32 frontier against
+  integrate/pull-up shapes). The family's end-to-end gate, `JsonCASIndexBuildTest`, asserts
+  postings-set equality ("postings … must not depend on how the index was built") plus a
+  zero-self-heal witness during bulk builds; no structural or byte assertion exists anywhere in
+  the family's tests, and per the verdict above none should.
+- **All four construction routes are read-equivalent** (20 000 keys × 2 key patterns × point
+  lookups — identical postings). That is the property the gates encode.
+
+**Open, predating this campaign:** the incremental path in descending order leaves **stale
+`height` fields** (nested indirects all claiming `h=1`). Harmless while readers route by
+invariants, but `HOTIncrementalInsert.integrate`'s `parent.height > B.height` decision consumes
+heights, so any future "bulk-build the tail, integrate incrementally" hybrid must fix this first.
 
 ---
 
-## 0. Premise audit — what already exists (and what the campaign premise got wrong)
+## 2. Why the projection slot sink accumulates with a cap, not one splice at the end
 
-The campaign premise assumed bottom-up bulk construction for HOT structures had to be
-designed from scratch. The tree at `226ceaac8` already contains most of the machinery:
+`spliceBulkBuiltRoot` refuses a non-empty tree, so a bulk sink can only serve a build that never
+reads its own persisted tree — and the obvious shape, accumulate the whole build and splice once,
+is what the arithmetic below rejects.
 
-| Piece | Where | State |
-|---|---|---|
-| Bottom-up builder (`R(S)` + SMHP compression) | `io.sirix.index.hot.HOTBulkBuilder` | **EXISTS**, formally modeled (`docs/HOT_FORMAL_FOUNDATION.md` Thm 1, `HOTFormalModelTest`), property-tested |
-| Accumulate–sort–fold–build loader | `io.sirix.index.hot.AbstractHOTBulkIndexLoader` (+ `HOTBulkIndexLoader` for CAS/NAME, `HOTLongBulkIndexLoader` for PATH) | **EXISTS**; block-arena keys, int-permutation sort, exact-size entry list |
-| Root splice for an empty tree | `AbstractHOTIndexWriter.spliceBulkBuiltRoot` (AbstractHOTIndexWriter.java:1136) | **EXISTS**; refuses non-empty trees |
-| TIL adoption of a fresh HOT subtree | `AbstractHOTIndexWriter.registerFreshSubtree` → `registerFreshPage` (AbstractHOTIndexWriter.java:4613–4661) | **EXISTS**; post-order `log.put(ref, PageContainer(page,page))`, `setCompleteDump(true)` on fresh leaves |
-| Bulk-load engagement for PATH/CAS/NAME | `PathIndexBuilder`/`CASIndexBuilder`/`NameIndexBuilder` constructors | **EXISTS**, but only when the builder starts against an **empty** tree (create-index-over-existing-revision) |
+Three premises make the arithmetic the binding constraint rather than visibility or flushing:
 
-Two premise corrections:
-
-1. **Adoption is not `KeyedTrieWriter.prepareLeafOfTree` for HOT.** That pair is the
-   *document-index* (bit-decomposition radix trie over `IndirectPage`s) adoption used by
-   `ParallelBulkJsonImporter`. HOT subtrees enter the TIL through
-   `registerFreshSubtree`, which is the exact HOT analog: children registered before
-   parents, each page its own `(complete==modified)` container, fresh leaves marked
-   complete-dump so commit emits full first fragments and readers never chase a chain.
-   Nothing new needs designing here — v1 reuses it unchanged.
-
-2. **HOT pages are never epoch-flushed.** The async-flush epochs
-   (`TransactionIntentLog.snapshot()`/`cleanupSnapshot()`) attempt only
-   `KeyValueLeafPage`s. Every HOT page (leaf and indirect) is **pinned**
-   (TransactionIntentLog.java:337–397, `PINNED_GENERATION`): one stable TIL identity for
-   the life of the transaction, serialized at final commit — or earlier by the bounded
-   **pinned-trie spill** under memory pressure
-   (`TransactionIntentLog.capturePinnedSpillCandidates`,
-   `NodeStorageEngineWriter.isPinnedTrieSpillPageEligible`,
-   NodeStorageEngineWriter.java:2092–2119). "Flush-eligible under the async-flush
-   epochs" therefore translates to **spill-eligible**, see §5.
-
-What does **not** exist — the actual campaign gap. The campaign is therefore NOT
-"invent a bottom-up builder"; it is **extend and route the existing
-`AbstractHOTBulkIndexLoader` family** into the write populations that bypass it:
-
-- The **projection family** (column-segment slots, order-directory slots, record
-  locator, fences, Bloom chunks, global-dictionary records) writes per-entry through
-  `ProjectionIndexHOTStorage.writeSlotValue` (ProjectionIndexHOTStorage.java:3397):
-  descent (`prepareLeafOfTree`) + branch-escape dispatch + `leaf.put` +
-  update-or-split cascade, once per slot. `ProjectionIndexHOTStorage` is a sibling
-  subclass of `AbstractHOTIndexWriter` that never touches the loader family
-  (`spliceBulkBuiltRoot`'s only caller is `AbstractHOTBulkIndexLoader.flush`:275;
-  the loaders' only consumers are the PATH/CAS/NAME builders gated on
-  `isEmptyTree()`). `ProjectionBulkLoad` keeps the *builder* alive across
-  auto-commits (process-global ACTIVE map keyed `resourceKey#defId`,
-  ProjectionBulkLoad.java:90; `DEFAULT_ROW_GROUP_PUBLISHER` is a method ref to
-  `putRowGroupAsColumnSegmentSlots`, :79) but still persists through the per-entry
-  path — it batches BUILD state, not WRITES.
-- **The dominant per-entry population is the order-label directory**: one slot per
-  record under `2^50 + nodeKey`, strictly ascending — ~95 % of all per-entry HOT
-  insertions in a fresh build, and already perfectly loader-shaped. (The
-  consolidated `bulkproj` worktree — NOT this base — already routes post-pass label
-  minting through an in-order label lane; this design assumes that lane exists and
-  must not re-fix it.)
-- The **parallel importer refuses PATH/CAS/NAME/valid-time maintenance**
-  (ParallelBulkJsonImporter.java:215–218 on `bulkHasPrimitiveIndexes()`, =
-  `indexController.hasAnyPrimitiveIndex()` via JsonNodeTrxImpl.java:1202–1204; the
-  non-parallel sink honors the same signal — WtxBulkRecordSink.java:40); lifting it
-  wants per-family accumulation in workers + one flush into the EXISTING
-  `create*BulkLoader()` per family at load end. **Lifted since** (Seam 1): PATH, CAS and NAME
-  are maintained by the load, valid-time is the one family that still refuses.
-- The existing `HOTBulkBuilder` **under-packed leaves by ~7×** on realistic
-  dense/strided key sets (§3; fixed in this worktree) — feeding it 100M-scale
-  projection slots without the packing fix would have multiplied page count, TIL
-  residency, and I/O.
-
----
-
-## 1. Shape canonicity — the finding that fixes the gate design
-
-Full evidence in the phase report; operative summary:
-
-- **`HOTBulkBuilder.build(S)` is deterministic in the key set** — same sorted entries in,
-  same structure out, regardless of the order pairs were fed to the loader. Verified
-  empirically (probe: `shape bulk==bulk2 (determinism): true` for both key patterns) and
-  by code (pure two-phase recursion; the only inputs are the sorted arrays).
-  With a fixed page-key allocator start, page keys are deterministic too (allocation
-  order is the DFS order of construction), so **byte-identity between two bulk builds
-  of the same entries is a valid gate**.
-- **The live incremental trie is NOT canonical and NOT order-independent.** Same
-  20 000-key set through the production `doIndex` in ascending vs descending order:
-  40 leaves/3 indirects/height-2 vs 40 leaves/20 indirects (a 6-deep chain);
-  every shape pair unequal except asc==shuffled (post-consolidation coincidence).
-  The code says so itself: the periodic consolidation sweep exists because "the
-  incremental insert over-partitions … under-full frozen leaves an insert never
-  re-routes to" (AbstractHOTIndexWriter.java:3384–3390), and it packs only toward
-  `CONSOLIDATION_TARGET = 384` (¾ of `MAX_ENTRIES`), not toward the bulk cut.
-- Consequence: **the v1 gate is layered, not byte-identical to the incremental
-  result** (§6). Byte-identity is reserved for bulk-vs-bulk reproducibility; the
-  bulk-vs-incremental gate is semantic (reads + census) plus the invariant oracle
-  (`HOTMalformedSubtreeDetector`), which both construction routes must pass with zero
-  findings.
-- **The sharper form of the question** ("does `spliceBulkBuiltRoot` produce trees
-  byte-identical to incremental insertion of the same keys, and do its existing users
-  prove that or merely tolerate divergence"): **No, and they tolerate it.** The probe
-  drove the REAL `createBulkLoader → flush → spliceBulkBuiltRoot` path against the
-  REAL `doIndex` on identical key sets: interior structure differs even after the
-  packing fix (bulk 40 leaves/9 indirects vs incremental-ascending 40/3 — SMHP
-  fanout-32 frontier vs integrate/pull-up shapes). The loader family's only
-  end-to-end user gate, `JsonCASIndexBuildTest`, asserts postings-set equality
-  ("postings … must not depend on how the index was built", :190–192) plus a
-  zero-self-heal witness during bulk builds (:176–180) — no structural or byte
-  assertion exists anywhere in the family's tests.
-- Additional measured facts the design leans on: (a) all four construction routes are
-  **read-equivalent** (20 000 keys × 2 patterns × point lookups — identical postings);
-  (b) the incremental path in descending order leaves **stale `height` fields**
-  (nested indirects all claiming `h=1`) — a latent divergence source for
-  `integrate`'s `parent.height > B.height` decision, noted as a separate follow-up,
-  not in v1 scope.
-
----
-
-## 2. The construction algorithm (as implemented, with the v1 packing fix)
-
-Input: a strictly-ascending, duplicate-free `(key, payload)` stream (the loader
-guarantees this: block-arena accumulation, one parallel int-sort by
-`(compositeKey, nodeKey)`, group-fold per distinct key —
-AbstractHOTBulkIndexLoader.java:223–277).
-
-Phase A — `buildR` (HOTBulkBuilder.java:191): Binna's binary Patricia trie by MSDB
-recursion over the sorted array. `O(n · keylen)` worst case, no allocation beyond the
-recursion frames and `RNode` records.
-
-Phase B — `bulk` compression (HOTBulkBuilder.java:268):
-
-- **Leaf cut:** a subtree of ≤ `HOTLeafPage.MAX_ENTRIES` (512) entries is speculatively
-  packed into one `HOTLeafPage` (64 KiB slot heap, `DEFAULT_SIZE`); byte overflow
-  recurses into the branch. A leaf page is always a *complete `R(S)` subtree* —
-  the invariant that makes multi-entry pages routable (foundation §3.2).
-- **Interior assembly:** greedy SMHP frontier expansion to ≤ 32 children
-  (`buildIndirect`), sparse-path partial encoding, SingleMask when the disc bits fit an
-  8-byte window, MultiMask otherwise; span node ≤ 16 children, multi node ≤ 32
-  (`assembleIndirect`, HOTBulkBuilder.java:439).
-
-### 2.1 The v1 packing fix — stop the frontier below the page boundary
-
-**Measured defect:** `buildIndirect` expands the block frontier by always splitting the
-*largest* frontier branch until 32 children exist. The expansion does not stop at
-branches whose whole key group would fit a leaf page, so page-fitting `R(S)` subtrees
-get split across several frontier slots, and their fragments recurse into *further*
-32-way expansions. Dense/strided 20 000-key sets build **280 leaves (min fill 16, mean
-~71)** where the highest-fitting-subtree cut yields **40 leaves (fill ≈ 512)** — the
-shape both the class javadoc ("cut a HOTLeafPage at the highest R(S) subtree whose key
-group fits a page") and foundation §3.2 *claim*. Exact arithmetic of the observed
-tree: root expands 20 000 keys into 24×512-blocks + 8×1024-blocks; each 1024-block
-re-expands into 32 leaves of 32 → 24 + 256 = 280 leaves, 1 + 8 = 9 indirects — the
-probe's numbers exactly.
-
-**Fix (IMPLEMENTED in this worktree, uncommitted):** during frontier expansion, a
-frontier node is *non-expandable* when its key group fits a leaf page
-(`BulkContext.isExpandable`/`fitsLeafPage` — count ≤ `MAX_ENTRIES` and a conservative
-byte upper bound `Σ(4 + keyLen + valueLen) ≤ HOTLeafPage.DEFAULT_SIZE`, early-exit,
-allocation-free; the bound charges the full key, the page stores only the
-post-prefix suffix, so a passing group can never overflow the real page —
-`tryBuildLeaf` stays the authoritative check and the recursion the fallback).
-Licensed by the model: "any frontier is invariant-correct by Theorem 1"
-(HOTBulkBuilder.java:266) — the fix only *chooses a different frontier*, all
-invariants and the determinism argument survive verbatim. Height cannot increase:
-stopping expansion earlier only removes interior levels.
-
-**Measured after the fix:** dense/strided 20 000-key builds go 280 → **40 leaves**
-(fill 32..512, exactly the highest-fitting-subtree count), bulk-vs-bulk determinism
-still byte-stable, and the full HOT gate battery is green (§6 G4 list, all run).
-
-**Blast radius:** `HOTBulkBuilder.build` also serves `splitLeafPage`'s halves
-(HOTIncrementalInsert.java:154–155 via `buildHalf`), `rebuildSubtree`
-(AbstractHOTIndexWriter.java:3499), and the malformed-subtree self-heal — live-tree
-shapes shift wherever a half or rebuilt subtree spans multiple pages. All shapes remain
-invariant-clean; gates in §6 cover the change. Three test scenarios manufactured their
-preconditions FROM the old fragmentation (full 32-child roots out of small random sets;
-mergeable BiNode pairs on fresh bulk output — now impossible by construction) and were
-repaired to force those shapes by key design / by a real `splitLeafPage` fold:
-`HOTIntegrateTest` (grouped keys, pair-overflow constraint `256 < perGroup ≤ 512`),
-`StraddleCanonicityProbe` (grouped keys), `HOTIndirectPageSplitFaithfulTest`
-(split-then-merge round trip), `HOTBulkBuilderTest` V5 (600-key byte-position groups
-keep the MultiMask span at 28 bytes), and `BetaIsDiscBitRoutingProbe` (a depth-0
-blind spot: the probe descended a stale root Page variable after a fold replaced the
-ROOT — unreachable pre-fix because canonical roots were always full and full nodes
-divert to the Q4 decomposition; base-tree baseline confirmed green pre-fix, the
-node-local routing printout proved the primitive correct, and the repaired probe now
-verifies 13/13 depth-0 folds route 100 % strict — coverage the old shapes never had).
-
----
-
-## 3. Integration seams (v1 targets, in payoff order)
-
-### Seam 1 — importer-side PATH/CAS/NAME materialization (the refusal lift)
-
-> **Landed.** The importer maintains PATH, CAS and NAME during the load exactly as planned here
-> (workers collect tuples, the coordinator drains them into `create*BulkLoader()` and flushes once
-> before the commit); valid-time still refuses. Shipped scope and cost:
-> [`BULK_IMPORT.md`](BULK_IMPORT.md). The design below is kept for the reasoning.
-
-`ParallelBulkJsonImporter` refused secondary-index maintenance at the time of writing. The
-EXISTING loaders make the lift mechanical; the per-family entry shape each loader
-needs, and where a worker can produce it:
-
-| Family | Loader `add(...)` shape | Worker-side availability |
-|---|---|---|
-| PATH | `HOTLongBulkIndexLoader.add(long pcr, long nodeKey)` | nodeKey: assigned by the worker; PCR: needs the path-summary node for the record's path — available where the importer maintains the summary; otherwise a coordinator-side replay of collected (pathStep, nodeKey) tuples. OPEN DEPENDENCY: verify at which point the importer's summary is consistent enough to resolve PCRs. |
-| CAS | `HOTBulkIndexLoader<CASValue>.add(CASValue key, long nodeKey)` (key = PCR + typed atom) | atom text + node kind known at token time in the worker; type coercion needs the index definition (coordinator-owned, read-only — shareable). Same PCR dependency as PATH. |
-| NAME | `HOTBulkIndexLoader<QNm>.add(QNm, long nodeKey)` | trivially known at token time. |
-
-1. Workers collect the tuples per chunk into primitive-friendly buffers.
-2. Coordinator (single-threaded, owns the trx) drains them into
-   `create*BulkLoader()` — feed order is free, the loader sorts — and calls
-   `flush()` once at load end, before the single commit. `spliceBulkBuiltRoot` +
-   `registerFreshSubtree` do the adoption; commit serializes.
-3. Precondition: the index tree is virgin in this revision. GUARANTEED here — the
-   importer refuses non-fresh resources (ParallelBulkJsonImporter.java:219–221), so
-   `isEmptyTree()` holds at load end by construction.
-
-No new trie API is needed. What is new: the worker-side accumulation plumbing, the
-PCR-availability answer, and the memory budget (§5.2) — pairs for 100M rows are
-resident until flush.
-
-### Seam 2 — projection fresh build: batch the slot writes
-
-A fresh projection build (post-pass `ProjectionIndexBuilder` or load-time
-`ProjectionBulkLoad`) emits, per row group: one descriptor slot + one slot per column
-segment, keys `(rowGroupId << 16) | slotKind` — row-group ids assigned contiguously
-from 1 (ProjectionIndexHOTStorage.java:49–56) — then fences (2^42 namespace), Bloom
-chunks (2^43), metadata blobs. Row-group slot keys are therefore **append-ordered by
-construction** during a fresh build; fences/Bloom/metadata arrive in their own
-ascending namespaces afterward. This is exactly the loader's ideal input.
-
-The dominant sub-population is the **order-label lane** (~95 % of fresh-build
-insertions, one slot per record at `2^50 + nodeKey`, strictly ascending) — assume the
-in-order lane exists (see §0) and target it first: strictly-ascending small-payload
-slots are the loader family's ideal input.
-
-**Loader-contract gap.** `AbstractHOTBulkIndexLoader` is postings-shaped: it carries a
-`long nodeKey` per entry and its `toEntry` FOLDS a key's node keys into one chunked
-`NodeReferences` run (AbstractHOTBulkIndexLoader.java:303–320). Projection slots are
-REPLACE-semantics opaque `byte[]` payloads. So the projection cannot consume the
-concrete class as-is; the v1 seam is a **sibling in the same family** (share the
-block-arena accumulation, the int-permutation sort, the exact-size entry list, and the
-`spliceBulkBuiltRoot` splice; swap the per-entry parallel array from `nodeKeys[]` to a
-packed payload position/length, payload bytes in the same block arena):
-`HOTBulkSlotLoader` — engaged by `ProjectionIndexHOTStorage` when the tree is empty
-(fresh build), routing `writeSlotValue`/`putBlob` into accumulation instead of N
-descents, spliced once at build end. Constraints that shape it:
-
-- **Replace-not-OR-merge slot semantics** (branch-escape guard javadoc,
-  AbstractHOTIndexWriter.java:1746–1759): the accumulator must key-dedupe with
-  last-writer-wins, not fold postings — its own `toEntry` (keep the last payload).
-- **Read-your-writes during the build**: `putRowGroupAsColumnSegmentSlots` reads the
-  prior descriptor (`getBlobIfReadable`, ProjectionIndexHOTStorage.java:617 — null on
-  a fresh build) and the fence/Bloom rewrite paths read earlier chunks. While
-  accumulating, reads must be served from the accumulator (a key-indexed view) or the
-  sink is restricted to sites verified write-only for the fresh build. This is the
-  main v1 engineering risk on Seam 2.
-- **Side maps / OverflowPages** (`putSegmentPage`): segment references hang off the
-  leaf that *physically holds the owning slot*. Attach **after** the build via the
-  existing `reattachSegmentRefs` discipline (used by every rebuild path), which
-  resolves owner slots against the finished leaves.
-- **Tombstones cannot occur in a fresh build** (nothing to delete) — in-scope for v1.
-- **Auto-commit windows:** the non-parallel bulk load commits every
-  `-Dsirix.autoCommit.nodes` nodes; after the first commit the tree is no longer
-  virgin and v1 must fall back to the per-entry path for subsequent windows (v2:
-  subtree-level merge — out of scope). The parallel importer's single-commit shape
-  avoids this entirely, so Seam 2 lands cleanly there first.
-
-### Seam 2a — measured perf gate + the streaming-vs-splice-once decision (phase 2)
-
-**Perf gate (ProjectionBulkVsPerEntryBench, production paths both arms, interleaved
-reps, best-of; witnesses untimed: sampled read-back equality + detector-clean):**
-
-| shape | entries | perEntry ns/entry | bulk ns/entry | ratio |
-|---|---|---|---|---|
-| label (2^50+k, 30 B) | 1 M | 1 506.6 | 159.6 | **9.44×** |
-| label | 10 M | 1 986.1 | 159.4 | **12.46×** |
-| segslot ((rg<<16)\|slot) | 1 M | 1 463.9 | 129.5 | **11.30×** |
-| segslot | 10 M | 2 199.0 | 156.5 | **14.05×** |
-
-Per-entry cost GROWS with scale (deeper descents, more split cascades); bulk stays
-flat ≈ 130–160 ns/entry. Gate threshold (≥3×) passed with 3–4.7× margin.
-
-**The decision.** `spliceBulkBuiltRoot` refuses non-empty trees while the build writes
-continuously. Two clarifications change the option space:
-
-- **Flush-epoch rotation is NOT the obstacle**: epochs never touch HOT pages (§0.3 —
-  pinned region); the tree becomes non-empty through the build's own writes and real
-  auto-COMMITS. The rider stale-marks the index for the whole load
-  (`ProjectionBulkLoad` metadata `staleTombstone`, :302), so intermediate revisions
-  never serve from the half-built projection — accumulation is visibility-safe; the
-  binding constraint is memory.
+- **Flush epochs never relieve a build in progress.** The async-flush epochs
+  (`TransactionIntentLog.snapshot`/`cleanupSnapshot`) attempt only `KeyValueLeafPage`s; every HOT
+  page is pinned for the life of the transaction. The relief valve is the bounded pinned-trie
+  spill (`NodeStorageEngineWriter.isPinnedTrieSpillPageEligible`) — and during
+  `HOTBulkBuilder.build` none of the pages are TIL-registered yet, so **the built pages are
+  unconditionally resident until the splice**, on top of the loader arena.
 - **A leaf owns a 64 KiB slot segment regardless of fill** (`HOTLeafPage` ctor →
-  `allocator.allocate(DEFAULT_SIZE)`, HOTLeafPage.java:458), and during
-  `HOTBulkBuilder.build` none of the pages are TIL-registered, so the pinned-trie
-  spill cannot relieve them — the BUILT PAGES are unconditionally resident until the
-  splice, on top of the loader arena.
+  `allocator.allocate(DEFAULT_SIZE)`), so built-page cost is per page, not per byte.
+- **Visibility is already safe.** The load-time rider stale-marks the index for the whole load
+  (`ProjectionBulkLoad` writes `ProjectionIndexMetadata.staleTombstone()` into slot 0), so
+  intermediate revisions never serve from a half-built projection. Accumulating longer buys no
+  correctness problem — only memory.
 
-Arithmetic (label lane, 8 B keys + 30 B payloads; slot-loader arena ≈ 70 B/entry
-(key+payload block bytes + 24 B index); built tree ≈ 64 KiB / 512 entries =
+Arithmetic for the dominant lane (order labels, 8-byte keys + ~30-byte payloads; slot-loader arena
+≈ 70 B/entry — key + payload block bytes + a 24 B index; built tree ≈ 64 KiB / 512 entries =
 128 B/entry):
 
-| entries per splice | arena | built pages | total transient | vs ≤2 G rule |
+| entries per splice | arena | built pages | total transient | vs a ≤ 2 G transient rule |
 |---|---|---|---|---|
 | 1 M | 70 MB | 128 MB | ~0.2 GB | fine |
 | 8 M | 560 MB | 1.0 GB | ~1.6 GB | fine — the chosen cap |
 | 30 M | 2.1 GB | 3.8 GB | ~5.9 GB | FAIL |
 | 100 M | 7.0 GB | 12.5 GB | ~19.5 GB | FAIL outright |
 
-- **(a) whole-build splice-once — REJECTED at scale** (fails from ~15 M entries).
-- **(b) bulk only the first window — REJECTED as primary** (rider win ≈ A/total ≈ 1 %
-  at 100 M; post-pass degenerates to (a)).
-- **CHOSEN v1 — (a-bounded): accumulate-with-cap + graceful drain.**
-  `HOTBulkSlotLoader` accumulates while the tree is virgin, capped at 8 M entries /
-  512 MB arena bytes. Build ends under the cap → sort + last-writer-wins fold +
-  splice-once (full 9–14× win — covers every fresh build ≤ 8 M slots). Cap trip, any
-  read of projection state, a side-ref attach, or transaction rollover → **drain**:
-  replay the folded entries ascending through the per-entry path and disable
-  accumulation. Never worse than today; bounded memory by construction; the drain is
-  the production write path in its best-case key order.
-- **(c/d) v2 design (not implemented): right-edge append splice.** Both lanes ascend
-  strictly across the whole build, so general subtree-merge is never needed:
-  chunk-wise, pop the rightmost leaf (≤512 entries), bulk-build R(leaf ∪ chunk),
-  attach on the right spine at the I11-chosen depth (first spine node whose block
-  bits are all more significant than `msdb(oldMax, newMin)`), path-copy, propagate
-  height/partials via the existing Stage-3c machinery. Bounded at chunk size, full
-  bulk win at any scale; gate is semantic + detector (per §1, the appended shape need
-  not equal `bulkBuild(S_union)`).
+- **(a) Whole-build splice-once — rejected.** It fails from roughly 15 M entries, and a projection
+  build is routinely an order of magnitude past that.
+- **(b) Bulk only the first window, per-entry afterwards — rejected as the primary shape.** The
+  win degenerates to the first window's share of the build (≈ 1 % at 100 M).
+- **(a-bounded) accumulate-with-cap plus a graceful drain — chosen.** The accumulator runs while
+  the tree is virgin, capped at `BULK_SLOT_MAX_ENTRIES` / `BULK_SLOT_MAX_ARENA_BYTES`
+  (8 M entries / 512 MB, `ProjectionIndexHOTStorage`). A build that ends under the cap sorts,
+  folds last-writer-wins and splices once — the full win, which covers every fresh build up to
+  the cap. A cap trip splices the accumulated prefix (legal: the tree is still virgin) and falls
+  through to the per-entry path. The floor is the property that makes the cap safe to pick
+  aggressively: **the drain is the production write path in its best-case key order**, so the
+  bounded shape is never worse than not accumulating at all.
 
-### Seam 2b — v1 implementation (as designed; landed)
-
-- **`io.sirix.index.hot.HOTBulkSlotLoader`** — the slot-store sibling of the loader
-  family: long-key + opaque-payload block-arena accumulation, `Long2IntOpenHashMap`
-  membership/last-ordinal, permutation sort, last-writer-wins fold, splice through the
-  production `spliceBulkBuiltRoot`. Standalone (the abstract loader is `sealed` and
-  postings-shaped).
-- **`ProjectionIndexHOTStorage`** integration, four hooks:
-  - `beginBulkSlotAccumulation()` — engages only on a VIRGIN tree (the positive
-    witness the read-through contract rests on);
-  - `writeSlotValue` head — accumulate; a capacity refusal splices the prefix (legal:
-    the tree is still virgin) and falls through per-entry;
-  - `readSlotValueForWrite` head — **read-through**: an accumulated payload is
-    authoritative (zero-length = tombstoned), a miss falls to the (empty) tree; this
-    is what keeps the order-label walk (reads of earlier-minted labels) and the
-    row-group prior-descriptor probes (reads of absent keys) from forfeiting the win;
-  - `putSegmentPage` / `getSegmentPageBytes` / `removeSegmentPage` — side-page
-    attaches against accumulated owner slots are **DEFERRED** (payload retained, the
-    exact `new OverflowPage(bytes)` ownership contract; 512 MB budget; last-writer-wins
-    by refKey; read-through mid-build) and run through the production `putSegmentPage`
-    right after the splice. Without deferral the first big column segment would have
-    tripped the splice on row group 1 and forfeited the label lane.
-  - `resetTree` discards accumulator + pendings; `finalizeBulkSlotAccumulation()`
-    splices + attaches, safe in `finally` (persists exactly the per-entry prefix
-    semantics on failure).
-- **Wired call site:** `ProjectionIndexBuilder.buildAndPersist` (the post-pass fresh
-  build) — `begin` right after `resetTree`, `finalize` in a wrapping `finally`. The
-  load-time rider (`ProjectionBulkLoad`) is intentionally NOT wired in v1: its
-  auto-commit windows need a pre-commit finalize hook or the accumulated window is
-  lost at commit — v2 work, documented, not hand-waved.
-- **Witness:** `ProjectionBulkSlotAccumulationTest` — the same operation sequence
-  (50 000 label writes with interleaved read-backs, a re-put, a tombstone, an inline
-  blob, a REFERENCED 200 KB blob) through both arms; asserts read-identity
-  in-transaction (pre- AND post-splice), after a REAL commit (trie-navigated reads +
-  side-page bytes), zero malformed subtrees both arms, and the construction-route
-  witness (`bulkSplicedEntryCount` 50 002 vs 0).
-- **Perf gate:** `ProjectionBulkVsPerEntryBench` (see the table above).
-
-### Seam 2c — consolidation into the epoch-riding post-pass (bulkproj)
-
-The consolidated `buildAndPersist` rides the writer's async-flush epochs
-(`BulkBuildEpoch` + mid-build `asyncFlush()` at log boundaries — the bounded-retention
-fix) and mints labels through the in-order lane. Two additions make the accumulator
-compose with that shape:
-
-- **Epoch transplant** — `BulkBuildEpoch.rebind` constructs a fresh storage per epoch;
-  `ProjectionIndexHOTStorage.adoptBulkSlotAccumulation` moves the loader, the deferred
-  side attaches (insertion order preserved into the empty fresh map), the byte
-  accounting and the witness counter onto it BEFORE the root re-seed, so the re-seed's
-  read sees the accumulated root label through the new storage's read-through. The
-  accumulator holds only un-materialized writes for the same still-virgin tree, so it
-  is tree-state-independent and moves wholesale. (In practice accumulation keeps the
-  log so small that boundaries rarely trip — measured live entries ≈ 9 mid-build vs
-  the 64-entry epoch bound — so the transplant is the safety net for corpora whose
-  DOCUMENT-side entries still trip rotations.)
-- **Post-splice drain** — the finalize-splice registers the whole tree in one burst
-  AFTER the last in-loop boundary check, which the bounded-retention witness
-  (`ProjectionPostPassBoundedRetentionTest`) correctly caught: mid-build retention
-  IMPROVED (≈9 live entries vs the 64 bound) but the end-of-build measurement saw the
-  un-rotated burst (161/152 live). The success path therefore finalizes explicitly
-  (idempotent; the outer `finally` stays the exception backstop) and drains through
-  the SAME rotation mechanism the in-loop checks use — a progress-guarded
-  `asyncFlush()` loop; the pinned-trie spill empties it bottom-up (complete-dump
-  leaves first, interiors once their children are durable). Witness green again
-  (≤ 64 live at return, both scenarios).
-
-### Seam 3 — order-directory / locator / dictionary
-
-Same pattern as Seam 2 (dense or strided ascending keys during a fresh build; the
-inventory table in the phase report lists each site's exact key formula and loop).
-These ride the same sink; nothing structurally new.
+The cap is a memory bound, not a tuned constant — move it only against the table above.
 
 ---
 
-## 4. TIL adoption — reuse `registerFreshSubtree`, verbatim
+## 3. Designs deliberately not built
 
-`spliceBulkBuiltRoot` (empty-tree check → `HOTBulkBuilder.build` → root
-`setPage` → `registerFreshSubtree`) is the v1 adoption for whole trees, and
-`registerFreshSubtree` alone for subtree splices. Its invariants, which any caller
-must preserve (all hold for bulk output by construction):
-
-- post-order registration (children before parents — `log.put` nulls the in-memory
-  page on the reference);
-- stop at shared subtrees (`ref.getLogKey() >= 0 || ref.getKey() >= 0`) — moot for a
-  fresh build, load-bearing for future merge work;
-- every fresh leaf `setCompleteDump(true)` → full first fragment at commit, no
-  fragment chain for readers;
-- failure paths retire the unregistered fresh suffix (`closeUnregisteredFreshChildren`,
-  `recoverFromRegistrationFailure`) — off-heap leaf segments never leak.
-
----
-
-## 5. Epoch interplay and memory
-
-### 5.1 Spill eligibility — dense bulk pages are eligible by construction
-
-`isPinnedTrieSpillPageEligible` (NodeStorageEngineWriter.java:2092):
-
-- `HOTLeafPage`: eligible iff `!wouldEmitSparseFragment()` — a fresh complete-dump
-  leaf with no committed predecessor never emits sparse, so **bulk-built leaves are
-  eligible immediately** — and `allSideReferencesDurableAndUnclaimed()` (projection
-  side refs must be durable first; ordinary index leaves have none);
-- `HOTIndirectPage`: eligible iff every child reference is already durable — so a
-  bulk subtree spills strictly bottom-up, leaves → interiors, exactly the order the
-  spill's round-robin cursor discovers them.
-
-This closes the brief's question: the sparse-fragment exclusion
-(`sparse-fragment-spilled-standalone-loses-clean-entries`) cannot bite a fresh bulk
-subtree; only CoW'd leaves with committed ancestry emit sparse.
-
-### 5.2 Memory budget
-
-A bulk build holds, simultaneously: the loader arena (`n × (keyBytes + 20)` — the
-class javadoc's figure), the `R(S)` recursion (transient), and the finished pages
-(pinned until commit or spill). For Seam 1 at 100M rows this is the dominant new cost
-and must be measured before enabling by default; the pinned-trie spill bounds the
-page half, the arena is freed at `flush()` (`releaseBuffers`). Mitigation if the
-arena binds: per-family flush at epoch boundaries into *separate index numbers* is NOT
-possible (one tree per family), so v1 either sizes for residency or defers the family
-to the post-pass builder. Honest open point, not hand-waved.
+- **Right-edge append splice (removes the cap).** Both dominant lanes ascend strictly across the
+  whole build, so general subtree merge is never needed: chunk-wise, pop the rightmost leaf
+  (≤ 512 entries), bulk-build `R(leaf ∪ chunk)`, attach on the right spine at the I11-chosen depth
+  (the first spine node whose block bits are all more significant than `msdb(oldMax, newMin)`),
+  path-copy, and propagate height/partials through the existing Stage-3c machinery. Transient
+  memory is bounded at chunk size, so the full bulk win holds at any scale. Per §1 the gate is
+  semantic + detector: the appended shape need not equal `bulkBuild(S_union)`.
+- **Wiring the load-time rider to the slot sink.** `ProjectionBulkLoad` still persists every slot
+  through the per-entry path; only the post-pass `ProjectionIndexBuilder` engages the accumulator.
+  The blocker is concrete: the rider's auto-commit windows would lose an accumulated window at
+  commit, so it needs a pre-commit finalize hook to splice at each window boundary. Until that
+  exists, wiring it would trade a bounded win for a correctness hazard. The same missing hook is
+  why any auto-committing load cannot accumulate past its first window: after that commit the
+  tree is no longer virgin, and `spliceBulkBuiltRoot` refuses it.
+- **A residency cap for index-everything definitions.** The PATH/CAS/NAME loaders
+  (`AbstractHOTBulkIndexLoader`) hold the whole entry set until `flush()` — roughly
+  `n × (key bytes + 20)` — which is the price of a single-pass canonical construction and is fine
+  for the selective definitions measured in [`BULK_IMPORT.md`](BULK_IMPORT.md). A definition that
+  indexes *everything* over a 100 M-row corpus has no bound at all, and no per-family flush can be
+  interposed because a family is one tree: the loader would have to spill its arena, or the family
+  would have to be deferred to the post-pass builder. Unsolved, and the reason index-everything
+  definitions at that scale are not a supported shape.
+- **A sorted-merge reattach for side references.** `AbstractHOTIndexWriter.reattachSegmentRefs` is
+  `O(refs × leaf lookup)` — fine per rebuild, and fine for the deferred attaches the slot sink
+  replays after its splice, but a whole 100 M-row projection tree bulk-built with populated side
+  maps needs a sorted merge walk instead.
 
 ---
 
-## 6. Gate plan (per the canonicity finding)
+## Appendix A — per-entry HOT slot-write call sites
 
-- **G1 — bulk determinism (byte gate).** Build the same sorted entry list twice with
-  allocators started at the same value; assert identical structure AND identical
-  serialized page bytes. Valid because build order, page-key assignment, and layout
-  choice are all deterministic (§1). Probe already covers the structural half.
-- **G2 — semantic equivalence vs the per-entry path (the replacement gate).** For each
-  converted call site: build once per-entry, once bulk, same inputs; assert identical
-  point reads (`get`), identical range-cursor sequences, and — for the projection —
-  the census differential: `readAllRowGroupsFromColumnSegmentSlots` validates the
-  exact ordered descriptor set and every segment hash, so a lost/duplicated/misplaced
-  slot fails loudly. Byte-identity is **not** asserted against the incremental tree
-  (proven order-dependent, §1).
-- **G3 — invariant oracle.** `HOTMalformedSubtreeDetector` reports zero malformed
-  subtrees on every bulk output (already the production self-heal oracle; also the
-  existing `HOTFormalModelTest` V1–V4 batteries stay green).
-- **G4 — packing gate (for §2.1) — RUN, all green.** Dense/strided 20 000-key builds
-  produce the highest-fitting-subtree leaf count (measured 40, was 280). Battery run
-  one class per JVM: `HOTBulkBuilderTest` 5/5 (incl. 1575 adversarial sets, 0
-  violations), `HOTFormalModelTest` 3/3, `StraddleCanonicityProbe` 3/3,
-  `HOTIntegrateTest` 4/4, `HOTMalformedSubtreeDetectorTest` 11/11,
-  `HOTLeafPageSplitFaithfulTest` 3/3, `HOTIndirectPageSplitFaithfulTest` 11/11,
-  `HOTDescentAnalysisTest` 4/4, `HOTIncrementalSplitSegmentRefTest` 2/2,
-  `HOTInsertionOrderShapeProbe` 1/1, and end-to-end `JsonCASIndexBuildTest` 6/6
-  (bulk-loader postings == change-listener postings at DB level). Every failure on
-  the way was a coverage-generator shape dependence, reviewed and repaired — never a
-  silenced assertion (§2.1 blast-radius list).
-- **Perf gate (campaign-level).** Per-family build time at 1M/10M rows, per-entry vs
-  bulk; TIL pinned-entry count; peak RSS. No mechanism ships on benchmark-only
-  evidence (`benchmark-mechanisms-must-be-generally-applicable`): the loaders/builder
-  are general-purpose index machinery, the projection sink must be, too.
-
----
-
-## 7. Risks / open questions
-
-1. **Packing fix changes live shapes** through `splitLeafPage`/`rebuildSubtree` —
-   any hidden exact-shape dependence (tests or readers) surfaces in G4. Readers route
-   by invariants, so this is expected-quiet, but unverified until run.
-2. **Loader arena at 100M** (§5.2) — measure before default-on.
-3. **Auto-commit windows** break the empty-tree precondition for Seam 2's
-   non-parallel path; v1 falls back per-entry after the first window. v2 needs
-   subtree merge (append-region splice), deliberately out of scope.
-4. **Stale incremental heights** (probe finding, §1) predate this campaign but
-   interact with any future "bulk-build the tail, integrate incrementally" hybrid:
-   integrate's intermediate-node decision consumes heights. Fix separately.
-5. **Projection side-ref reattach at bulk scale** — `reattachSegmentRefs` is
-   O(refs × leaf lookup); fine per-rebuild today, needs a sorted merge walk if a
-   whole 100M projection tree is bulk-built with populated side maps.
-
----
-
-## Appendix A — per-entry HOT write call sites (fresh-build inventory)
-
-All sites below funnel into `ProjectionIndexHOTStorage.writeSlotValue` /
-`putBlob` (each = one `prepareLeafOfTree` descent + branch-escape dispatch +
-`leaf.put` + update-or-split cascade) unless noted. "Append-ordered" = keys
-non-decreasing across the calls of one fresh build.
+The per-entry slot writes a fresh projection build performs, and the key pattern each produces —
+the input any bulk sink has to cover. Every site funnels into
+`ProjectionIndexHOTStorage.writeSlotValue` / `putBlob` — one `prepareLeafOfTree` descent, a
+branch-escape dispatch, a `leaf.put`, and an update-or-split cascade per call — unless noted. Each
+slot key reaches the trie as its sign-flipped 8-byte big-endian image (`slotKeyBytes`), so the
+namespaces below are ordered by the same comparison the trie uses. "Append-ordered" means keys are
+non-decreasing across the calls of one fresh build. Symbols, not line numbers: these resolve by
+grep and survive edits.
 
 | Site | Key formula | Order in a fresh build | Bulk candidate |
 |---|---|---|---|
-| Row-group descriptor slot — `putRowGroupAsColumnSegmentSlots` (ProjectionIndexHOTStorage.java:596→640), called from `ProjectionIndexBuilder` + `ProjectionBulkLoad` (ProjectionBulkLoad.java:80) + `ProjectionIndexChangeListener.writeRowGroup`:3090 | `rowGroupId << 16` (slotKind 0), sign-flipped 8-byte BE | rowGroupId contiguous from 1 in emit order → append-ordered | YES |
-| Column-segment slots — `writeChangedColumnSegmentSlots` per segment | `(rowGroupId << 16) \| (columnSegmentId + 1)` | ascending within a group; groups ascend → append-ordered | YES |
-| Segment overflow pages — `putSegmentPage` (ProjectionIndexHOTStorage.java:3452) | side-map key `(ownerSlotKey << 16) \| columnSegmentId`, attached to the OWNING LEAF, not the trie | follows the owning slot | attach-after-build via `reattachSegmentRefs` |
-| Order-directory slots — `ProjectionStructuralOrderDirectory.HotSlotStore.put` → `putStructuralOrderSlot` (ProjectionStructuralOrderDirectory.java:142) | `2^50 + nodeKey`, ONE SLOT PER RECORD | strictly ascending in a fresh build (assume the in-order label lane, §0) | **YES — ~95 % of all per-entry insertions; the primary target** |
-| Record locator — `ProjectionRecordLocator.put`:95 → `putRawSlot(slotKey(recordKey))` | `slotKey(recordKey)` | update/move path (rebalance); low volume in a fresh build (not fully traced) | LOW PRIORITY |
-| Fences — `ProjectionIndexFences` (`putBlob` at :350/:355/:362/:904/:917) | `CHUNK_SLOT_BASE + chunkId` (2^42 namespace), `ORDER_HEADER_SLOT` | chunkId ascending; header last → append-ordered | YES |
-| Bloom chunks — `ProjectionBloomChunks` (`putBlob` at :136/:684/:706/:853/:938) | `bloomBlockSlotKey(column)` + chunk slots (2^43 namespace) | per-column ascending chunks | YES |
-| Set-summary chunks — `ProjectionSetSummaryChunks` :54/:164/:388 | `slotKey(column)` | per-column | YES |
-| Metadata blob — `ProjectionIndexBuilder`:898, `ProjectionBulkLoad`:302, listener :2313/:3139 | slot 0 | once at end | trivial |
-| PATH/CAS/NAME entries — `AbstractHOTIndexWriter.doIndex` via builders | serializer-specific composite keys | traversal order (not sorted) | ALREADY BULK for virgin trees (`create*BulkLoader`); importer-side lift = Seam 1 |
-
-Answers to the three campaign questions:
-
-- `ProjectionIndexHOTStorage` uses **no** bulk loader today (zero references to
-  `createBulkLoader`/`spliceBulkBuiltRoot` in `io.sirix.index.projection`).
-- The parallel importer's refusal: `ParallelBulkJsonImporter.refuseUnsupportedShape`
-  (ParallelBulkJsonImporter.java:215–218) throws on `bulkHasPrimitiveIndexes()`; it
-  also requires a FRESH resource (:219–221), so at load end every index tree is
-  virgin — the bulk loaders' empty-tree precondition holds by construction. (Since Seam 1
-  landed, only valid-time and an unarmed projection are refused there; the fresh-resource
-  requirement — and with it the empty-tree precondition — is unchanged.)
-- `ProjectionBulkLoad` keeps the real `ProjectionIndexBuilder` machinery alive across
-  auto-commit windows and streams full leaves through
-  `putRowGroupAsColumnSegmentSlots` — i.e., it batches BUILD state, not WRITES; every
-  persisted slot still pays the per-entry descent.
+| Row-group descriptor slot — `ProjectionIndexHOTStorage.putRowGroupAsColumnSegmentSlots`, from `ProjectionIndexBuilder`, `ProjectionBulkLoad` and `ProjectionIndexChangeListener.writeRowGroup` | `rowGroupId << 16` (slot kind 0) | rowGroupId contiguous from 1 in emit order → append-ordered | yes |
+| Column-segment slots — `writeChangedColumnSegmentSlots`, per segment | `(rowGroupId << 16) \| (columnSegmentId + 1)` | ascending within a group, groups ascend → append-ordered | yes |
+| Segment overflow pages — `putSegmentPage` | side-map key `(ownerSlotKey << 16) \| columnSegmentId`, attached to the OWNING LEAF, not the trie | follows the owning slot | attach after the build (`reattachSegmentRefs`) |
+| Order-directory slots — `ProjectionStructuralOrderDirectory.HotSlotStore.put` → `putStructuralOrderSlot` | `2^50 + nodeKey`, ONE SLOT PER RECORD | strictly ascending in a fresh build (the in-order append lane mints them) | **yes — ~95 % of all per-entry insertions, the primary target** |
+| Record locator — `ProjectionRecordLocator.put` → `putRawSlot` | `Long.MIN_VALUE \| recordKey` (sign-bit namespace) | update/move path (rebalance); low volume in a fresh build | low priority |
+| Fences — `ProjectionIndexFences` (`putBlob`) | `CHUNK_SLOT_BASE + chunkId` (2^42 namespace), `ORDER_HEADER_SLOT` | chunkId ascending, header last → append-ordered | yes |
+| Bloom chunks — `ProjectionBloomChunks` (`putBlob`) | per-column bloom block + chunk slots (2^43 namespace) | per-column ascending chunks | yes |
+| Set-summary chunks — `ProjectionSetSummaryChunks` | `slotKey(column)` (2^44 namespace) | per column | yes |
+| Metadata blob — `ProjectionIndexBuilder`, `ProjectionBulkLoad`, the change listener | slot 0 | once, strictly last | trivial |
+| PATH/CAS/NAME entries — `AbstractHOTIndexWriter.doIndex` via the family builders | serializer-specific composite keys | traversal order (not sorted; the loader sorts) | already bulk for virgin trees (`create*BulkLoader`) |

--- a/docs/HOT_BULK_BUILD.md
+++ b/docs/HOT_BULK_BUILD.md
@@ -1,6 +1,13 @@
 # HOT Bulk Construction for Secondary Structures — Design (Campaign #76, Phase 1)
 
-**Status:** design + measured evidence; nothing here is committed. Companion probe:
+**Status:** design record — the v1 design and the measured evidence behind it. It has since
+LANDED: the §2.1 leaf-packing fix, Seam 1 (the importer now maintains PATH/CAS/NAME during the
+load), and Seam 2's slot accumulator (`HOTBulkSlotLoader`, engaged by the post-pass
+`ProjectionIndexBuilder`; the load-time rider still writes per entry — see Seam 2b). What the
+shipped loaders actually do, refuse and cost is owned by
+[`BULK_IMPORT.md`](BULK_IMPORT.md); read this one for WHY. Every "today"/"currently"/"this
+worktree" statement below describes the tree at `226ceaac8`, the base this design was written
+against. Companion probe:
 `bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java`.
 
 **Scope v1:** fresh subtrees only — no merge into populated trees, no tombstone
@@ -71,7 +78,8 @@ What does **not** exist — the actual campaign gap. The campaign is therefore N
   `indexController.hasAnyPrimitiveIndex()` via JsonNodeTrxImpl.java:1202–1204; the
   non-parallel sink honors the same signal — WtxBulkRecordSink.java:40); lifting it
   wants per-family accumulation in workers + one flush into the EXISTING
-  `create*BulkLoader()` per family at load end.
+  `create*BulkLoader()` per family at load end. **Lifted since** (Seam 1): PATH, CAS and NAME
+  are maintained by the load, valid-time is the one family that still refuses.
 - The existing `HOTBulkBuilder` **under-packed leaves by ~7×** on realistic
   dense/strided key sets (§3; fixed in this worktree) — feeding it 100M-scale
   projection slots without the packing fix would have multiplied page count, TIL
@@ -199,7 +207,12 @@ verifies 13/13 depth-0 folds route 100 % strict — coverage the old shapes neve
 
 ### Seam 1 — importer-side PATH/CAS/NAME materialization (the refusal lift)
 
-`ParallelBulkJsonImporter` currently refuses secondary-index maintenance. The
+> **Landed.** The importer maintains PATH, CAS and NAME during the load exactly as planned here
+> (workers collect tuples, the coordinator drains them into `create*BulkLoader()` and flushes once
+> before the commit); valid-time still refuses. Shipped scope and cost:
+> [`BULK_IMPORT.md`](BULK_IMPORT.md). The design below is kept for the reasoning.
+
+`ParallelBulkJsonImporter` refused secondary-index maintenance at the time of writing. The
 EXISTING loaders make the lift mechanical; the per-family entry shape each loader
 needs, and where a worker can produce it:
 
@@ -330,7 +343,7 @@ Arithmetic (label lane, 8 B keys + 30 B payloads; slot-loader arena ≈ 70 B/ent
   bulk win at any scale; gate is semantic + detector (per §1, the appended shape need
   not equal `bulkBuild(S_union)`).
 
-### Seam 2b — v1 implementation (this worktree, uncommitted)
+### Seam 2b — v1 implementation (as designed; landed)
 
 - **`io.sirix.index.hot.HOTBulkSlotLoader`** — the slot-store sibling of the loader
   family: long-key + opaque-payload block-arena accumulation, `Long2IntOpenHashMap`
@@ -532,7 +545,9 @@ Answers to the three campaign questions:
 - The parallel importer's refusal: `ParallelBulkJsonImporter.refuseUnsupportedShape`
   (ParallelBulkJsonImporter.java:215–218) throws on `bulkHasPrimitiveIndexes()`; it
   also requires a FRESH resource (:219–221), so at load end every index tree is
-  virgin — the bulk loaders' empty-tree precondition holds by construction.
+  virgin — the bulk loaders' empty-tree precondition holds by construction. (Since Seam 1
+  landed, only valid-time and an unarmed projection are refused there; the fresh-resource
+  requirement — and with it the empty-tree precondition — is unchanged.)
 - `ProjectionBulkLoad` keeps the real `ProjectionIndexBuilder` machinery alive across
   auto-commit windows and streams full leaves through
   `putRowGroupAsColumnSegmentSlots` — i.e., it batches BUILD state, not WRITES; every

--- a/docs/HOT_BULK_BUILD.md
+++ b/docs/HOT_BULK_BUILD.md
@@ -1,0 +1,539 @@
+# HOT Bulk Construction for Secondary Structures — Design (Campaign #76, Phase 1)
+
+**Status:** design + measured evidence; nothing here is committed. Companion probe:
+`bundles/sirix-core/src/test/java/io/sirix/index/hot/HOTInsertionOrderShapeProbe.java`.
+
+**Scope v1:** fresh subtrees only — no merge into populated trees, no tombstone
+migration, no cross-revision fragment interplay beyond what `registerFreshSubtree`
+already guarantees.
+
+---
+
+## 0. Premise audit — what already exists (and what the campaign premise got wrong)
+
+The campaign premise assumed bottom-up bulk construction for HOT structures had to be
+designed from scratch. The tree at `226ceaac8` already contains most of the machinery:
+
+| Piece | Where | State |
+|---|---|---|
+| Bottom-up builder (`R(S)` + SMHP compression) | `io.sirix.index.hot.HOTBulkBuilder` | **EXISTS**, formally modeled (`docs/HOT_FORMAL_FOUNDATION.md` Thm 1, `HOTFormalModelTest`), property-tested |
+| Accumulate–sort–fold–build loader | `io.sirix.index.hot.AbstractHOTBulkIndexLoader` (+ `HOTBulkIndexLoader` for CAS/NAME, `HOTLongBulkIndexLoader` for PATH) | **EXISTS**; block-arena keys, int-permutation sort, exact-size entry list |
+| Root splice for an empty tree | `AbstractHOTIndexWriter.spliceBulkBuiltRoot` (AbstractHOTIndexWriter.java:1136) | **EXISTS**; refuses non-empty trees |
+| TIL adoption of a fresh HOT subtree | `AbstractHOTIndexWriter.registerFreshSubtree` → `registerFreshPage` (AbstractHOTIndexWriter.java:4613–4661) | **EXISTS**; post-order `log.put(ref, PageContainer(page,page))`, `setCompleteDump(true)` on fresh leaves |
+| Bulk-load engagement for PATH/CAS/NAME | `PathIndexBuilder`/`CASIndexBuilder`/`NameIndexBuilder` constructors | **EXISTS**, but only when the builder starts against an **empty** tree (create-index-over-existing-revision) |
+
+Two premise corrections:
+
+1. **Adoption is not `KeyedTrieWriter.prepareLeafOfTree` for HOT.** That pair is the
+   *document-index* (bit-decomposition radix trie over `IndirectPage`s) adoption used by
+   `ParallelBulkJsonImporter`. HOT subtrees enter the TIL through
+   `registerFreshSubtree`, which is the exact HOT analog: children registered before
+   parents, each page its own `(complete==modified)` container, fresh leaves marked
+   complete-dump so commit emits full first fragments and readers never chase a chain.
+   Nothing new needs designing here — v1 reuses it unchanged.
+
+2. **HOT pages are never epoch-flushed.** The async-flush epochs
+   (`TransactionIntentLog.snapshot()`/`cleanupSnapshot()`) attempt only
+   `KeyValueLeafPage`s. Every HOT page (leaf and indirect) is **pinned**
+   (TransactionIntentLog.java:337–397, `PINNED_GENERATION`): one stable TIL identity for
+   the life of the transaction, serialized at final commit — or earlier by the bounded
+   **pinned-trie spill** under memory pressure
+   (`TransactionIntentLog.capturePinnedSpillCandidates`,
+   `NodeStorageEngineWriter.isPinnedTrieSpillPageEligible`,
+   NodeStorageEngineWriter.java:2092–2119). "Flush-eligible under the async-flush
+   epochs" therefore translates to **spill-eligible**, see §5.
+
+What does **not** exist — the actual campaign gap. The campaign is therefore NOT
+"invent a bottom-up builder"; it is **extend and route the existing
+`AbstractHOTBulkIndexLoader` family** into the write populations that bypass it:
+
+- The **projection family** (column-segment slots, order-directory slots, record
+  locator, fences, Bloom chunks, global-dictionary records) writes per-entry through
+  `ProjectionIndexHOTStorage.writeSlotValue` (ProjectionIndexHOTStorage.java:3397):
+  descent (`prepareLeafOfTree`) + branch-escape dispatch + `leaf.put` +
+  update-or-split cascade, once per slot. `ProjectionIndexHOTStorage` is a sibling
+  subclass of `AbstractHOTIndexWriter` that never touches the loader family
+  (`spliceBulkBuiltRoot`'s only caller is `AbstractHOTBulkIndexLoader.flush`:275;
+  the loaders' only consumers are the PATH/CAS/NAME builders gated on
+  `isEmptyTree()`). `ProjectionBulkLoad` keeps the *builder* alive across
+  auto-commits (process-global ACTIVE map keyed `resourceKey#defId`,
+  ProjectionBulkLoad.java:90; `DEFAULT_ROW_GROUP_PUBLISHER` is a method ref to
+  `putRowGroupAsColumnSegmentSlots`, :79) but still persists through the per-entry
+  path — it batches BUILD state, not WRITES.
+- **The dominant per-entry population is the order-label directory**: one slot per
+  record under `2^50 + nodeKey`, strictly ascending — ~95 % of all per-entry HOT
+  insertions in a fresh build, and already perfectly loader-shaped. (The
+  consolidated `bulkproj` worktree — NOT this base — already routes post-pass label
+  minting through an in-order label lane; this design assumes that lane exists and
+  must not re-fix it.)
+- The **parallel importer refuses PATH/CAS/NAME/valid-time maintenance**
+  (ParallelBulkJsonImporter.java:215–218 on `bulkHasPrimitiveIndexes()`, =
+  `indexController.hasAnyPrimitiveIndex()` via JsonNodeTrxImpl.java:1202–1204; the
+  non-parallel sink honors the same signal — WtxBulkRecordSink.java:40); lifting it
+  wants per-family accumulation in workers + one flush into the EXISTING
+  `create*BulkLoader()` per family at load end.
+- The existing `HOTBulkBuilder` **under-packed leaves by ~7×** on realistic
+  dense/strided key sets (§3; fixed in this worktree) — feeding it 100M-scale
+  projection slots without the packing fix would have multiplied page count, TIL
+  residency, and I/O.
+
+---
+
+## 1. Shape canonicity — the finding that fixes the gate design
+
+Full evidence in the phase report; operative summary:
+
+- **`HOTBulkBuilder.build(S)` is deterministic in the key set** — same sorted entries in,
+  same structure out, regardless of the order pairs were fed to the loader. Verified
+  empirically (probe: `shape bulk==bulk2 (determinism): true` for both key patterns) and
+  by code (pure two-phase recursion; the only inputs are the sorted arrays).
+  With a fixed page-key allocator start, page keys are deterministic too (allocation
+  order is the DFS order of construction), so **byte-identity between two bulk builds
+  of the same entries is a valid gate**.
+- **The live incremental trie is NOT canonical and NOT order-independent.** Same
+  20 000-key set through the production `doIndex` in ascending vs descending order:
+  40 leaves/3 indirects/height-2 vs 40 leaves/20 indirects (a 6-deep chain);
+  every shape pair unequal except asc==shuffled (post-consolidation coincidence).
+  The code says so itself: the periodic consolidation sweep exists because "the
+  incremental insert over-partitions … under-full frozen leaves an insert never
+  re-routes to" (AbstractHOTIndexWriter.java:3384–3390), and it packs only toward
+  `CONSOLIDATION_TARGET = 384` (¾ of `MAX_ENTRIES`), not toward the bulk cut.
+- Consequence: **the v1 gate is layered, not byte-identical to the incremental
+  result** (§6). Byte-identity is reserved for bulk-vs-bulk reproducibility; the
+  bulk-vs-incremental gate is semantic (reads + census) plus the invariant oracle
+  (`HOTMalformedSubtreeDetector`), which both construction routes must pass with zero
+  findings.
+- **The sharper form of the question** ("does `spliceBulkBuiltRoot` produce trees
+  byte-identical to incremental insertion of the same keys, and do its existing users
+  prove that or merely tolerate divergence"): **No, and they tolerate it.** The probe
+  drove the REAL `createBulkLoader → flush → spliceBulkBuiltRoot` path against the
+  REAL `doIndex` on identical key sets: interior structure differs even after the
+  packing fix (bulk 40 leaves/9 indirects vs incremental-ascending 40/3 — SMHP
+  fanout-32 frontier vs integrate/pull-up shapes). The loader family's only
+  end-to-end user gate, `JsonCASIndexBuildTest`, asserts postings-set equality
+  ("postings … must not depend on how the index was built", :190–192) plus a
+  zero-self-heal witness during bulk builds (:176–180) — no structural or byte
+  assertion exists anywhere in the family's tests.
+- Additional measured facts the design leans on: (a) all four construction routes are
+  **read-equivalent** (20 000 keys × 2 patterns × point lookups — identical postings);
+  (b) the incremental path in descending order leaves **stale `height` fields**
+  (nested indirects all claiming `h=1`) — a latent divergence source for
+  `integrate`'s `parent.height > B.height` decision, noted as a separate follow-up,
+  not in v1 scope.
+
+---
+
+## 2. The construction algorithm (as implemented, with the v1 packing fix)
+
+Input: a strictly-ascending, duplicate-free `(key, payload)` stream (the loader
+guarantees this: block-arena accumulation, one parallel int-sort by
+`(compositeKey, nodeKey)`, group-fold per distinct key —
+AbstractHOTBulkIndexLoader.java:223–277).
+
+Phase A — `buildR` (HOTBulkBuilder.java:191): Binna's binary Patricia trie by MSDB
+recursion over the sorted array. `O(n · keylen)` worst case, no allocation beyond the
+recursion frames and `RNode` records.
+
+Phase B — `bulk` compression (HOTBulkBuilder.java:268):
+
+- **Leaf cut:** a subtree of ≤ `HOTLeafPage.MAX_ENTRIES` (512) entries is speculatively
+  packed into one `HOTLeafPage` (64 KiB slot heap, `DEFAULT_SIZE`); byte overflow
+  recurses into the branch. A leaf page is always a *complete `R(S)` subtree* —
+  the invariant that makes multi-entry pages routable (foundation §3.2).
+- **Interior assembly:** greedy SMHP frontier expansion to ≤ 32 children
+  (`buildIndirect`), sparse-path partial encoding, SingleMask when the disc bits fit an
+  8-byte window, MultiMask otherwise; span node ≤ 16 children, multi node ≤ 32
+  (`assembleIndirect`, HOTBulkBuilder.java:439).
+
+### 2.1 The v1 packing fix — stop the frontier below the page boundary
+
+**Measured defect:** `buildIndirect` expands the block frontier by always splitting the
+*largest* frontier branch until 32 children exist. The expansion does not stop at
+branches whose whole key group would fit a leaf page, so page-fitting `R(S)` subtrees
+get split across several frontier slots, and their fragments recurse into *further*
+32-way expansions. Dense/strided 20 000-key sets build **280 leaves (min fill 16, mean
+~71)** where the highest-fitting-subtree cut yields **40 leaves (fill ≈ 512)** — the
+shape both the class javadoc ("cut a HOTLeafPage at the highest R(S) subtree whose key
+group fits a page") and foundation §3.2 *claim*. Exact arithmetic of the observed
+tree: root expands 20 000 keys into 24×512-blocks + 8×1024-blocks; each 1024-block
+re-expands into 32 leaves of 32 → 24 + 256 = 280 leaves, 1 + 8 = 9 indirects — the
+probe's numbers exactly.
+
+**Fix (IMPLEMENTED in this worktree, uncommitted):** during frontier expansion, a
+frontier node is *non-expandable* when its key group fits a leaf page
+(`BulkContext.isExpandable`/`fitsLeafPage` — count ≤ `MAX_ENTRIES` and a conservative
+byte upper bound `Σ(4 + keyLen + valueLen) ≤ HOTLeafPage.DEFAULT_SIZE`, early-exit,
+allocation-free; the bound charges the full key, the page stores only the
+post-prefix suffix, so a passing group can never overflow the real page —
+`tryBuildLeaf` stays the authoritative check and the recursion the fallback).
+Licensed by the model: "any frontier is invariant-correct by Theorem 1"
+(HOTBulkBuilder.java:266) — the fix only *chooses a different frontier*, all
+invariants and the determinism argument survive verbatim. Height cannot increase:
+stopping expansion earlier only removes interior levels.
+
+**Measured after the fix:** dense/strided 20 000-key builds go 280 → **40 leaves**
+(fill 32..512, exactly the highest-fitting-subtree count), bulk-vs-bulk determinism
+still byte-stable, and the full HOT gate battery is green (§6 G4 list, all run).
+
+**Blast radius:** `HOTBulkBuilder.build` also serves `splitLeafPage`'s halves
+(HOTIncrementalInsert.java:154–155 via `buildHalf`), `rebuildSubtree`
+(AbstractHOTIndexWriter.java:3499), and the malformed-subtree self-heal — live-tree
+shapes shift wherever a half or rebuilt subtree spans multiple pages. All shapes remain
+invariant-clean; gates in §6 cover the change. Three test scenarios manufactured their
+preconditions FROM the old fragmentation (full 32-child roots out of small random sets;
+mergeable BiNode pairs on fresh bulk output — now impossible by construction) and were
+repaired to force those shapes by key design / by a real `splitLeafPage` fold:
+`HOTIntegrateTest` (grouped keys, pair-overflow constraint `256 < perGroup ≤ 512`),
+`StraddleCanonicityProbe` (grouped keys), `HOTIndirectPageSplitFaithfulTest`
+(split-then-merge round trip), `HOTBulkBuilderTest` V5 (600-key byte-position groups
+keep the MultiMask span at 28 bytes), and `BetaIsDiscBitRoutingProbe` (a depth-0
+blind spot: the probe descended a stale root Page variable after a fold replaced the
+ROOT — unreachable pre-fix because canonical roots were always full and full nodes
+divert to the Q4 decomposition; base-tree baseline confirmed green pre-fix, the
+node-local routing printout proved the primitive correct, and the repaired probe now
+verifies 13/13 depth-0 folds route 100 % strict — coverage the old shapes never had).
+
+---
+
+## 3. Integration seams (v1 targets, in payoff order)
+
+### Seam 1 — importer-side PATH/CAS/NAME materialization (the refusal lift)
+
+`ParallelBulkJsonImporter` currently refuses secondary-index maintenance. The
+EXISTING loaders make the lift mechanical; the per-family entry shape each loader
+needs, and where a worker can produce it:
+
+| Family | Loader `add(...)` shape | Worker-side availability |
+|---|---|---|
+| PATH | `HOTLongBulkIndexLoader.add(long pcr, long nodeKey)` | nodeKey: assigned by the worker; PCR: needs the path-summary node for the record's path — available where the importer maintains the summary; otherwise a coordinator-side replay of collected (pathStep, nodeKey) tuples. OPEN DEPENDENCY: verify at which point the importer's summary is consistent enough to resolve PCRs. |
+| CAS | `HOTBulkIndexLoader<CASValue>.add(CASValue key, long nodeKey)` (key = PCR + typed atom) | atom text + node kind known at token time in the worker; type coercion needs the index definition (coordinator-owned, read-only — shareable). Same PCR dependency as PATH. |
+| NAME | `HOTBulkIndexLoader<QNm>.add(QNm, long nodeKey)` | trivially known at token time. |
+
+1. Workers collect the tuples per chunk into primitive-friendly buffers.
+2. Coordinator (single-threaded, owns the trx) drains them into
+   `create*BulkLoader()` — feed order is free, the loader sorts — and calls
+   `flush()` once at load end, before the single commit. `spliceBulkBuiltRoot` +
+   `registerFreshSubtree` do the adoption; commit serializes.
+3. Precondition: the index tree is virgin in this revision. GUARANTEED here — the
+   importer refuses non-fresh resources (ParallelBulkJsonImporter.java:219–221), so
+   `isEmptyTree()` holds at load end by construction.
+
+No new trie API is needed. What is new: the worker-side accumulation plumbing, the
+PCR-availability answer, and the memory budget (§5.2) — pairs for 100M rows are
+resident until flush.
+
+### Seam 2 — projection fresh build: batch the slot writes
+
+A fresh projection build (post-pass `ProjectionIndexBuilder` or load-time
+`ProjectionBulkLoad`) emits, per row group: one descriptor slot + one slot per column
+segment, keys `(rowGroupId << 16) | slotKind` — row-group ids assigned contiguously
+from 1 (ProjectionIndexHOTStorage.java:49–56) — then fences (2^42 namespace), Bloom
+chunks (2^43), metadata blobs. Row-group slot keys are therefore **append-ordered by
+construction** during a fresh build; fences/Bloom/metadata arrive in their own
+ascending namespaces afterward. This is exactly the loader's ideal input.
+
+The dominant sub-population is the **order-label lane** (~95 % of fresh-build
+insertions, one slot per record at `2^50 + nodeKey`, strictly ascending) — assume the
+in-order lane exists (see §0) and target it first: strictly-ascending small-payload
+slots are the loader family's ideal input.
+
+**Loader-contract gap.** `AbstractHOTBulkIndexLoader` is postings-shaped: it carries a
+`long nodeKey` per entry and its `toEntry` FOLDS a key's node keys into one chunked
+`NodeReferences` run (AbstractHOTBulkIndexLoader.java:303–320). Projection slots are
+REPLACE-semantics opaque `byte[]` payloads. So the projection cannot consume the
+concrete class as-is; the v1 seam is a **sibling in the same family** (share the
+block-arena accumulation, the int-permutation sort, the exact-size entry list, and the
+`spliceBulkBuiltRoot` splice; swap the per-entry parallel array from `nodeKeys[]` to a
+packed payload position/length, payload bytes in the same block arena):
+`HOTBulkSlotLoader` — engaged by `ProjectionIndexHOTStorage` when the tree is empty
+(fresh build), routing `writeSlotValue`/`putBlob` into accumulation instead of N
+descents, spliced once at build end. Constraints that shape it:
+
+- **Replace-not-OR-merge slot semantics** (branch-escape guard javadoc,
+  AbstractHOTIndexWriter.java:1746–1759): the accumulator must key-dedupe with
+  last-writer-wins, not fold postings — its own `toEntry` (keep the last payload).
+- **Read-your-writes during the build**: `putRowGroupAsColumnSegmentSlots` reads the
+  prior descriptor (`getBlobIfReadable`, ProjectionIndexHOTStorage.java:617 — null on
+  a fresh build) and the fence/Bloom rewrite paths read earlier chunks. While
+  accumulating, reads must be served from the accumulator (a key-indexed view) or the
+  sink is restricted to sites verified write-only for the fresh build. This is the
+  main v1 engineering risk on Seam 2.
+- **Side maps / OverflowPages** (`putSegmentPage`): segment references hang off the
+  leaf that *physically holds the owning slot*. Attach **after** the build via the
+  existing `reattachSegmentRefs` discipline (used by every rebuild path), which
+  resolves owner slots against the finished leaves.
+- **Tombstones cannot occur in a fresh build** (nothing to delete) — in-scope for v1.
+- **Auto-commit windows:** the non-parallel bulk load commits every
+  `-Dsirix.autoCommit.nodes` nodes; after the first commit the tree is no longer
+  virgin and v1 must fall back to the per-entry path for subsequent windows (v2:
+  subtree-level merge — out of scope). The parallel importer's single-commit shape
+  avoids this entirely, so Seam 2 lands cleanly there first.
+
+### Seam 2a — measured perf gate + the streaming-vs-splice-once decision (phase 2)
+
+**Perf gate (ProjectionBulkVsPerEntryBench, production paths both arms, interleaved
+reps, best-of; witnesses untimed: sampled read-back equality + detector-clean):**
+
+| shape | entries | perEntry ns/entry | bulk ns/entry | ratio |
+|---|---|---|---|---|
+| label (2^50+k, 30 B) | 1 M | 1 506.6 | 159.6 | **9.44×** |
+| label | 10 M | 1 986.1 | 159.4 | **12.46×** |
+| segslot ((rg<<16)\|slot) | 1 M | 1 463.9 | 129.5 | **11.30×** |
+| segslot | 10 M | 2 199.0 | 156.5 | **14.05×** |
+
+Per-entry cost GROWS with scale (deeper descents, more split cascades); bulk stays
+flat ≈ 130–160 ns/entry. Gate threshold (≥3×) passed with 3–4.7× margin.
+
+**The decision.** `spliceBulkBuiltRoot` refuses non-empty trees while the build writes
+continuously. Two clarifications change the option space:
+
+- **Flush-epoch rotation is NOT the obstacle**: epochs never touch HOT pages (§0.3 —
+  pinned region); the tree becomes non-empty through the build's own writes and real
+  auto-COMMITS. The rider stale-marks the index for the whole load
+  (`ProjectionBulkLoad` metadata `staleTombstone`, :302), so intermediate revisions
+  never serve from the half-built projection — accumulation is visibility-safe; the
+  binding constraint is memory.
+- **A leaf owns a 64 KiB slot segment regardless of fill** (`HOTLeafPage` ctor →
+  `allocator.allocate(DEFAULT_SIZE)`, HOTLeafPage.java:458), and during
+  `HOTBulkBuilder.build` none of the pages are TIL-registered, so the pinned-trie
+  spill cannot relieve them — the BUILT PAGES are unconditionally resident until the
+  splice, on top of the loader arena.
+
+Arithmetic (label lane, 8 B keys + 30 B payloads; slot-loader arena ≈ 70 B/entry
+(key+payload block bytes + 24 B index); built tree ≈ 64 KiB / 512 entries =
+128 B/entry):
+
+| entries per splice | arena | built pages | total transient | vs ≤2 G rule |
+|---|---|---|---|---|
+| 1 M | 70 MB | 128 MB | ~0.2 GB | fine |
+| 8 M | 560 MB | 1.0 GB | ~1.6 GB | fine — the chosen cap |
+| 30 M | 2.1 GB | 3.8 GB | ~5.9 GB | FAIL |
+| 100 M | 7.0 GB | 12.5 GB | ~19.5 GB | FAIL outright |
+
+- **(a) whole-build splice-once — REJECTED at scale** (fails from ~15 M entries).
+- **(b) bulk only the first window — REJECTED as primary** (rider win ≈ A/total ≈ 1 %
+  at 100 M; post-pass degenerates to (a)).
+- **CHOSEN v1 — (a-bounded): accumulate-with-cap + graceful drain.**
+  `HOTBulkSlotLoader` accumulates while the tree is virgin, capped at 8 M entries /
+  512 MB arena bytes. Build ends under the cap → sort + last-writer-wins fold +
+  splice-once (full 9–14× win — covers every fresh build ≤ 8 M slots). Cap trip, any
+  read of projection state, a side-ref attach, or transaction rollover → **drain**:
+  replay the folded entries ascending through the per-entry path and disable
+  accumulation. Never worse than today; bounded memory by construction; the drain is
+  the production write path in its best-case key order.
+- **(c/d) v2 design (not implemented): right-edge append splice.** Both lanes ascend
+  strictly across the whole build, so general subtree-merge is never needed:
+  chunk-wise, pop the rightmost leaf (≤512 entries), bulk-build R(leaf ∪ chunk),
+  attach on the right spine at the I11-chosen depth (first spine node whose block
+  bits are all more significant than `msdb(oldMax, newMin)`), path-copy, propagate
+  height/partials via the existing Stage-3c machinery. Bounded at chunk size, full
+  bulk win at any scale; gate is semantic + detector (per §1, the appended shape need
+  not equal `bulkBuild(S_union)`).
+
+### Seam 2b — v1 implementation (this worktree, uncommitted)
+
+- **`io.sirix.index.hot.HOTBulkSlotLoader`** — the slot-store sibling of the loader
+  family: long-key + opaque-payload block-arena accumulation, `Long2IntOpenHashMap`
+  membership/last-ordinal, permutation sort, last-writer-wins fold, splice through the
+  production `spliceBulkBuiltRoot`. Standalone (the abstract loader is `sealed` and
+  postings-shaped).
+- **`ProjectionIndexHOTStorage`** integration, four hooks:
+  - `beginBulkSlotAccumulation()` — engages only on a VIRGIN tree (the positive
+    witness the read-through contract rests on);
+  - `writeSlotValue` head — accumulate; a capacity refusal splices the prefix (legal:
+    the tree is still virgin) and falls through per-entry;
+  - `readSlotValueForWrite` head — **read-through**: an accumulated payload is
+    authoritative (zero-length = tombstoned), a miss falls to the (empty) tree; this
+    is what keeps the order-label walk (reads of earlier-minted labels) and the
+    row-group prior-descriptor probes (reads of absent keys) from forfeiting the win;
+  - `putSegmentPage` / `getSegmentPageBytes` / `removeSegmentPage` — side-page
+    attaches against accumulated owner slots are **DEFERRED** (payload retained, the
+    exact `new OverflowPage(bytes)` ownership contract; 512 MB budget; last-writer-wins
+    by refKey; read-through mid-build) and run through the production `putSegmentPage`
+    right after the splice. Without deferral the first big column segment would have
+    tripped the splice on row group 1 and forfeited the label lane.
+  - `resetTree` discards accumulator + pendings; `finalizeBulkSlotAccumulation()`
+    splices + attaches, safe in `finally` (persists exactly the per-entry prefix
+    semantics on failure).
+- **Wired call site:** `ProjectionIndexBuilder.buildAndPersist` (the post-pass fresh
+  build) — `begin` right after `resetTree`, `finalize` in a wrapping `finally`. The
+  load-time rider (`ProjectionBulkLoad`) is intentionally NOT wired in v1: its
+  auto-commit windows need a pre-commit finalize hook or the accumulated window is
+  lost at commit — v2 work, documented, not hand-waved.
+- **Witness:** `ProjectionBulkSlotAccumulationTest` — the same operation sequence
+  (50 000 label writes with interleaved read-backs, a re-put, a tombstone, an inline
+  blob, a REFERENCED 200 KB blob) through both arms; asserts read-identity
+  in-transaction (pre- AND post-splice), after a REAL commit (trie-navigated reads +
+  side-page bytes), zero malformed subtrees both arms, and the construction-route
+  witness (`bulkSplicedEntryCount` 50 002 vs 0).
+- **Perf gate:** `ProjectionBulkVsPerEntryBench` (see the table above).
+
+### Seam 2c — consolidation into the epoch-riding post-pass (bulkproj)
+
+The consolidated `buildAndPersist` rides the writer's async-flush epochs
+(`BulkBuildEpoch` + mid-build `asyncFlush()` at log boundaries — the bounded-retention
+fix) and mints labels through the in-order lane. Two additions make the accumulator
+compose with that shape:
+
+- **Epoch transplant** — `BulkBuildEpoch.rebind` constructs a fresh storage per epoch;
+  `ProjectionIndexHOTStorage.adoptBulkSlotAccumulation` moves the loader, the deferred
+  side attaches (insertion order preserved into the empty fresh map), the byte
+  accounting and the witness counter onto it BEFORE the root re-seed, so the re-seed's
+  read sees the accumulated root label through the new storage's read-through. The
+  accumulator holds only un-materialized writes for the same still-virgin tree, so it
+  is tree-state-independent and moves wholesale. (In practice accumulation keeps the
+  log so small that boundaries rarely trip — measured live entries ≈ 9 mid-build vs
+  the 64-entry epoch bound — so the transplant is the safety net for corpora whose
+  DOCUMENT-side entries still trip rotations.)
+- **Post-splice drain** — the finalize-splice registers the whole tree in one burst
+  AFTER the last in-loop boundary check, which the bounded-retention witness
+  (`ProjectionPostPassBoundedRetentionTest`) correctly caught: mid-build retention
+  IMPROVED (≈9 live entries vs the 64 bound) but the end-of-build measurement saw the
+  un-rotated burst (161/152 live). The success path therefore finalizes explicitly
+  (idempotent; the outer `finally` stays the exception backstop) and drains through
+  the SAME rotation mechanism the in-loop checks use — a progress-guarded
+  `asyncFlush()` loop; the pinned-trie spill empties it bottom-up (complete-dump
+  leaves first, interiors once their children are durable). Witness green again
+  (≤ 64 live at return, both scenarios).
+
+### Seam 3 — order-directory / locator / dictionary
+
+Same pattern as Seam 2 (dense or strided ascending keys during a fresh build; the
+inventory table in the phase report lists each site's exact key formula and loop).
+These ride the same sink; nothing structurally new.
+
+---
+
+## 4. TIL adoption — reuse `registerFreshSubtree`, verbatim
+
+`spliceBulkBuiltRoot` (empty-tree check → `HOTBulkBuilder.build` → root
+`setPage` → `registerFreshSubtree`) is the v1 adoption for whole trees, and
+`registerFreshSubtree` alone for subtree splices. Its invariants, which any caller
+must preserve (all hold for bulk output by construction):
+
+- post-order registration (children before parents — `log.put` nulls the in-memory
+  page on the reference);
+- stop at shared subtrees (`ref.getLogKey() >= 0 || ref.getKey() >= 0`) — moot for a
+  fresh build, load-bearing for future merge work;
+- every fresh leaf `setCompleteDump(true)` → full first fragment at commit, no
+  fragment chain for readers;
+- failure paths retire the unregistered fresh suffix (`closeUnregisteredFreshChildren`,
+  `recoverFromRegistrationFailure`) — off-heap leaf segments never leak.
+
+---
+
+## 5. Epoch interplay and memory
+
+### 5.1 Spill eligibility — dense bulk pages are eligible by construction
+
+`isPinnedTrieSpillPageEligible` (NodeStorageEngineWriter.java:2092):
+
+- `HOTLeafPage`: eligible iff `!wouldEmitSparseFragment()` — a fresh complete-dump
+  leaf with no committed predecessor never emits sparse, so **bulk-built leaves are
+  eligible immediately** — and `allSideReferencesDurableAndUnclaimed()` (projection
+  side refs must be durable first; ordinary index leaves have none);
+- `HOTIndirectPage`: eligible iff every child reference is already durable — so a
+  bulk subtree spills strictly bottom-up, leaves → interiors, exactly the order the
+  spill's round-robin cursor discovers them.
+
+This closes the brief's question: the sparse-fragment exclusion
+(`sparse-fragment-spilled-standalone-loses-clean-entries`) cannot bite a fresh bulk
+subtree; only CoW'd leaves with committed ancestry emit sparse.
+
+### 5.2 Memory budget
+
+A bulk build holds, simultaneously: the loader arena (`n × (keyBytes + 20)` — the
+class javadoc's figure), the `R(S)` recursion (transient), and the finished pages
+(pinned until commit or spill). For Seam 1 at 100M rows this is the dominant new cost
+and must be measured before enabling by default; the pinned-trie spill bounds the
+page half, the arena is freed at `flush()` (`releaseBuffers`). Mitigation if the
+arena binds: per-family flush at epoch boundaries into *separate index numbers* is NOT
+possible (one tree per family), so v1 either sizes for residency or defers the family
+to the post-pass builder. Honest open point, not hand-waved.
+
+---
+
+## 6. Gate plan (per the canonicity finding)
+
+- **G1 — bulk determinism (byte gate).** Build the same sorted entry list twice with
+  allocators started at the same value; assert identical structure AND identical
+  serialized page bytes. Valid because build order, page-key assignment, and layout
+  choice are all deterministic (§1). Probe already covers the structural half.
+- **G2 — semantic equivalence vs the per-entry path (the replacement gate).** For each
+  converted call site: build once per-entry, once bulk, same inputs; assert identical
+  point reads (`get`), identical range-cursor sequences, and — for the projection —
+  the census differential: `readAllRowGroupsFromColumnSegmentSlots` validates the
+  exact ordered descriptor set and every segment hash, so a lost/duplicated/misplaced
+  slot fails loudly. Byte-identity is **not** asserted against the incremental tree
+  (proven order-dependent, §1).
+- **G3 — invariant oracle.** `HOTMalformedSubtreeDetector` reports zero malformed
+  subtrees on every bulk output (already the production self-heal oracle; also the
+  existing `HOTFormalModelTest` V1–V4 batteries stay green).
+- **G4 — packing gate (for §2.1) — RUN, all green.** Dense/strided 20 000-key builds
+  produce the highest-fitting-subtree leaf count (measured 40, was 280). Battery run
+  one class per JVM: `HOTBulkBuilderTest` 5/5 (incl. 1575 adversarial sets, 0
+  violations), `HOTFormalModelTest` 3/3, `StraddleCanonicityProbe` 3/3,
+  `HOTIntegrateTest` 4/4, `HOTMalformedSubtreeDetectorTest` 11/11,
+  `HOTLeafPageSplitFaithfulTest` 3/3, `HOTIndirectPageSplitFaithfulTest` 11/11,
+  `HOTDescentAnalysisTest` 4/4, `HOTIncrementalSplitSegmentRefTest` 2/2,
+  `HOTInsertionOrderShapeProbe` 1/1, and end-to-end `JsonCASIndexBuildTest` 6/6
+  (bulk-loader postings == change-listener postings at DB level). Every failure on
+  the way was a coverage-generator shape dependence, reviewed and repaired — never a
+  silenced assertion (§2.1 blast-radius list).
+- **Perf gate (campaign-level).** Per-family build time at 1M/10M rows, per-entry vs
+  bulk; TIL pinned-entry count; peak RSS. No mechanism ships on benchmark-only
+  evidence (`benchmark-mechanisms-must-be-generally-applicable`): the loaders/builder
+  are general-purpose index machinery, the projection sink must be, too.
+
+---
+
+## 7. Risks / open questions
+
+1. **Packing fix changes live shapes** through `splitLeafPage`/`rebuildSubtree` —
+   any hidden exact-shape dependence (tests or readers) surfaces in G4. Readers route
+   by invariants, so this is expected-quiet, but unverified until run.
+2. **Loader arena at 100M** (§5.2) — measure before default-on.
+3. **Auto-commit windows** break the empty-tree precondition for Seam 2's
+   non-parallel path; v1 falls back per-entry after the first window. v2 needs
+   subtree merge (append-region splice), deliberately out of scope.
+4. **Stale incremental heights** (probe finding, §1) predate this campaign but
+   interact with any future "bulk-build the tail, integrate incrementally" hybrid:
+   integrate's intermediate-node decision consumes heights. Fix separately.
+5. **Projection side-ref reattach at bulk scale** — `reattachSegmentRefs` is
+   O(refs × leaf lookup); fine per-rebuild today, needs a sorted merge walk if a
+   whole 100M projection tree is bulk-built with populated side maps.
+
+---
+
+## Appendix A — per-entry HOT write call sites (fresh-build inventory)
+
+All sites below funnel into `ProjectionIndexHOTStorage.writeSlotValue` /
+`putBlob` (each = one `prepareLeafOfTree` descent + branch-escape dispatch +
+`leaf.put` + update-or-split cascade) unless noted. "Append-ordered" = keys
+non-decreasing across the calls of one fresh build.
+
+| Site | Key formula | Order in a fresh build | Bulk candidate |
+|---|---|---|---|
+| Row-group descriptor slot — `putRowGroupAsColumnSegmentSlots` (ProjectionIndexHOTStorage.java:596→640), called from `ProjectionIndexBuilder` + `ProjectionBulkLoad` (ProjectionBulkLoad.java:80) + `ProjectionIndexChangeListener.writeRowGroup`:3090 | `rowGroupId << 16` (slotKind 0), sign-flipped 8-byte BE | rowGroupId contiguous from 1 in emit order → append-ordered | YES |
+| Column-segment slots — `writeChangedColumnSegmentSlots` per segment | `(rowGroupId << 16) \| (columnSegmentId + 1)` | ascending within a group; groups ascend → append-ordered | YES |
+| Segment overflow pages — `putSegmentPage` (ProjectionIndexHOTStorage.java:3452) | side-map key `(ownerSlotKey << 16) \| columnSegmentId`, attached to the OWNING LEAF, not the trie | follows the owning slot | attach-after-build via `reattachSegmentRefs` |
+| Order-directory slots — `ProjectionStructuralOrderDirectory.HotSlotStore.put` → `putStructuralOrderSlot` (ProjectionStructuralOrderDirectory.java:142) | `2^50 + nodeKey`, ONE SLOT PER RECORD | strictly ascending in a fresh build (assume the in-order label lane, §0) | **YES — ~95 % of all per-entry insertions; the primary target** |
+| Record locator — `ProjectionRecordLocator.put`:95 → `putRawSlot(slotKey(recordKey))` | `slotKey(recordKey)` | update/move path (rebalance); low volume in a fresh build (not fully traced) | LOW PRIORITY |
+| Fences — `ProjectionIndexFences` (`putBlob` at :350/:355/:362/:904/:917) | `CHUNK_SLOT_BASE + chunkId` (2^42 namespace), `ORDER_HEADER_SLOT` | chunkId ascending; header last → append-ordered | YES |
+| Bloom chunks — `ProjectionBloomChunks` (`putBlob` at :136/:684/:706/:853/:938) | `bloomBlockSlotKey(column)` + chunk slots (2^43 namespace) | per-column ascending chunks | YES |
+| Set-summary chunks — `ProjectionSetSummaryChunks` :54/:164/:388 | `slotKey(column)` | per-column | YES |
+| Metadata blob — `ProjectionIndexBuilder`:898, `ProjectionBulkLoad`:302, listener :2313/:3139 | slot 0 | once at end | trivial |
+| PATH/CAS/NAME entries — `AbstractHOTIndexWriter.doIndex` via builders | serializer-specific composite keys | traversal order (not sorted) | ALREADY BULK for virgin trees (`create*BulkLoader`); importer-side lift = Seam 1 |
+
+Answers to the three campaign questions:
+
+- `ProjectionIndexHOTStorage` uses **no** bulk loader today (zero references to
+  `createBulkLoader`/`spliceBulkBuiltRoot` in `io.sirix.index.projection`).
+- The parallel importer's refusal: `ParallelBulkJsonImporter.refuseUnsupportedShape`
+  (ParallelBulkJsonImporter.java:215–218) throws on `bulkHasPrimitiveIndexes()`; it
+  also requires a FRESH resource (:219–221), so at load end every index tree is
+  virgin — the bulk loaders' empty-tree precondition holds by construction.
+- `ProjectionBulkLoad` keeps the real `ProjectionIndexBuilder` machinery alive across
+  auto-commit windows and streams full leaves through
+  `putRowGroupAsColumnSegmentSlots` — i.e., it batches BUILD state, not WRITES; every
+  persisted slot still pays the per-entry descent.

--- a/docs/PROJECTION_INDEXES.md
+++ b/docs/PROJECTION_INDEXES.md
@@ -56,9 +56,9 @@ larger filter — are answered from the projection instead of the tree.
 ### Building during the load (one pass)
 
 `jn:create-projection-index` walks a *finished* resource, so it costs a second pass over the
-corpus. Embedded callers can instead declare the projection up front and let the shred itself
-produce the rows — the definition is catalogued on the still-empty resource and the load's own
-change notifications feed the builder, so the index is complete when the load commits:
+corpus. Embedded callers can instead declare the projection up front and let the load itself
+produce the rows — the definition is catalogued on the still-empty resource and the load feeds
+the builder as it shreds, so the index is complete when the load commits:
 
 ```java
 final var projection = new ProjectionSpec("/[]",
@@ -69,9 +69,20 @@ store.create("mydb", "sales.jn", jsonReader, projection);
 ```
 
 The spec uses exactly the vocabulary of the query form (same root path, field paths, and type
-names), so the two cannot drift apart. Until the load's final commit the projection's metadata
-slot holds the stale tombstone, so an interrupted load leaves queries on the generic pipeline
-rather than serving them from a half-filled index.
+names), so the two cannot drift apart. A sequential shred feeds the builder through its own
+change notifications; the parallel bulk importer feeds the same builder from the rows its build
+workers extract, so both routes produce a byte-identical index — see
+[`BULK_IMPORT.md`](BULK_IMPORT.md) for the load-side contract (armed builds, refusals, cost).
+
+Until the load's final commit the projection's metadata slot holds the stale tombstone, so an
+interrupted load leaves queries on the generic pipeline rather than serving them from a
+half-filled index. One failure completes the LOAD but not the projection: a resource-wide value
+dictionary that hits its byte budget mid-build abandons the projection rather than the load. That
+prints `[proj] PROJECTION ABANDONED` on stderr (unconditionally — the warning alone is invisible
+under the shipped log configuration), and the tombstone records the reason plus its remedy: give
+the loader an expected-row-count hint so the oversized column is declined up front and the rest of
+the projection still builds, or raise `-Dsirix.projection.globalDict.budgetBytes`, then rebuild
+with `jn:create-projection-index`.
 
 ## Querying
 
@@ -132,6 +143,15 @@ chunks, bounded per-column set summaries, sparse locators, and immutable global-
 radix paths. An unresolvable or corrupt touched unit fails the owning transaction and requires
 rollback. Calling `jn:create-projection-index` with a different shape creates an additional
 projection.
+
+Serving is memory-bounded, not all-or-nothing. Kernels that want a column's whole byte image get
+it eagerly while the projection's worst-case resident size fits
+`-Dsirix.projection.eagerMaterializeBytes` (default: the smaller of half the projection cache
+budget and a quarter of the heap); above that the same kernels read through bounded 128-leaf
+windows instead, and a column fill that would exceed the budget declines: the query re-enters the
+windowed whole-leaf route where one exists, and otherwise falls back to the record path.
+Declining is a routing decision, not a corruption signal — the index stays valid and keeps
+serving everything else.
 
 Uncommitted state is servable too: an executor constructed over an open write transaction
 (`new SirixVectorizedExecutor(wtx, threads)`) answers unpredicated aggregates, group-bys and

--- a/docs/PROJECTION_INDEX_DEEP_DIVE.md
+++ b/docs/PROJECTION_INDEX_DEEP_DIVE.md
@@ -629,6 +629,19 @@ in place (all writes ride one CoW commit anyway, but the ordering keeps the
 two writers — builder and maintenance — consistent). The fence chunks (§5.4)
 are written alongside; unchanged chunks carry forward as no-ops.
 
+The slot writes above do **not** each descend the trie. A fresh build starts
+from a virgin tree, so the builder engages `HOTBulkSlotLoader`
+(`beginBulkSlotAccumulation`): every slot write accumulates, point reads are
+served back out of the accumulator, side-page attaches are deferred, and the
+whole tree is materialized in one canonical `HOTBulkBuilder` pass at
+`finalizeBulkSlotAccumulation`. Accumulation is bounded — a capacity trip
+splices the accumulated prefix and falls back to the per-entry path, which is
+always safe because the drain replays in ascending key order. The class javadoc
+on `HOTBulkSlotLoader` and `ProjectionIndexHOTStorage` documents the mechanism;
+`docs/HOT_BULK_BUILD.md` §2 holds the memory arithmetic behind the cap.
+Incremental maintenance (§8) never takes this path — it writes a non-virgin
+tree per entry.
+
 ### 6.2 The commit chain — how referenced segment pages get their identity
 
 This applies to *referenced* segments only; inline small segments (§5.1,
@@ -1319,6 +1332,7 @@ rewrite, not an ETL export.
 | Double transform | `index/projection/ProjectionDoubleEncoding.java` |
 | Extraction + exactness | `index/projection/ProjectionIndexRowExtractor.java` |
 | Streaming build | `index/projection/ProjectionIndexBuilder.java` |
+| Fresh-build slot accumulation (bulk splice) | `index/hot/HOTBulkSlotLoader.java` |
 | Incremental maintenance | `index/projection/ProjectionIndexChangeListener.java` |
 | Catalog / hydrate | `index/projection/ProjectionIndexCatalog.java` |
 | Kernels | `index/projection/ProjectionIndexByteScan.java` |

--- a/docs/PROJECTION_INDEX_DEEP_DIVE.md
+++ b/docs/PROJECTION_INDEX_DEEP_DIVE.md
@@ -554,7 +554,7 @@ Slot-0 states are deliberately distinct:
 | State | Representation | Meaning |
 |---|---|---|
 | Valid metadata | `PIXB` → current-version `PIXM`, stale bit clear | projection serves |
-| Stale tombstone | `PIXB` → tiny `PIXM` with `FLAG_STALE` | dropped definition, unfinished load-time build, or corruption valve; rebuild on the next same-shape create |
+| Stale tombstone | `PIXB` → tiny `PIXM` with `FLAG_STALE`, plus the writer's `StaleReason` in the reason bits (see `DISK_FORMAT.md`) | dropped definition, unfinished load-time build, a load-time build abandoned by an over-budget global dictionary, or corruption valve; the reason carries the remedy the writer knew, so a report need not guess it, and a rebuild on the next same-shape create clears the tombstone |
 | Truthful empty store | valid metadata, `leafCount = 0` | zero-record root; still valid |
 | Unsupported/corrupt layout | slot-0 bytes are not `PIXB`, or `PIXM` version ≠ 0 | decline; maintenance fails closed |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ list of files.
 |-----|----------------|
 | [ARCHITECTURE.md](ARCHITECTURE.md) | How SirixDB works: the node-tree encoding, copy-on-write page layout, sliding-snapshot versioning, indexes, and the bitemporal model. The best single doc for understanding the system. |
 | [operations.md](operations.md) | Running SirixDB in production: configuration, memory/JVM tuning, supported environments, and deployment guidance. |
+| [BULK_IMPORT.md](BULK_IMPORT.md) | The sequential and parallel bulk JSON loaders: API, the configurations they refuse, which index families they maintain in the load's single pass, verification guarantees, tuning knobs, and measured numbers. |
 | [NATIVE_IMAGE.md](NATIVE_IMAGE.md) | Building and running the GraalVM native binaries (instant startup for the CLI, shell, and REST server). |
 | [MCP_SERVER_DESIGN.md](MCP_SERVER_DESIGN.md) | The Model Context Protocol server for AI agents: tools, resources, snapshot/diff workflow, and security model. |
 
@@ -64,7 +65,8 @@ user-facing documentation.
   [HOT_OPTION_B_PHASE_5_DESIGN.md](HOT_OPTION_B_PHASE_5_DESIGN.md),
   [HOT_PHASE_7_DESIGN.md](HOT_PHASE_7_DESIGN.md),
   [HOT_PHASE_7Q_DESIGN.md](HOT_PHASE_7Q_DESIGN.md),
-  [HOT_INCREMENTAL_PORT_PLAN.md](HOT_INCREMENTAL_PORT_PLAN.md)
+  [HOT_INCREMENTAL_PORT_PLAN.md](HOT_INCREMENTAL_PORT_PLAN.md),
+  [HOT_BULK_BUILD.md](HOT_BULK_BUILD.md)
 - **HOT index — verification, audits & results:**
   [HOT_INCREMENTAL_SPLIT_VERIFICATION.md](HOT_INCREMENTAL_SPLIT_VERIFICATION.md),
   [HOT_EXISTING_CODE_AUDIT.md](HOT_EXISTING_CODE_AUDIT.md),


### PR DESCRIPTION
## Intent

One landing for the bulk-import index campaign. The parallel JSON importer now maintains every index family it can feed in the load's single pass: projection rows are extracted in the build workers from the primitives they already hold and replayed in document order through the unchanged leaf/dictionary machinery (byte-identical to the post-pass by a 4020-slot census; 1M one-pass fell 497 s to 23.8 s, 1.9x bare import and 2.8x faster than bare-then-post-pass), and PATH/CAS/NAME tuples ride the same worker hooks into the families' bulk loaders (sequential-oracle-identical across 20 probes; +10.2% import cost for four real defs). Order labels mint through a lookup-free in-order lane that also cures the post-pass's first-label full-corpus mintRun walk; intermediate TIL epoch flushes bound its retention (~330k pinned pages before leaf 1 at 100M previously); the HOT bulk splice packs leaves canonically (a pre-existing leaf-packing bug produced 7x fragmentation in every PATH/CAS/NAME bulk build; fixed with the invariant battery green). From the review branch: executor retirement moves the pool join off the compile path onto a shared reaper (closing a verified ~1G-per-retired-executor native retention: the fresh-executor A/B now runs flat where it previously climbed to a kernel OOM kill) with the warm-up queue drained rather than interrupted, and the slab allocator reserves an oversized headroom its ratchet can never consume. Fat string columns now serve through windowed 128-leaf loads under an eagerMaterializeBytes budget instead of whole-column eager materialization: at 100M, q5 completes in 48.1 s and q20 in 17.5 s inside an 8G-heap envelope where every prior attempt OOMed, and an over-budget column fill declines through the store's established non-memoizing door (deliberately not marked as corruption). The #45/#50/#52/#53/#55 set lands adapted to current semantics: stale tombstones carry machine-readable reasons and the one silent load-degradation (dictionary budget breach) prints unconditionally to stderr; the HOT fragment-merge/carry-forward/in-place-split paths gain flag-gated counters whose sharpest member is a permanent sentinel on the complete-dump break; three of its pieces were dropped as structurally superseded (chunked-arena growth clamp, interval-sweep locate, refusal-site counters), each with the stronger in-tree equivalent named in the commit. The streaming-dictionary follow-on (resident probe front, writer dict-record memo, Unsafe-free XXH3) is pre-existing committed history in this lineage, not part of this delta. Two latent defects found and fixed on the way: builders' resolved-path-class caches going stale under a growing summary, and the cached valid-time flag bypassing catalogued-but-unbound defs. Valid-time maintenance still refuses, now def-based. Deliberate choices a reviewer should not flag: no defensive guard on the post-pass intermediate flushes (an earlier guard was deleted after a 40k-record forced-rotation experiment proved flushed pages of the open transaction read back exactly); whole-build splice-once was rejected by memory arithmetic in favor of an 8M-entry/512MB accumulate-with-cap; the rider deliberately does NOT use the bulk slot loader yet (needs a pre-commit finalize hook, documented as v2); intermediate commits of the series are review units — the tip is the fully-gated tree (10,570 core + 1,466 query tests green, plus the 100M acceptance runs).

## What Changed

- **One-pass index maintenance in the parallel bulk JSON importer.** New `ParallelBulkJsonImporter`/`BulkJsonTreeAssembler` loaders (feeder scan, worker page builders, ordered adoption, NDJSON adapter) now extract projection rows *and* PATH/CAS/NAME tuples in the build workers from the primitives they already hold; the coordinator drains them in document order into the families' ordinary bulk loaders, with one flush per family before the caller's commit. A catalogued projection with no armed load-time build is refused rather than silently left unmaintained; valid-time interval maintenance still refuses, now def-based. The post-pass projection build gains a lookup-free in-order label lane and intermediate TIL epoch flushes to bound retention, and `HOTBulkBuilder`'s splice now packs leaves canonically — a pre-existing fit-bound bug had been fragmenting every PATH/CAS/NAME bulk build.
- **Wide projection string columns serve through bounded windowed leaf loads.** Columns whose worst-case resident size exceeds `-Dsirix.projection.eagerMaterializeBytes` are read from 128-leaf windows via `ProjectionWindowedRowGroupPayloads`/`ProjectionColumnStore` instead of whole-column eager materialization; an over-budget fill declines through the store's non-memoizing door as a routing decision (the windowed whole-leaf route or the record path answers), not a corruption signal, so the index stays valid.
- **Reliability and diagnostics.** Vectorized executor retirement moves the pool join off the compile path onto a shared daemon reaper with the warm-up queue drained rather than interrupted; `FrameSlotAllocator` reserves an oversized-allocation headroom that permanent slab commitment can never consume; stale projection tombstones carry machine-readable reasons on previously reserved flag bits (`PIXM` wire format unchanged) and a dictionary-budget breach prints `[proj] PROJECTION ABANDONED` with the breaching quantity unconditionally to stderr; HOT fragment-merge/carry-forward/in-place-split paths gain flag-gated counters plus a permanent sentinel on the complete-dump break. Two latent defects fixed: builders' resolved-path-class caches going stale under a growing path summary, and the cached valid-time flag bypassing catalogued-but-unbound definitions. Adds `docs/BULK_IMPORT.md` and `docs/HOT_BULK_BUILD.md`, plus equivalence/oracle test suites for bulk assembly, primitive-index and projection parity, windowed serving, and HOT dump-merge and tombstone eviction.

## Risk Assessment

⚠️ Medium: The delta is very large and its memory-budget/windowed-serving machinery has been rewritten across eleven rounds, but the current state has no substantiated reachable correctness defect — every fill door prices and charges through one shared incremental helper, the windowed view carries no session-derived state, and every route that can receive a budget decline now treats it as routing; the two residual findings are an uncounted decline plus misattributed javadoc, both safe as follow-ups.

## Testing

I exercised the dictionary-budget abandon path end-to-end through real load-time builds and confirmed the operator notice now prints coherent arithmetic. The decisive evidence is a same-corpus, same-calibrated-budget A/B: with the four production files reverted to the pre-fix commit the notice reads "retained 1114240 B ... past its 39850930 B budget" and the loud arm fails, while the commit under test prints "needed 39854408 B (flush-peak) ... past its 39850930 B budget (1114240 B retained)" and passes — the announced quantity genuinely exceeds the announced budget, the tripping term is named, and retention is demoted to context. I also confirmed the exception message behind the notice now quotes a budget worth raising to. Because the notice test reaches only the flush-peak refusal family, I extended GlobalValueDictionaryWriterBudgetTest to assert the byte-decline invariant directly on the exception and added a case covering the structural-ceiling family, which weighs no bytes and must not claim a breach — previously unpinned, and the one way this fix could silently regress. Twenty focused tests pass across the notice, writer-budget, stale-reason and generation-rotation suites; the worktree is clean apart from the intentional test addition. No screenshot artifact applies: the changed surface is a stderr line emitted by a database loading process, with no UI, HTML or rendered output, so the captured terminal transcript is the actual end-user experience.

<details>
<summary>Evidence: Operator stderr notice: before/after the breaching-quantity fix (same corpus, same budget)</summary>

<code>BEFORE (pre-fix production code):&#10;[proj] PROJECTION ABANDONED during the load: index 0, column 0 retained 1114240 B over 10227 distinct values, past its 39850930 B budget. The load completes; the projection is STALE and every query will take the generic pipeline until jn:create-projection-index rebuilds it.&#10;-&gt; 1,114,240 B declared &#34;past&#34; a 39,850,930 B budget: a number 36x larger. Test FAILS.&#10;&#10;AFTER (12dc10bc8):&#10;[proj] PROJECTION ABANDONED during the load: index 0, column 0 needed 39854408 B (flush-peak) over 10227 distinct values, past its 39850930 B budget (1114240 B retained). The load completes; the projection is STALE and every query will take the generic pipeline until jn:create-projection-index rebuilds it.&#10;-&gt; 39,854,408 B &gt; 39,850,930 B. Term named. Retention kept as context. Test PASSES.</code>

```text
Operator-facing evidence: the dictionary-budget abandon notice now prints the quantity
that actually breached, so its own arithmetic explains the breach it announces.

Surface: stderr of the loading process (System.err, deliberately not a log appender, so the
shipped logback root-at-ERROR configuration cannot swallow it).

Both transcripts below come from THE SAME test, THE SAME 30,000-record corpus and THE SAME
budget, which the test calibrates from the real writer rather than hard-coding.  Only the
production code differs, so the numbers are directly comparable.

-----------------------------------------------------------------------------------------
BEFORE  (production files reverted to c17d3b378, the commit before the fix)
-----------------------------------------------------------------------------------------
$ ./gradlew :sirix-core:test --rerun \
      --tests 'io.sirix.index.projection.ProjectionDictionaryBudgetAbandonNoticeTest'

[proj] PROJECTION ABANDONED during the load: index 0, column 0 retained 1114240 B over 10227
distinct values, past its 39850930 B budget. The load completes; the projection is STALE and
every query will take the generic pipeline until jn:create-projection-index rebuilds it.

    ^ 1,114,240 B is declared to be "past" a 39,850,930 B budget -- a number 36x LARGER.
      The operator is told a guard fired, shown arithmetic that says it should not have,
      and given no figure to raise the budget to.

ProjectionDictionaryBudgetAbandonNoticeTest >
    aDictionaryBudgetBreachAnnouncesTheAbandonedProjectionEvenWithLoggingOff() FAILED
    org.opentest4j.AssertionFailedError: the notice no longer states index, column, the
    breaching term and the budget: [proj] PROJECTION ABANDONED during the load: ...
        at ProjectionDictionaryBudgetAbandonNoticeTest.java:163
2 tests completed, 1 failed
BUILD FAILED

-----------------------------------------------------------------------------------------
AFTER  (12dc10bc8, the commit under test)
-----------------------------------------------------------------------------------------
$ ./gradlew :sirix-core:test --rerun \
      --tests 'io.sirix.index.projection.ProjectionDictionaryBudgetAbandonNoticeTest' \
      --tests 'io.sirix.index.projection.GlobalValueDictionaryWriterBudgetTest' \
      --tests 'io.sirix.index.projection.ProjectionStaleReasonTest'

[proj] PROJECTION ABANDONED during the load: index 0, column 0 needed 39854408 B (flush-peak)
over 10227 distinct values, past its 39850930 B budget (1114240 B retained). The load
completes; the projection is STALE and every query will take the generic pipeline until
jn:create-projection-index rebuilds it.

    ^ 39,854,408 B > 39,850,930 B.  The announced quantity really does exceed the announced
      budget; the term that tripped the predicate is NAMED (flush-peak, i.e. the projected
      cost of flushing, not current occupancy); and retention is kept as context rather than
      being passed off as the thing that breached.

BUILD SUCCESSFUL
  ProjectionDictionaryBudgetAbandonNoticeTest    tests=2  failures=0  errors=0
  GlobalValueDictionaryWriterBudgetTest          tests=13 failures=0  errors=0
  ProjectionStaleReasonTest                      tests=5  failures=0  errors=0

Note the tripping term: retention was only 2.8% of the number that actually failed the
comparison, which is precisely why quoting retention read as a misfiring guard.
```
</details>
<details>
<summary>Evidence: Exception messages per decline family (real writer, no fault injection)</summary>

<code>=== BYTE-BUDGET BREACH ===&#10;breachingTerm = flush-peak ; breachingBytes = 510680 ; budgetBytes = 509824 ; retainedBytes = 118400 ; breaching &gt; budget ? true&#10;message: Resource-wide value dictionary for column 3 reached its configured aggregate budget of 509824 B; its flush-peak came to 510680 B, past the 509824 B budget, with 118400 B already retained across 103 distinct values. ... Raise the configured byte budget to at least 510680 B, use per-leaf dictionaries, or split the ingest into bounded append generations.&#10;&#10;=== STRUCTURAL DECLINE (nothing weighed in bytes) ===&#10;breachingTerm = null ; breachingBytes = 51072 (== retained)&#10;message: Resource-wide value dictionary for column -1 declined an unsafe allocation before mutation: value length 262145 exceeds the safe V0 limit of 262144 bytes; retained 51072 B across 0 distinct values. ... raising the byte budget cannot override a structural allocation ceiling.</code>

```text
Operator-facing evidence: the exception message behind the notice, per decline family.
Produced by driving the real GlobalValueDictionaryWriter to each decline through its own
API (no fault injection) and printing what the operator would read in the log.

=== BYTE-BUDGET BREACH (the family the abandon notice reports) ===
budgetBytes   = 509824
breachingTerm = flush-peak
breachingBytes= 510680
retainedBytes = 118400
breaching > budget ? true
message: Resource-wide value dictionary for column 3 reached its configured aggregate budget of 509824 B; its flush-peak came to 510680 B, past the 509824 B budget, with 118400 B already retained across 103 distinct values. The projection is abandoned for this load (readers fall back to the generic pipeline); the load itself completes. Raise the configured byte budget to at least 510680 B, use per-leaf dictionaries, or split the ingest into bounded append generations.

=== STRUCTURAL DECLINE (nothing was weighed in bytes) ===
budgetBytes   = 9223372036854775807
breachingTerm = null
breachingBytes= 51072  (== retained 51072)
message: Resource-wide value dictionary for column -1 declined an unsafe allocation before mutation: value length 262145 exceeds the safe V0 limit of 262144 bytes; retained 51072 B across 0 distinct values. The projection is abandoned for this load (readers fall back to the generic pipeline); the load itself completes. Use per-leaf dictionaries or split the ingest into bounded append generations; raising the byte budget cannot override a structural allocation ceiling.
```
</details>
<details>
<summary>Evidence: Focused test results (JUnit XML summary)</summary>

```text
GlobalValueDictionaryWriterBudgetTest.xml: tests=13 skipped=0 failures=0 errors=0
ProjectionDictionaryBudgetAbandonNoticeTest.xml: tests=2 skipped=0 failures=0 errors=0
ProjectionStaleReasonTest.xml: tests=5 skipped=0 failures=0 errors=0
new case present: testcase name="A structural ceiling declines without claiming any quantity exceeded the byte budget"
ProjectionGlobalDictionaryGenerationRotationTest: BUILD SUCCESSFUL
#67 WITNESS: distinct=36864 (ceiling 16384), records=147456 | ONE-PASS: stale=false columnKind=5 rowGroups=144 | POST-PASS: THREW IllegalStateException: Forced global value dictionary for column 0 cannot continue safely: append entry 16,385 exceeds the safe per-append limit of 16,384
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (3) ✅ across 4 runs (1h1m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"400fc5f6c22a9c207482baad48e816b2cf5edc53","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

_... (7 earlier update rounds omitted to keep the PR body within GitHub's 65536-char limit; full history is in the run log.)_

<details>
<summary>⚠️ **Review** - 2 infos</summary>

🔧 Fix: Per-caller window views, cumulative fill budget, honest declines
4 issues (1 warning, 3 infos) still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:1842` - This round gave every column-bytes door a budget check and a ledger charge — `column` (:790, :806), `columnMasked` (:1287), `columnBytes` (:1571, :1582), `columnDistinctIdentity` (:1085, :1099) — and the DATA weigher&#39;s new comment (ProjectionIndexCatalog.java:147-152) rests the flat 1.25x charge on that: &#34;the store&#39;s CUMULATIVE retained-fill budget caps that sum at eagerMaterializeBytes, which is what makes this flat charge an upper bound rather than a hope&#34;. `recordKeys(ColumnSegmentFetcher)` is the one fill door that got neither. It calls `fetchSegmentChain(-1, keysColumnSegmentId(), SEG_KIND_KEYS, false, fetcher)` with NO keep mask — every leaf&#39;s KEYS segment at once — and publishes the decoded `long[][]` into `recordKeySlices` (:290), retained for the store&#39;s whole cache lifetime, charged nothing. Concrete path on the workload the intent advertises: a 100M-row windowed handle, `for $r in $doc[] where $r.SearchPhrase eq &#34;...&#34; return $r` reaches `predicateScanRecordKeys`, whose gate `predsSliceable` is kind-only (SirixVectorizedExecutor.java:2788) and admits it; `ProjectionColumnScan.matchingRecordKeys` (:439/:554/:769) calls `store.recordKeys(fetcher)`, which fetches ~800 MB of raw KEYS bytes and retains a decoded `long[100M]` (~800 MB) beside the ~2 GB the ledger permits — i.e. ~1.6 GB of transient plus ~800 MB of permanent residency that the weigher&#39;s 2.5 GB charge does not cover, on the 8 G heap the change advertises as OOM-free, with four such handles admissible concurrently. `bloomBytes` (:217) and `stringExtrema` (:300) are smaller instances of the same omission. Fix at the boundary the round already established: price the KEYS fill through `checkFillBudget` and charge `retainedFillBytes` on publish, exactly as the four sibling doors do — an over-budget KEYS chain then declines through `FillBudgetExceededException`, which the predicate-scan callers already answer by falling back.
- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexCatalog.java:868` - `windowedResidentWeightBytes` clamps the EAGER branch to `Math.max(1L, CACHE_BYTES &gt;&gt; 1)` (:873) to stop a handle heavier than `maximumWeight` from self-evicting on insert — but that branch is only reached when `projectedWeightBytes &lt;= eagerMaterializeBytes`, and `eagerMaterializeBytes` defaults to `min(CACHE_BYTES / 2, maxMemory / 4)` (:755-756), so the value is already at or below the clamp: the clamp is dead by construction. The WINDOWED branch (:868), which returns `eagerMaterializeBytes * 1.25`, carries no clamp at all — and it is the one that can exceed the cache&#39;s own `maximumWeight` (`max(1, CACHE_BYTES &gt;&gt; 10)` units, :141-143) when `-Dsirix.projection.eagerMaterializeBytes` is set above `cacheBytes / 2`: e.g. `-Dsirix.projection.eagerMaterializeBytes=17179869184` with the default 8 GiB `cacheBytes` charges 20 GiB (weight 20,971,521 &gt; 8,388,608), reproducing exactly the insert-time self-eviction and per-lookup re-decode this method was changed to prevent. Clamp the returned value once, after the branch, rather than inside the branch that cannot exceed it.
- ℹ️ `bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java:13391` - The two new budget-decline handlers diverge on their terminal case. `groupByAggregate`&#39;s returns `declineGroupAgg(&#34;column fill over budget on the whole-leaf route too&#34;)` (:13129), which ticks GROUP_AGG_DECLINED and logs a reason. `constGroupAggregate`&#39;s returns a bare `null` (:13391), so a const-group query that declines on BOTH passes and falls to the generic navigational pipeline is invisible in every counter — neither GROUP_AGG_DECLINED nor GROUP_AGG_FAILED moves. That is the same observability hole the round-5 finding raised about the first version of these handlers, left standing on this one arm. Route it through the arm&#39;s own decline helper (or tick the decline counter) so the double-decline is countable.
- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionWindowedRowGroupPayloads.java:61` - `ReaderSource`&#39;s javadoc still describes the design this round replaced: &#34;each CONSULT rebinds the source to the calling reader&#39;s own live session ({@code bindReaderSource}), and a window fetch opens its transaction through whatever source is bound at that moment&#34;. `bindReaderSource` no longer exists, and &#34;whatever source is bound at that moment&#34; is precisely the last-writer-wins semantics the round removed — the class javadoc twenty lines above (:41-47) now states the opposite and correct contract. A reader who reaches this block first is told the shared cache carries a mutable binding. Rewrite it to describe `boundTo`/`BoundView` (source lives on the per-caller view, passed into `payload(index, source)` per access).

🔧 Fix: Price record-key fills, clamp weigher once, count const declines
2 issues (1 warning, 1 info) still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:876` - The whole fill-budget system prices RAW segment bytes, but the residency it exists to bound is raw + the decoded arrays — and the change&#39;s own code prices those decoded arrays everywhere else. `projectedColumnFillBytes(col)` (:876-903) sums only `RowGroupDescriptor.entryByteLen` for BODY and DICT; its own javadoc (:871-874) says so (&#34;An UNDERestimate of the resident total (decoded id/value arrays come on top)&#34;). `ProjectionIndexCatalog.residentWeightOf` (:661-682), which computes `projectedWeightBytes` for the SAME columns, explicitly adds `((long) rows &lt;&lt; 3) + presenceBytes` for every `isLongLaneKind` column — the 8 B/row decoded lane. And this round&#39;s new `projectedRecordKeysFillBytes` (:692-699) counts `8L * rowCount` per leaf with a comment stating exactly why (&#34;Unlike the column doors this counts the decoded form explicitly, because that is the part that stays&#34;). The column doors are the exception, and they are the ones the budget rests on. Concrete path on the advertised 8 G heap (`columnFillBudgetBytes` = `eagerMaterializeBytes` = min(cacheBytes/2, maxMemory/4) = 2 GB): a 100M-row windowed handle with bit-packed NUMERIC_LONG columns, each BODY ~100 MB packed. `columnFillable`/`columnFillWithinBudget` (:762-768) admit ~20 such columns before `retainedFillBytes` reaches 2 GB; `column()` retains for each of them BOTH the raw `byte[][]` (charged, via `columnBytes` at :1610-1622) AND the decoded `ColumnSlice[]` whose `numericValues()` is a `long[rows]` — ~800 MB per column, ~16 GB total, none of it priced. Nothing declines, and the heap the intent advertises as OOM-free is exhausted. The same understatement propagates to the DATA weigher: `ProjectionIndexCatalog.java:147-154` charges a windowed handle a flat 1.25x `eagerMaterializeBytes` and rests that on the ledger (&#34;the store&#39;s CUMULATIVE retained-fill budget caps that sum at eagerMaterializeBytes, which is what makes this flat charge an upper bound rather than a hope&#34;) — a claim that is false while the ledger counts packed bytes and the heap holds decoded ones, so up to four such handles are admitted concurrently. Fix at the pricing boundary the rest of the file already uses: have `projectedColumnFillBytes` (and `projectedMaskedFillBytes`, `projectedColumnIdentityFillBytes`) add the decoded lane the same way `residentWeightOf` does — `(rows &lt;&lt; 3) + presenceBytes` per long-lane column over the leaves the fill touches — so one budget figure means the same thing on both sides of the cache.
- ℹ️ `bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java:13159` - Two fix rounds re-created the exact defect round 1 reported and the author fixed in `Names`/`PathSummaryWriter`/`StorageEngineWriter`: a new member inserted between an existing doc block and the member it documented. (1) `SirixVectorizedExecutor.java:13159` — the block `/** Constant-key group-bys served in one scalar pass (test oracle, same doctrine as the rest). */` now precedes `declineConstGroupAgg`&#39;s own javadoc and method, leaving `CONST_GROUP_AGG_SERVED` (:13176) undocumented and stacking two doc blocks on one method. (2) `ProjectionIndexCatalog.java:848-855` — the block documenting `servesWindowedPayloads` (&#34;Whether a handle of this projected weight is served by the WINDOWED payload view...&#34;, with its own `@param`/`@return`) now precedes `windowedResidentWeightBytes`&#39;s javadoc and method, leaving `servesWindowedPayloads` (:879) undocumented. Generated javadoc attributes each stale block to the wrong member, and the `@param projectedWeightBytes` in the catalog block duplicates the one below it. Move each new method below the member its preceding block belongs to.

🔧 Fix: Price fills by decoded residency through one shared function
2 issues (1 warning, 1 info) still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:898` - The new shared pricing function returns 0 for the exact column kind the change exists to serve. `decodedColumnResidentBytes` (:886-899) prices the 8 B/row lane + presence for `isLongLaneKind` and two presence words for BOOLEAN, and falls through to `return 0` for `COLUMN_KIND_STRING_DICT` (2) and `COLUMN_KIND_STRING_SET` (4). But a STRING_DICT fill retains, per leaf: `int[] ids` from `decodePackedIds` — 4 B/row (ProjectionIndexRowGroupCodec.java:697-704), `long[] presence` (presenceBytes), `int[] dictOffsets` — 4 B per dict entry, and for `DICT_MODE_FSST`/`DICT_MODE_FSST_ROW_COUNTS` a freshly DECOMPRESSED dictionary `Arrays.copyOf(scratch, pos)` (ProjectionIndexColumnSegmentCodec.java:2432, reached from decodeStringSlice at :1660-1662) that is several times the compressed DICT segment bytes the budget counts. The file&#39;s own diagnostic `sliceRetainedBytes` (:1529-1556) enumerates precisely these terms, so the formula is already known here. Concrete path on the 8 G heap the intent advertises (`columnFillBudgetBytes` = `eagerMaterializeBytes` = min(cacheBytes/2, maxMemory/4) = 2 GB): a 100M-row `SearchPhrase`/`URL` STRING_DICT column whose BODY+compressed-DICT projection prices at ~1.9 GB passes `columnFillWithinBudget` (:766-769) and `column()` retains ~400 MB of id lanes plus an FSST-expanded dictionary on top of it — and because round 7 wired the DATA weigher to this same function (ProjectionIndexCatalog.java:667-671), the cache ADMITS handles on the same understated figure while its comment (:147-154) calls the flat charge &#34;an upper bound rather than a hope&#34;. This is the identical defect class the round fixed for long lanes, left standing on the kind q5/q20 exercise. Secondary evidence that the string side was not considered: the loop this round added to `projectedColumnIdentityFillBytes` (:1087-1089) runs only for a column that is STRING_DICT by construction (early return at :1044-1048), so it contributes exactly 0 — dead arithmetic — while the identity fill&#39;s real decoded residency (4 B/row ids + 8 B/entry `dictHashes`) goes uncounted. Fix inside the shared function: add 4 B/row + presence for STRING_DICT/STRING_SET, 4 B per dict entry for the offsets, and a conservative expansion multiple on the DICT segment bytes for the FSST modes.
- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:838` - The cumulative retained-fill ledger counts every column&#39;s BODY chain twice. `column(col, fetcher)` prices `projectedColumnFillBytes(col)` — BODY + DICT + decoded (:823) — and charges it at :838; the fill it performs starts with `fillColumn` (:1425) → `columnBytes(col, fetcher)` (:1431), which independently prices `projectedColumnBodyFillBytes(col)` (:701-717, the BODY chain alone) and charges it at :1660 into the same monotonic `retainedFillBytes` AtomicLong (:991, never decremented). One retained copy of the BODY arrays, two charges. `columnDistinctIdentity` has the same shape: it charges `projectedColumnIdentityFillBytes` (:1156/:1170), whose walk includes the BODY chain, while `fillIdentityColumn` calls `columnBytes` at :1213. Effect is over-conservative rather than wrong: after one fill the ledger reports more residency than exists, so `columnFillWithinBudget` (:766-769), `columnFillable` (:788) and `columnIdentityFillable` (:1105-1108) decline the next viable fill earlier than the budget intends and the planner steers a servable query to the slower whole-leaf route — never a wrong answer, but the campaign&#39;s whole point is route quality, and `retainedFillBytes()` is also the number the new tests read. Charge the delta instead: have `column()`/`columnDistinctIdentity` add only what `columnBytes` did not already charge (e.g. `projected - projectedColumnBodyFillBytes(col)`).

🔧 Fix: Price string fills by decoded residency, charge ledger once
2 issues (1 warning, 1 info) still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:824` - Round 9 made the ledger CHARGE each retained byte once (`chargeRetained`, :1055, subtracting `projectedColumnBodyFillBytes` when `columnBytes[col]` is already published) but left the budget CHECK and the planner predicates pricing the GROSS projection against that same ledger, so a body chain already counted in `retained` is counted a second time in `projected`. Concrete reachable path: `ProjectionColumnSegmentFoldScan` fills raw BODY bytes directly through `store.columnBytes(col, fetcher)` for long-lane columns (:196, :318, :763, :916) — the fused fold route for a plain `sum($r.age)` — which publishes `columnBytes[col]` and charges `projectedColumnBodyFillBytes(col)` at ProjectionColumnStore.java:1724. A later query on the SAME cached handle takes the sliced group route on that column and reaches `column(col, fetcher)`, whose `checkFillBudget(col, projected, &#34;slice fill&#34;)` at :824 evaluates `retained + projectedColumnFillBytes(col) &gt; columnFillBudgetBytes`. Numbers on the 8 G heap the intent advertises (`columnFillBudgetBytes` = `eagerMaterializeBytes` = 2 GB): a NUMERIC_LONG column whose packed BODY is 0.4 GB across leaves and whose decoded 8 B/row lane is 1.6 GB projects 2.0 GB, so the fold scan leaves `retained = 0.4 GB` and the check computes 0.4 + 2.0 = 2.4 GB &gt; 2.0 GB and throws `FillBudgetExceededException` — although the store&#39;s true residency after the fill would be exactly 2.0 GB, inside the budget, because the 0.4 GB body arrays are the very same objects. The group arms answer that decline by re-entering `wholeLeafOnly = true` (SirixVectorizedExecutor.java:13121, :13399), so a servable sliced query is permanently steered to the slower whole-leaf byte-kernel scan for 0.4 GB of phantom residency. The same double count sits in the planner predicates `columnFillWithinBudget` (:769) and `columnIdentityFillable` (:1171), and in `columnDistinctIdentity`&#39;s check (:1221), so the route is rejected before the door is even reached. Never a wrong answer, but it is the exact defect class the round set out to remove (&#34;the ledger charges each retained byte exactly ONCE&#34;), fixed on the mutation side and missed on the predicate side. Fix at the same boundary: price the CHECK against the delta too — e.g. have `checkFillBudget`/`columnFillWithinBudget`/`columnIdentityFillable` subtract `projectedColumnBodyFillBytes(col)` when `columnBytes[col]` is already published, exactly as `chargeRetained` does, so the gate and the ledger agree about what a fill will add.
- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:1024` - The `retainedFillBytes` javadoc still documents the behaviour commit 2a11405ab removed: &#34;The charge is per PUBLISH and may double-count BODY bytes shared between a raw-bytes fill and an identity fill of the same column. That direction is deliberate: over-counting declines earlier, which is the safe side of a residency cap.&#34; `chargeRetained` (:1042-1060), added in that same commit and called from both `column()` (:838) and `columnDistinctIdentity()` (:1234), now subtracts what `columnBytes` already charged specifically so the BODY chain is counted once — and its own javadoc says the over-charge &#34;steers servable queries off the sliced route for residency that is not there&#34;, i.e. the opposite verdict. A reader who reaches the field&#39;s doc first is told the ledger is deliberately over-conservative, which is the assumption that would justify leaving the check side double-counting. Rewrite the paragraph to state the charge-once rule and name `chargeRetained` as where it is enforced.

🔧 Fix: Price fill-budget checks incrementally, matching the ledger
2 issues (1 warning, 1 info) still open:
- ⚠️ `bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java:14735` - The fix rounds taught the two group-aggregate arms that a `FillBudgetExceededException` is a routing decision (catch at :13121 and :13399, re-enter `wholeLeafOnly`, tick no defect counter), but two other routes that perform unmasked whole-column fills still treat it as corruption. (1) SORTED SCAN: `sortedScanRecordKeys` gates its sliced arm on `predsSliceable` only (:14636, kind-only since round 4) and does NOT gate the ORDER columns at all; `ProjectionColumnScan.topKRecordKeys` then calls `store.column(sortColumns[k], fetcher)` (ProjectionColumnScan.java:1211), which throws the budget decline for an over-budget column. It escapes to `catch (final RuntimeException e)` at :14733 and increments `SORTED_SCAN_FAILED` (:14735). Concrete path on the advertised 8 G heap (`columnFillBudgetBytes` = `eagerMaterializeBytes` ≈ 2 GB): a 100M projection whose `URL` STRING_DICT column projects ~3.5 GB; `for $r in $doc[] order by $r.URL return $r` with a limit selects the sliced top-K arm (`anyStringKey &amp;&amp; sliced &amp;&amp; limit &gt;= 0`), the fill declines, and every such query ticks a defect counter AND falls to the generic navigational pipeline over 100M records instead of the whole-leaf windowed byte kernel the budget declined it toward. `collectMatchingSortTuples` on the same route (:14666) has the identical shape. (2) PREDICATE VALUE EMISSION: `ProjectionColumnScan.matchingFieldValues` takes `keep == null ? store.column(valueColumn, fetcher) : store.columnMasked(...)` (ProjectionColumnScan.java:892-893) — both doors now price against the budget — and the decline escapes to `catch (final RuntimeException e)` at :14571, incrementing `PREDICATE_VALUE_EMISSION_FAILED` (:14572). A CONTAINS or ordering literal on a fat STRING_DICT column reaches the null-mask arm because `computeKeepMask` prunes strings only for `Op.EQ`. This is the same defect the group arms were fixed for, left standing on the routes the fix rounds did not visit, and it contradicts the intent&#39;s &#34;declines through the store&#39;s established non-memoizing door (deliberately not marked as corruption)&#34;. Fix at the shared boundary the group arms already use: add a `catch (final ProjectionColumnStore.FillBudgetExceededException declined)` arm ahead of the generic `RuntimeException` handler at both sites, so an over-budget fill declines quietly (and, where a whole-leaf arm exists on the same route — `sortedScanRecordKeys` already has the `!sliced` byte-scan branch at :14668-14673 — re-enters it with `sliced = false` rather than dropping to the generic pipeline).
- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnStore.java:701` - `projectedColumnBodyFillBytes(col)` (:701-717) walks every leaf descriptor with a `RowGroupDescriptor.entryIndexOf` binary search per leaf, and it is NOT memoized — unlike its sibling `projectedColumnFillBytes`, which caches into the `projectedFillBytes` array (:952-960) for exactly this reason (&#34;a real sum is never 0&#34;). Round 10 moved this walk from the publish path onto the PLANNER path: `incrementalFillBytes` (:1076) calls it, and `columnFillWithinBudget` (:768) / `columnIdentityFillable` (:1191) call `incrementalFillBytes`, so `columnFillable` — invoked per gated column by `allColumnsSliceable`, `aggColumnsFillable`, `predsFillable` and `treeSliceable` on every group/aggregate query, twice more on a `wholeLeafOnly` re-entry — now redoes the walk whenever that column&#39;s raw BODY chain is already published. That is precisely the ClickBench-shaped case the change targets: a fused fold scan (`ProjectionColumnSegmentFoldScan` → `store.columnBytes`) fills the body, and every later query on the same cached handle pays ~97,654 × 5 descriptor probes per gated column. CLAUDE.md&#39;s hot-path rules call this out; the fix is mechanical — memoize it in an `AtomicReference&lt;long[]&gt;` exactly as `projectedColumnFillBytes` does, since the figure is a pure function of the immutable descriptors.

🔧 Fix: Treat budget declines as routing on every fill route
2 infos still open:
- ℹ️ `bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java:14659` - The new budget re-entry cannot serve the case it was added for, and the decline goes uncounted. `sortedScanRecordKeys`&#39;s FillBudgetExceededException handler (:14755) re-enters with `wholeLeafOnly = true`, which forces `sliced = false` (:14658); the very next gate is `if (anyStringKey &amp;&amp; !(sliced &amp;&amp; limit &gt;= 0)) return null;` (:14659), so a STRING_DICT order key returns null at the gate — before the whole-leaf collector, and before any counter. `SORTED_SCAN_DECLINED` only ticks when the second pass throws again (:14761), which cannot happen once the gate short-circuits. Concrete path (the one round 10 named): a 100M projection whose `URL` STRING_DICT column projects ~3.5 GB against the ~2 GB `columnFillBudgetBytes`; `for $r in $doc[] order by $r.URL return $r` with a limit takes the sliced top-K arm, `ProjectionColumnScan.topKRecordKeys` calls `store.column(URL, fetcher)` (:1211), the store refuses, the retry hits :14659 and returns null. Net behavior is unchanged from before this commit (the generic navigational pipeline answers) and the false `SORTED_SCAN_FAILED` tick is correctly gone, but the method&#39;s new javadoc (:14594-14598, &#34;the whole-leaf branch below … can [serve], so the decline re-enters there instead of dropping a servable query to the generic navigational pipeline&#34;) is false for this arm — the fall-through collectors carry long tuples only (:14680) — and the route change is invisible in both counters, which is the bare-null observability hole the earlier rounds asked to close. Fix: tick `SORTED_SCAN_DECLINED` at :14659 when `wholeLeafOnly` is set, and narrow the javadoc to say the whole-leaf re-entry serves long order keys only.
- ℹ️ `bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java:14829` - This commit re-created the orphaned-javadoc defect that round 1 reported and the author fixed in `Names`/`PathSummaryWriter`/`StorageEngineWriter`, and round 7 fixed again in `SirixVectorizedExecutor`/`ProjectionIndexCatalog`: a new member inserted between an existing doc block and the member it documented. (1) :14829 — `/** Sorted-scan serving attempts that FAILED with an exception (not gate declines). */` now precedes the newly inserted `SORTED_SCAN_DECLINED` field and its own doc block, stacking two doc comments on one member and leaving `SORTED_SCAN_FAILED` (:14837) undocumented. (2) :14867 — `/** Value-emission attempts that FAILED with an exception (not gate declines). */` now precedes `PREDICATE_VALUE_EMISSION_DECLINED`, leaving `PREDICATE_VALUE_EMISSION_FAILED` (:14875) undocumented. Generated javadoc attributes each stale block to the wrong counter, and the two blocks say opposite things about the same member (&#34;FAILED with an exception&#34; vs &#34;a route decision, not corruption&#34;). Move each new field/accessor pair below the member the preceding block belongs to.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (3) ✅</summary>

- ⚠️ `bundles/sirix-query/build.gradle:207` - The `projectionRefusalTest` Gradle task added by this change (bundles/sirix-query/build.gradle:207) is wired into `check` but verifies nothing: it includes `**/ProjectionRefusalPathTest.class`, and no `ProjectionRefusalPathTest` source or class exists anywhere in the repository. The system property it provides, `sirix.projection.maxIncrementalRecords`, is also read by no Java code — it appears only in build.gradle. `./gradlew :sirix-query:projectionRefusalTest --rerun-tasks` reports BUILD SUCCESSFUL and produces no test-results XML at all. The paired `exclude &#39;**/ProjectionRefusalPathTest.class&#39;` in the main `test` task is likewise a no-op. The intent says three pieces were dropped as structurally superseded, including &#34;refusal-site counters&#34;, so this is most likely vestigial build wiring left behind by that drop — but as it stands `check` gained a verification gate that can never fail. The author should decide whether to land the missing test or remove the task; I did not change build configuration myself since that is beyond a test fix.
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.projection.ParallelBulkProjectionEquivalenceTest --tests io.sirix.access.trx.node.json.ParallelBulkPrimitiveIndexEquivalenceTest --tests io.sirix.index.projection.ProjectionWindowedPayloadServeTest --tests io.sirix.index.projection.ProjectionPostPassBoundedRetentionTest --tests io.sirix.index.projection.ProjectionBulkSlotAccumulationTest --tests io.sirix.index.projection.ProjectionStaleReasonTest --tests io.sirix.index.projection.ProjectionStoreKindConsistencyTest --tests io.sirix.index.projection.ProjectionSegmentResurrectionTest --tests io.sirix.index.projection.ProjectionGlobalDictionaryGenerationRotationTest --tests io.sirix.page.HOTCompleteDumpMergeTest --tests io.sirix.page.HOTTombstoneEvictionTest --tests io.sirix.index.hot.HOTBulkBuilderTest --tests io.sirix.index.hot.HOTIntegrateTest --tests io.sirix.cache.FrameSlotAllocatorTest --tests io.sirix.io.HashAccessesEquivalenceTest --tests io.sirix.access.trx.node.json.BulkAssemblyEquivalenceOracleTest` — 101 tests, 0 failures</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.hot.StraddleCanonicityProbe --tests io.sirix.index.hot.HOTInsertionOrderShapeProbe --tests io.sirix.index.hot.BetaIsDiscBitRoutingProbe --tests io.sirix.index.hot.HOTIndirectPageSplitFaithfulTest --tests io.sirix.access.trx.page.AsyncFlushHftPhaseTelemetryTest --tests io.sirix.index.projection.ProjectionStreamingGlobalDictionaryTest` — 24 tests, 0 failures</code>
- <code>`./gradlew :sirix-query:test --tests io.sirix.query.ProjectionIndexCatalogServingTest` — 45 tests, 0 failures</code>
- <code>`./gradlew :sirix-query:test --tests io.sirix.query.scan.SirixVectorizedExecutorLifecycleTest --tests io.sirix.query.ProjectionLoadTimeBuildEquivalenceTest --tests io.sirix.query.GlobalDictMaintenanceVerdictTest --tests io.sirix.query.ProjectionSegmentSlotMaintenanceTest --tests io.sirix.query.bench.clickbench.ClickBenchProjectionTest --tests io.sirix.query.function.jn.temporal.StoreValidTimeAutoIndexTest` — 46 tests, 0 failures</code>
- <code>`./gradlew :sirix-query:projectionRefusalTest --rerun-tasks` — BUILD SUCCESSFUL but produced no test-results XML (task matches no test class)</code>
- <code>`java ... io.sirix.query.bench.clickbench.ClickBenchGenerateMain /tmp/cbev/hits-200k.json 200000 42` — generated the 200,000-record / 390 MB synthetic ClickBench corpus used by every end-to-end run</code>
- <code>`java ... io.sirix.query.bench.clickbench.ClickBenchPrimitiveIndexImportCostMain /tmp/cbev/hits-200k.json /tmp/cbev/work 3` — bare vs indexed one-pass import, with URL PATH/NAME posting read-back</code>
- <code>`java ... io.sirix.query.bench.clickbench.ClickBenchParallelProjectionCostMain /tmp/cbev/hits-200k.json /tmp/cbev/work 3` — default dictionary election; post-pass arm aborts at distinct entry 16,385</code>
- <code>`java -Dsirix.projection.globalDict=never ... ClickBenchParallelProjectionCostMain /tmp/cbev/hits-200k.json /tmp/cbev/work 2` — three-arm bare / one-pass / post-pass timing comparison</code>
- <code>`java ... io.sirix.query.bench.clickbench.ClickBenchLoadMain /tmp/cbev/db-200k generate:200000` — one-pass 25-column projection built during the shred, dictProbes=0, validation OK</code>
- <code>`java ... io.sirix.query.bench.clickbench.ClickBenchRunMain /tmp/cbev/db-200k --tries 3 --dump /tmp/cbev/dump-all43` — all 43 ClickBench queries against the one-pass index, with RSS sampled every 250 ms across 129 retired executors</code>
- <code>`java ... ClickBenchRunMain /tmp/cbev/db-200k --queries 5,20 --tries 3 --dump ...` run three times at default, `-Dsirix.projection.eagerMaterializeBytes=8388608` and `=524288` with `-Dsirix.projection.fillDiag=true`</code>
- <code>`diff -r /tmp/cbev/dump-default /tmp/cbev/dump-squeezed` — byte-identical result dumps across a ~3 GB and a 512 KB fill budget</code>
- <code>`git status --porcelain` — worktree clean; all generated corpora, databases and result dumps removed from /tmp after capture</code>

🔧 Fix: Remove vacuous projectionRefusalTest task from sirix-query build
1 warning still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java:1681` - The intent requires that &#34;the one silent load-degradation (dictionary budget breach) prints unconditionally to stderr&#34;. That notice is emitted by abandonForOversizedDictionary (ProjectionIndexChangeListener.java:1681), added by 75e0fc480, and no test in the repository exercises it — grep for GLOBAL_DICTIONARY_BUDGET_EXCEEDED finds only enum round-trip coverage in ProjectionStaleReasonTest, never the emitted line. I wrote a focused test (real ParallelBulkJsonImporter loads, tee-captured System.err, loud arm + healthy control arm) and could not reach the abandon path through the public API. With sirix.projection.globalDict=auto the election declines the column on isGlobalDictionaryWorthwhile before any mid-load breach can occur — I swept budgets of 1, 2, 4, 8, 16, 32, 64, 128, 256 and 512 MiB against 20k/100k/300k-record all-distinct corpora and every run published a live per-leaf STRING_DICT column (kind 2) with no abandon. With globalDict=always the breach is reached, but AdmissionPolicy.FAIL_CLOSED wraps it in an IllegalStateException that kills the load instead of abandoning, so the notice never prints. The two election knobs that would open the window (sirix.projection.globalDict.minEntries, .dedupFactor) are private static final Integer.getInteger(...) fields resolved at class initialization, so a test cannot set them — they would have to arrive as JVM flags via a dedicated forked Gradle test task, which is precisely the pattern you just directed me to remove from bundles/sirix-query/build.gradle. I removed my test rather than leave a failing or knob-dependent one; the worktree is clean. Your call on how to proceed: add a package-private fault-injection seam on ProjectionBulkLoad so the typed decline can be raised deterministically, relax the election constants to instance/parameter values a test can supply, or accept that this notice is verified only by the 100M acceptance runs and not by CI.
- <code>`./gradlew :sirix-query:check --dry-run` — task graph now terminates at `:sirix-query:test`, no `projectionRefusalTest` node</code>
- <code>`./gradlew :sirix-query:projectionRefusalTest --dry-run` — fails with &#34;not found in project &#39;:sirix-query&#39;&#34;, confirming the task is gone</code>
- <code>`git grep -nE &#39;projectionRefusal|ProjectionRefusalPath|sirix\.projection\.maxIncrementalRecords&#39;` — zero matches tree-wide</code>
- <code>`./gradlew :sirix-query:test --tests io.sirix.query.ProjectionIndexCatalogServingTest` — 45 tests, incl. `anOverBudgetSortedScanReEntersTheWholeLeafArmInsteadOfCountingAsCorruption` and `anOverBudgetColumnRoutesToTheWholeLeafKernelInsteadOfDecliningIntoTheSlicedArm` from the newest review commits</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.projection.ParallelBulkProjectionEquivalenceTest` — one-pass vs post-pass byte differential plus its `theDifferentialCanFail` negative control</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.projection.ProjectionWindowedPayloadServeTest` — 13 tests over windowed 128-leaf loads, cumulative fill pricing, and the non-memoizing decline door</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.projection.ProjectionStaleReasonTest` — machine-readable stale-tombstone reasons and their remedies</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.access.trx.node.json.ParallelBulkPrimitiveIndexEquivalenceTest` — PATH/CAS/NAME probed against a sequential-import oracle, incl. the late-binding path-class probe pinning the stale resolved-path-cache fix</code>
- <code>`./gradlew :sirix-core:test --tests io.sirix.access.trx.node.json.BulkAssemblyEquivalenceOracleTest` — 19 full-field dump differentials incl. mid-load async-flush epochs</code>
- <code>Manual end-to-end: compiled and ran `BulkIndexCampaignDemo` against the project&#39;s test runtime classpath — bulk import + `jn:create-projection-index` in one commit, cold re-open, four JSONiq queries through `SirixVectorizedExecutor`, each cross-checked against `SirixCompileChain.createWithJsonStoreWithoutAutoWiring` and reported with the catalog&#39;s served counter</code>
- <code>Attempted (removed): a focused `System.err` capture test for the dictionary-budget abandon notice; swept budgets 1 MiB→512 MiB × 20k/100k/300k records in both `auto` and `always` dictionary modes — the abandon path was unreachable through the public load API</code>

🔧 Fix: Test the unconditional dictionary-budget abandon notice
1 warning still open:
- ⚠️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionIndexChangeListener.java:1681` - The abandon notice required by the intent now prints and is properly tested, but the numbers it prints are self-contradictory. Observed verbatim from a real load: &#34;[proj] PROJECTION ABANDONED during the load: index 0, column 0 retained 1114240 B over 10227 distinct values, past its 39850930 B budget.&#34; — it reports 1.1 MB retained and calls that &#34;past&#34; a 39.8 MB budget, a number 36x larger. Cause: the budget predicate at GlobalValueDictionaryWriter.java:412-413 tests max(saturatedAdd(retainedBytes(), allocationBytes), flushPeak) &gt; budgetBytes, but refuseAdmission (GlobalValueDictionaryWriter.java:748) constructs GlobalDictionaryBudgetExceededException with retainedBytes() alone. The quantity that actually breached (the projected flush peak, or retained+allocation) is never carried and never printed. This is structural, not a quirk of my corpus: all three refusal sites (lines 413, 728, 741) compare retained PLUS a reservation against the budget, and a dictionary whose retention alone exceeded the budget would already have been refused on an earlier admission — so retained &lt; budget holds on essentially every refusal, meaning this notice can never print a coherent pair. Operator impact: the notice is the sole signal for this degradation and its own remedy text (via the exception message) says &#34;Raise the configured byte budget&#34;, but the line gives no usable number to raise it by, and reads as though the guard misfired. The new test does not catch this: NOTICE group 3 captures retained but the loud arm asserts only groups 1, 2, 4 and 5, never a retained-vs-budget relationship, so it pins the contradictory format. Fixing this means adding the breaching quantity to GlobalDictionaryBudgetExceededException and to the notice — a production change to an operator-facing output contract, beyond a test-phase fix — so it is your call whether to correct the notice (and tighten the test to assert the printed quantity actually exceeds the printed budget) or accept the current wording.
- <code>`./gradlew :sirix-core:test --tests &#39;io.sirix.index.projection.ProjectionDictionaryBudgetAbandonNoticeTest&#39; --rerun` — 2/2 passed (loud arm + healthy control arm)</code>
- <code>`./gradlew :sirix-core:test --tests &#39;io.sirix.index.projection.ProjectionStaleReasonTest&#39; --rerun` — 5/5 passed (machine-readable stale-reason half of the same intent clause)</code>
- <code>Reachability trace of `abandonForOversizedDictionary`: callers at `ProjectionIndexChangeListener.java:1650` (`beforeCommit`) and `:1708` (`beforePageFlush`); decline raised at `GlobalValueDictionaryWriter.java:748`; budget predicate at `GlobalValueDictionaryWriter.java:412-413`</code>
- <code>Mutation 1 (non-vacuity): suppressed the notice via `if (false) System.err.println(...)` at `ProjectionIndexChangeListener.java:1681` → loud arm FAILED (`expected: &lt;1&gt; but was: &lt;0&gt;`), control arm still passed; reverted</code>
- <code>Mutation 2 (unsuppressible-channel contract): rerouted the identical text from `System.err.println` to `LOGGER.warn` → loud arm FAILED with empty captured stderr under `Level.OFF`, control arm still passed; reverted</code>
- `Captured the verbatim operator-facing stderr line emitted by a real 30,000-record shredder load with the root logger set to OFF`
- <code>Verified `git status --porcelain` is empty after both mutations were reverted — no production or test source left modified</code>

🔧 Fix: Print the breaching quantity in the dictionary abandon notice
✅ Re-checked - no issues remain.
- <code>`./gradlew :sirix-core:test --rerun --tests &#39;io.sirix.index.projection.ProjectionDictionaryBudgetAbandonNoticeTest&#39; --tests &#39;io.sirix.index.projection.GlobalValueDictionaryWriterBudgetTest&#39; --tests &#39;io.sirix.index.projection.ProjectionStaleReasonTest&#39;` — 20 tests, 0 failures; captured the real operator stderr line from a live 30k-record load</code>
- <code>Regression A/B: `git checkout HEAD~1 -- bundles/sirix-core/src/main/java/io/sirix/index/projection/{GlobalDictionaryBudgetExceededException,GlobalValueDictionaryProbeFront,GlobalValueDictionaryWriter,ProjectionIndexChangeListener}.java` then re-ran `ProjectionDictionaryBudgetAbandonNoticeTest` — loud arm FAILS on the pre-fix notice (AssertionFailedError at ProjectionDictionaryBudgetAbandonNoticeTest.java:163), passes after restoring the fix. Production files restored.</code>
- <code>`./gradlew :sirix-core:test --rerun --tests &#39;io.sirix.index.projection.ProjectionGlobalDictionaryGenerationRotationTest&#39;` — the FAIL_CLOSED structural-ceiling wrapper path still matches its message assertion (`mentionsTheCeiling`), unaffected by the two-factory refactor</code>
- <code>Test improvement: extended `boundedWriterRefusesAtTheBudget` to assert the byte-decline invariant on the exception (term named, `breachingBytes &gt; budgetBytes`, `retained &lt;= breaching`, message states its own arithmetic, remedy quotes a raisable budget)</code>
- <code>Test improvement: added `GlobalValueDictionaryWriterBudgetTest &gt; &#34;A structural ceiling declines without claiming any quantity exceeded the byte budget&#34;` — drives the real writer into the entry-count and value-length ceilings and asserts `breachingTerm() == null`, no &#34;past the&#34; breach claim, and the structural remedy text</code>
- <code>Manual verification: drove the real `GlobalValueDictionaryWriter` to each decline family through its own API (no fault injection) and printed the operator-facing message for both, confirming the byte-budget message is self-consistent and the structural message invents no comparison</code>
- <code>Cleanup verified: `git status --short --untracked-files=all` shows only the intentional test-file modification; scratch verification program and extracted classpath removed from /tmp</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `docs/HOT_BULK_BUILD.md:3` - docs/HOT_BULK_BUILD.md (546 lines) is a design record pinned to base commit 226ceaac8, and this change landed most of it. I removed the contradictions in place (status header, the §0 premise bullet, Seam 1&#39;s &#39;currently refuses&#39;, Seam 2b&#39;s &#39;uncommitted&#39; heading, the Appendix answer) and pointed shipped behavior at BULK_IMPORT.md, rather than rewriting the document. A follow-up could trim it to the reasoning that is still load-bearing and let BULK_IMPORT.md own everything about what the loaders do today; that consolidation is larger than this change made stale, so I left it out.
- ℹ️ `docs/PROJECTION_INDEXES.md:147` - The code defines ~50 `sirix.projection.*` system properties; only six appear in any document, scattered across five files, and no document owns the projection tuning surface. I documented just the one this change made user-visible (`sirix.projection.eagerMaterializeBytes`, in PROJECTION_INDEXES.md, matching where projection knobs already live — operations.md deliberately owns only the `sirix.cache.*` budgets). A durable fix is a generated property table checked for drift against the source, which is out of scope here.

🔧 Fix: Consolidate HOT bulk design record into reasoning-only owner
2 infos still open:
- ℹ️ `docs/HOT_BULK_BUILD.md:1` - Judgment call worth confirming: I deleted the §2.1 leaf-packing narrative (the measured 280→40 leaf improvement) because the operative invariant is owned by HOTBulkBuilder.isExpandable/fitsLeafPage javadoc and the placement policy forbids incident narratives in prose. But the deleted text was the only place asserting the outcome — HOTInsertionOrderShapeProbe REPORTS leaf counts and asserts only read-equivalence (probe line 56: &#34;Shape equality is REPORTED, not asserted&#34;), and HOTBulkBuilderTest asserts leaf counts only for determinism (line 248, ra vs rb) and the single-leaf case (line 210). So the highest-fitting-subtree packing policy currently has no regression guard: a future frontier change could silently reintroduce the ~7x fragmentation and every existing gate would stay green. Adding an assertion is a test change, out of scope for this documentation/lint phase.
- ℹ️ `docs/PROJECTION_INDEX_DEEP_DIVE.md:631` - Judgment call on where the descriptive material went. The instruction said to move descriptive content to BULK_IMPORT.md, but one block did not belong there: the bulk slot sink is engaged by the POST-PASS projection build (jn:create-projection-index via ProjectionIndexBuilder), not by either JSON bulk loader — the load-time rider ProjectionBulkLoad deliberately still writes per entry. Filing it under BULK_IMPORT.md would have made that document the owner of a fact about a code path it does not cover, against the one-owner rule. I routed it to PROJECTION_INDEX_DEEP_DIVE.md §6.1 (the projection write path&#39;s owner) instead, and pointed HOT_BULK_BUILD.md there. Loader-side descriptive material (residency limit, the postings-vs-bytes gate correction) did go to BULK_IMPORT.md as directed.

🔧 Fix: Guard HOT leaf-packing invariant; mutation-proven by reverting fit-bound
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
