### PR TITLE
perf(sirix-core): dense group-index and count-and-sum accumulator layouts

### DIFF
--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java
@@ -1,13 +1,17 @@
 package io.sirix.index.projection;
 
 import it.unimi.dsi.fastutil.HashCommon;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongLongBiConsumer;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 
 import java.util.Arrays;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntConsumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -38,7 +42,8 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * Thread contract: {@link #worker(int)} hands each parallel slot its own single-threaded
  * {@link Worker}; {@link #finish()} runs on the coordinating thread after the parallel section has
- * joined and publishes the sizes.
+ * joined and publishes the sizes. Its parallel overload uses the caller's joined task runner to
+ * combine the disjoint group stripes independently.
  */
 public final class GroupDistinctAccumulator {
 
@@ -107,8 +112,34 @@ public final class GroupDistinctAccumulator {
     return STRIPES;
   }
 
+  /** The common singleton group needs no hash table or backing array. */
+  private static final class DistinctValues {
+    private final long first;
+    private LongOpenHashSet rest;
+
+    DistinctValues(final long first) {
+      this.first = first;
+    }
+
+    boolean add(final long value) {
+      if (value == first) {
+        return false;
+      }
+      if (rest == null) {
+        rest = new LongOpenHashSet(1);
+      }
+      return rest.add(value);
+    }
+
+    long size() {
+      return 1L + (rest == null
+          ? 0L
+          : rest.size());
+    }
+  }
+
   private static final class Stripe {
-    final Long2ObjectOpenHashMap<LongOpenHashSet> groups = new Long2ObjectOpenHashMap<>();
+    final Long2ObjectOpenHashMap<DistinctValues> groups = new Long2ObjectOpenHashMap<>();
     LongOpenHashSet missing;
   }
 
@@ -167,6 +198,17 @@ public final class GroupDistinctAccumulator {
       return sink;
     }
 
+    /** Record a numeric group directly, without retaining a per-group sink object. */
+    void addToGroup(final long group, final long value) {
+      if (passShift < 64) {
+        final int p = (int) (HashCommon.mix(group) >>> passShift);
+        if (p < passLo || p >= passHi) {
+          return;
+        }
+      }
+      add(group, value);
+    }
+
     /** The sink for rows whose group key is missing — owned by the pass holding partition 0. */
     public Sink missing() {
       return passShift < 64 && passLo > 0
@@ -221,15 +263,16 @@ public final class GroupDistinctAccumulator {
       int added = 0;
       synchronized (target) {
         long lastGroup = 0L;
-        LongOpenHashSet lastSet = null;
+        DistinctValues lastSet = null;
         for (int i = 0; i < fill; i++) {
           final long group = groups[i];
-          LongOpenHashSet set = lastSet;
+          DistinctValues set = lastSet;
           if (set == null || group != lastGroup) {
             set = target.groups.get(group);
             if (set == null) {
-              set = new LongOpenHashSet(16);
+              set = new DistinctValues(values[i]);
               target.groups.put(group, set);
+              added++;
             }
             lastGroup = group;
             lastSet = set;
@@ -286,6 +329,7 @@ public final class GroupDistinctAccumulator {
   private final LongAdder entries = new LongAdder();
   private volatile boolean exceeded;
   private Long2LongOpenHashMap sizes;
+  private Long2LongOpenHashMap[] sizesByGroupStripe;
   private long missingSize;
   private boolean finished;
 
@@ -358,6 +402,7 @@ public final class GroupDistinctAccumulator {
     entries.reset();
     exceeded = false;
     sizes = null;
+    sizesByGroupStripe = null;
     missingSize = 0L;
     finished = false;
   }
@@ -387,34 +432,102 @@ public final class GroupDistinctAccumulator {
    * after the parallel section has joined; idempotent.
    */
   public void finish() {
+    finish((tasks, task) -> {
+      for (int i = 0; i < tasks; i++) {
+        task.accept(i);
+      }
+    });
+  }
+
+  /**
+   * Runs every indexed task exactly once and joins all accepted tasks before returning or throwing.
+   */
+  @FunctionalInterface
+  public interface ParallelTasks {
+    void run(int tasks, IntConsumer task);
+  }
+
+  /**
+   * Publish counts using the caller's existing worker pool. Group stripes own disjoint keys, so each
+   * task combines only its value stripes and needs no shared output map or lock. Call only after all
+   * scan workers have joined; the dispatcher must join its tasks too.
+   */
+  public void finish(final ParallelTasks parallel) {
+    requireNonNull(parallel, "parallel");
     if (finished) {
       return;
     }
     for (final Worker w : workers) {
       w.flushAll();
     }
-    final Long2LongOpenHashMap out = new Long2LongOpenHashMap();
-    out.defaultReturnValue(0L);
-    long missing = 0L;
-    for (final Stripe stripe : stripes) {
-      synchronized (stripe) {
-        for (final Long2ObjectMap.Entry<LongOpenHashSet> e : stripe.groups.long2ObjectEntrySet()) {
-          out.addTo(e.getLongKey(), e.getValue().size());
+    final int groups = 1 << GROUP_STRIPE_BITS;
+    final Long2LongOpenHashMap[] counts = new Long2LongOpenHashMap[groups];
+    final long[] missing = new long[groups];
+    parallel.run(groups, group -> {
+      final int first = group << VALUE_STRIPE_BITS;
+      final int end = first + (1 << VALUE_STRIPE_BITS);
+      int expected = 0;
+      for (int stripe = first; stripe < end; stripe++) {
+        expected = Math.max(expected, stripes[stripe].groups.size());
+      }
+      final Long2LongOpenHashMap out = new Long2LongOpenHashMap(expected);
+      for (int stripe = first; stripe < end; stripe++) {
+        final Stripe source = stripes[stripe];
+        final ObjectIterator<Long2ObjectMap.Entry<DistinctValues>> entries =
+            source.groups.long2ObjectEntrySet().fastIterator();
+        while (entries.hasNext()) {
+          final Long2ObjectMap.Entry<DistinctValues> entry = entries.next();
+          out.addTo(entry.getLongKey(), entry.getValue().size());
         }
-        if (stripe.missing != null) {
-          missing += stripe.missing.size();
+        if (source.missing != null) {
+          missing[group] += source.missing.size();
         }
       }
+      counts[group] = out;
+    });
+    long missingTotal = 0L;
+    for (int group = 0; group < groups; group++) {
+      if (counts[group] == null) {
+        throw new IllegalStateException("distinct-count publication did not complete stripe " + group);
+      }
+      missingTotal += missing[group];
     }
-    sizes = out;
-    missingSize = missing;
+    sizesByGroupStripe = counts;
+    missingSize = missingTotal;
     finished = true;
   }
 
-  /** Exact distinct count per group (0 for an unseen group), after {@link #finish()}. */
+  /** Visit each completed group once without constructing a combined hash map. */
+  public void forEachGroupSize(final LongLongBiConsumer consumer) {
+    requireNonNull(consumer, "consumer");
+    if (!finished) {
+      throw new IllegalStateException("finish() has not run");
+    }
+    for (final Long2LongOpenHashMap stripe : sizesByGroupStripe) {
+      final ObjectIterator<Long2LongMap.Entry> entries = stripe.long2LongEntrySet().fastIterator();
+      while (entries.hasNext()) {
+        final Long2LongMap.Entry entry = entries.next();
+        consumer.accept(entry.getLongKey(), entry.getLongValue());
+      }
+    }
+  }
+
+  /**
+   * Exact distinct count per group (0 for an unseen group), after {@link #finish()}. Materializes a
+   * combined map lazily; {@link #forEachGroupSize} visits published counts without that allocation.
+   */
   public Long2LongOpenHashMap groupSizes() {
     if (!finished) {
       throw new IllegalStateException("finish() has not run");
+    }
+    if (sizes == null) {
+      int groups = 0;
+      for (final Long2LongOpenHashMap stripe : sizesByGroupStripe) {
+        groups = Math.addExact(groups, stripe.size());
+      }
+      final Long2LongOpenHashMap combined = new Long2LongOpenHashMap(groups);
+      forEachGroupSize((group, count) -> combined.put(group, count));
+      sizes = combined;
     }
     return sizes;
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java
@@ -112,6 +112,12 @@ public final class GroupDistinctAccumulator {
     return STRIPES;
   }
 
+  /**
+   * Retain the previous set sizing after leaving the inline singleton case, avoiding repeated
+   * small-table growth while holding the stripe monitor.
+   */
+  private static final int PROMOTED_SET_ENTRIES = 16;
+
   /** The common singleton group needs no hash table or backing array. */
   private static final class DistinctValues {
     private final long first;
@@ -126,7 +132,7 @@ public final class GroupDistinctAccumulator {
         return false;
       }
       if (rest == null) {
-        rest = new LongOpenHashSet(1);
+        rest = new LongOpenHashSet(PROMOTED_SET_ENTRIES);
       }
       return rest.add(value);
     }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -63,11 +63,23 @@ import static java.util.Objects.requireNonNull;
  */
 public final class GroupTableSpill {
 
-  /** Use compact hash indexes and dense accumulator records (default on). */
+  /** Use compact hash indexes and dense accumulator records (default on above the crossover). */
   public static final String DENSE_INDEX_PROPERTY = "sirix.projection.groupTable.denseIndex";
 
+  /**
+   * The narrowest stripe the dense layout is worth, from the lanes each layout holds per LIVE group
+   * at the 3/4 growth threshold. The interleaved layout reserves a whole stripe in every bucket, so
+   * it holds {@code stride / (3/4) = (4/3) * stride} lanes per live group. The dense layout packs the
+   * stripes with no holes and adds one index lane per bucket, so it holds {@code stride + 4/3}. Those
+   * are equal at {@code stride == 4} and the dense form is larger below it: at the three lanes of
+   * {@code GROUP BY x ORDER BY count(*)} it is 4.33 lanes against 4.0, and it charges a second
+   * dependent load per probe to prove the key behind the index hit. So dense saves lanes only for
+   * {@code stride > 4}, and the gate admits exactly those shapes.
+   */
+  public static final int DENSE_INDEX_MIN_STRIDE = 5;
+
   private static boolean denseIndexEnabled(final int stride) {
-    return stride >= 3 && Boolean.parseBoolean(System.getProperty(DENSE_INDEX_PROPERTY, "true"));
+    return stride >= DENSE_INDEX_MIN_STRIDE && Boolean.parseBoolean(System.getProperty(DENSE_INDEX_PROPERTY, "true"));
   }
 
   /** Configured flush threshold in groups per worker table. */

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -949,6 +949,14 @@ public final class GroupTableSpill {
     return pool;
   }
 
+  /**
+   * The recycler for the dense layout's compact index chunks, or {@code null} when this spill's
+   * stripe stays interleaved or the pool is switched off (test observability).
+   */
+  LongChunkPool probeChunkPool() {
+    return probePool;
+  }
+
   /** Attach this spill's pool to a table that holds no group yet. */
   private NumericGroupAggTable adopt(final NumericGroupAggTable table) {
     if (denseIndex) {
@@ -1357,9 +1365,9 @@ public final class GroupTableSpill {
    * refreshes the budget by a forced collection measures whatever is still REFERENCED, not what the
    * arm intends to keep: at 100M (q32) the aborted pass's 16.6M spilled groups read as 3.9 GB of live
    * heap, the budget FELL 11.5M → 7.9M and the restart ran 16 passes instead of 8. Call after the
-   * parallel section has joined and before re-planning; the spill is not reused. The pool is drained
-   * for the same reason: what it holds is retained by intent only, and the measurement must not count
-   * it.
+   * parallel section has joined and before re-planning; the spill is not reused. The pools are drained
+   * for the same reason: what they hold is retained by intent only, and the measurement must not
+   * count it.
    */
   public void releaseTables() {
     for (int p = 0; p < partitions; p++) {
@@ -1390,6 +1398,10 @@ public final class GroupTableSpill {
     if (pool != null && !pool.isShared()) {
       // A per-scan pool is invisible to the budget; a shared one is added back to the headroom.
       pool.drain();
+    }
+    if (probePool != null) {
+      // Always per-scan, so never added back: the released tables' index chunks must go too.
+      probePool.drain();
     }
     RELEASES.increment();
   }

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -1367,7 +1367,8 @@ public final class GroupTableSpill {
    * heap, the budget FELL 11.5M → 7.9M and the restart ran 16 passes instead of 8. Call after the
    * parallel section has joined and before re-planning; the spill is not reused. The pools are
    * drained for the same reason: what they hold is retained by intent only, and the measurement must
-   * not count it.
+   * not count it. Drain LAST, therefore: a caller that owns tables of its own must release them
+   * BEFORE this call, or their chunks land in a pool this call has already emptied.
    */
   public void releaseTables() {
     for (int p = 0; p < partitions; p++) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -1365,9 +1365,9 @@ public final class GroupTableSpill {
    * refreshes the budget by a forced collection measures whatever is still REFERENCED, not what the
    * arm intends to keep: at 100M (q32) the aborted pass's 16.6M spilled groups read as 3.9 GB of live
    * heap, the budget FELL 11.5M → 7.9M and the restart ran 16 passes instead of 8. Call after the
-   * parallel section has joined and before re-planning; the spill is not reused. The pools are drained
-   * for the same reason: what they hold is retained by intent only, and the measurement must not
-   * count it.
+   * parallel section has joined and before re-planning; the spill is not reused. The pools are
+   * drained for the same reason: what they hold is retained by intent only, and the measurement must
+   * not count it.
    */
   public void releaseTables() {
     for (int p = 0; p < partitions; p++) {

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -953,7 +953,7 @@ public final class GroupTableSpill {
    * The recycler for the dense layout's compact index chunks, or {@code null} when this spill's
    * stripe stays interleaved or the pool is switched off (test observability).
    */
-  LongChunkPool probeChunkPool() {
+  public LongChunkPool probeChunkPool() {
     return probePool;
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java
@@ -32,7 +32,9 @@ import static java.util.Objects.requireNonNull;
  * recycles the ones it outgrew, and the caller releases the merged tables once a pass has emitted
  * its candidates — so a pass allocates its storage once and G1 promotes it once, instead of copying
  * ≈ 9 GB of short-lived tables through the young generation per pass (the q32 profile at 100M).
- * Kill switch {@code -Dsirix.projection.groupTable.chunkPool=false}.
+ * Kill switch {@code -Dsirix.projection.groupTable.chunkPool=false}. Dense table indexes use a
+ * separate recycler scoped to this spill. Payload recycling retains the existing policy; index
+ * chunks never enter a new global pool. The group budget is unchanged.
  * </p>
  *
  * <p>
@@ -60,6 +62,13 @@ import static java.util.Objects.requireNonNull;
  * </p>
  */
 public final class GroupTableSpill {
+
+  /** Use compact hash indexes and dense accumulator records (default on). */
+  public static final String DENSE_INDEX_PROPERTY = "sirix.projection.groupTable.denseIndex";
+
+  private static boolean denseIndexEnabled(final int stride) {
+    return stride >= 3 && Boolean.parseBoolean(System.getProperty(DENSE_INDEX_PROPERTY, "true"));
+  }
 
   /** Configured flush threshold in groups per worker table. */
   public static final String FLUSH_GROUPS_PROPERTY = "sirix.projection.groupTable.flushGroups";
@@ -801,6 +810,8 @@ public final class GroupTableSpill {
   private final long budget;
   /** Shared by every table of this spill, or {@code null} when the pool is switched off. */
   private final LongChunkPool pool;
+  private final LongChunkPool probePool;
+  private final boolean denseIndex;
   private final LongAdder spilled = new LongAdder();
   /**
    * Stripes sitting in the partition buffers: resident state the abort must price, not yet
@@ -876,6 +887,7 @@ public final class GroupTableSpill {
         : flushGroups();
     // One probe table fixes the layout every table of this spill shares; it never holds a group.
     final int stride = factory.apply(workerTableHint()).stride();
+    this.denseIndex = denseIndexEnabled(stride);
     this.stripeStride = stride;
     if (stripeSpill) {
       this.stripeBuffers = new StripeBuffer[partitions];
@@ -897,11 +909,17 @@ public final class GroupTableSpill {
       final int capacity = poolCapacityChunks(budget, threshold, stride, chunkLanes);
       // The shared pool outlives this pass: the chunks the previous pass (or the previous query)
       // handed back are this pass's tables, and nothing is allocated for them.
+      final int probeChunks =
+          (int) Math.max(1L, Math.min(Integer.MAX_VALUE, budget / (NumericGroupAggTable.MAX_STORAGE_CHUNK_LANES / 2L)));
+      this.probePool = denseIndex
+          ? new LongChunkPool(NumericGroupAggTable.MAX_STORAGE_CHUNK_LANES, probeChunks)
+          : null;
       this.pool = LongChunkPool.retainAcrossScans()
           ? LongChunkPool.shared(chunkLanes, capacity)
           : new LongChunkPool(chunkLanes, capacity);
     } else {
       this.pool = null;
+      this.probePool = null;
     }
   }
 
@@ -921,6 +939,12 @@ public final class GroupTableSpill {
 
   /** Attach this spill's pool to a table that holds no group yet. */
   private NumericGroupAggTable adopt(final NumericGroupAggTable table) {
+    if (denseIndex) {
+      table.useDenseIndex();
+      if (probePool != null) {
+        table.attachProbePool(probePool);
+      }
+    }
     return pool == null
         ? table
         : table.attachChunkPool(pool);

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java
@@ -439,9 +439,11 @@ public final class NumericGroupAggTable {
 
   /**
    * Use a compact hash index and append accumulators densely. Each index entry holds a 32-bit hash
-   * tag and a record handle; the complete key and identity still prove equality. At the maximum load,
-   * count-only stripes plus their index use fewer lanes than the six charged by the pass budget.
-   * Wider stripes save space over the interleaved sparse layout. Must be enabled before the first
+   * tag and a record handle; the complete key and identity still prove equality. Packed stripes plus
+   * one index lane per bucket hold {@code stride + 4/3} lanes per live group at the growth threshold,
+   * against the interleaved layout's {@code (4/3) * stride}, so this saves lanes only for stripes
+   * wider than four — see {@link GroupTableSpill#DENSE_INDEX_MIN_STRIDE} for the gate that applies
+   * it. Narrower stripes remain correct here and are used by tests. Must be enabled before the first
    * insertion or pool attachment.
    */
   public NumericGroupAggTable useDenseIndex() {
@@ -1349,14 +1351,16 @@ public final class NumericGroupAggTable {
    * Blocks of different widths would fold lane-misaligned, and an aux-less destination has no lane to
    * carry a source reference INTO — its neighbour's key lane sits there instead. A source that folded
    * a lane the destination does not (or the reverse) would merge a real sum into an unread lane, or
-   * an unfolded zero into a real one — both silent.
+   * an unfolded zero into a real one — both silent. The compact and ordinary layouts can reach the
+   * SAME slotWidth at different column counts, and their operand blocks are two lanes wide against
+   * four, so the flag is checked (and reported) in its own right.
    */
   private static void requireMergeable(final NumericGroupAggTable src, final NumericGroupAggTable into) {
     if (src.slotWidth != into.slotWidth || src.withAux != into.withAux || src.sumExactMask != into.sumExactMask
         || src.idWidth != into.idWidth || src.sumsOnly != into.sumsOnly) {
       throw new IllegalStateException("incompatible group tables: slotWidth " + src.slotWidth + "/" + into.slotWidth
           + ", aux " + src.withAux + "/" + into.withAux + ", sumExactMask " + src.sumExactMask + "/" + into.sumExactMask
-          + ", idWidth " + src.idWidth + "/" + into.idWidth);
+          + ", idWidth " + src.idWidth + "/" + into.idWidth + ", sumsOnly " + src.sumsOnly + "/" + into.sumsOnly);
     }
   }
 

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java
@@ -2,13 +2,16 @@ package io.sirix.index.projection;
 
 import it.unimi.dsi.fastutil.HashCommon;
 
+import java.util.Arrays;
+
 /**
- * Flat open-addressed hash table for per-group aggregates keyed by a single {@code long} group
- * value, with each key INTERLEAVED with its own accumulator in one stripe so that a group's probe
- * and its fold touch the same cache line.
+ * Open-addressed hash table for per-group aggregates keyed by a {@code long} value or an exact
+ * tuple identity. Each storage stripe contains the key and its accumulator. By default, stripes
+ * occupy hash buckets; {@link #useDenseIndex()} instead stores them sequentially behind a compact
+ * hash index, so collisions probe tags and handles before loading a complete stripe.
  *
  * <p>
- * Logical bucket {@code b} owns one contiguous stripe within one fixed-size storage chunk:
+ * Each record owns one contiguous stripe within one fixed-size storage chunk:
  *
  * <pre>
  *   lane 0                : key         — {@code
@@ -26,13 +29,16 @@ import it.unimi.dsi.fastutil.HashCommon;
  * probe AND the fold AND the winner decode.
  *
  * <p>
- * The accumulator block's INTERNAL layout is byte-for-byte
+ * The ordinary accumulator layout is byte-for-byte
  * {@link ProjectionIndexByteScan#newGroupAggAcc}'s, unchanged by the interleave, which is why
  * {@link #acquire} hands back an encoded accumulator handle. Callers resolve it once through
  * {@link #storageAtAccBase} and {@link #offsetAtAccBase}; the resulting array and offset have the
  * same block layout as a STANDALONE {@code long[]} (the missing-key and constant-group accumulators
  * keep that standalone shape). From a handle, the key is one load BELOW the resolved offset
  * ({@link #keyAtAccBase}) and the aux lane one {@code slotWidth} ABOVE it ({@link #auxAtAccBase}).
+ * {@link #sumsOnly(int, int, boolean, long, int)} omits operand extrema and uses present-count/sum
+ * pairs; callers must use its matching fold and expand selected results with
+ * {@link #expandSumsAccumulator(long[], int, int)}.
  *
  * <h2>Non-humongous storage</h2>
  *
@@ -44,7 +50,11 @@ import it.unimi.dsi.fastutil.HashCommon;
  * crosses a chunk boundary. The fixed chunk ceiling is below G1's 2-MiB humongous threshold with
  * the canonical 4-MiB regions, including array-header and alignment margin. High-cardinality scans
  * retain their full up-front capacity (and therefore avoid incremental rehashing); only the
- * physical allocation changes.
+ * physical allocation changes. Dense indexing retains the same chunk ceiling and load factor, but
+ * allocates payload chunks in insertion order. Its index stores a 32-bit hash tag and a record
+ * ordinal; full keys and identity lanes still prove equality. Growing that index preserves record
+ * handles, while backing arrays for small payloads can still move. Callers must always re-resolve
+ * the array and offset after an acquisition that can grow the table.
  *
  * <p>
  * Chunks may come from a {@link LongChunkPool} attached before the first insertion
@@ -93,6 +103,7 @@ public final class NumericGroupAggTable {
   private final int slotWidth;
   private final int stride;
   private final int aggColumns;
+  private final boolean sumsOnly;
   /**
    * Bit {@code a} set ⇒ aggregate column {@code a}'s SUM lane is read by the query (a {@code sum} or
    * {@code avg}), so it folds and merges under {@link Math#addExact} and an overflow declines. Bit
@@ -129,6 +140,13 @@ public final class NumericGroupAggTable {
   /** Lane distance from a stripe's accumulator base to its first identity lane. */
   private final int idOffsetFromAcc;
   private long[][] storage;
+  /** Null for interleaved buckets; otherwise hash-tag/record-handle entries in bounded chunks. */
+  private long[][] probeIndex;
+  /** Separate, scan-local recycler: payload and index chunks must never share live ownership. */
+  private LongChunkPool probePool;
+  private static final int PROBE_CHUNK_SHIFT = 14;
+  private static final int PROBE_CHUNK_MASK = (1 << PROBE_CHUNK_SHIFT) - 1;
+  private static final long PROBE_TAG_MASK = 0xFFFF_FFFF_0000_0000L;
   /** Chunk recycler, or {@code null} for plain allocation. Set once, before the first insertion. */
   private LongChunkPool pool;
   private int bucketsPerChunk;
@@ -199,6 +217,20 @@ public final class NumericGroupAggTable {
    */
   public NumericGroupAggTable(final int aggColumns, final int expectedEntries, final boolean withAux,
       final long sumExactMask, final int idWidth) {
+    this(aggColumns, expectedEntries, withAux, sumExactMask, idWidth, false);
+  }
+
+  /**
+   * Count-and-sum layout: each operand stores its present count and exact sum, with no extrema.
+   * Callers must use the compact fold and expand winners before reading the ordinary layout.
+   */
+  public static NumericGroupAggTable sumsOnly(final int aggColumns, final int expectedEntries, final boolean withAux,
+      final long sumExactMask, final int idWidth) {
+    return new NumericGroupAggTable(aggColumns, expectedEntries, withAux, sumExactMask, idWidth, true);
+  }
+
+  private NumericGroupAggTable(final int aggColumns, final int expectedEntries, final boolean withAux,
+      final long sumExactMask, final int idWidth, final boolean sumsOnly) {
     if (aggColumns < 0) {
       throw new IllegalArgumentException("aggColumns must be >= 0");
     }
@@ -207,13 +239,16 @@ public final class NumericGroupAggTable {
     }
     this.aggColumns = aggColumns;
     this.sumExactMask = sumExactMask;
-    this.slotWidth = 2 + 4 * aggColumns;
+    this.sumsOnly = sumsOnly;
+    this.slotWidth = 2 + (sumsOnly
+        ? 2
+        : 4) * aggColumns;
     this.withAux = withAux;
     this.idWidth = idWidth;
     this.idOffsetFromAcc = slotWidth + (withAux
         ? 1
         : 0);
-    this.stride = strideFor(aggColumns, withAux, idWidth);
+    this.stride = strideFor(aggColumns, withAux, idWidth, sumsOnly);
     if (stride > MAX_STORAGE_CHUNK_LANES) {
       throw new IllegalArgumentException(
           "aggregate stripe of " + stride + " lanes exceeds the non-humongous chunk ceiling");
@@ -228,7 +263,7 @@ public final class NumericGroupAggTable {
     installEmptyStorage(cap);
     this.mask = cap - 1;
     this.growAt = cap - (cap >>> 2);
-    this.zeroSlot = newAcc(slotWidth);
+    this.zeroSlot = newAcc(slotWidth, sumsOnly);
   }
 
   /**
@@ -250,15 +285,27 @@ public final class NumericGroupAggTable {
    * @throws IllegalArgumentException if any argument is negative
    */
   public static int strideFor(final int aggColumns, final boolean withAux, final int idWidth) {
+    return strideFor(aggColumns, withAux, idWidth, false);
+  }
+
+  /** Storage lanes per group, including the optional count-and-sum layout. */
+  public static int strideFor(final int aggColumns, final boolean withAux, final int idWidth, final boolean sumsOnly) {
     if (aggColumns < 0) {
       throw new IllegalArgumentException("aggColumns must be >= 0: " + aggColumns);
     }
     if (idWidth < 0) {
       throw new IllegalArgumentException("idWidth must be >= 0: " + idWidth);
     }
-    return 1 + (2 + 4 * aggColumns) + (withAux
-        ? 1
-        : 0) + idWidth;
+    final long lanes = 3L + (sumsOnly
+        ? 2L
+        : 4L) * aggColumns + (withAux
+            ? 1L
+            : 0L)
+        + idWidth;
+    if (lanes > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException("group stripe has too many lanes: " + lanes);
+    }
+    return (int) lanes;
   }
 
   /**
@@ -277,14 +324,36 @@ public final class NumericGroupAggTable {
         : cap;
   }
 
-  private static long[] newAcc(final int slotWidth) {
+  private static long[] newAcc(final int slotWidth, final boolean sumsOnly) {
     final long[] acc = new long[slotWidth];
     acc[1] = Long.MAX_VALUE;
-    for (int base = 2; base < slotWidth; base += 4) {
+    for (int base = 2; !sumsOnly && base < slotWidth; base += 4) {
       acc[base + 2] = Long.MAX_VALUE;
       acc[base + 3] = Long.MIN_VALUE;
     }
     return acc;
+  }
+
+  /** Whether operand blocks contain only a present count and a sum. */
+  public boolean sumsOnly() {
+    return sumsOnly;
+  }
+
+  /** Expand one selected compact accumulator to the ordinary result-emission layout. */
+  public static long[] expandSumsAccumulator(final long[] source, final int base, final int aggColumns) {
+    final long expandedWidth = 2L + 4L * aggColumns;
+    if (aggColumns < 0 || base < 0 || (long) base + 2L + 2L * aggColumns > source.length
+        || expandedWidth > MAX_ARRAY_LENGTH) {
+      throw new IllegalArgumentException("compact accumulator outside source bounds");
+    }
+    final long[] expanded = newAcc((int) expandedWidth, false);
+    expanded[0] = source[base];
+    expanded[1] = source[base + 1];
+    for (int a = 0; a < aggColumns; a++) {
+      expanded[2 + 4 * a] = source[base + 2 + 2 * a];
+      expanded[3 + 4 * a] = source[base + 3 + 2 * a];
+    }
+    return expanded;
   }
 
   /** Aggregate columns this table's accumulator blocks carry. */
@@ -368,6 +437,57 @@ public final class NumericGroupAggTable {
     return this;
   }
 
+  /**
+   * Use a compact hash index and append accumulators densely. Each index entry holds a 32-bit hash
+   * tag and a record handle; the complete key and identity still prove equality. At the maximum load,
+   * count-only stripes plus their index use fewer lanes than the six charged by the pass budget.
+   * Wider stripes save space over the interleaved sparse layout. Must be enabled before the first
+   * insertion or pool attachment.
+   */
+  public NumericGroupAggTable useDenseIndex() {
+    if (size != 0 || hasZeroKey || pool != null) {
+      throw new IllegalStateException("dense index enabled after table use");
+    }
+    if (stride < 3) {
+      throw new IllegalArgumentException("dense indexing needs a stripe of at least three lanes");
+    }
+    probeIndex = new long[(int) (((long) mask + 1L + PROBE_CHUNK_MASK) >>> PROBE_CHUNK_SHIFT)][];
+    return this;
+  }
+
+  /** Attach the spill's separate recycler for compact index chunks. */
+  NumericGroupAggTable attachProbePool(final LongChunkPool recycler) {
+    if (size != 0 || hasZeroKey || recycler.chunkLanes() != 1 << PROBE_CHUNK_SHIFT) {
+      throw new IllegalArgumentException("incompatible or late probe pool");
+    }
+    probePool = recycler;
+    return this;
+  }
+
+  private long[] newProbeChunk(final int capacity) {
+    final int lanes = Math.min(capacity, 1 << PROBE_CHUNK_SHIFT);
+    return probePool != null && lanes == 1 << PROBE_CHUNK_SHIFT
+        ? probePool.take()
+        : new long[lanes];
+  }
+
+  private void recycleProbeIndex(final long[][] index) {
+    if (probePool != null) {
+      for (final long[] chunk : index) {
+        if (chunk != null && chunk.length == 1 << PROBE_CHUNK_SHIFT) {
+          probePool.give(chunk);
+        }
+      }
+    }
+  }
+
+  private long probeEntry(final int bucket) {
+    final long[] chunk = probeIndex[bucket >>> PROBE_CHUNK_SHIFT];
+    return chunk == null
+        ? 0L
+        : chunk[bucket & PROBE_CHUNK_MASK];
+  }
+
   /** The attached chunk recycler, or {@code null}. */
   public LongChunkPool chunkPool() {
     return pool;
@@ -390,6 +510,10 @@ public final class NumericGroupAggTable {
       }
     }
     storage = RELEASED_STORAGE;
+    if (probeIndex != null) {
+      recycleProbeIndex(probeIndex);
+      probeIndex = RELEASED_STORAGE;
+    }
   }
 
   /** Whether {@link #release} has run. */
@@ -480,6 +604,21 @@ public final class NumericGroupAggTable {
     final long key = probeHash == 0L
         ? ZERO_PROBE_SUBSTITUTE
         : probeHash;
+    if (probeIndex != null) {
+      final long hash = HashCommon.mix(key);
+      int bucket = (int) hash & mask;
+      while (true) {
+        final long entry = probeEntry(bucket);
+        if (entry == 0L) {
+          throw new IllegalStateException("no group carries probe key " + probeHash);
+        }
+        final int handle = (int) entry - 1;
+        if (((entry ^ hash) & PROBE_TAG_MASK) == 0L && keyAtAccBase(handle) == key) {
+          return handle;
+        }
+        bucket = bucket + 1 & mask;
+      }
+    }
     final int start = (int) HashCommon.mix(key) & mask;
     int bucket = start;
     do {
@@ -520,6 +659,12 @@ public final class NumericGroupAggTable {
    * Key of bucket {@code bucket}; {@code 0} = empty (the real key 0 lives in {@link #zeroSlot()}).
    */
   public long keyAtBucket(final int bucket) {
+    if (probeIndex != null) {
+      final long entry = probeEntry(bucket);
+      return entry == 0L
+          ? 0L
+          : keyAtAccBase((int) entry - 1);
+    }
     final int chunk = bucket >>> chunkBucketShift;
     final int off = (bucket & chunkBucketMask) * stride;
     final long[] block = storage[chunk];
@@ -530,7 +675,9 @@ public final class NumericGroupAggTable {
 
   /** Encoded accumulator handle of {@code bucket} — valid only when its key lane is non-zero. */
   public int accBaseOfBucket(final int bucket) {
-    return bucket;
+    return probeIndex == null
+        ? bucket
+        : (int) probeEntry(bucket) - 1;
   }
 
   /**
@@ -626,6 +773,9 @@ public final class NumericGroupAggTable {
     if (outOfPass(key)) {
       return DISCARD_HANDLE;
     }
+    if (probeIndex != null) {
+      return acquireDense(key, firstSeenOrdinal, null, 0);
+    }
     final long[][] chunks = storage;
     final int st = stride;
     final int bucketShift = chunkBucketShift;
@@ -654,7 +804,7 @@ public final class NumericGroupAggTable {
       chunks[chunkIndex] = chunk;
     }
     chunk[off] = key;
-    initBlock(chunk, off + 1, firstSeenOrdinal, slotWidth);
+    initBlock(chunk, off + 1, firstSeenOrdinal, slotWidth, sumsOnly);
     if (++size > growAt) {
       rehash();
       // The stripe moved with its key; re-probe in the grown table (guaranteed present).
@@ -692,6 +842,9 @@ public final class NumericGroupAggTable {
     if (outOfPass(key)) {
       return DISCARD_HANDLE;
     }
+    if (probeIndex != null) {
+      return acquireDense(key, firstSeenOrdinal, identity, identityOffset);
+    }
     final long[][] chunks = storage;
     final int st = stride;
     final int bucketShift = chunkBucketShift;
@@ -725,13 +878,105 @@ public final class NumericGroupAggTable {
       chunks[chunkIndex] = chunk;
     }
     chunk[off] = key;
-    initBlock(chunk, off + 1, firstSeenOrdinal, slotWidth);
+    initBlock(chunk, off + 1, firstSeenOrdinal, slotWidth, sumsOnly);
     System.arraycopy(identity, identityOffset, chunk, off + idOff, width);
     if (++size > growAt) {
       rehash();
       return findExact(key, identity, identityOffset);
     }
     return bucket;
+  }
+
+  private int acquireDense(final long key, final long firstSeenOrdinal, final long[] identity,
+      final int identityOffset) {
+    final long hash = HashCommon.mix(key);
+    int bucket = (int) hash & mask;
+    while (true) {
+      final int indexChunk = bucket >>> PROBE_CHUNK_SHIFT;
+      long[] index = probeIndex[indexChunk];
+      final int indexOffset = bucket & PROBE_CHUNK_MASK;
+      final long entry = index == null
+          ? 0L
+          : index[indexOffset];
+      if (entry == 0L) {
+        final int handle = size;
+        final int chunkIndex = handle >>> chunkBucketShift;
+        long[] chunk = storage[chunkIndex];
+        if (chunk == null) {
+          chunk = newChunk(bucketsPerChunk * stride);
+          storage[chunkIndex] = chunk;
+        }
+        final int offset = (handle & chunkBucketMask) * stride;
+        chunk[offset] = key;
+        initBlock(chunk, offset + 1, firstSeenOrdinal, slotWidth, sumsOnly);
+        if (idWidth != 0) {
+          System.arraycopy(identity, identityOffset, chunk, offset + 1 + idOffsetFromAcc, idWidth);
+        }
+        if (index == null) {
+          index = newProbeChunk(mask + 1);
+          probeIndex[indexChunk] = index;
+        }
+        index[indexOffset] = (hash & PROBE_TAG_MASK) | (handle + 1L);
+        if (++size > growAt) {
+          rehash();
+        }
+        return handle;
+      }
+      if (((entry ^ hash) & PROBE_TAG_MASK) == 0L) {
+        final int handle = (int) entry - 1;
+        final long[] chunk = storage[handle >>> chunkBucketShift];
+        final int offset = (handle & chunkBucketMask) * stride;
+        if (chunk[offset] == key) {
+          if (idWidth == 0 || identityMatches(chunk, offset + 1 + idOffsetFromAcc, identity, identityOffset, idWidth)) {
+            return handle;
+          }
+          probeKeyCollision = true;
+        }
+      }
+      bucket = bucket + 1 & mask;
+    }
+  }
+
+  /** Rebuild only the compact index; accumulator handles remain dense record ordinals. */
+  private void rehashDense(final int capacity) {
+    final int newMask = capacity - 1;
+    final long[][] grownIndex = new long[(int) (((long) capacity + PROBE_CHUNK_MASK) >>> PROBE_CHUNK_SHIFT)][];
+    for (int handle = 0; handle < size; handle++) {
+      final long key = keyAtAccBase(handle);
+      final long hash = HashCommon.mix(key);
+      int bucket = (int) hash & newMask;
+      while (true) {
+        final int chunkIndex = bucket >>> PROBE_CHUNK_SHIFT;
+        long[] index = grownIndex[chunkIndex];
+        final int offset = bucket & PROBE_CHUNK_MASK;
+        if (index == null) {
+          index = newProbeChunk(capacity);
+          grownIndex[chunkIndex] = index;
+        }
+        if (index[offset] == 0L) {
+          index[offset] = (hash & PROBE_TAG_MASK) | (handle + 1L);
+          break;
+        }
+        bucket = bucket + 1 & newMask;
+      }
+    }
+    final int chunkBuckets = bucketsPerChunk(capacity);
+    if (chunkBuckets != bucketsPerChunk) {
+      final long[] grown = newChunk(chunkBuckets * stride);
+      System.arraycopy(storage[0], 0, grown, 0, size * stride);
+      recycle(storage[0]);
+      storage = new long[][] {grown};
+    } else {
+      storage = Arrays.copyOf(storage, capacity / chunkBuckets);
+    }
+    recycleProbeIndex(probeIndex);
+    probeIndex = grownIndex;
+    bucketsPerChunk = chunkBuckets;
+    chunkBucketMask = chunkBuckets - 1;
+    chunkBucketShift = Integer.numberOfTrailingZeros(chunkBuckets);
+    mask = newMask;
+    growAt = capacity - (capacity >>> 2);
+    rehashes++;
   }
 
   private static boolean identityMatches(final long[] chunk, final int base, final long[] identity,
@@ -796,9 +1041,14 @@ public final class NumericGroupAggTable {
     return bucket;
   }
 
-  private static void initBlock(final long[] t, final int accBase, final long firstSeenOrdinal, final int slotWidth) {
+  private static void initBlock(final long[] t, final int accBase, final long firstSeenOrdinal, final int slotWidth,
+      final boolean sumsOnly) {
     t[accBase] = 0L;
     t[accBase + 1] = firstSeenOrdinal;
+    if (sumsOnly) {
+      Arrays.fill(t, accBase + 2, accBase + slotWidth, 0L);
+      return;
+    }
     for (int b = accBase + 2; b < accBase + slotWidth; b += 4) {
       t[b] = 0L;
       t[b + 1] = 0L;
@@ -816,6 +1066,10 @@ public final class NumericGroupAggTable {
     final long newLength = (long) newCap * stride;
     if (newLength > MAX_ARRAY_LENGTH) {
       throw new IllegalStateException("group table exceeds " + MAX_ARRAY_LENGTH + " lanes");
+    }
+    if (probeIndex != null) {
+      rehashDense(newCap);
+      return;
     }
     final int newMask = newCap - 1;
     final int st = stride;
@@ -850,6 +1104,7 @@ public final class NumericGroupAggTable {
           grown[chunkIndex] = targetChunk;
         }
         System.arraycopy(oldChunk, o, targetChunk, to, st);
+
       }
       recycle(oldChunk);
     }
@@ -960,7 +1215,7 @@ public final class NumericGroupAggTable {
         if (aux && dstTable[dstBase] == 0L) {
           dstTable[dstBase + slotWidth] = srcTable[srcBase + slotWidth];
         }
-        mergeBlock(dstTable, dstBase, srcTable, srcBase, slotWidth, into.sumExactMask);
+        mergeBlock(dstTable, dstBase, srcTable, srcBase, slotWidth, into.sumExactMask, into.sumsOnly);
       }
       mergeZeroGroup(src, into, slotWidth, partition);
     }
@@ -1011,7 +1266,7 @@ public final class NumericGroupAggTable {
             // same group value, so first-arrival is as good as first-seen).
             dstTable[dstBase + slotWidth] = srcTable[srcBase + slotWidth];
           }
-          mergeBlock(dstTable, dstBase, srcTable, srcBase, slotWidth, into.sumExactMask);
+          mergeBlock(dstTable, dstBase, srcTable, srcBase, slotWidth, into.sumExactMask, into.sumsOnly);
         }
       }
       mergeZeroGroup(src, into, slotWidth, partition);
@@ -1059,7 +1314,7 @@ public final class NumericGroupAggTable {
       if (aux && dst[dstBase] == 0L) {
         dst[dstBase + width] = stripes[srcBase + width];
       }
-      mergeBlock(dst, dstBase, stripes, srcBase, width, exact);
+      mergeBlock(dst, dstBase, stripes, srcBase, width, exact, sumsOnly);
     }
   }
 
@@ -1087,7 +1342,7 @@ public final class NumericGroupAggTable {
     if (fresh && src.withAux) {
       into.zeroAux = src.zeroAux;
     }
-    mergeBlock(dst, 0, src.zeroSlot, 0, slotWidth, into.sumExactMask);
+    mergeBlock(dst, 0, src.zeroSlot, 0, slotWidth, into.sumExactMask, into.sumsOnly);
   }
 
   /**
@@ -1098,7 +1353,7 @@ public final class NumericGroupAggTable {
    */
   private static void requireMergeable(final NumericGroupAggTable src, final NumericGroupAggTable into) {
     if (src.slotWidth != into.slotWidth || src.withAux != into.withAux || src.sumExactMask != into.sumExactMask
-        || src.idWidth != into.idWidth) {
+        || src.idWidth != into.idWidth || src.sumsOnly != into.sumsOnly) {
       throw new IllegalStateException("incompatible group tables: slotWidth " + src.slotWidth + "/" + into.slotWidth
           + ", aux " + src.withAux + "/" + into.withAux + ", sumExactMask " + src.sumExactMask + "/" + into.sumExactMask
           + ", idWidth " + src.idWidth + "/" + into.idWidth);
@@ -1106,10 +1361,19 @@ public final class NumericGroupAggTable {
   }
 
   private static void mergeBlock(final long[] dst, final int dstBase, final long[] src, final int srcBase,
-      final int slotWidth, final long sumExactMask) {
+      final int slotWidth, final long sumExactMask, final boolean sumsOnly) {
     dst[dstBase] += src[srcBase];
     if (src[srcBase + 1] < dst[dstBase + 1]) {
       dst[dstBase + 1] = src[srcBase + 1];
+    }
+    if (sumsOnly) {
+      for (int off = 2, a = 0; off < slotWidth; off += 2, a++) {
+        dst[dstBase + off] += src[srcBase + off];
+        if (sumsExact(sumExactMask, a)) {
+          dst[dstBase + off + 1] = Math.addExact(dst[dstBase + off + 1], src[srcBase + off + 1]);
+        }
+      }
+      return;
     }
     for (int off = 2, a = 0; off < slotWidth; off += 4, a++) {
       dst[dstBase + off] += src[srcBase + off];

--- a/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnGroupScan.java
+++ b/bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnGroupScan.java
@@ -183,7 +183,11 @@ public final class ProjectionColumnGroupScan {
           final long[] slotArr;
           final int base;
           GroupDistinctAccumulator.Sink dset = null;
-          if ((groupPresWord & 1L << bit) == 0L) {
+          final boolean groupMissing = (groupPresWord & 1L << bit) == 0L;
+          final long distinctGroup = groupMissing
+              ? 0L
+              : groupValues[rowIdx];
+          if (groupMissing) {
             slotArr = missingAcc;
             base = 0;
             if (slotArr[0] == 0) {
@@ -191,7 +195,7 @@ public final class ProjectionColumnGroupScan {
             }
             dset = distinctMissing;
           } else {
-            final long gv = groupValues[rowIdx];
+            final long gv = distinctGroup;
             if (gv == 0L) {
               slotArr = out.acquireZero(leafOrdinalBase | rowIdx);
               base = 0;
@@ -200,13 +204,13 @@ public final class ProjectionColumnGroupScan {
               slotArr = out.storageAtAccBase(handle);
               base = out.offsetAtAccBase(handle);
             }
-            if (distinctBlock >= 0) {
-              dset = distinctOut.sinkFor(gv);
-            }
           }
           foldSliced(slotArr, base, aggValues, aggPresence, aggIds, ds.stringLengths, stringLengthModes, aggCount, w,
               bit, rowIdx, distinctBlock, dset, budget, cdDictBytes, cdDictOffsets, cdHash, null, null, sumExactMask,
-              leafLengthTables);
+              leafLengthTables, groupMissing
+                  ? null
+                  : distinctOut,
+              distinctGroup);
         }
       }
     }
@@ -778,6 +782,23 @@ public final class ProjectionColumnGroupScan {
     }
   }
 
+  /** Fold integral operands into present-count/sum pairs; missing operands retain a zero count. */
+  private static void foldSumsSliced(final long[] accumulator, final int base, final long[][] values,
+      final long[][] presence, final int columns, final int word, final int bit, final int row,
+      final long sumExactMask) {
+    accumulator[base]++;
+    final long presentBit = 1L << bit;
+    for (int a = 0; a < columns; a++) {
+      if ((presence[a][word] & presentBit) != 0L) {
+        final int at = base + 2 + 2 * a;
+        accumulator[at]++;
+        if (NumericGroupAggTable.sumsExact(sumExactMask, a)) {
+          accumulator[at + 1] = Math.addExact(accumulator[at + 1], values[a][row]);
+        }
+      }
+    }
+  }
+
   /**
    * One row's aggregate fold over hoisted slice arrays — the byte kernel's foldRow twin.
    *
@@ -797,6 +818,18 @@ public final class ProjectionColumnGroupScan {
       final GroupDistinctAccumulator.Sink dset, final long[] budget, final byte[] cdDictBytes,
       final int[] cdDictOffsets, final long[] cdHash, final GroupDistinctBitmaps bitmaps, final long[] dwords,
       final long sumExactMask, final int[][] leafLengthTables) {
+    foldSliced(slotArr, base, aggValues, aggPresence, aggIds, stringLengths, stringLengthModes, aggCount, w, bit,
+        rowIdx, distinctBlock, dset, budget, cdDictBytes, cdDictOffsets, cdHash, bitmaps, dwords, sumExactMask,
+        leafLengthTables, null, 0L);
+  }
+
+  private static void foldSliced(final long[] slotArr, final int base, final long[][] aggValues,
+      final long[][] aggPresence, final int[][] aggIds, final int[][] stringLengths, final byte[] stringLengthModes,
+      final int aggCount, final int w, final int bit, final int rowIdx, final int distinctBlock,
+      final GroupDistinctAccumulator.Sink dset, final long[] budget, final byte[] cdDictBytes,
+      final int[] cdDictOffsets, final long[] cdHash, final GroupDistinctBitmaps bitmaps, final long[] dwords,
+      final long sumExactMask, final int[][] leafLengthTables, final GroupDistinctAccumulator.Worker directDistinct,
+      final long distinctGroup) {
     slotArr[base]++;
     for (int a = 0; a < aggCount; a++) {
       final boolean stringLengthAgg =
@@ -838,8 +871,11 @@ public final class ProjectionColumnGroupScan {
           if (!bitmaps.set(dwords, v)) {
             budget[1] = 1; // id outside the sized range — decline; a dropped id is a low count
           }
-        } else
+        } else if (directDistinct != null) {
+          directDistinct.addToGroup(distinctGroup, v);
+        } else {
           dset.add(v); // exact and bounded inside the shared accumulator; its overrun declines the arm
+        }
         continue;
       }
       final int aggBase = base + 2 + 4 * a;
@@ -1307,12 +1343,11 @@ public final class ProjectionColumnGroupScan {
             }
             if (countOnly) {
               slotArr[base]++;
+            } else if (out.sumsOnly()) {
+              foldSumsSliced(slotArr, base, aggValues, aggPresence, aggCount, w, bit, rowIdx, sumExactMask);
             } else {
               foldSliced(slotArr, base, aggValues, aggPresence, null, null, null, aggCount, w, bit, rowIdx,
-                  distinctBlock, distinctBlock >= 0
-                      ? distinctOut.sinkFor(h)
-                      : null,
-                  budget, null, null, null, null, null, sumExactMask, null);
+                  distinctBlock, null, budget, null, null, null, null, null, sumExactMask, null, distinctOut, h);
             }
           }
         }
@@ -1474,12 +1509,11 @@ public final class ProjectionColumnGroupScan {
           }
           if (countOnly) {
             slotArr[base]++;
+          } else if (out.sumsOnly()) {
+            foldSumsSliced(slotArr, base, aggValues, aggPresence, aggCount, w, bit, rowIdx, sumExactMask);
           } else {
             foldSliced(slotArr, base, aggValues, aggPresence, null, null, null, aggCount, w, bit, rowIdx, distinctBlock,
-                distinctBlock >= 0
-                    ? distinctOut.sinkFor(h)
-                    : null,
-                budget, null, null, null, null, null, sumExactMask, null);
+                null, budget, null, null, null, null, null, sumExactMask, null, distinctOut, h);
           }
         }
       }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/DenseGroupIndexTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/DenseGroupIndexTest.java
@@ -1,0 +1,134 @@
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.SplittableRandom;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class DenseGroupIndexTest {
+
+  @Test
+  void denseRecordsMatchSparseBucketsAcrossGrowthCollisionsAndRepeatedGroups() {
+    final NumericGroupAggTable sparse = new NumericGroupAggTable(2, 16, true, 3L, 2);
+    final NumericGroupAggTable dense = new NumericGroupAggTable(2, 16, true, 3L, 2).useDenseIndex();
+    final SplittableRandom random = new SplittableRandom(193);
+    final long[] identity = new long[2];
+    for (int row = 0; row < 180_000; row++) {
+      final int group = row < 60_000
+          ? row
+          : random.nextInt(60_000);
+      identity[0] = group;
+      identity[1] = ~group;
+      final long hash = group % 8_191; // Real hash collisions, including the zero probe hash.
+      fold(sparse, hash, identity, row);
+      fold(dense, hash, identity, row);
+    }
+    assertEquals(sparse.size(), dense.size());
+    assertTrue(dense.rehashes() > 0);
+    assertTrue(dense.hasProbeKeyCollision());
+    for (int group = 0; group < 60_000; group++) {
+      identity[0] = group;
+      identity[1] = ~group;
+      final int expected = sparse.acquireExact(group % 8_191, 0L, identity, 0);
+      final int actual = dense.acquireExact(group % 8_191, 0L, identity, 0);
+      assertEquals(group, actual, "dense handles retain insertion order across index growth");
+      assertArrayEquals(accumulator(sparse, expected), accumulator(dense, actual));
+      assertEquals(sparse.auxAtAccBase(expected), dense.auxAtAccBase(actual));
+    }
+    int buckets = 0;
+    for (int bucket = 0; bucket < dense.capacity(); bucket++) {
+      final long key = dense.keyAtBucket(bucket);
+      if (key != 0L) {
+        assertEquals(key, dense.keyAtAccBase(dense.accBaseOfBucket(bucket)));
+        buckets++;
+      }
+    }
+    assertEquals(dense.size(), buckets);
+  }
+
+  @Test
+  void indexChunksRecycleAndProbeOnlyLookupKeepsFullKeys() {
+    final LongChunkPool payload = new LongChunkPool(NumericGroupAggTable.fullChunkLanes(8), 128);
+    final LongChunkPool index = new LongChunkPool(NumericGroupAggTable.MAX_STORAGE_CHUNK_LANES, 128);
+    final NumericGroupAggTable table =
+        new NumericGroupAggTable(1, 16, true).useDenseIndex().attachProbePool(index).attachChunkPool(payload);
+    for (int key = 1; key <= 100_000; key++) {
+      final int handle = table.acquire(key, key);
+      table.storageAtAccBase(handle)[table.offsetAtAccBase(handle)]++;
+    }
+    for (int key = 1; key <= 100_000; key++) {
+      assertEquals(key, table.keyAtAccBase(table.handleOfProbeKey(key)));
+    }
+    table.acquireZero(0L)[0] = 3L;
+    assertEquals(100_001, table.sizeIncludingZero());
+    assertThrows(IllegalStateException.class, table::useDenseIndex);
+    table.release();
+    assertTrue(table.released());
+    final long[] recycled = index.take();
+    for (final long lane : recycled) {
+      assertEquals(0L, lane);
+    }
+  }
+
+  @Test
+  void countOnlyDenseStripesPreserveZeroAndPassOwnership() {
+    final NumericGroupAggTable table = new NumericGroupAggTable(0, 16).useDenseIndex();
+    table.setPassRange(60, 0, 8);
+    long accepted = 0L;
+    for (int row = 0; row < 160_000; row++) {
+      final long key = row % 40_000 + 1;
+      final int handle = table.acquire(key, row);
+      if (NumericGroupAggTable.partitionOf(key, 60) < 8) {
+        table.storageAtAccBase(handle)[table.offsetAtAccBase(handle)]++;
+        accepted++;
+      } else {
+        assertEquals(NumericGroupAggTable.DISCARD_HANDLE, handle);
+      }
+    }
+    long rows = 0L;
+    for (int bucket = 0; bucket < table.capacity(); bucket++) {
+      if (table.keyAtBucket(bucket) != 0L) {
+        final int handle = table.accBaseOfBucket(bucket);
+        final long count = table.storageAtAccBase(handle)[table.offsetAtAccBase(handle)];
+        assertEquals(4L, count);
+        rows += count;
+      }
+    }
+    assertEquals(accepted, rows);
+    table.acquireZero(0L)[0] = 2L;
+    assertEquals(2L, table.zeroSlot()[0]);
+  }
+
+  private static void fold(final NumericGroupAggTable table, final long hash, final long[] identity,
+      final int ordinal) {
+    final int handle = table.acquireExact(hash, ordinal, identity, 0);
+    final long[] block = table.storageAtAccBase(handle);
+    final int base = table.offsetAtAccBase(handle);
+    if (block[base] == 0L) {
+      table.setAuxAtAccBase(handle, ordinal);
+    }
+    block[base]++;
+    for (int column = 0; column < 2; column++) {
+      if ((ordinal + column) % 3 != 0) {
+        final long value = column == 0
+            ? ordinal
+            : -ordinal;
+        final int at = base + 2 + 4 * column;
+        block[at]++;
+        block[at + 1] = Math.addExact(block[at + 1], value);
+        block[at + 2] = Math.min(block[at + 2], value);
+        block[at + 3] = Math.max(block[at + 3], value);
+      }
+    }
+  }
+
+  private static long[] accumulator(final NumericGroupAggTable table, final int handle) {
+    final long[] result = new long[table.slotWidth()];
+    System.arraycopy(table.storageAtAccBase(handle), table.offsetAtAccBase(handle), result, 0, result.length);
+    return result;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.SplittableRandom;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -27,6 +28,111 @@ final class GroupDistinctAccumulatorTest {
   /** Group ids that stress the hashing: zero, negatives, the extremes, and a few dense small ones. */
   private static final long[] GROUPS =
       {0L, 1L, 2L, 3L, -1L, Long.MIN_VALUE, Long.MAX_VALUE, 0x5DEECE66DL, 1L << 40, -(1L << 33), 42L, 43L, 1_000_003L};
+
+  @Test
+  void directGroupsUseTheSamePassAndDuplicateSemanticsAsSinks() {
+    final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(2, Long.MAX_VALUE);
+    acc.setPassRange(60, 3, 8);
+    for (final long group : GROUPS) {
+      acc.worker(0).addToGroup(group, Long.MIN_VALUE);
+      acc.worker(0).addToGroup(group, 0L);
+      acc.worker(1).sinkFor(group).add(Long.MIN_VALUE);
+      acc.worker(1).sinkFor(group).add(0L);
+    }
+    acc.worker(0).missing().add(1L);
+    acc.finish();
+    for (final long group : GROUPS) {
+      final int partition = NumericGroupAggTable.partitionOf(group, 60);
+      assertEquals(partition >= 3 && partition < 8
+          ? 2L
+          : 0L, acc.groupSizes().get(group));
+    }
+    assertEquals(0L, acc.missingSize());
+  }
+
+  @Test
+  void singletonGroupsPromoteExactlyAndResetBetweenPasses() {
+    final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(3, Long.MAX_VALUE);
+    for (int pass = 0; pass < 2; pass++) {
+      for (int group = 0; group < 30_000; group++) {
+        final long first = group + pass;
+        acc.worker(0).sinkFor(group).add(first);
+        acc.worker(1).sinkFor(group).add(first);
+        if (group % 3 == 0) {
+          acc.worker(2).sinkFor(group).add(~first);
+          acc.worker(2).sinkFor(group).add(~first);
+        }
+      }
+      acc.finish();
+      assertEquals(40_000L, acc.entries());
+      assertEquals(30_000, acc.groupSizes().size());
+      for (int group = 0; group < 30_000; group++) {
+        assertEquals(group % 3 == 0
+            ? 2L
+            : 1L, acc.groupSizes().get(group));
+      }
+      acc.reset();
+    }
+  }
+
+  @Test
+  void parallelCountPublicationVisitsEveryGroupOnceAndResets() {
+    final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(3, Long.MAX_VALUE);
+    assertThrows(IllegalStateException.class, () -> acc.forEachGroupSize((group, count) -> {
+    }));
+    try (final ExecutorService pool = Executors.newFixedThreadPool(4)) {
+      for (int pass = 0; pass < 2; pass++) {
+        for (int group = -20_000; group < 20_000; group++) {
+          for (int value = 0; value < 7; value++) {
+            acc.worker(value % 3).addToGroup(group, value + pass);
+            acc.worker((value + 1) % 3).addToGroup(group, value + pass);
+          }
+        }
+        for (int worker = 0; worker < 3; worker++) {
+          acc.worker(worker).missing().add(Long.MIN_VALUE);
+          acc.worker(worker).missing().add(0L);
+        }
+        acc.finish((tasks, task) -> {
+          final CompletableFuture<?>[] futures = new CompletableFuture<?>[tasks];
+          for (int i = 0; i < tasks; i++) {
+            final int index = i;
+            futures[i] = CompletableFuture.runAsync(() -> task.accept(index), pool);
+          }
+          CompletableFuture.allOf(futures).join();
+        });
+        acc.finish((tasks, task) -> {
+          throw new AssertionError("finish must be idempotent");
+        });
+        final Long2LongOpenHashMap visited = new Long2LongOpenHashMap();
+        acc.forEachGroupSize((group, count) -> {
+          assertEquals(0L, visited.put(group, count), "one callback per completed group");
+          assertEquals(7L, count);
+        });
+        assertEquals(40_000, visited.size());
+        assertEquals(visited, acc.groupSizes());
+        assertEquals(2L, acc.missingSize());
+        acc.reset();
+        assertThrows(IllegalStateException.class, () -> acc.forEachGroupSize((group, count) -> {
+        }));
+      }
+    }
+  }
+
+  @Test
+  void failedPublicationDoesNotExposePartialCountsAndCanBeRetried() {
+    final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(1, Long.MAX_VALUE);
+    acc.worker(0).addToGroup(0L, 5L);
+    acc.worker(0).addToGroup(-1L, 7L);
+    acc.worker(0).missing().add(9L);
+    assertThrows(IllegalStateException.class, () -> acc.finish((tasks, task) -> task.accept(0)));
+    assertThrows(IllegalStateException.class, acc::groupSizes);
+    assertThrows(IllegalStateException.class, acc::missingSize);
+    acc.finish();
+    assertEquals(1L, acc.groupSizes().get(0L));
+    assertEquals(1L, acc.groupSizes().get(-1L));
+    assertEquals(1L, acc.missingSize());
+    assertEquals(3L, acc.entries());
+  }
 
   @Test
   @DisplayName("exact under duplication across workers, including the missing-key rows")
@@ -124,7 +230,7 @@ final class GroupDistinctAccumulatorTest {
   }
 
   @Test
-  @DisplayName("the same pair always lands on the same stripe, and the four value stripes partition a group")
+  @DisplayName("the same pair always lands on the same stripe, and the value stripes partition a group")
   void stripingIsDeterministicAndPartitioning() {
     final SplittableRandom rnd = new SplittableRandom(11);
     for (int i = 0; i < 100_000; i++) {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java
@@ -76,6 +76,32 @@ final class GroupDistinctAccumulatorTest {
   }
 
   @Test
+  @DisplayName("a group is exact on either side of the promoted set's sizing, and pairs are counted once")
+  void groupsRemainExactAcrossThePromotedSetSizing() {
+    // Cover singleton, small and larger groups; values are distributed across the value stripes.
+    final int[] distinctPerGroup = {1, 2, 17, 24, 25, 200};
+    final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(3, Long.MAX_VALUE);
+    long expectedEntries = 0L;
+    for (int group = 0; group < distinctPerGroup.length; group++) {
+      expectedEntries += distinctPerGroup[group];
+      for (int value = 0; value < distinctPerGroup[group]; value++) {
+        // Every worker sees every value: the stripe keeps the pair once however often it arrives.
+        for (int worker = 0; worker < 3; worker++) {
+          acc.worker(worker).sinkFor(group).add(value);
+          acc.worker(worker).sinkFor(group).add(value);
+        }
+      }
+    }
+    acc.finish();
+    assertFalse(acc.exceeded());
+    assertEquals(expectedEntries, acc.entries(), "one entry per distinct pair, whatever the group's size");
+    assertEquals(distinctPerGroup.length, acc.groupSizes().size());
+    for (int group = 0; group < distinctPerGroup.length; group++) {
+      assertEquals(distinctPerGroup[group], acc.groupSizes().get(group), "group " + group);
+    }
+  }
+
+  @Test
   void parallelCountPublicationVisitsEveryGroupOnceAndResets() {
     final GroupDistinctAccumulator acc = new GroupDistinctAccumulator(3, Long.MAX_VALUE);
     assertThrows(IllegalStateException.class, () -> acc.forEachGroupSize((group, count) -> {

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableDenseIndexGateTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableDenseIndexGateTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, SirixDB. All rights reserved.
+ */
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * WHICH shapes a spill hands the dense record layout to.
+ *
+ * <p>
+ * The two layouts are not ordered: at the 3/4 growth threshold the interleaved form reserves a
+ * whole stripe in every bucket and so holds {@code (4/3) * stride} lanes per live group, while the
+ * dense form packs the stripes and adds one index lane per bucket, holding {@code stride + 4/3}.
+ * Those cross at four lanes. Below the crossing the dense form holds MORE memory AND charges a
+ * second dependent load per probe to prove the key behind the index hit, so the gate must not admit
+ * it there — {@code GROUP BY x ORDER BY count(*)} is exactly such a shape at three lanes.
+ * </p>
+ */
+final class GroupTableDenseIndexGateTest {
+
+  private static final int PARTITIONS = 32;
+  private static final int SHIFT = 59;
+  /** Well under the growth threshold of the hint below, so no rehash moves an interleaved handle. */
+  private static final int GROUPS = 512;
+  private static final int HINT = 1 << 12;
+
+  @Test
+  @DisplayName("the threshold IS the lane crossing: dense holds fewer lanes exactly from five on")
+  void theThresholdIsTheLaneCrossing() {
+    for (int stride = 1; stride <= 64; stride++) {
+      // (4/3) * stride against stride + 4/3, cleared of the denominator: 4 * stride vs 3 * stride + 4.
+      final boolean denseHoldsFewerLanes = 4 * stride > 3 * stride + 4;
+      assertEquals(denseHoldsFewerLanes, stride >= GroupTableSpill.DENSE_INDEX_MIN_STRIDE,
+          "stride " + stride + ": interleaved " + 4 * stride + "/3 lanes per group, dense " + (3 * stride + 4) + "/3");
+    }
+    assertEquals(3, NumericGroupAggTable.strideFor(0, false, 0), "GROUP BY x ORDER BY count(*) is three lanes");
+    assertTrue(3 < GroupTableSpill.DENSE_INDEX_MIN_STRIDE, "and three lanes is below the crossing");
+  }
+
+  @Test
+  @DisplayName("stripes at or below the crossing keep interleaved buckets")
+  void narrowStripesKeepInterleavedBuckets() {
+    assertLayout(0, false, 0, false);
+    assertLayout(0, true, 0, false);
+  }
+
+  @Test
+  @DisplayName("stripes above the crossing get dense records behind the compact index")
+  void wideStripesGetDenseRecords() {
+    assertLayout(0, true, 1, true);
+    assertLayout(1, false, 0, true);
+    assertLayout(2, true, 2, true);
+  }
+
+  @Test
+  @DisplayName("both layouts fold the same rows to the same counts, aux and identity")
+  void theLayoutsAgreeOnEveryGroupAndTheKillSwitchSelectsBetweenThem() {
+    final long[] keys = keys();
+    final NumericGroupAggTable dense = workerTable(1, true, 1);
+    final NumericGroupAggTable interleaved = withDenseIndexDisabled(() -> workerTable(1, true, 1));
+    assertTrue(handlesAreInsertionOrdinals(fold(dense, keys, true)), "a nine-lane stripe is dense by default");
+    final int[] interleavedHandles = fold(interleaved, keys, true);
+    assertTrue(handlesAreTheirOwnBuckets(interleaved, keys, interleavedHandles), "the kill switch restores buckets");
+    assertFalse(handlesAreInsertionOrdinals(interleavedHandles));
+
+    assertEquals(keys.length, dense.size());
+    assertEquals(dense.size(), interleaved.size());
+    for (int group = 0; group < keys.length; group++) {
+      final int denseHandle = dense.acquireExact(keys[group], 0L, identity(keys[group]), 0);
+      final int otherHandle = interleaved.acquireExact(keys[group], 0L, identity(keys[group]), 0);
+      assertEquals(keys[group], dense.keyAtAccBase(denseHandle));
+      assertEquals(keys[group], interleaved.keyAtAccBase(otherHandle));
+      assertArrayEquals(accumulator(interleaved, otherHandle), accumulator(dense, denseHandle), "group " + group);
+      assertEquals(interleaved.auxAtAccBase(otherHandle), dense.auxAtAccBase(denseHandle), "aux of group " + group);
+      assertEquals(interleaved.identityAtAccBase(otherHandle, 0), dense.identityAtAccBase(denseHandle, 0),
+          "identity of group " + group);
+    }
+    assertEquals(keys.length, dense.size(), "no group was created by the verification probes");
+    assertEquals(keys.length, interleaved.size());
+  }
+
+  private static void assertLayout(final int aggColumns, final boolean withAux, final int idWidth,
+      final boolean expectDense) {
+    final int stride = NumericGroupAggTable.strideFor(aggColumns, withAux, idWidth);
+    assertEquals(expectDense, stride >= GroupTableSpill.DENSE_INDEX_MIN_STRIDE, "shape of " + stride + " lanes");
+    final NumericGroupAggTable table = workerTable(aggColumns, withAux, idWidth);
+    assertEquals(stride, table.stride());
+    final long[] keys = keys();
+    final int[] handles = fold(table, keys, withAux);
+    assertEquals(keys.length, table.size());
+    assertEquals(expectDense, handlesAreInsertionOrdinals(handles),
+        "stride " + stride + ": dense handles are record ordinals");
+    assertEquals(!expectDense, handlesAreTheirOwnBuckets(table, keys, handles),
+        "stride " + stride + ": an interleaved handle IS the bucket holding its key");
+    for (int group = 0; group < keys.length; group++) {
+      final int handle = table.acquireExact(keys[group], 0L, identity(keys[group]), 0);
+      assertEquals(handles[group], handle, "stride " + stride + ": group " + group + " re-probes to its record");
+      assertEquals(group + 1L, table.storageAtAccBase(handle)[table.offsetAtAccBase(handle)],
+          "stride " + stride + ": group " + group + " folded its rows");
+    }
+  }
+
+  /** A worker table exactly as a spill of this shape hands it out. */
+  private static NumericGroupAggTable workerTable(final int aggColumns, final boolean withAux, final int idWidth) {
+    final Supplier<NumericGroupAggTable> factory =
+        () -> new NumericGroupAggTable(aggColumns, HINT, withAux, -1L, idWidth);
+    return new GroupTableSpill(PARTITIONS, SHIFT, factory).freshLocal();
+  }
+
+  private static <T> T withDenseIndexDisabled(final Supplier<T> body) {
+    final String previous = System.setProperty(GroupTableSpill.DENSE_INDEX_PROPERTY, "false");
+    try {
+      return body.get();
+    } finally {
+      if (previous == null) {
+        System.clearProperty(GroupTableSpill.DENSE_INDEX_PROPERTY);
+      } else {
+        System.setProperty(GroupTableSpill.DENSE_INDEX_PROPERTY, previous);
+      }
+    }
+  }
+
+  /**
+   * Distinct non-zero probe keys, scattered so neither layout's handles are the other's by accident.
+   */
+  private static long[] keys() {
+    final long[] keys = new long[GROUPS];
+    for (int group = 0; group < GROUPS; group++) {
+      keys[group] = 0x9E37_79B9_7F4A_7C15L * (group + 1);
+    }
+    return keys;
+  }
+
+  private static long[] identity(final long key) {
+    return new long[] {key, ~key};
+  }
+
+  /**
+   * Fold {@code group + 1} rows into each group. The aux lane is stamped only where the shape has
+   * one: without it, the lane one slotWidth above the accumulator base is the NEXT stripe's key.
+   */
+  private static int[] fold(final NumericGroupAggTable table, final long[] keys, final boolean withAux) {
+    final int[] handles = new int[keys.length];
+    for (int group = 0; group < keys.length; group++) {
+      final long[] identity = identity(keys[group]);
+      for (int row = 0; row <= group; row++) {
+        final int handle = table.acquireExact(keys[group], group, identity, 0);
+        if (row == 0 && withAux) {
+          table.setAuxAtAccBase(handle, ~(long) group);
+        }
+        table.storageAtAccBase(handle)[table.offsetAtAccBase(handle)]++;
+        handles[group] = handle;
+      }
+    }
+    return handles;
+  }
+
+  private static boolean handlesAreInsertionOrdinals(final int[] handles) {
+    for (int i = 0; i < handles.length; i++) {
+      if (handles[i] != i) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean handlesAreTheirOwnBuckets(final NumericGroupAggTable table, final long[] keys,
+      final int[] handles) {
+    for (int i = 0; i < keys.length; i++) {
+      if (table.keyAtBucket(handles[i]) != keys[i] || table.accBaseOfBucket(handles[i]) != handles[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static long[] accumulator(final NumericGroupAggTable table, final int handle) {
+    final long[] block = new long[table.slotWidth()];
+    System.arraycopy(table.storageAtAccBase(handle), table.offsetAtAccBase(handle), block, 0, block.length);
+    return block;
+  }
+}

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableSpillPassPlanTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableSpillPassPlanTest.java
@@ -236,6 +236,46 @@ final class GroupTableSpillPassPlanTest {
   }
 
   @Test
+  @DisplayName("the dense layout's index recycler follows the payload pool: retained across tables, drained by the release")
+  void releaseTablesDrainsTheProbePool() {
+    final int previous = GroupTableSpill.setChunkPoolForTesting(1);
+    final int retainBefore = LongChunkPool.setRetainForTesting(0);
+    try {
+      // Eight lanes per stripe is above the dense crossing, and a hint whose capacity spans whole
+      // index chunks is what makes those chunks recyclable at all.
+      final GroupTableSpill spill =
+          new GroupTableSpill(32, 59, () -> new NumericGroupAggTable(1, 1 << 14, true, 0L, 0), 0, 32, 50L);
+      final LongChunkPool probes = spill.probeChunkPool();
+      assertTrue(probes != null, "a stripe above the dense crossing gets an index recycler");
+      assertFalse(probes.isShared(), "the index recycler is per-scan, so nothing adds it back to the headroom");
+
+      final NumericGroupAggTable local = spill.freshLocal();
+      for (long key = 1; key <= 5_000; key++) {
+        local.acquire(key, key);
+      }
+      spill.flush(local);
+      assertTrue(local.released(), "the flush releases the worker table it spilled");
+      assertTrue(probes.pooled() > 0, "the released table's index chunks sit in the recycler: " + probes);
+
+      final long hitsBefore = probes.hits();
+      final NumericGroupAggTable next = spill.freshLocal();
+      for (long key = 5_001; key <= 10_000; key++) {
+        next.acquire(key, key);
+      }
+      assertTrue(probes.hits() > hitsBefore, "the next worker table's index is a recycled chunk: " + probes);
+      spill.flush(next);
+
+      assertTrue(spill.aborted());
+      assertTrue(probes.pooled() > 0, "index chunks are still held when the aborted pass is released: " + probes);
+      spill.releaseTables();
+      assertEquals(0, probes.pooled(), "no index chunk survives into the restart's budget measurement");
+    } finally {
+      LongChunkPool.setRetainForTesting(retainBefore);
+      GroupTableSpill.setChunkPoolForTesting(previous);
+    }
+  }
+
+  @Test
   @DisplayName("the shared pool outlives the spill: an aborted pass's tables and a finished pass's chunks are the next spill's tables")
   void sharedPoolOutlivesTheSpill() {
     final int previous = GroupTableSpill.setChunkPoolForTesting(1);

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java
@@ -74,7 +74,10 @@ final class NumericGroupSumTableTest {
     final NumericGroupAggTable compact = NumericGroupAggTable.sumsOnly(2, 16, false, 1L, 0);
     final NumericGroupAggTable ordinary = new NumericGroupAggTable(1, 16, false, 1L);
     assertEquals(compact.slotWidth(), ordinary.slotWidth());
-    assertThrows(IllegalStateException.class,
+    final IllegalStateException refused = assertThrows(IllegalStateException.class,
         () -> NumericGroupAggTable.mergePartition(new NumericGroupAggTable[] {ordinary}, 0, 64, compact));
+    // The layout flag is the ONLY difference here, so a diagnostic that omits it names no cause at all.
+    assertTrue(refused.getMessage().contains("sumsOnly false/true"),
+        "the refusal must name the mismatch: " + refused.getMessage());
   }
 }

--- a/bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java
+++ b/bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java
@@ -1,0 +1,80 @@
+package io.sirix.index.projection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class NumericGroupSumTableTest {
+
+  @Test
+  void compactStripesPreserveCountsSumsIdentityAndSourceAcrossGrowth() {
+    final NumericGroupAggTable table = NumericGroupAggTable.sumsOnly(2, 16, true, 1L, 2);
+    assertEquals(10, table.stride());
+    assertEquals(6, table.slotWidth());
+    final long[] stripe = new long[table.stride()];
+    for (int round = 0; round < 2; round++) {
+      for (int group = 1; group <= 6_000; group++) {
+        stripe[0] = group % 127 + 1;
+        stripe[1] = 1;
+        stripe[2] = 10 - round;
+        stripe[3] = round == 0 || group % 2 == 0
+            ? 1
+            : 0;
+        stripe[4] = round == 0
+            ? group
+            : group % 2 == 0
+                ? -group
+                : 0;
+        stripe[5] = group % 3 == 0
+            ? 1
+            : 0;
+        stripe[6] = 0; // An unread sum is never accumulated.
+        stripe[7] = 100 + round;
+        stripe[8] = group;
+        stripe[9] = ~group;
+        table.mergeStripes(stripe, 0, stripe.length);
+      }
+    }
+    assertEquals(6_000, table.size());
+    assertTrue(table.rehashes() > 0);
+    assertTrue(table.hasProbeKeyCollision());
+    final long[] identity = new long[2];
+    for (int group = 1; group <= 6_000; group++) {
+      identity[0] = group;
+      identity[1] = ~group;
+      final int handle = table.acquireExact(group % 127 + 1, 0L, identity, 0);
+      final long[] expanded =
+          NumericGroupAggTable.expandSumsAccumulator(table.storageAtAccBase(handle), table.offsetAtAccBase(handle), 2);
+      assertEquals(2L, expanded[0]);
+      assertEquals(9L, expanded[1]);
+      assertEquals(group % 2 == 0
+          ? 2L
+          : 1L, expanded[2]);
+      assertEquals(group % 2 == 0
+          ? 0L
+          : group, expanded[3]);
+      assertEquals(group % 3 == 0
+          ? 2L
+          : 0L, expanded[6]);
+      assertEquals(0L, expanded[7]);
+      assertEquals(100L, table.auxAtAccBase(handle));
+    }
+  }
+
+  @Test
+  void compactMergeChecksExactOverflowAndRejectsAnOrdinaryLayout() {
+    final NumericGroupAggTable table = NumericGroupAggTable.sumsOnly(1, 16, false, 1L, 0);
+    final long[] first = {7L, 1L, 2L, 1L, Long.MAX_VALUE};
+    final long[] second = {7L, 1L, 1L, 1L, 1L};
+    table.mergeStripes(first, 0, first.length);
+    assertThrows(ArithmeticException.class, () -> table.mergeStripes(second, 0, second.length));
+    // Equal slot widths alone do not make ordinary and compact blocks compatible.
+    final NumericGroupAggTable compact = NumericGroupAggTable.sumsOnly(2, 16, false, 1L, 0);
+    final NumericGroupAggTable ordinary = new NumericGroupAggTable(1, 16, false, 1L);
+    assertEquals(compact.slotWidth(), ordinary.slotWidth());
+    assertThrows(IllegalStateException.class,
+        () -> NumericGroupAggTable.mergePartition(new NumericGroupAggTable[] {ordinary}, 0, 64, compact));
+  }
+}

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -1013,6 +1013,14 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
     return GROUP_AGG_SERVED.sum();
   }
 
+  /** Completed group scans using compact operand state — test observability. */
+  private static final LongAdder COMPACT_SUM_GROUPS_SERVED = new LongAdder();
+
+  /** Completed group scans that used the count-and-sum accumulator layout. */
+  public static long compactSumGroupsServedCount() {
+    return COMPACT_SUM_GROUPS_SERVED.sum();
+  }
+
   /** Of those, servings whose scan read column SLICES instead of whole-leaf payloads. */
   private static final LongAdder GROUP_AGG_SLICED_SERVED = new LongAdder();
 
@@ -13490,6 +13498,25 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
   /** Shared empty result of {@link #summedColumns} — no allocation on the min/max/count-only path. */
   private static final int[] EMPTY_INT_ARRAY = new int[0];
 
+  /** Only row-count ordering reads no operand lanes while the selector retains compact state. */
+  private static boolean countOrderedSums(final String[] funcs, final String[] aggFields, final int[] orderIndexes,
+      final int keyCount) {
+    if (orderIndexes == null || orderIndexes.length != 1) {
+      return false;
+    }
+    final int order = orderIndexes[0] - keyCount;
+    if (order < 0 || order >= funcs.length || !"count".equals(funcs[order]) || aggFields[order] != null) {
+      return false;
+    }
+    for (final String function : funcs) {
+      final String base = baseFunc(function);
+      if (!"count".equals(base) && !"sum".equals(base) && !"avg".equals(base)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /**
    * The subset of {@code aggCols} that an ACCUMULATING function reads — the only columns whose group
    * sums must be proven to fit a long. {@code min}/{@code max}/{@code count} never add, so a column
@@ -15878,7 +15905,11 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
               eagerIdentity = true;
             }
           }
-          final int slotWidth = 2 + 4 * aggColsFlat.length;
+          final boolean compactSums = compositeSlicedArm && aggColsFlat.length > 0 && cdBlock < 0 && having == null
+              && !anyStringLengthAgg && !anyDeferred && countOrderedSums(funcs, aggFields, orderIndexes, keyCount);
+          final int slotWidth = 2 + (compactSums
+              ? 2
+              : 4) * aggColsFlat.length;
           // ORD_KEY on THIS arm: the key lane is a source reference, so the order value comes from
           // the group's EXACT identity, which for a monotonic transformed key (the only shape whose
           // plan can carry an ORD_KEY here — a composite key's component never resolves one) is a
@@ -15899,7 +15930,8 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
           // ONE stride for both consumers: it fixes the budget here and is stored on the plan below,
           // where refreshBudget charges groupBudgetCeiling(strideLanes). Two expressions that must
           // agree are two expressions that can drift.
-          final int strideLanes = NumericGroupAggTable.strideFor(aggColsFlat.length, true, compositeIdWidth);
+          final int strideLanes =
+              NumericGroupAggTable.strideFor(aggColsFlat.length, true, compositeIdWidth, compactSums);
           final long groupBudget = plannedGroupBudget(strideLanes);
           // Set when a key-ordered pass meets a ZERO group, which an identity-mode table cannot hold
           // (acquireZero refuses one) and whose side slot carries no identity lanes to order on.
@@ -15940,8 +15972,9 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
                 cdAcc.setPassRange(shift, passLo, passHi);
               }
             }
-            final GroupTableSpill spill = new GroupTableSpill(partitionsF, shift,
-                hint -> new NumericGroupAggTable(aggColsFlat.length, hint, true, sumExactMask, compositeIdWidth),
+            final GroupTableSpill spill = new GroupTableSpill(partitionsF, shift, hint -> compactSums
+                ? NumericGroupAggTable.sumsOnly(aggColsFlat.length, hint, true, sumExactMask, compositeIdWidth)
+                : new NumericGroupAggTable(aggColsFlat.length, hint, true, sumExactMask, compositeIdWidth),
                 plan.plannedGroups(), passLo, passHi, plan.passBudget());
             final long[] scanNanos = PROJ_DIAG
                 ? new long[eff]
@@ -16097,7 +16130,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
               return declineGroupAgg("composite key transform raised on a matching row");
             }
             if (cdAcc != null) {
-              cdAcc.finish();
+              cdAcc.finish((tasks, task) -> parallel(tasks, task::accept));
               if (cdAcc.exceeded()) {
                 return declineGroupAgg("count(distinct) exact-set budget exceeded (composite arm)");
               }
@@ -16135,9 +16168,11 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
                 plan.notePartition(part, 0);
                 return; // nothing landed here: the merge split is sized for the largest shapes
               }
-              final NumericGroupAggTable into =
-                  spill.takeOrCreate(part, () -> new NumericGroupAggTable(aggColsFlat.length,
-                      (int) Math.min(1 << 20, perPartitionEstimate), true, sumExactMask, compositeIdWidth));
+              final NumericGroupAggTable into = spill.takeOrCreate(part, () -> compactSums
+                  ? NumericGroupAggTable.sumsOnly(aggColsFlat.length, (int) Math.min(1 << 20, perPartitionEstimate),
+                      true, sumExactMask, compositeIdWidth)
+                  : new NumericGroupAggTable(aggColsFlat.length, (int) Math.min(1 << 20, perPartitionEstimate), true,
+                      sumExactMask, compositeIdWidth));
               NumericGroupAggTable.mergePartitionIndexed(tables, partIdx, part, into);
               if (cdAcc != null) {
                 // The per-group COUNT(DISTINCT) sets are keyed by the probe hash alone, which is
@@ -16344,10 +16379,16 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
                   longParts, present, isLong, effKeyOffsets, effKeySubstr, keyCondCols, keyCondLits, keySubstLit,
                   effKeyDivMod, winnerGlobalKeyViews);
             }
-            out.add(groupAggRecordComposite(keyNames, present, isLong, strParts, longParts, finalSel.accAt(i), funcs,
+            final long[] accumulator = compactSums
+                ? NumericGroupAggTable.expandSumsAccumulator(finalSel.accAt(i), finalSel.baseAt(i), aggColsFlat.length)
+                : finalSel.accAt(i);
+            out.add(groupAggRecordComposite(keyNames, present, isLong, strParts, longParts, accumulator, funcs,
                 aggFields, outNames, distinctFields, cdBase, keyDisplays, rankStringViews));
           }
           GROUP_AGG_SERVED.increment();
+          if (compactSums) {
+            COMPACT_SUM_GROUPS_SERVED.increment();
+          }
           if (compositeSlicedArm) {
             GROUP_AGG_SLICED_SERVED.increment();
           }
@@ -16722,7 +16763,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
             return declineGroupAgg("regex key over a row missing the key field");
           }
           if (cdAcc != null) {
-            cdAcc.finish();
+            cdAcc.finish((tasks, task) -> parallel(tasks, task::accept));
             if (cdAcc.exceeded()) {
               return declineGroupAgg("count(distinct) exact-set budget exceeded (string arm)");
             }
@@ -18423,7 +18464,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
           continue;
         }
         if (cdAcc != null) {
-          cdAcc.finish();
+          cdAcc.finish((tasks, task) -> parallel(tasks, task::accept));
           if (cdAcc.exceeded()) {
             return declineGroupAgg("count(distinct) exact-set budget exceeded (numeric arm)");
           }
@@ -21008,23 +21049,20 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    * <p>
    * Each partition used to filter the WHOLE map itself, which is {@code partitions × groups} work and
    * is why the count-distinct arms were pinned to a narrow split while everything else merged over a
-   * thousand partitions. Bucketing is two passes over the map and lets those arms take the same split
-   * — q13's merge was half its wall at 100M.
+   * thousand partitions. Bucketing visits the disjoint count shards twice and lets those arms take
+   * the same split — q13's merge was half its wall at 100M.
    */
   private static long[][] bucketDistinctSizes(final GroupDistinctAccumulator distinct, final int partitions,
       final int shift) {
-    final Long2LongOpenHashMap sizes = distinct.groupSizes();
     final int[] lanes = new int[partitions];
-    for (final Long2LongMap.Entry entry : sizes.long2LongEntrySet()) {
-      lanes[NumericGroupAggTable.partitionOf(entry.getLongKey(), shift)] += 2;
-    }
+    distinct.forEachGroupSize((group, size) -> lanes[NumericGroupAggTable.partitionOf(group, shift)] += 2);
     final long[][] out = newDistinctBuckets(lanes);
-    for (final Long2LongMap.Entry entry : sizes.long2LongEntrySet()) {
-      final int part = NumericGroupAggTable.partitionOf(entry.getLongKey(), shift);
+    distinct.forEachGroupSize((group, size) -> {
+      final int part = NumericGroupAggTable.partitionOf(group, shift);
       final long[] bucket = out[part];
-      bucket[lanes[part]++] = entry.getLongKey();
-      bucket[lanes[part]++] = entry.getLongValue();
-    }
+      bucket[lanes[part]++] = group;
+      bucket[lanes[part]++] = size;
+    });
     return out;
   }
 

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -13629,15 +13629,15 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
    * → 7.9M and the restart paid 16 passes for 8. Release before re-planning; the estimate needs only
    * the spill's counters, which {@link GroupTableSpill#releaseTables} keeps.
    */
-  private static void releaseAbortedPass(final GroupTableSpill spill, final NumericGroupAggTable[] tables,
+  static void releaseAbortedPass(final GroupTableSpill spill, final NumericGroupAggTable[] tables,
       final int[][][] partIdx) {
-    spill.releaseTables();
     for (int t = 0; t < tables.length; t++) {
       final NumericGroupAggTable table = tables[t];
       if (table != null && !table.released()) {
         table.release(); // its chunks are the restart's tables
       }
     }
+    spill.releaseTables();
     Arrays.fill(tables, null);
     Arrays.fill(partIdx, null);
   }

--- a/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
+++ b/bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
@@ -13637,6 +13637,7 @@ public final class SirixVectorizedExecutor implements SirixExecutorProvider {
         table.release(); // its chunks are the restart's tables
       }
     }
+    // After the loop: releaseTables() drains the per-scan pools, which the releases above refill.
     spill.releaseTables();
     Arrays.fill(tables, null);
     Arrays.fill(partIdx, null);

--- a/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupAbortedPassReleaseTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupAbortedPassReleaseTest.java
@@ -86,7 +86,7 @@ final class GroupAbortedPassReleaseTest {
       assertNotNull(probes, "a stripe above the dense crossing gets an index recycler");
       assertTrue(payload.isShared(), "retention on: the payload pool outlives the scan and IS added back");
 
-      final NumericGroupAggTable[] tables = { spill.freshLocal() };
+      final NumericGroupAggTable[] tables = {spill.freshLocal()};
       for (long key = 1L; key <= 20_000L; key++) {
         tables[0].acquire(key, key);
       }

--- a/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupAbortedPassReleaseTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupAbortedPassReleaseTest.java
@@ -1,0 +1,103 @@
+package io.sirix.query.scan;
+
+import io.sirix.index.projection.GroupTableSpill;
+import io.sirix.index.projection.LongChunkPool;
+import io.sirix.index.projection.NumericGroupAggTable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The release order an aborted pass owes its restart: a per-scan recycler is invisible to
+ * {@link LongChunkPool#retainedBytes()}, so every chunk still sitting in one when
+ * {@link SirixVectorizedExecutor.GroupPasses#restart} forces its collection is measured as live
+ * heap and subtracted from the refreshed budget. The finished workers' final tables must therefore
+ * hand their payload and index chunks back BEFORE the spill drains, not after.
+ */
+final class GroupAbortedPassReleaseTest {
+
+  private static final int PARTITIONS = 32;
+
+  private static final int SHIFT = 59;
+
+  /** Eight lanes per stripe (key + 6 slot + aux), i.e. above {@code DENSE_INDEX_MIN_STRIDE}. */
+  private static NumericGroupAggTable denseTable() {
+    return new NumericGroupAggTable(1, 1 << 14, true, 0L, 0);
+  }
+
+  @Test
+  @DisplayName("releasing an aborted pass leaves neither per-scan recycler holding a chunk")
+  void abortedPassLeavesNoChunkForTheBudgetRefreshToMeasure() {
+    final int poolBefore = GroupTableSpill.setChunkPoolForTesting(1);
+    final int retainBefore = LongChunkPool.setRetainForTesting(0);
+    try {
+      final GroupTableSpill spill =
+          new GroupTableSpill(PARTITIONS, SHIFT, GroupAbortedPassReleaseTest::denseTable, 0, PARTITIONS, 50_000L);
+      final LongChunkPool payload = spill.chunkPool();
+      final LongChunkPool probes = spill.probeChunkPool();
+      assertNotNull(payload, "the pool is switched on for this test");
+      assertNotNull(probes, "a stripe above the dense crossing gets an index recycler");
+      assertFalse(payload.isShared(), "retention off: the payload pool is per-scan and never added back");
+      assertFalse(probes.isShared(), "the index recycler is always per-scan and never added back");
+
+      // Two workers finished their chunk before the pass aborted: never flushed, so their tables
+      // still own every payload and index chunk they took.
+      final NumericGroupAggTable[] tables = new NumericGroupAggTable[2];
+      for (int t = 0; t < tables.length; t++) {
+        final NumericGroupAggTable local = spill.freshLocal();
+        final long base = (long) t * 20_000L;
+        for (long key = 1L; key <= 20_000L; key++) {
+          local.acquire(base + key, base + key);
+        }
+        spill.noteAbandonedLocal(local.size());
+        tables[t] = local;
+      }
+      final long abandoned = spill.groupsAbandoned();
+      assertEquals(40_000L, abandoned, "the estimate has already read the abandoned locals");
+
+      SirixVectorizedExecutor.releaseAbortedPass(spill, tables, new int[tables.length][][]);
+
+      assertEquals(0, payload.pooled(), "no payload chunk survives into the restart's budget measurement: " + payload);
+      assertEquals(0, probes.pooled(), "no index chunk survives into the restart's budget measurement: " + probes);
+      assertEquals(abandoned, spill.groupsAbandoned(), "the counters the estimate reads survive the release");
+      for (final NumericGroupAggTable table : tables) {
+        assertTrue(table == null, "the aborted pass keeps no reference to its tables");
+      }
+    } finally {
+      LongChunkPool.setRetainForTesting(retainBefore);
+      GroupTableSpill.setChunkPoolForTesting(poolBefore);
+    }
+  }
+
+  @Test
+  @DisplayName("a shared payload pool keeps its chunks; only the per-scan index recycler drains")
+  void aSharedPayloadPoolIsRetainedWhileTheIndexRecyclerDrains() {
+    final int poolBefore = GroupTableSpill.setChunkPoolForTesting(1);
+    final int retainBefore = LongChunkPool.setRetainForTesting(1);
+    try {
+      final GroupTableSpill spill =
+          new GroupTableSpill(PARTITIONS, SHIFT, GroupAbortedPassReleaseTest::denseTable, 0, PARTITIONS, 50_000L);
+      final LongChunkPool payload = spill.chunkPool();
+      final LongChunkPool probes = spill.probeChunkPool();
+      assertNotNull(probes, "a stripe above the dense crossing gets an index recycler");
+      assertTrue(payload.isShared(), "retention on: the payload pool outlives the scan and IS added back");
+
+      final NumericGroupAggTable[] tables = { spill.freshLocal() };
+      for (long key = 1L; key <= 20_000L; key++) {
+        tables[0].acquire(key, key);
+      }
+
+      SirixVectorizedExecutor.releaseAbortedPass(spill, tables, new int[1][][]);
+
+      assertTrue(payload.pooled() > 0, "the shared pool keeps the aborted pass's chunks for the restart: " + payload);
+      assertEquals(0, probes.pooled(), "the per-scan index recycler still drains: " + probes);
+    } finally {
+      LongChunkPool.setRetainForTesting(retainBefore);
+      GroupTableSpill.setChunkPoolForTesting(poolBefore);
+    }
+  }
+}

--- a/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupTopKDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupTopKDifferentialTest.java
@@ -7,6 +7,7 @@ import io.brackit.query.util.serialize.StringSerializer;
 import io.sirix.access.Databases;
 import io.sirix.api.json.JsonResourceSession;
 import io.sirix.index.projection.GroupTableSpill;
+import io.sirix.index.projection.NumericGroupAggTable;
 import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.query.SirixCompileChain;
 import io.sirix.query.SirixQueryContext;
@@ -164,6 +165,43 @@ public final class GroupTopKDifferentialTest {
       GroupTableSpill.setFlushGroupsForTesting(threshold);
       GroupTableSpill.setSubChunkLeavesForTesting(morsel);
     }
+  }
+
+  @Test
+  void theDenseIndexKillSwitchAnswersIdenticallyThroughTheQueryEngine() throws Exception {
+    // A composite key with two operands is far above the dense gate's crossing, so the default run
+    // folds its groups into dense records behind the compact index while the kill-switch run keeps
+    // interleaved buckets. The recovery lever is only a recovery lever if BOTH layouts hand the
+    // engine the same window, in the same emission order, as the interpreter.
+    final String query = "subsequence(for $u in " + SRC + " let $a := $u.k40, $b := $u.dept group by $a, $b"
+        + " let $c := count($u), $s := sum($u.amount), $m := max($u.id)"
+        + " order by $c descending return {\"a\":$a,\"b\":$b,\"c\":$c,\"s\":$s,\"m\":$m},1,16)";
+    // Two full operand blocks alone already clear the crossing, whatever the key width and aux lane
+    // add on top, so this query cannot silently fall below the gate and make the comparison vacuous.
+    assertTrue(NumericGroupAggTable.strideFor(2, false, 0) >= GroupTableSpill.DENSE_INDEX_MIN_STRIDE,
+        "this shape must be one the dense gate admits, or the differential proves nothing");
+
+    final String interpreted = run(query, false);
+    final long servedBefore = SirixVectorizedExecutor.groupAggServedCount();
+    final String dense = run(query, true);
+    final long servedAfterDense = SirixVectorizedExecutor.groupAggServedCount();
+    assertTrue(servedAfterDense > servedBefore, "the default layout must serve, or agreement is vacuous");
+
+    final String previous = System.setProperty(GroupTableSpill.DENSE_INDEX_PROPERTY, "false");
+    final String interleaved;
+    try {
+      interleaved = run(query, true);
+    } finally {
+      if (previous == null) {
+        System.clearProperty(GroupTableSpill.DENSE_INDEX_PROPERTY);
+      } else {
+        System.setProperty(GroupTableSpill.DENSE_INDEX_PROPERTY, previous);
+      }
+    }
+    assertTrue(SirixVectorizedExecutor.groupAggServedCount() > servedAfterDense,
+        "the kill switch must keep the group-aggregate route, not decline the query to the interpreter");
+    assertEquals(interpreted, dense, "dense records changed the served window");
+    assertEquals(dense, interleaved, "the kill switch changed the served window");
   }
 
   @Test

--- a/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupTopKDifferentialTest.java
+++ b/bundles/sirix-query/src/test/java/io/sirix/query/scan/GroupTopKDifferentialTest.java
@@ -6,6 +6,7 @@ import io.brackit.query.jdm.Sequence;
 import io.brackit.query.util.serialize.StringSerializer;
 import io.sirix.access.Databases;
 import io.sirix.api.json.JsonResourceSession;
+import io.sirix.index.projection.GroupTableSpill;
 import io.sirix.index.projection.ProjectionIndexCatalog;
 import io.sirix.query.SirixCompileChain;
 import io.sirix.query.SirixQueryContext;
@@ -145,6 +146,34 @@ public final class GroupTopKDifferentialTest {
   }
 
   // ---- numeric single key -------------------------------------------------------------------
+
+  @Test
+  void compactSumsPreserveSparseOperandsAndCountTiesAcrossSpills() throws Exception {
+    final long budget = GroupTableSpill.setGroupBudgetForTesting(16);
+    final int threshold = GroupTableSpill.setFlushGroupsForTesting(4);
+    final int morsel = GroupTableSpill.setSubChunkLeavesForTesting(1);
+    try {
+      final long before = SirixVectorizedExecutor.compactSumGroupsServedCount();
+      assertOrderedDifferentialServed(
+          "subsequence(for $u in " + SRC + " where $u.id >= 7 let $a := $u.k7, $b := $u.tier group by $a, $b"
+              + " let $c := count($u), $s := sum($u.amount), $v := xs:double(avg($u.bonus))"
+              + " order by $c descending return {\"a\":$a,\"b\":$b,\"c\":$c,\"s\":$s,\"v\":$v},1,12)");
+      assertEquals(before + 1, SirixVectorizedExecutor.compactSumGroupsServedCount());
+    } finally {
+      GroupTableSpill.setGroupBudgetForTesting(budget);
+      GroupTableSpill.setFlushGroupsForTesting(threshold);
+      GroupTableSpill.setSubChunkLeavesForTesting(morsel);
+    }
+  }
+
+  @Test
+  void requestedExtremaKeepTheFullAccumulator() throws Exception {
+    final long before = SirixVectorizedExecutor.compactSumGroupsServedCount();
+    assertOrderedDifferentialServed("subsequence(for $u in " + SRC + " let $a := $u.k7, $b := $u.k40 group by $a, $b"
+        + " let $c := count($u), $s := sum($u.amount), $m := max($u.bonus)"
+        + " order by $c descending return {\"a\":$a,\"b\":$b,\"c\":$c,\"s\":$s,\"m\":$m},1,12)");
+    assertEquals(before, SirixVectorizedExecutor.compactSumGroupsServedCount());
+  }
 
   @Test
   void repeatedNumericKeyOffsetsPreserveCountTies() throws Exception {

--- a/docs/CLICKBENCH.md
+++ b/docs/CLICKBENCH.md
@@ -546,13 +546,16 @@ the same ten rows because group emission order is implementation-defined for tha
 group-aggregate detector does recognize this order-free form and serves Q17 from the projection; the
 permutation is not evidence of a Brackit-only fallback.
 
-### What still declines, and why — historical snapshot, 2026-08-15
+### What still declines, and why — historical snapshot, before the 2026-08-16 campaign
 
-> **Historical, not current status.** Everything in this section describes the state on
-> **2026-08-15**, i.e. *before* the 2026-08-16 kernel campaign recorded in the serving table above.
-> The named query lists went stale that day and have not been maintained since; for what serves
-> today, read the serving table above, which is the authoritative current status. The section is
-> kept only because *why* each shape once declined is still worth having.
+> **Historical, not current status.** Everything in this section describes the state **before
+> 2026-08-16**, i.e. before the kernel campaign recorded in the serving table above. That bound is
+> checkable from the section itself: its first bullet still calls string NE unrepresentable, so it
+> predates the serving table's `+ string NE` row (7 of 43), which in turn sits above the table's two
+> 2026-08-16 rows. Nothing in this repository dates the section more precisely than that, so no
+> exact day is claimed. The named query lists have not been maintained since; for what serves today,
+> read the serving table above, which is the authoritative current status. The section is kept only
+> because *why* each shape once declined is still worth having.
 
 * **String NE is unrepresentable** — `PredicateNode.StrEq` carries no operator, and `Not(StrEq)` is
   not equivalent: over a record MISSING the field the interpreter yields the empty sequence, which a

--- a/docs/CLICKBENCH.md
+++ b/docs/CLICKBENCH.md
@@ -546,7 +546,13 @@ the same ten rows because group emission order is implementation-defined for tha
 group-aggregate detector does recognize this order-free form and serves Q17 from the projection; the
 permutation is not evidence of a Brackit-only fallback.
 
-### What still declines, and why
+### What still declines, and why — historical snapshot, 2026-08-15
+
+> **Historical, not current status.** Everything in this section describes the state on
+> **2026-08-15**, i.e. *before* the 2026-08-16 kernel campaign recorded in the serving table above.
+> The named query lists went stale that day and have not been maintained since; for what serves
+> today, read the serving table above, which is the authoritative current status. The section is
+> kept only because *why* each shape once declined is still worth having.
 
 * **String NE is unrepresentable** — `PredicateNode.StrEq` carries no operator, and `Not(StrEq)` is
   not equivalent: over a record MISSING the field the interpreter yields the empty sequence, which a

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
@@ -1,1266 +1,2318 @@
 {
-  "base_commit": "aa4d81d547fb0e2353ede959786d6e8ba442edf2",
-  "candidate_commit": "f13a32e68fbad8ade9e3f8d3140606e07726d4c5",
-  "lock_acquired": "2026-09-08T02:30:48.119121+00:00",
-  "lock_released": "2026-09-08T02:35:46.452368+00:00",
-  "runs": [
-    {
-      "label": "base",
-      "start": "2026-09-08T02:30:48.129069+00:00",
-      "exit": 0,
-      "end": "2026-09-08T02:33:31.056085+00:00"
-    },
-    {
-      "label": "candidate",
-      "start": "2026-09-08T02:33:31.075036+00:00",
-      "exit": 0,
-      "end": "2026-09-08T02:35:46.450952+00:00"
+  "status": "provisional: measurement rig repair pending",
+  "performance_validated": false,
+  "accepted_score": null,
+  "restriction": "All pre-repair timing figures are provisional. Do not use them for tuning, performance acceptance or delivery. Firstmate must grant a new 100M window after rig validation.",
+  "tested_source_identity": {
+    "head": "b3d34899b0320d35bcd166c0017d09c6c9a35e16",
+    "head_subject": "Document accepted aggregation gain and exclusive measurement requirement",
+    "baseline_commit": "aa4d81d547fb0e2353ede959786d6e8ba442edf2",
+    "worktree_diff_sha256": "b6eff370a6765945421c4b2a7e3326f28eb06caffa5045d307e37e921bfb7bd4",
+    "worktree_dirty_files": [
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java",
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java",
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableDenseIndexGateTest.java",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java"
+    ],
+    "changed_sources": {
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupDistinctAccumulator.java": "4654b7a97bcd2bb5b78c4020c29c7263cc701a5d5b584ff5bbb530ef9c5c025d",
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/GroupTableSpill.java": "36d71ffc6e7d147a5dab268eff488ddb404dd93049a5a8764d14f0521c57d5f7",
+      "bundles/sirix-core/src/main/java/io/sirix/index/projection/NumericGroupAggTable.java": "bf328b40e62fc77050db405b980b832a5e94d8e09c843f6b968c1e09ac942897",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupDistinctAccumulatorTest.java": "ed669c3904027de7d26de08b306019269fabdcc48b1e01e5ba445820103ae374",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/GroupTableDenseIndexGateTest.java": "0794091f79dbf38b05fe94818c3bfc7ad8f321d4155df5e8e946a76f874a767a",
+      "bundles/sirix-core/src/test/java/io/sirix/index/projection/NumericGroupSumTableTest.java": "4ba08cc9ba266c66790862d50d50a2f3b5313eb81c54a38bf67db5d51620cc55"
     }
-  ],
-  "runtime": "Oracle GraalVM 25.0.3, C2, 20 query workers, Intel i7-12700H",
-  "jvm_flags": [
-    "--add-opens",
-    "java.base/sun.nio.ch=ALL-UNNAMED",
-    "--add-opens",
-    "java.base/java.nio=ALL-UNNAMED",
-    "--add-modules",
-    "jdk.incubator.vector",
-    "--enable-native-access=ALL-UNNAMED",
-    "--enable-preview",
-    "-XX:+UnlockExperimentalVMOptions",
-    "-XX:-UseJVMCICompiler",
-    "-Xms6g",
-    "-Xmx14g",
-    "-Dsirix.projection.eagerMaterializeBytes=5368709120",
-    "-Dsirix.offheap.bytes=10737418240",
-    "-Dsirix.query.autoVectorize=true",
-    "-Dsirix.chunkedBody.enable=true",
-    "-Dsirix.chunkedBody.targetChunkBytes=16384"
-  ],
-  "measurement": "43 queries, 3 tries, hot=min(try2,try3); one continuously held exclusive rig lock",
-  "correctness": "all 43 100M outputs byte-identical; zero serving declines; 1M DuckDB gate zero mismatch/missing/unverifiable/declines and all 43 baseline outputs byte-identical",
-  "sum_ln_saved": 2.225992125303854,
-  "tail_queries": [
-    5,
-    8,
-    9,
-    12,
-    13,
-    14,
-    16,
-    18,
-    28,
-    30,
-    31,
-    32,
-    33,
-    34
-  ],
-  "tail_geometric_speedup": 1.1755789457871717,
-  "queries": [
+  },
+  "recovery": "All six files recovered byte-identically to tested hashes. Only formatting and two comment corrections followed recovery.",
+  "correctness": {
+    "focused_tests": 137,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 0,
+    "one_million": {
+      "queries": 43,
+      "match": 33,
+      "tie_ambiguous": 10,
+      "unverifiable": 0,
+      "mismatch": 0,
+      "missing": 0,
+      "serving_declines": 0,
+      "byte_identical_to_baseline": 43
+    },
+    "recovery_verification": {
+      "tests": 15,
+      "failures": 0,
+      "errors": 0,
+      "skipped": 0,
+      "production_tokens_unchanged": true
+    }
+  },
+  "provisional_pairs": [
     {
-      "query": 0,
-      "base_seconds": [
-        0.054,
-        0.002,
-        0.001
+      "base": "aa4d81d547fb0e2353ede959786d6e8ba442edf2",
+      "candidate_head": "b3d34899b0320d35bcd166c0017d09c6c9a35e16",
+      "candidate_worktree_diff_sha256": "b6eff370a6765945421c4b2a7e3326f28eb06caffa5045d307e37e921bfb7bd4",
+      "java": "/home/johannes/.sdkman/candidates/java/25.0.3-graal/bin/java",
+      "flags": [
+        "--add-opens",
+        "java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens",
+        "java.base/java.nio=ALL-UNNAMED",
+        "--add-modules",
+        "jdk.incubator.vector",
+        "--enable-native-access=ALL-UNNAMED",
+        "--enable-preview",
+        "-XX:+UnlockExperimentalVMOptions",
+        "-XX:-UseJVMCICompiler",
+        "-Xms6g",
+        "-Xmx14g",
+        "-Dsirix.projection.eagerMaterializeBytes=5368709120",
+        "-Dsirix.offheap.bytes=10737418240",
+        "-Dsirix.query.autoVectorize=true",
+        "-Dsirix.chunkedBody.enable=true",
+        "-Dsirix.chunkedBody.targetChunkBytes=16384"
       ],
-      "candidate_seconds": [
-        0.051,
-        0.001,
-        0.001
+      "artifacts": {
+        "baseline_query_classes_sha256": "46d6b56c795a9a0e04345e0b940479a417284e4eef6a0fd97ec24d72d5e45ccb",
+        "baseline_core_jar_sha256": "8058e6c681fb14cd423833023359ebed27cb57c3fc37100fe7b853e5079551f4",
+        "candidate_query_classes_sha256": "c67c13eb6c50a5ae30fada549acc7b098c3b6237d3418dfa2d2a681ae86d071c",
+        "candidate_core_jar_sha256": "e340e07dfa7dc8af4765c115155ddf152d6688c354daf585886551d2cf031ddb"
+      },
+      "lock_acquired": "2026-09-08T03:25:55.778910+00:00",
+      "lock_released": "2026-09-08T03:31:28.950618+00:00",
+      "label": "exclusive2",
+      "status": "provisional",
+      "runs": [
+        {
+          "label": "base",
+          "start": "2026-09-08T03:25:55.788699+00:00",
+          "pid": 628040,
+          "exit": 0,
+          "end": "2026-09-08T03:28:56.416698+00:00"
+        },
+        {
+          "label": "candidate",
+          "start": "2026-09-08T03:28:56.433583+00:00",
+          "pid": 637748,
+          "exit": 0,
+          "end": "2026-09-08T03:31:28.940960+00:00"
+        }
       ],
-      "base_cpu_seconds": [
-        0.1,
-        0.0,
-        0.0
+      "queries": [
+        {
+          "query": 0,
+          "output_sha256": "6274012ba71547fe2fc1d4a5fe09989ceb1568002642e429d13aca0e4de29324",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.039,
+            0.002,
+            0.001
+          ],
+          "base_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.056,
+            0.002,
+            0.001
+          ],
+          "candidate_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "query": 1,
+          "output_sha256": "df271e2c68e1217c6218272ef6f3ed42574e60d6e137250523d3e7e72eacf2aa",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.315,
+            0.043,
+            0.041
+          ],
+          "base_cpu_seconds": [
+            3.3,
+            0.4,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.444,
+            0.043,
+            0.042
+          ],
+          "candidate_cpu_seconds": [
+            5.4,
+            0.4,
+            0.4
+          ]
+        },
+        {
+          "query": 2,
+          "output_sha256": "68d6acd8c4d6cb65ab89b275d8ff5db9e4edd064be63a642efaec968c2a51fcd",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.235,
+            0.068,
+            0.047
+          ],
+          "base_cpu_seconds": [
+            3.0,
+            0.9,
+            0.5
+          ],
+          "candidate_wall_seconds": [
+            0.327,
+            0.07,
+            0.048
+          ],
+          "candidate_cpu_seconds": [
+            3.9,
+            0.8,
+            0.5
+          ]
+        },
+        {
+          "query": 3,
+          "output_sha256": "56339714bc6ff65c968dec28d1847178d77ac735028e922f85fb6902b7790a9b",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.055,
+            0.136,
+            0.036
+          ],
+          "base_cpu_seconds": [
+            7.3,
+            2.4,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.932,
+            0.12,
+            0.038
+          ],
+          "candidate_cpu_seconds": [
+            6.9,
+            2.0,
+            0.4
+          ]
+        },
+        {
+          "query": 4,
+          "output_sha256": "2b756178cde1d94167b4ae6e4d24f9d20e73a7eddeef6d126b9326c709eb3f69",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.371,
+            0.471,
+            0.29
+          ],
+          "base_cpu_seconds": [
+            4.9,
+            6.6,
+            3.6
+          ],
+          "candidate_wall_seconds": [
+            0.419,
+            0.518,
+            0.316
+          ],
+          "candidate_cpu_seconds": [
+            5.5,
+            7.3,
+            3.9
+          ]
+        },
+        {
+          "query": 5,
+          "output_sha256": "34cdf1a69e01fc9438d5ae22fb8639ebc9f681249be45a214cf7392761624be2",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.798,
+            0.643,
+            0.578
+          ],
+          "base_cpu_seconds": [
+            37.0,
+            6.2,
+            5.8
+          ],
+          "candidate_wall_seconds": [
+            2.843,
+            0.824,
+            0.726
+          ],
+          "candidate_cpu_seconds": [
+            37.0,
+            8.7,
+            7.4
+          ]
+        },
+        {
+          "query": 6,
+          "output_sha256": "925d081ee74c49651addbd4a935e6b8eab9bd80ae8129ce0345b0304fd7cba2c",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.054,
+            0.03,
+            0.026
+          ],
+          "base_cpu_seconds": [
+            0.3,
+            0.1,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.047,
+            0.026,
+            0.025
+          ],
+          "candidate_cpu_seconds": [
+            0.3,
+            0.2,
+            0.1
+          ]
+        },
+        {
+          "query": 7,
+          "output_sha256": "7826e1bf67eaee52ede7f99e2f5d6686922101168ccb03dcde7a4dc63cb95cd1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.218,
+            0.033,
+            0.017
+          ],
+          "base_cpu_seconds": [
+            2.1,
+            0.4,
+            0.2
+          ],
+          "candidate_wall_seconds": [
+            0.259,
+            0.052,
+            0.039
+          ],
+          "candidate_cpu_seconds": [
+            2.3,
+            0.5,
+            0.4
+          ]
+        },
+        {
+          "query": 8,
+          "output_sha256": "be8bbbcf3956a0506fcf0b1a659a4c67c51b9805bd78b395db8cf1e79a1a64c1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.476,
+            0.58,
+            0.58
+          ],
+          "base_cpu_seconds": [
+            21.8,
+            8.8,
+            8.6
+          ],
+          "candidate_wall_seconds": [
+            1.451,
+            0.663,
+            0.656
+          ],
+          "candidate_cpu_seconds": [
+            21.3,
+            9.9,
+            9.6
+          ]
+        },
+        {
+          "query": 9,
+          "output_sha256": "d6ad56d1ec86424944040abf7659bd52c59872ba2a1c0eab527ff361b0ded6c5",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.991,
+            0.701,
+            0.694
+          ],
+          "base_cpu_seconds": [
+            14.9,
+            10.2,
+            10.5
+          ],
+          "candidate_wall_seconds": [
+            1.016,
+            0.763,
+            0.747
+          ],
+          "candidate_cpu_seconds": [
+            15.5,
+            11.4,
+            11.5
+          ]
+        },
+        {
+          "query": 10,
+          "output_sha256": "371d54beabadf57bace382b5f7ab79169d5e0975ee22250e238458119a52dabf",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.461,
+            0.381,
+            0.292
+          ],
+          "base_cpu_seconds": [
+            17.0,
+            2.9,
+            2.0
+          ],
+          "candidate_wall_seconds": [
+            1.701,
+            0.36,
+            0.361
+          ],
+          "candidate_cpu_seconds": [
+            14.6,
+            3.2,
+            1.8
+          ]
+        },
+        {
+          "query": 11,
+          "output_sha256": "d13e37dfbf6e4eec136058921b2ac59496c5dd3f261c3e74c01b12692a3993fd",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.92,
+            0.335,
+            0.246
+          ],
+          "base_cpu_seconds": [
+            20.6,
+            3.1,
+            1.9
+          ],
+          "candidate_wall_seconds": [
+            1.177,
+            0.254,
+            0.221
+          ],
+          "candidate_cpu_seconds": [
+            14.8,
+            2.0,
+            1.4
+          ]
+        },
+        {
+          "query": 12,
+          "output_sha256": "fcc014a2ba3c83d3aabcda329d71337d1fdb82d065776908e10536f2f1e786e7",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.773,
+            0.73,
+            0.762
+          ],
+          "base_cpu_seconds": [
+            23.7,
+            9.4,
+            9.7
+          ],
+          "candidate_wall_seconds": [
+            2.019,
+            0.777,
+            0.863
+          ],
+          "candidate_cpu_seconds": [
+            28.5,
+            10.0,
+            10.7
+          ]
+        },
+        {
+          "query": 13,
+          "output_sha256": "674be045f937f8fc8504ffbc78c110e1eaa35c23031ec26161184660ebcf3117",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            3.573,
+            2.738,
+            2.697
+          ],
+          "base_cpu_seconds": [
+            32.2,
+            33.5,
+            30.9
+          ],
+          "candidate_wall_seconds": [
+            1.994,
+            1.513,
+            1.401
+          ],
+          "candidate_cpu_seconds": [
+            28.5,
+            19.3,
+            18.4
+          ]
+        },
+        {
+          "query": 14,
+          "output_sha256": "9d02fdb0bdc35d9fb2e20bdff7c618092614725eac713d1663a4ef7f72a679fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.524,
+            0.888,
+            0.972
+          ],
+          "base_cpu_seconds": [
+            32.3,
+            11.8,
+            13.2
+          ],
+          "candidate_wall_seconds": [
+            1.905,
+            0.836,
+            0.91
+          ],
+          "candidate_cpu_seconds": [
+            28.7,
+            11.0,
+            11.7
+          ]
+        },
+        {
+          "query": 15,
+          "output_sha256": "4984ef226b59ff43b5329c22928f051348d3212cafab52a907c1935d7645b0b1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.002,
+            0.425,
+            0.42
+          ],
+          "base_cpu_seconds": [
+            18.7,
+            8.0,
+            8.1
+          ],
+          "candidate_wall_seconds": [
+            0.995,
+            0.443,
+            0.451
+          ],
+          "candidate_cpu_seconds": [
+            17.1,
+            8.1,
+            8.4
+          ]
+        },
+        {
+          "query": 16,
+          "output_sha256": "9c2cb1d94a1a5e216dfadfbb39b0a69875ab3bd31ee7f219fcb2ea67c917f049",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            4.758,
+            2.071,
+            2.043
+          ],
+          "base_cpu_seconds": [
+            67.2,
+            28.5,
+            27.8
+          ],
+          "candidate_wall_seconds": [
+            3.299,
+            1.8,
+            1.839
+          ],
+          "candidate_cpu_seconds": [
+            46.7,
+            23.4,
+            22.7
+          ]
+        },
+        {
+          "query": 17,
+          "output_sha256": "d9f19c41559e311ae37aed66999d0216bbdec7cd510d3eac9761da1d4b4d8792",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.362,
+            0.06,
+            0.059
+          ],
+          "base_cpu_seconds": [
+            5.8,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.347,
+            0.038,
+            0.043
+          ],
+          "candidate_cpu_seconds": [
+            5.3,
+            0.2,
+            0.3
+          ]
+        },
+        {
+          "query": 18,
+          "output_sha256": "3562c975e7413e13bd61d5dff44397479ad93e032f421b4bbb2c8f4e7b8e59fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            7.274,
+            4.111,
+            3.996
+          ],
+          "base_cpu_seconds": [
+            104.6,
+            65.6,
+            63.3
+          ],
+          "candidate_wall_seconds": [
+            5.877,
+            3.135,
+            3.137
+          ],
+          "candidate_cpu_seconds": [
+            88.0,
+            49.1,
+            49.0
+          ]
+        },
+        {
+          "query": 19,
+          "output_sha256": "3250356ef481c5756db99d19a1aff7f72ac21d31da97cee5ec867e2abed33b27",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.033,
+            0.02,
+            0.014
+          ],
+          "base_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.033,
+            0.015,
+            0.017
+          ],
+          "candidate_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "query": 20,
+          "output_sha256": "3561da5045e865e0b4da382b5f882246b0d0f9673d2b6447fdc679b4558fae58",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            3.513,
+            0.044,
+            0.031
+          ],
+          "base_cpu_seconds": [
+            33.8,
+            0.6,
+            0.5
+          ],
+          "candidate_wall_seconds": [
+            2.404,
+            0.053,
+            0.037
+          ],
+          "candidate_cpu_seconds": [
+            19.2,
+            0.7,
+            0.7
+          ]
+        },
+        {
+          "query": 21,
+          "output_sha256": "a6569917873542718e52cec662b1fad8dd035e904362abd7287770879423894f",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.296,
+            0.235,
+            0.16
+          ],
+          "base_cpu_seconds": [
+            2.6,
+            2.7,
+            1.7
+          ],
+          "candidate_wall_seconds": [
+            0.286,
+            0.215,
+            0.103
+          ],
+          "candidate_cpu_seconds": [
+            3.4,
+            3.1,
+            1.0
+          ]
+        },
+        {
+          "query": 22,
+          "output_sha256": "c6972e15129b9cd0ba18263b3206a8a1734a9b97c7864c7722d3018145558fe8",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            9.771,
+            1.506,
+            0.369
+          ],
+          "base_cpu_seconds": [
+            30.3,
+            3.3,
+            3.1
+          ],
+          "candidate_wall_seconds": [
+            5.607,
+            0.405,
+            0.376
+          ],
+          "candidate_cpu_seconds": [
+            24.1,
+            3.6,
+            3.6
+          ]
+        },
+        {
+          "query": 23,
+          "output_sha256": "e3cd36c66ebf0a0d9611657bb32fc15b2f96487222160422fd25b139faa2dad1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.001,
+            0.134,
+            0.126
+          ],
+          "base_cpu_seconds": [
+            4.3,
+            0.4,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.517,
+            0.134,
+            0.132
+          ],
+          "candidate_cpu_seconds": [
+            3.9,
+            0.4,
+            0.4
+          ]
+        },
+        {
+          "query": 24,
+          "output_sha256": "04ac5dddc732db72b94072eaad307d529300609e466fd2ece4fb6dac4327ae3b",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.114,
+            0.019,
+            0.019
+          ],
+          "base_cpu_seconds": [
+            0.2,
+            0.1,
+            0.1
+          ],
+          "candidate_wall_seconds": [
+            0.095,
+            0.021,
+            0.02
+          ],
+          "candidate_cpu_seconds": [
+            0.2,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "query": 25,
+          "output_sha256": "ecef47964fa651c24162085870df6dd047ca411dbafb5c0d40372318154474b2",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.403,
+            0.152,
+            0.222
+          ],
+          "base_cpu_seconds": [
+            3.3,
+            1.6,
+            2.7
+          ],
+          "candidate_wall_seconds": [
+            0.357,
+            0.201,
+            0.085
+          ],
+          "candidate_cpu_seconds": [
+            3.0,
+            2.2,
+            0.6
+          ]
+        },
+        {
+          "query": 26,
+          "output_sha256": "d5e5ad30fb7e79c7ea91bffc9971393d4a493951ee7dd11577e60810f8b59308",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.046,
+            0.025,
+            0.027
+          ],
+          "base_cpu_seconds": [
+            0.3,
+            0.2,
+            0.1
+          ],
+          "candidate_wall_seconds": [
+            0.024,
+            0.019,
+            0.124
+          ],
+          "candidate_cpu_seconds": [
+            0.1,
+            0.0,
+            1.7
+          ]
+        },
+        {
+          "query": 27,
+          "output_sha256": "2cb6b1ea1025878822b0b4cf52d32da45c5bc458921e9ed9ca80bbf808a80e9d",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.712,
+            0.292,
+            0.198
+          ],
+          "base_cpu_seconds": [
+            24.3,
+            3.8,
+            3.7
+          ],
+          "candidate_wall_seconds": [
+            1.689,
+            0.243,
+            0.231
+          ],
+          "candidate_cpu_seconds": [
+            26.9,
+            4.5,
+            4.4
+          ]
+        },
+        {
+          "query": 28,
+          "output_sha256": "e66d2ca783d9b31ea45cc94f7f3aae773a04d008458932a864da15441f82fdff",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            13.948,
+            9.198,
+            9.21
+          ],
+          "base_cpu_seconds": [
+            133.1,
+            78.2,
+            79.0
+          ],
+          "candidate_wall_seconds": [
+            12.301,
+            9.12,
+            9.013
+          ],
+          "candidate_cpu_seconds": [
+            121.9,
+            78.6,
+            77.3
+          ]
+        },
+        {
+          "query": 29,
+          "output_sha256": "07030719e298cb26685c7587ce7cd73028f78521afa4a33b2cbcb5acfbc61259",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.544,
+            0.035,
+            0.032
+          ],
+          "base_cpu_seconds": [
+            1.9,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.174,
+            0.039,
+            0.033
+          ],
+          "candidate_cpu_seconds": [
+            1.1,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 30,
+          "output_sha256": "bcb3b6bf0903e37a66d537aacd06a689154790914bba4677d4b687271b5d3e40",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.562,
+            0.519,
+            0.526
+          ],
+          "base_cpu_seconds": [
+            27.4,
+            9.3,
+            9.3
+          ],
+          "candidate_wall_seconds": [
+            1.987,
+            0.359,
+            0.363
+          ],
+          "candidate_cpu_seconds": [
+            30.1,
+            6.4,
+            6.4
+          ]
+        },
+        {
+          "query": 31,
+          "output_sha256": "3ed0b1ffb37fc60c0ea514df3b682a773d2fe8d853bbf249c718b06ceb75534a",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            3.094,
+            3.688,
+            3.145
+          ],
+          "base_cpu_seconds": [
+            26.9,
+            29.4,
+            25.5
+          ],
+          "candidate_wall_seconds": [
+            1.888,
+            1.542,
+            0.96
+          ],
+          "candidate_cpu_seconds": [
+            16.4,
+            15.7,
+            14.9
+          ]
+        },
+        {
+          "query": 32,
+          "output_sha256": "adf4de00a0078c7868f0cfb32eb0909dcd0c9b971c6eb93097adf08bf2e466e9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            10.116,
+            7.131,
+            6.976
+          ],
+          "base_cpu_seconds": [
+            150.9,
+            126.3,
+            123.7
+          ],
+          "candidate_wall_seconds": [
+            5.051,
+            4.17,
+            4.067
+          ],
+          "candidate_cpu_seconds": [
+            88.7,
+            77.2,
+            74.8
+          ]
+        },
+        {
+          "query": 33,
+          "output_sha256": "1625b2743dcb650f344dfcf296045d2db75387d94891bc9211a674f44f576bc9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            3.539,
+            2.575,
+            2.474
+          ],
+          "base_cpu_seconds": [
+            39.9,
+            33.0,
+            32.0
+          ],
+          "candidate_wall_seconds": [
+            2.783,
+            2.477,
+            2.507
+          ],
+          "candidate_cpu_seconds": [
+            38.0,
+            34.9,
+            35.6
+          ]
+        },
+        {
+          "query": 34,
+          "output_sha256": "a5aab2614aafe82b7ca4623a9e08e2bb7096334e7e5e1855b84b15d087a45bb9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.317,
+            2.253,
+            2.23
+          ],
+          "base_cpu_seconds": [
+            30.5,
+            30.5,
+            30.5
+          ],
+          "candidate_wall_seconds": [
+            2.759,
+            3.312,
+            5.258
+          ],
+          "candidate_cpu_seconds": [
+            39.4,
+            49.8,
+            78.1
+          ]
+        },
+        {
+          "query": 35,
+          "output_sha256": "55995b79571d8b725d8784700db64d46fce8f5bcee26120314e993f60e329e18",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.599,
+            0.398,
+            0.386
+          ],
+          "base_cpu_seconds": [
+            11.2,
+            7.4,
+            7.5
+          ],
+          "candidate_wall_seconds": [
+            1.364,
+            1.071,
+            1.049
+          ],
+          "candidate_cpu_seconds": [
+            25.7,
+            19.4,
+            18.9
+          ]
+        },
+        {
+          "query": 36,
+          "output_sha256": "5d21847795a6e050a5dce7647ce872bcb53714624b12a304f6398def4b1a89ce",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.311,
+            0.064,
+            0.063
+          ],
+          "base_cpu_seconds": [
+            2.3,
+            0.4,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.629,
+            0.148,
+            0.102
+          ],
+          "candidate_cpu_seconds": [
+            5.4,
+            1.3,
+            0.6
+          ]
+        },
+        {
+          "query": 37,
+          "output_sha256": "c8703a4b5282c1d6d749ad70d6c319cf95405ca509cc0cc96ab0c543ba34a8fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.076,
+            0.048,
+            0.045
+          ],
+          "base_cpu_seconds": [
+            3.3,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.575,
+            0.069,
+            0.076
+          ],
+          "candidate_cpu_seconds": [
+            3.0,
+            0.4,
+            0.4
+          ]
+        },
+        {
+          "query": 38,
+          "output_sha256": "8fb648551c53248efb46b4cbaa595c3d955e691afd652c36fd02e11c26eeb2ea",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.716,
+            0.041,
+            0.048
+          ],
+          "base_cpu_seconds": [
+            2.6,
+            0.3,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.377,
+            0.065,
+            0.064
+          ],
+          "candidate_cpu_seconds": [
+            2.7,
+            0.4,
+            0.4
+          ]
+        },
+        {
+          "query": 39,
+          "output_sha256": "8aca19fe3c2403c22c8baf14a7a7ad8b1e482bb358499f4ce30ceeaace0e6a0a",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.758,
+            0.371,
+            0.337
+          ],
+          "base_cpu_seconds": [
+            7.2,
+            3.6,
+            3.6
+          ],
+          "candidate_wall_seconds": [
+            0.926,
+            0.627,
+            0.939
+          ],
+          "candidate_cpu_seconds": [
+            10.0,
+            7.2,
+            11.7
+          ]
+        },
+        {
+          "query": 40,
+          "output_sha256": "e2f8ca91287f21045242639aa04f53f4edab349e07e6f24f4bd841decd81ce57",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.138,
+            0.042,
+            0.038
+          ],
+          "base_cpu_seconds": [
+            0.5,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.116,
+            0.039,
+            0.039
+          ],
+          "candidate_cpu_seconds": [
+            0.4,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 41,
+          "output_sha256": "66902b46c180a393cdb87a05e10082eb3c6fb5d8d6ef5b79b694c6d5f0e0fd06",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.099,
+            0.055,
+            0.053
+          ],
+          "base_cpu_seconds": [
+            0.4,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.123,
+            0.071,
+            0.064
+          ],
+          "candidate_cpu_seconds": [
+            0.5,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 42,
+          "output_sha256": "852d75893a0be63de0156646ff76340114540de4b390e64e2e9997eea6819a76",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.45,
+            0.045,
+            0.047
+          ],
+          "base_cpu_seconds": [
+            2.3,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.342,
+            0.069,
+            0.068
+          ],
+          "candidate_cpu_seconds": [
+            2.9,
+            0.5,
+            0.4
+          ]
+        }
       ],
-      "candidate_cpu_seconds": [
-        0.1,
-        0.0,
-        0.0
-      ],
-      "base_hot": 0.001,
-      "candidate_hot": 0.001,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "6274012ba71547fe2fc1d4a5fe09989ceb1568002642e429d13aca0e4de29324"
+      "serving_declines": {
+        "base": 0,
+        "candidate": 0
+      }
     },
     {
-      "query": 1,
-      "base_seconds": [
-        0.429,
-        0.031,
-        0.029
-      ],
-      "candidate_seconds": [
-        0.392,
-        0.036,
-        0.035
-      ],
-      "base_cpu_seconds": [
-        5.1,
-        0.2,
-        0.2
-      ],
-      "candidate_cpu_seconds": [
-        4.8,
-        0.4,
-        0.3
-      ],
-      "base_hot": 0.029,
-      "candidate_hot": 0.035,
-      "hot_speedup": 0.8285714285714285,
-      "ln_saved": -0.14310084364067344,
-      "output_sha256": "df271e2c68e1217c6218272ef6f3ed42574e60d6e137250523d3e7e72eacf2aa"
-    },
-    {
-      "query": 2,
-      "base_seconds": [
-        0.29,
-        0.075,
-        0.066
-      ],
-      "candidate_seconds": [
-        0.297,
-        0.053,
-        0.047
-      ],
-      "base_cpu_seconds": [
-        3.6,
-        1.0,
-        0.9
-      ],
-      "candidate_cpu_seconds": [
-        3.2,
-        0.6,
-        0.5
-      ],
-      "base_hot": 0.066,
-      "candidate_hot": 0.047,
-      "hot_speedup": 1.4042553191489362,
-      "ln_saved": 0.28768207245178085,
-      "output_sha256": "68d6acd8c4d6cb65ab89b275d8ff5db9e4edd064be63a642efaec968c2a51fcd"
-    },
-    {
-      "query": 3,
-      "base_seconds": [
-        0.642,
-        0.086,
-        0.032
-      ],
-      "candidate_seconds": [
-        0.618,
-        0.105,
-        0.032
-      ],
-      "base_cpu_seconds": [
-        7.2,
-        1.3,
-        0.4
-      ],
-      "candidate_cpu_seconds": [
-        5.7,
-        1.6,
-        0.4
-      ],
-      "base_hot": 0.032,
-      "candidate_hot": 0.032,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "56339714bc6ff65c968dec28d1847178d77ac735028e922f85fb6902b7790a9b"
-    },
-    {
-      "query": 4,
-      "base_seconds": [
-        0.469,
-        0.358,
-        0.273
-      ],
-      "candidate_seconds": [
-        0.421,
-        0.447,
-        0.311
-      ],
-      "base_cpu_seconds": [
-        6.7,
-        4.8,
-        3.5
-      ],
-      "candidate_cpu_seconds": [
-        5.5,
-        6.3,
-        3.9
-      ],
-      "base_hot": 0.273,
-      "candidate_hot": 0.311,
-      "hot_speedup": 0.8778135048231512,
-      "ln_saved": -0.12599422548677813,
-      "output_sha256": "2b756178cde1d94167b4ae6e4d24f9d20e73a7eddeef6d126b9326c709eb3f69"
-    },
-    {
-      "query": 5,
-      "base_seconds": [
-        2.304,
-        0.624,
-        0.591
-      ],
-      "candidate_seconds": [
-        2.243,
-        0.785,
-        0.747
-      ],
-      "base_cpu_seconds": [
-        29.3,
-        6.1,
-        5.8
-      ],
-      "candidate_cpu_seconds": [
-        28.1,
-        7.6,
-        7.1
-      ],
-      "base_hot": 0.591,
-      "candidate_hot": 0.747,
-      "hot_speedup": 0.7911646586345381,
-      "ln_saved": -0.2307683189022412,
-      "output_sha256": "34cdf1a69e01fc9438d5ae22fb8639ebc9f681249be45a214cf7392761624be2"
-    },
-    {
-      "query": 6,
-      "base_seconds": [
-        0.053,
-        0.029,
-        0.024
-      ],
-      "candidate_seconds": [
-        0.05,
-        0.028,
-        0.023
-      ],
-      "base_cpu_seconds": [
-        0.3,
-        0.2,
-        0.0
-      ],
-      "candidate_cpu_seconds": [
-        0.3,
-        0.1,
-        0.0
-      ],
-      "base_hot": 0.024,
-      "candidate_hot": 0.023,
-      "hot_speedup": 1.0434782608695652,
-      "ln_saved": 0.02985296314968113,
-      "output_sha256": "925d081ee74c49651addbd4a935e6b8eab9bd80ae8129ce0345b0304fd7cba2c"
-    },
-    {
-      "query": 7,
-      "base_seconds": [
-        0.257,
-        0.034,
-        0.032
-      ],
-      "candidate_seconds": [
-        0.225,
-        0.029,
-        0.035
-      ],
-      "base_cpu_seconds": [
-        2.4,
-        0.4,
-        0.4
-      ],
-      "candidate_cpu_seconds": [
-        2.3,
-        0.3,
-        0.4
-      ],
-      "base_hot": 0.032,
-      "candidate_hot": 0.029,
-      "hot_speedup": 1.103448275862069,
-      "ln_saved": 0.07410797215372204,
-      "output_sha256": "7826e1bf67eaee52ede7f99e2f5d6686922101168ccb03dcde7a4dc63cb95cd1"
-    },
-    {
-      "query": 8,
-      "base_seconds": [
-        1.834,
-        0.628,
-        0.562
-      ],
-      "candidate_seconds": [
-        1.398,
-        0.665,
-        0.659
-      ],
-      "base_cpu_seconds": [
-        26.7,
-        9.0,
-        8.5
-      ],
-      "candidate_cpu_seconds": [
-        21.1,
-        9.9,
-        9.6
-      ],
-      "base_hot": 0.562,
-      "candidate_hot": 0.659,
-      "hot_speedup": 0.8528072837632777,
-      "ln_saved": -0.15664506874843048,
-      "output_sha256": "be8bbbcf3956a0506fcf0b1a659a4c67c51b9805bd78b395db8cf1e79a1a64c1"
-    },
-    {
-      "query": 9,
-      "base_seconds": [
-        1.002,
-        0.799,
-        0.653
-      ],
-      "candidate_seconds": [
-        1.023,
-        0.778,
-        0.771
-      ],
-      "base_cpu_seconds": [
-        15.3,
-        11.1,
-        10.2
-      ],
-      "candidate_cpu_seconds": [
-        15.3,
-        11.4,
-        11.7
-      ],
-      "base_hot": 0.653,
-      "candidate_hot": 0.771,
-      "hot_speedup": 0.8469520103761349,
-      "ln_saved": -0.1638001596538235,
-      "output_sha256": "d6ad56d1ec86424944040abf7659bd52c59872ba2a1c0eab527ff361b0ded6c5"
-    },
-    {
-      "query": 10,
-      "base_seconds": [
-        2.258,
-        0.354,
-        0.248
-      ],
-      "candidate_seconds": [
-        1.414,
-        0.365,
-        0.349
-      ],
-      "base_cpu_seconds": [
-        16.1,
-        2.9,
-        1.6
-      ],
-      "candidate_cpu_seconds": [
-        13.9,
-        1.4,
-        2.4
-      ],
-      "base_hot": 0.248,
-      "candidate_hot": 0.349,
-      "hot_speedup": 0.7106017191977078,
-      "ln_saved": -0.3303628035666614,
-      "output_sha256": "371d54beabadf57bace382b5f7ab79169d5e0975ee22250e238458119a52dabf"
-    },
-    {
-      "query": 11,
-      "base_seconds": [
-        1.738,
-        0.247,
-        0.235
-      ],
-      "candidate_seconds": [
-        1.34,
-        0.265,
-        0.242
-      ],
-      "base_cpu_seconds": [
-        17.0,
-        2.1,
-        1.6
-      ],
-      "candidate_cpu_seconds": [
-        17.5,
-        2.1,
-        1.5
-      ],
-      "base_hot": 0.235,
-      "candidate_hot": 0.242,
-      "hot_speedup": 0.9710743801652892,
-      "ln_saved": -0.028170876966696335,
-      "output_sha256": "d13e37dfbf6e4eec136058921b2ac59496c5dd3f261c3e74c01b12692a3993fd"
-    },
-    {
-      "query": 12,
-      "base_seconds": [
-        2.1,
-        0.741,
-        0.737
-      ],
-      "candidate_seconds": [
-        1.758,
-        0.731,
-        0.746
-      ],
-      "base_cpu_seconds": [
-        20.9,
-        9.2,
-        9.2
-      ],
-      "candidate_cpu_seconds": [
-        25.0,
-        9.0,
-        9.0
-      ],
-      "base_hot": 0.737,
-      "candidate_hot": 0.731,
-      "hot_speedup": 1.0082079343365253,
-      "ln_saved": 0.008064559836730495,
-      "output_sha256": "fcc014a2ba3c83d3aabcda329d71337d1fdb82d065776908e10536f2f1e786e7"
-    },
-    {
-      "query": 13,
-      "base_seconds": [
-        3.266,
-        3.157,
-        2.376
-      ],
-      "candidate_seconds": [
-        1.563,
-        1.306,
-        1.271
-      ],
-      "base_cpu_seconds": [
-        31.7,
-        39.0,
-        26.8
-      ],
-      "candidate_cpu_seconds": [
-        19.7,
-        16.4,
-        16.3
-      ],
-      "base_hot": 2.376,
-      "candidate_hot": 1.271,
-      "hot_speedup": 1.8693941778127459,
-      "ln_saved": 0.6219773007611271,
-      "output_sha256": "674be045f937f8fc8504ffbc78c110e1eaa35c23031ec26161184660ebcf3117"
-    },
-    {
-      "query": 14,
-      "base_seconds": [
-        2.191,
-        0.986,
-        0.998
-      ],
-      "candidate_seconds": [
-        2.005,
-        0.807,
-        0.859
-      ],
-      "base_cpu_seconds": [
-        32.7,
-        13.4,
-        14.0
-      ],
-      "candidate_cpu_seconds": [
-        30.8,
-        10.6,
-        11.7
-      ],
-      "base_hot": 0.986,
-      "candidate_hot": 0.807,
-      "hot_speedup": 1.22180916976456,
-      "ln_saved": 0.19810816272459533,
-      "output_sha256": "9d02fdb0bdc35d9fb2e20bdff7c618092614725eac713d1663a4ef7f72a679fc"
-    },
-    {
-      "query": 15,
-      "base_seconds": [
-        0.954,
-        0.422,
-        0.42
-      ],
-      "candidate_seconds": [
-        0.57,
-        0.359,
-        0.448
-      ],
-      "base_cpu_seconds": [
-        16.6,
-        7.8,
-        7.8
-      ],
-      "candidate_cpu_seconds": [
-        9.8,
-        6.8,
-        8.2
-      ],
-      "base_hot": 0.42,
-      "candidate_hot": 0.359,
-      "hot_speedup": 1.16991643454039,
-      "ln_saved": 0.15298856464708083,
-      "output_sha256": "4984ef226b59ff43b5329c22928f051348d3212cafab52a907c1935d7645b0b1"
-    },
-    {
-      "query": 16,
-      "base_seconds": [
-        3.754,
-        2.06,
-        2.087
-      ],
-      "candidate_seconds": [
-        3.937,
-        1.693,
-        1.747
-      ],
-      "base_cpu_seconds": [
-        54.3,
-        28.3,
-        29.0
-      ],
-      "candidate_cpu_seconds": [
-        53.1,
-        21.9,
-        22.9
-      ],
-      "base_hot": 2.06,
-      "candidate_hot": 1.693,
-      "hot_speedup": 1.216774955699941,
-      "ln_saved": 0.19515720559672634,
-      "output_sha256": "9c2cb1d94a1a5e216dfadfbb39b0a69875ab3bd31ee7f219fcb2ea67c917f049"
-    },
-    {
-      "query": 17,
-      "base_seconds": [
-        0.264,
-        0.054,
-        0.064
-      ],
-      "candidate_seconds": [
-        0.271,
-        0.052,
-        0.055
-      ],
-      "base_cpu_seconds": [
-        3.5,
-        0.4,
-        0.4
-      ],
-      "candidate_cpu_seconds": [
-        3.8,
-        0.4,
-        0.3
-      ],
-      "base_hot": 0.054,
-      "candidate_hot": 0.052,
-      "hot_speedup": 1.0384615384615385,
-      "ln_saved": 0.03174869831458027,
-      "output_sha256": "d9f19c41559e311ae37aed66999d0216bbdec7cd510d3eac9761da1d4b4d8792"
-    },
-    {
-      "query": 18,
-      "base_seconds": [
-        7.019,
-        4.121,
-        3.956
-      ],
-      "candidate_seconds": [
-        5.072,
-        3.144,
-        3.116
-      ],
-      "base_cpu_seconds": [
-        104.5,
-        66.5,
-        63.9
-      ],
-      "candidate_cpu_seconds": [
-        78.0,
-        49.0,
-        49.0
-      ],
-      "base_hot": 3.956,
-      "candidate_hot": 3.116,
-      "hot_speedup": 1.269576379974326,
-      "ln_saved": 0.23800379809831929,
-      "output_sha256": "3562c975e7413e13bd61d5dff44397479ad93e032f421b4bbb2c8f4e7b8e59fc"
-    },
-    {
-      "query": 19,
-      "base_seconds": [
-        0.022,
-        0.015,
-        0.015
-      ],
-      "candidate_seconds": [
-        0.032,
-        0.015,
-        0.015
-      ],
-      "base_cpu_seconds": [
-        0.0,
-        0.0,
-        0.0
-      ],
-      "candidate_cpu_seconds": [
-        0.0,
-        0.0,
-        0.0
-      ],
-      "base_hot": 0.015,
-      "candidate_hot": 0.015,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "3250356ef481c5756db99d19a1aff7f72ac21d31da97cee5ec867e2abed33b27"
-    },
-    {
-      "query": 20,
-      "base_seconds": [
-        2.339,
-        0.03,
-        0.03
-      ],
-      "candidate_seconds": [
-        1.629,
-        0.03,
-        0.036
-      ],
-      "base_cpu_seconds": [
-        21.1,
-        0.4,
-        0.4
-      ],
-      "candidate_cpu_seconds": [
-        18.2,
-        0.4,
-        0.4
-      ],
-      "base_hot": 0.03,
-      "candidate_hot": 0.03,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "3561da5045e865e0b4da382b5f882246b0d0f9673d2b6447fdc679b4558fae58"
-    },
-    {
-      "query": 21,
-      "base_seconds": [
-        0.255,
-        0.236,
-        0.139
-      ],
-      "candidate_seconds": [
-        0.22,
-        0.137,
-        0.124
-      ],
-      "base_cpu_seconds": [
-        2.8,
-        2.8,
-        1.2
-      ],
-      "candidate_cpu_seconds": [
-        1.3,
-        1.1,
-        1.1
-      ],
-      "base_hot": 0.139,
-      "candidate_hot": 0.124,
-      "hot_speedup": 1.120967741935484,
-      "ln_saved": 0.10610650599454777,
-      "output_sha256": "a6569917873542718e52cec662b1fad8dd035e904362abd7287770879423894f"
-    },
-    {
-      "query": 22,
-      "base_seconds": [
-        5.989,
-        0.36,
-        0.344
-      ],
-      "candidate_seconds": [
-        5.29,
-        0.315,
-        0.302
-      ],
-      "base_cpu_seconds": [
-        23.4,
-        2.7,
-        2.7
-      ],
-      "candidate_cpu_seconds": [
-        24.0,
-        2.7,
-        2.6
-      ],
-      "base_hot": 0.344,
-      "candidate_hot": 0.302,
-      "hot_speedup": 1.1390728476821192,
-      "ln_saved": 0.12629372532429206,
-      "output_sha256": "c6972e15129b9cd0ba18263b3206a8a1734a9b97c7864c7722d3018145558fe8"
-    },
-    {
-      "query": 23,
-      "base_seconds": [
-        0.655,
-        0.137,
-        0.123
-      ],
-      "candidate_seconds": [
-        0.5,
-        0.133,
-        0.124
-      ],
-      "base_cpu_seconds": [
-        3.3,
-        0.4,
-        0.4
-      ],
-      "candidate_cpu_seconds": [
-        4.1,
-        0.4,
-        0.4
-      ],
-      "base_hot": 0.123,
-      "candidate_hot": 0.124,
-      "hot_speedup": 0.9919354838709677,
-      "ln_saved": -0.007490671729157626,
-      "output_sha256": "e3cd36c66ebf0a0d9611657bb32fc15b2f96487222160422fd25b139faa2dad1"
-    },
-    {
-      "query": 24,
-      "base_seconds": [
-        0.092,
-        0.022,
-        0.02
-      ],
-      "candidate_seconds": [
-        0.074,
-        0.018,
-        0.022
-      ],
-      "base_cpu_seconds": [
-        0.2,
-        0.0,
-        0.0
-      ],
-      "candidate_cpu_seconds": [
-        0.2,
-        0.0,
-        0.1
-      ],
-      "base_hot": 0.02,
-      "candidate_hot": 0.018,
-      "hot_speedup": 1.1111111111111112,
-      "ln_saved": 0.06899287148695142,
-      "output_sha256": "04ac5dddc732db72b94072eaad307d529300609e466fd2ece4fb6dac4327ae3b"
-    },
-    {
-      "query": 25,
-      "base_seconds": [
-        0.4,
-        0.214,
-        0.118
-      ],
-      "candidate_seconds": [
-        0.25,
-        0.17,
-        0.272
-      ],
-      "base_cpu_seconds": [
-        3.2,
-        2.6,
-        1.3
-      ],
-      "candidate_cpu_seconds": [
-        2.2,
-        1.8,
-        3.5
-      ],
-      "base_hot": 0.118,
-      "candidate_hot": 0.17,
-      "hot_speedup": 0.6941176470588234,
-      "ln_saved": -0.3409265869705933,
-      "output_sha256": "ecef47964fa651c24162085870df6dd047ca411dbafb5c0d40372318154474b2"
-    },
-    {
-      "query": 26,
-      "base_seconds": [
-        0.047,
-        0.02,
-        0.02
-      ],
-      "candidate_seconds": [
-        0.043,
-        0.02,
-        0.02
-      ],
-      "base_cpu_seconds": [
-        0.3,
-        0.1,
-        0.1
-      ],
-      "candidate_cpu_seconds": [
-        0.3,
-        0.0,
-        0.1
-      ],
-      "base_hot": 0.02,
-      "candidate_hot": 0.02,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "d5e5ad30fb7e79c7ea91bffc9971393d4a493951ee7dd11577e60810f8b59308"
-    },
-    {
-      "query": 27,
-      "base_seconds": [
-        1.428,
-        0.216,
-        0.217
-      ],
-      "candidate_seconds": [
-        1.396,
-        0.25,
-        0.235
-      ],
-      "base_cpu_seconds": [
-        22.0,
-        3.8,
-        4.0
-      ],
-      "candidate_cpu_seconds": [
-        23.7,
-        4.6,
-        4.5
-      ],
-      "base_hot": 0.216,
-      "candidate_hot": 0.235,
-      "hot_speedup": 0.9191489361702128,
-      "ln_saved": -0.08072321127244103,
-      "output_sha256": "2cb6b1ea1025878822b0b4cf52d32da45c5bc458921e9ed9ca80bbf808a80e9d"
-    },
-    {
-      "query": 28,
-      "base_seconds": [
-        12.499,
-        9.089,
-        8.867
-      ],
-      "candidate_seconds": [
-        11.577,
-        8.865,
-        8.864
-      ],
-      "base_cpu_seconds": [
-        118.4,
-        82.7,
-        77.7
-      ],
-      "candidate_cpu_seconds": [
-        111.2,
-        80.0,
-        77.4
-      ],
-      "base_hot": 8.867,
-      "candidate_hot": 8.864,
-      "hot_speedup": 1.0003384476534296,
-      "ln_saved": 0.0003380091294644796,
-      "output_sha256": "e66d2ca783d9b31ea45cc94f7f3aae773a04d008458932a864da15441f82fdff"
-    },
-    {
-      "query": 29,
-      "base_seconds": [
-        0.2,
-        0.035,
-        0.033
-      ],
-      "candidate_seconds": [
-        0.141,
-        0.037,
-        0.035
-      ],
-      "base_cpu_seconds": [
-        1.7,
-        0.3,
-        0.3
-      ],
-      "candidate_cpu_seconds": [
-        1.1,
-        0.3,
-        0.3
-      ],
-      "base_hot": 0.033,
-      "candidate_hot": 0.035,
-      "hot_speedup": 0.9428571428571428,
-      "ln_saved": -0.0454623740767574,
-      "output_sha256": "07030719e298cb26685c7587ce7cd73028f78521afa4a33b2cbcb5acfbc61259"
-    },
-    {
-      "query": 30,
-      "base_seconds": [
-        2.176,
-        0.539,
-        0.54
-      ],
-      "candidate_seconds": [
-        2.077,
-        0.348,
-        0.345
-      ],
-      "base_cpu_seconds": [
-        28.7,
-        9.2,
-        9.2
-      ],
-      "candidate_cpu_seconds": [
-        33.0,
-        6.2,
-        6.0
-      ],
-      "base_hot": 0.539,
-      "candidate_hot": 0.345,
-      "hot_speedup": 1.5623188405797104,
-      "ln_saved": 0.43598065203411496,
-      "output_sha256": "bcb3b6bf0903e37a66d537aacd06a689154790914bba4677d4b687271b5d3e40"
-    },
-    {
-      "query": 31,
-      "base_seconds": [
-        2.728,
-        1.645,
-        1.5
-      ],
-      "candidate_seconds": [
-        1.102,
-        1.146,
-        0.901
-      ],
-      "base_cpu_seconds": [
-        24.5,
-        26.8,
-        25.8
-      ],
-      "candidate_cpu_seconds": [
-        15.6,
-        16.4,
-        15.2
-      ],
-      "base_hot": 1.5,
-      "candidate_hot": 0.901,
-      "hot_speedup": 1.664816870144284,
-      "ln_saved": 0.5053220325490116,
-      "output_sha256": "3ed0b1ffb37fc60c0ea514df3b682a773d2fe8d853bbf249c718b06ceb75534a"
-    },
-    {
-      "query": 32,
-      "base_seconds": [
-        8.834,
-        6.811,
-        6.798
-      ],
-      "candidate_seconds": [
-        5.204,
-        4.179,
-        4.182
-      ],
-      "base_cpu_seconds": [
-        152.5,
-        126.3,
-        126.9
-      ],
-      "candidate_cpu_seconds": [
-        89.1,
-        77.6,
-        77.9
-      ],
-      "base_hot": 6.798,
-      "candidate_hot": 4.179,
-      "hot_speedup": 1.626704953338119,
-      "ln_saved": 0.4856363493061751,
-      "output_sha256": "adf4de00a0078c7868f0cfb32eb0909dcd0c9b971c6eb93097adf08bf2e466e9"
-    },
-    {
-      "query": 33,
-      "base_seconds": [
-        3.364,
-        2.365,
-        2.3
-      ],
-      "candidate_seconds": [
-        2.481,
-        2.203,
-        2.157
-      ],
-      "base_cpu_seconds": [
-        41.4,
-        31.8,
-        31.4
-      ],
-      "candidate_cpu_seconds": [
-        33.8,
-        30.3,
-        29.2
-      ],
-      "base_hot": 2.3,
-      "candidate_hot": 2.157,
-      "hot_speedup": 1.0662957811775613,
-      "ln_saved": 0.06390380197948005,
-      "output_sha256": "1625b2743dcb650f344dfcf296045d2db75387d94891bc9211a674f44f576bc9"
-    },
-    {
-      "query": 34,
-      "base_seconds": [
-        2.254,
-        2.242,
-        2.229
-      ],
-      "candidate_seconds": [
-        2.169,
-        2.126,
-        2.124
-      ],
-      "base_cpu_seconds": [
-        31.1,
-        30.8,
-        30.6
-      ],
-      "candidate_cpu_seconds": [
-        29.1,
-        29.0,
-        29.0
-      ],
-      "base_hot": 2.229,
-      "candidate_hot": 2.124,
-      "hot_speedup": 1.0494350282485876,
-      "ln_saved": 0.04803118473705606,
-      "output_sha256": "a5aab2614aafe82b7ca4623a9e08e2bb7096334e7e5e1855b84b15d087a45bb9"
-    },
-    {
-      "query": 35,
-      "base_seconds": [
-        0.498,
-        0.39,
-        0.388
-      ],
-      "candidate_seconds": [
-        0.64,
-        0.339,
-        0.343
-      ],
-      "base_cpu_seconds": [
-        9.3,
-        7.3,
-        7.2
-      ],
-      "candidate_cpu_seconds": [
-        12.1,
-        6.4,
-        6.5
-      ],
-      "base_hot": 0.388,
-      "candidate_hot": 0.339,
-      "hot_speedup": 1.1445427728613569,
-      "ln_saved": 0.1313800830820105,
-      "output_sha256": "55995b79571d8b725d8784700db64d46fce8f5bcee26120314e993f60e329e18"
-    },
-    {
-      "query": 36,
-      "base_seconds": [
-        0.252,
-        0.105,
-        0.06
-      ],
-      "candidate_seconds": [
-        0.337,
-        0.066,
-        0.064
-      ],
-      "base_cpu_seconds": [
-        1.9,
-        1.2,
-        0.3
-      ],
-      "candidate_cpu_seconds": [
-        3.3,
-        0.4,
-        0.3
-      ],
-      "base_hot": 0.06,
-      "candidate_hot": 0.064,
-      "hot_speedup": 0.9375,
-      "ln_saved": -0.055569851154810765,
-      "output_sha256": "5d21847795a6e050a5dce7647ce872bcb53714624b12a304f6398def4b1a89ce"
-    },
-    {
-      "query": 37,
-      "base_seconds": [
-        0.615,
-        0.05,
-        0.048
-      ],
-      "candidate_seconds": [
-        0.328,
-        0.045,
-        0.041
-      ],
-      "base_cpu_seconds": [
-        2.8,
-        0.3,
-        0.3
-      ],
-      "candidate_cpu_seconds": [
-        2.4,
-        0.3,
-        0.2
-      ],
-      "base_hot": 0.048,
-      "candidate_hot": 0.041,
-      "hot_speedup": 1.170731707317073,
-      "ln_saved": 0.12861737782209354,
-      "output_sha256": "c8703a4b5282c1d6d749ad70d6c319cf95405ca509cc0cc96ab0c543ba34a8fc"
-    },
-    {
-      "query": 38,
-      "base_seconds": [
-        0.445,
-        0.042,
-        0.04
-      ],
-      "candidate_seconds": [
-        0.249,
-        0.04,
-        0.044
-      ],
-      "base_cpu_seconds": [
-        3.4,
-        0.3,
-        0.3
-      ],
-      "candidate_cpu_seconds": [
-        1.9,
-        0.3,
-        0.3
-      ],
-      "base_hot": 0.04,
-      "candidate_hot": 0.04,
-      "hot_speedup": 1.0,
-      "ln_saved": 0.0,
-      "output_sha256": "8fb648551c53248efb46b4cbaa595c3d955e691afd652c36fd02e11c26eeb2ea"
-    },
-    {
-      "query": 39,
-      "base_seconds": [
-        0.488,
-        0.319,
-        0.264
-      ],
-      "candidate_seconds": [
-        0.512,
-        0.405,
-        0.401
-      ],
-      "base_cpu_seconds": [
-        5.0,
-        2.8,
-        2.3
-      ],
-      "candidate_cpu_seconds": [
-        5.3,
-        4.8,
-        4.6
-      ],
-      "base_hot": 0.264,
-      "candidate_hot": 0.401,
-      "hot_speedup": 0.6583541147132169,
-      "ln_saved": -0.40546510810816444,
-      "output_sha256": "8aca19fe3c2403c22c8baf14a7a7ad8b1e482bb358499f4ce30ceeaace0e6a0a"
-    },
-    {
-      "query": 40,
-      "base_seconds": [
-        0.128,
-        0.03,
-        0.039
-      ],
-      "candidate_seconds": [
-        0.107,
-        0.033,
-        0.022
-      ],
-      "base_cpu_seconds": [
-        0.5,
-        0.2,
-        0.2
-      ],
-      "candidate_cpu_seconds": [
-        0.4,
-        0.2,
-        0.1
-      ],
-      "base_hot": 0.03,
-      "candidate_hot": 0.022,
-      "hot_speedup": 1.3636363636363638,
-      "ln_saved": 0.22314355131420976,
-      "output_sha256": "e2f8ca91287f21045242639aa04f53f4edab349e07e6f24f4bd841decd81ce57"
-    },
-    {
-      "query": 41,
-      "base_seconds": [
-        0.088,
-        0.044,
-        0.044
-      ],
-      "candidate_seconds": [
-        0.077,
-        0.044,
-        0.036
-      ],
-      "base_cpu_seconds": [
-        0.3,
-        0.2,
-        0.2
-      ],
-      "candidate_cpu_seconds": [
-        0.3,
-        0.2,
-        0.2
-      ],
-      "base_hot": 0.044,
-      "candidate_hot": 0.036,
-      "hot_speedup": 1.2222222222222223,
-      "ln_saved": 0.16034265007517948,
-      "output_sha256": "66902b46c180a393cdb87a05e10082eb3c6fb5d8d6ef5b79b694c6d5f0e0fd06"
-    },
-    {
-      "query": 42,
-      "base_seconds": [
-        0.317,
-        0.053,
-        0.044
-      ],
-      "candidate_seconds": [
-        0.216,
-        0.047,
-        0.043
-      ],
-      "base_cpu_seconds": [
-        3.4,
-        0.2,
-        0.3
-      ],
-      "candidate_cpu_seconds": [
-        2.0,
-        0.4,
-        0.4
-      ],
-      "base_hot": 0.044,
-      "candidate_hot": 0.043,
-      "hot_speedup": 1.0232558139534884,
-      "ln_saved": 0.018692133012152546,
-      "output_sha256": "852d75893a0be63de0156646ff76340114540de4b390e64e2e9997eea6819a76"
+      "base": "aa4d81d547fb0e2353ede959786d6e8ba442edf2",
+      "candidate_head": "b3d34899b0320d35bcd166c0017d09c6c9a35e16",
+      "candidate_worktree_diff_sha256": "b6eff370a6765945421c4b2a7e3326f28eb06caffa5045d307e37e921bfb7bd4",
+      "java": "/home/johannes/.sdkman/candidates/java/25.0.3-graal/bin/java",
+      "flags": [
+        "--add-opens",
+        "java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens",
+        "java.base/java.nio=ALL-UNNAMED",
+        "--add-modules",
+        "jdk.incubator.vector",
+        "--enable-native-access=ALL-UNNAMED",
+        "--enable-preview",
+        "-XX:+UnlockExperimentalVMOptions",
+        "-XX:-UseJVMCICompiler",
+        "-Xms6g",
+        "-Xmx14g",
+        "-Dsirix.projection.eagerMaterializeBytes=5368709120",
+        "-Dsirix.offheap.bytes=10737418240",
+        "-Dsirix.query.autoVectorize=true",
+        "-Dsirix.chunkedBody.enable=true",
+        "-Dsirix.chunkedBody.targetChunkBytes=16384"
+      ],
+      "artifacts": {
+        "baseline_query_classes_sha256": "46d6b56c795a9a0e04345e0b940479a417284e4eef6a0fd97ec24d72d5e45ccb",
+        "baseline_core_jar_sha256": "8058e6c681fb14cd423833023359ebed27cb57c3fc37100fe7b853e5079551f4",
+        "candidate_query_classes_sha256": "c67c13eb6c50a5ae30fada549acc7b098c3b6237d3418dfa2d2a681ae86d071c",
+        "candidate_core_jar_sha256": "e340e07dfa7dc8af4765c115155ddf152d6688c354daf585886551d2cf031ddb"
+      },
+      "lock_acquired": "2026-09-08T03:34:22.861681+00:00",
+      "lock_released": "2026-09-08T03:39:26.704902+00:00",
+      "label": "exclusive3",
+      "status": "provisional",
+      "runs": [
+        {
+          "label": "base",
+          "start": "2026-09-08T03:34:22.871907+00:00",
+          "pid": 652933,
+          "exit": 0,
+          "end": "2026-09-08T03:37:03.079746+00:00"
+        },
+        {
+          "label": "candidate",
+          "start": "2026-09-08T03:37:03.095033+00:00",
+          "pid": 661670,
+          "exit": 0,
+          "end": "2026-09-08T03:39:26.701447+00:00"
+        }
+      ],
+      "queries": [
+        {
+          "query": 0,
+          "output_sha256": "6274012ba71547fe2fc1d4a5fe09989ceb1568002642e429d13aca0e4de29324",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.041,
+            0.001,
+            0.001
+          ],
+          "base_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.051,
+            0.001,
+            0.001
+          ],
+          "candidate_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "query": 1,
+          "output_sha256": "df271e2c68e1217c6218272ef6f3ed42574e60d6e137250523d3e7e72eacf2aa",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.36,
+            0.028,
+            0.033
+          ],
+          "base_cpu_seconds": [
+            4.4,
+            0.2,
+            0.2
+          ],
+          "candidate_wall_seconds": [
+            0.363,
+            0.046,
+            0.034
+          ],
+          "candidate_cpu_seconds": [
+            4.8,
+            0.4,
+            0.3
+          ]
+        },
+        {
+          "query": 2,
+          "output_sha256": "68d6acd8c4d6cb65ab89b275d8ff5db9e4edd064be63a642efaec968c2a51fcd",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.285,
+            0.055,
+            0.037
+          ],
+          "base_cpu_seconds": [
+            3.6,
+            0.6,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.318,
+            0.051,
+            0.039
+          ],
+          "candidate_cpu_seconds": [
+            3.8,
+            0.6,
+            0.4
+          ]
+        },
+        {
+          "query": 3,
+          "output_sha256": "56339714bc6ff65c968dec28d1847178d77ac735028e922f85fb6902b7790a9b",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.464,
+            0.106,
+            0.025
+          ],
+          "base_cpu_seconds": [
+            6.6,
+            1.8,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.704,
+            0.124,
+            0.031
+          ],
+          "candidate_cpu_seconds": [
+            6.6,
+            2.1,
+            0.4
+          ]
+        },
+        {
+          "query": 4,
+          "output_sha256": "2b756178cde1d94167b4ae6e4d24f9d20e73a7eddeef6d126b9326c709eb3f69",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.341,
+            0.434,
+            0.31
+          ],
+          "base_cpu_seconds": [
+            4.6,
+            5.9,
+            3.7
+          ],
+          "candidate_wall_seconds": [
+            0.355,
+            0.439,
+            0.32
+          ],
+          "candidate_cpu_seconds": [
+            4.8,
+            6.1,
+            4.0
+          ]
+        },
+        {
+          "query": 5,
+          "output_sha256": "34cdf1a69e01fc9438d5ae22fb8639ebc9f681249be45a214cf7392761624be2",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.984,
+            0.659,
+            0.579
+          ],
+          "base_cpu_seconds": [
+            25.5,
+            6.3,
+            6.0
+          ],
+          "candidate_wall_seconds": [
+            2.629,
+            0.89,
+            0.671
+          ],
+          "candidate_cpu_seconds": [
+            35.0,
+            9.6,
+            6.9
+          ]
+        },
+        {
+          "query": 6,
+          "output_sha256": "925d081ee74c49651addbd4a935e6b8eab9bd80ae8129ce0345b0304fd7cba2c",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.054,
+            0.029,
+            0.025
+          ],
+          "base_cpu_seconds": [
+            0.3,
+            0.1,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.057,
+            0.032,
+            0.03
+          ],
+          "candidate_cpu_seconds": [
+            0.3,
+            0.2,
+            0.1
+          ]
+        },
+        {
+          "query": 7,
+          "output_sha256": "7826e1bf67eaee52ede7f99e2f5d6686922101168ccb03dcde7a4dc63cb95cd1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.228,
+            0.103,
+            0.106
+          ],
+          "base_cpu_seconds": [
+            2.0,
+            1.0,
+            1.1
+          ],
+          "candidate_wall_seconds": [
+            0.274,
+            0.038,
+            0.02
+          ],
+          "candidate_cpu_seconds": [
+            2.6,
+            0.4,
+            0.2
+          ]
+        },
+        {
+          "query": 8,
+          "output_sha256": "be8bbbcf3956a0506fcf0b1a659a4c67c51b9805bd78b395db8cf1e79a1a64c1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.499,
+            0.608,
+            0.599
+          ],
+          "base_cpu_seconds": [
+            22.8,
+            9.2,
+            8.7
+          ],
+          "candidate_wall_seconds": [
+            1.404,
+            0.659,
+            0.673
+          ],
+          "candidate_cpu_seconds": [
+            21.1,
+            9.8,
+            9.6
+          ]
+        },
+        {
+          "query": 9,
+          "output_sha256": "d6ad56d1ec86424944040abf7659bd52c59872ba2a1c0eab527ff361b0ded6c5",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.05,
+            0.736,
+            0.665
+          ],
+          "base_cpu_seconds": [
+            15.2,
+            10.8,
+            10.2
+          ],
+          "candidate_wall_seconds": [
+            1.032,
+            0.784,
+            0.763
+          ],
+          "candidate_cpu_seconds": [
+            15.4,
+            11.3,
+            11.5
+          ]
+        },
+        {
+          "query": 10,
+          "output_sha256": "371d54beabadf57bace382b5f7ab79169d5e0975ee22250e238458119a52dabf",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.447,
+            0.415,
+            0.251
+          ],
+          "base_cpu_seconds": [
+            15.1,
+            3.2,
+            1.8
+          ],
+          "candidate_wall_seconds": [
+            1.272,
+            0.362,
+            0.316
+          ],
+          "candidate_cpu_seconds": [
+            14.6,
+            3.3,
+            2.4
+          ]
+        },
+        {
+          "query": 11,
+          "output_sha256": "d13e37dfbf6e4eec136058921b2ac59496c5dd3f261c3e74c01b12692a3993fd",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.321,
+            0.26,
+            0.239
+          ],
+          "base_cpu_seconds": [
+            17.4,
+            2.0,
+            1.6
+          ],
+          "candidate_wall_seconds": [
+            1.35,
+            0.27,
+            0.22
+          ],
+          "candidate_cpu_seconds": [
+            18.4,
+            2.0,
+            1.4
+          ]
+        },
+        {
+          "query": 12,
+          "output_sha256": "fcc014a2ba3c83d3aabcda329d71337d1fdb82d065776908e10536f2f1e786e7",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.657,
+            0.712,
+            0.749
+          ],
+          "base_cpu_seconds": [
+            20.9,
+            9.1,
+            9.2
+          ],
+          "candidate_wall_seconds": [
+            2.381,
+            0.77,
+            0.779
+          ],
+          "candidate_cpu_seconds": [
+            34.1,
+            9.8,
+            9.9
+          ]
+        },
+        {
+          "query": 13,
+          "output_sha256": "674be045f937f8fc8504ffbc78c110e1eaa35c23031ec26161184660ebcf3117",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.7,
+            2.609,
+            3.028
+          ],
+          "base_cpu_seconds": [
+            30.5,
+            30.3,
+            34.8
+          ],
+          "candidate_wall_seconds": [
+            2.198,
+            1.367,
+            1.366
+          ],
+          "candidate_cpu_seconds": [
+            32.2,
+            18.1,
+            17.2
+          ]
+        },
+        {
+          "query": 14,
+          "output_sha256": "9d02fdb0bdc35d9fb2e20bdff7c618092614725eac713d1663a4ef7f72a679fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.063,
+            1.108,
+            0.889
+          ],
+          "base_cpu_seconds": [
+            31.0,
+            15.7,
+            12.2
+          ],
+          "candidate_wall_seconds": [
+            2.278,
+            1.04,
+            0.836
+          ],
+          "candidate_cpu_seconds": [
+            35.0,
+            14.7,
+            11.1
+          ]
+        },
+        {
+          "query": 15,
+          "output_sha256": "4984ef226b59ff43b5329c22928f051348d3212cafab52a907c1935d7645b0b1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.984,
+            0.418,
+            0.421
+          ],
+          "base_cpu_seconds": [
+            17.6,
+            7.9,
+            8.1
+          ],
+          "candidate_wall_seconds": [
+            1.084,
+            0.434,
+            0.442
+          ],
+          "candidate_cpu_seconds": [
+            19.1,
+            8.4,
+            8.3
+          ]
+        },
+        {
+          "query": 16,
+          "output_sha256": "9c2cb1d94a1a5e216dfadfbb39b0a69875ab3bd31ee7f219fcb2ea67c917f049",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            4.204,
+            2.082,
+            2.081
+          ],
+          "base_cpu_seconds": [
+            61.9,
+            29.2,
+            28.4
+          ],
+          "candidate_wall_seconds": [
+            2.964,
+            1.848,
+            1.737
+          ],
+          "candidate_cpu_seconds": [
+            41.0,
+            24.1,
+            22.5
+          ]
+        },
+        {
+          "query": 17,
+          "output_sha256": "d9f19c41559e311ae37aed66999d0216bbdec7cd510d3eac9761da1d4b4d8792",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.236,
+            0.048,
+            0.065
+          ],
+          "base_cpu_seconds": [
+            3.3,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.235,
+            0.046,
+            0.049
+          ],
+          "candidate_cpu_seconds": [
+            3.4,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 18,
+          "output_sha256": "3562c975e7413e13bd61d5dff44397479ad93e032f421b4bbb2c8f4e7b8e59fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            7.437,
+            3.981,
+            3.854
+          ],
+          "base_cpu_seconds": [
+            114.9,
+            63.8,
+            62.7
+          ],
+          "candidate_wall_seconds": [
+            5.173,
+            3.387,
+            3.14
+          ],
+          "candidate_cpu_seconds": [
+            81.1,
+            52.2,
+            50.1
+          ]
+        },
+        {
+          "query": 19,
+          "output_sha256": "3250356ef481c5756db99d19a1aff7f72ac21d31da97cee5ec867e2abed33b27",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.032,
+            0.017,
+            0.015
+          ],
+          "base_cpu_seconds": [
+            0.0,
+            0.0,
+            0.0
+          ],
+          "candidate_wall_seconds": [
+            0.038,
+            0.017,
+            0.016
+          ],
+          "candidate_cpu_seconds": [
+            0.1,
+            0.0,
+            0.0
+          ]
+        },
+        {
+          "query": 20,
+          "output_sha256": "3561da5045e865e0b4da382b5f882246b0d0f9673d2b6447fdc679b4558fae58",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.848,
+            0.048,
+            0.038
+          ],
+          "base_cpu_seconds": [
+            31.2,
+            0.7,
+            0.7
+          ],
+          "candidate_wall_seconds": [
+            1.681,
+            0.025,
+            0.02
+          ],
+          "candidate_cpu_seconds": [
+            18.6,
+            0.4,
+            0.3
+          ]
+        },
+        {
+          "query": 21,
+          "output_sha256": "a6569917873542718e52cec662b1fad8dd035e904362abd7287770879423894f",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.345,
+            0.232,
+            0.205
+          ],
+          "base_cpu_seconds": [
+            4.2,
+            2.8,
+            2.8
+          ],
+          "candidate_wall_seconds": [
+            0.228,
+            0.147,
+            0.105
+          ],
+          "candidate_cpu_seconds": [
+            1.3,
+            1.3,
+            1.0
+          ]
+        },
+        {
+          "query": 22,
+          "output_sha256": "c6972e15129b9cd0ba18263b3206a8a1734a9b97c7864c7722d3018145558fe8",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            5.921,
+            0.418,
+            0.411
+          ],
+          "base_cpu_seconds": [
+            26.3,
+            3.6,
+            3.9
+          ],
+          "candidate_wall_seconds": [
+            5.476,
+            0.455,
+            0.303
+          ],
+          "candidate_cpu_seconds": [
+            26.7,
+            4.2,
+            2.4
+          ]
+        },
+        {
+          "query": 23,
+          "output_sha256": "e3cd36c66ebf0a0d9611657bb32fc15b2f96487222160422fd25b139faa2dad1",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.595,
+            0.135,
+            0.242
+          ],
+          "base_cpu_seconds": [
+            3.6,
+            0.4,
+            2.0
+          ],
+          "candidate_wall_seconds": [
+            0.513,
+            0.135,
+            0.132
+          ],
+          "candidate_cpu_seconds": [
+            3.9,
+            0.4,
+            0.4
+          ]
+        },
+        {
+          "query": 24,
+          "output_sha256": "04ac5dddc732db72b94072eaad307d529300609e466fd2ece4fb6dac4327ae3b",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.101,
+            0.021,
+            0.02
+          ],
+          "base_cpu_seconds": [
+            0.2,
+            0.0,
+            0.1
+          ],
+          "candidate_wall_seconds": [
+            0.081,
+            0.022,
+            0.021
+          ],
+          "candidate_cpu_seconds": [
+            0.2,
+            0.1,
+            0.1
+          ]
+        },
+        {
+          "query": 25,
+          "output_sha256": "ecef47964fa651c24162085870df6dd047ca411dbafb5c0d40372318154474b2",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.378,
+            0.151,
+            0.148
+          ],
+          "base_cpu_seconds": [
+            3.1,
+            1.3,
+            1.5
+          ],
+          "candidate_wall_seconds": [
+            0.343,
+            0.11,
+            0.187
+          ],
+          "candidate_cpu_seconds": [
+            3.2,
+            0.7,
+            1.9
+          ]
+        },
+        {
+          "query": 26,
+          "output_sha256": "d5e5ad30fb7e79c7ea91bffc9971393d4a493951ee7dd11577e60810f8b59308",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.041,
+            0.021,
+            0.022
+          ],
+          "base_cpu_seconds": [
+            0.1,
+            0.1,
+            0.1
+          ],
+          "candidate_wall_seconds": [
+            0.044,
+            0.025,
+            0.027
+          ],
+          "candidate_cpu_seconds": [
+            0.3,
+            0.2,
+            0.2
+          ]
+        },
+        {
+          "query": 27,
+          "output_sha256": "2cb6b1ea1025878822b0b4cf52d32da45c5bc458921e9ed9ca80bbf808a80e9d",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            1.529,
+            0.228,
+            0.2
+          ],
+          "base_cpu_seconds": [
+            25.6,
+            3.6,
+            3.6
+          ],
+          "candidate_wall_seconds": [
+            1.442,
+            0.236,
+            0.229
+          ],
+          "candidate_cpu_seconds": [
+            24.4,
+            4.4,
+            4.4
+          ]
+        },
+        {
+          "query": 28,
+          "output_sha256": "e66d2ca783d9b31ea45cc94f7f3aae773a04d008458932a864da15441f82fdff",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            11.914,
+            9.093,
+            9.096
+          ],
+          "base_cpu_seconds": [
+            114.7,
+            79.1,
+            77.8
+          ],
+          "candidate_wall_seconds": [
+            12.504,
+            9.031,
+            8.726
+          ],
+          "candidate_cpu_seconds": [
+            118.1,
+            79.6,
+            76.6
+          ]
+        },
+        {
+          "query": 29,
+          "output_sha256": "07030719e298cb26685c7587ce7cd73028f78521afa4a33b2cbcb5acfbc61259",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.183,
+            0.033,
+            0.034
+          ],
+          "base_cpu_seconds": [
+            1.2,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.163,
+            0.033,
+            0.03
+          ],
+          "candidate_cpu_seconds": [
+            1.3,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 30,
+          "output_sha256": "bcb3b6bf0903e37a66d537aacd06a689154790914bba4677d4b687271b5d3e40",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.403,
+            0.547,
+            0.546
+          ],
+          "base_cpu_seconds": [
+            34.0,
+            9.1,
+            9.3
+          ],
+          "candidate_wall_seconds": [
+            1.949,
+            0.339,
+            0.348
+          ],
+          "candidate_cpu_seconds": [
+            26.3,
+            5.9,
+            6.1
+          ]
+        },
+        {
+          "query": 31,
+          "output_sha256": "3ed0b1ffb37fc60c0ea514df3b682a773d2fe8d853bbf249c718b06ceb75534a",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.282,
+            1.548,
+            1.528
+          ],
+          "base_cpu_seconds": [
+            24.9,
+            26.1,
+            26.5
+          ],
+          "candidate_wall_seconds": [
+            1.909,
+            1.949,
+            1.043
+          ],
+          "candidate_cpu_seconds": [
+            16.5,
+            15.2,
+            15.4
+          ]
+        },
+        {
+          "query": 32,
+          "output_sha256": "adf4de00a0078c7868f0cfb32eb0909dcd0c9b971c6eb93097adf08bf2e466e9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            8.776,
+            6.755,
+            6.712
+          ],
+          "base_cpu_seconds": [
+            150.3,
+            124.9,
+            125.4
+          ],
+          "candidate_wall_seconds": [
+            5.985,
+            4.186,
+            4.156
+          ],
+          "candidate_cpu_seconds": [
+            91.9,
+            78.4,
+            78.0
+          ]
+        },
+        {
+          "query": 33,
+          "output_sha256": "1625b2743dcb650f344dfcf296045d2db75387d94891bc9211a674f44f576bc9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.811,
+            2.335,
+            2.274
+          ],
+          "base_cpu_seconds": [
+            37.3,
+            31.8,
+            31.2
+          ],
+          "candidate_wall_seconds": [
+            2.859,
+            2.435,
+            2.301
+          ],
+          "candidate_cpu_seconds": [
+            38.3,
+            33.0,
+            31.9
+          ]
+        },
+        {
+          "query": 34,
+          "output_sha256": "a5aab2614aafe82b7ca4623a9e08e2bb7096334e7e5e1855b84b15d087a45bb9",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            2.215,
+            2.233,
+            2.229
+          ],
+          "base_cpu_seconds": [
+            30.8,
+            30.5,
+            30.3
+          ],
+          "candidate_wall_seconds": [
+            2.288,
+            2.262,
+            2.344
+          ],
+          "candidate_cpu_seconds": [
+            31.7,
+            31.1,
+            32.2
+          ]
+        },
+        {
+          "query": 35,
+          "output_sha256": "55995b79571d8b725d8784700db64d46fce8f5bcee26120314e993f60e329e18",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.727,
+            0.393,
+            0.392
+          ],
+          "base_cpu_seconds": [
+            14.0,
+            7.4,
+            7.1
+          ],
+          "candidate_wall_seconds": [
+            0.743,
+            0.497,
+            0.509
+          ],
+          "candidate_cpu_seconds": [
+            12.3,
+            8.5,
+            8.5
+          ]
+        },
+        {
+          "query": 36,
+          "output_sha256": "5d21847795a6e050a5dce7647ce872bcb53714624b12a304f6398def4b1a89ce",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.263,
+            0.07,
+            0.063
+          ],
+          "base_cpu_seconds": [
+            1.8,
+            0.4,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.358,
+            0.121,
+            0.088
+          ],
+          "candidate_cpu_seconds": [
+            2.5,
+            1.0,
+            0.4
+          ]
+        },
+        {
+          "query": 37,
+          "output_sha256": "c8703a4b5282c1d6d749ad70d6c319cf95405ca509cc0cc96ab0c543ba34a8fc",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.441,
+            0.05,
+            0.05
+          ],
+          "base_cpu_seconds": [
+            2.1,
+            0.3,
+            0.3
+          ],
+          "candidate_wall_seconds": [
+            0.514,
+            0.071,
+            0.07
+          ],
+          "candidate_cpu_seconds": [
+            2.3,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 38,
+          "output_sha256": "8fb648551c53248efb46b4cbaa595c3d955e691afd652c36fd02e11c26eeb2ea",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.352,
+            0.051,
+            0.049
+          ],
+          "base_cpu_seconds": [
+            2.9,
+            0.3,
+            0.4
+          ],
+          "candidate_wall_seconds": [
+            0.273,
+            0.046,
+            0.043
+          ],
+          "candidate_cpu_seconds": [
+            2.0,
+            0.3,
+            0.3
+          ]
+        },
+        {
+          "query": 39,
+          "output_sha256": "8aca19fe3c2403c22c8baf14a7a7ad8b1e482bb358499f4ce30ceeaace0e6a0a",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.662,
+            0.282,
+            0.292
+          ],
+          "base_cpu_seconds": [
+            6.8,
+            2.8,
+            2.8
+          ],
+          "candidate_wall_seconds": [
+            0.634,
+            0.513,
+            0.321
+          ],
+          "candidate_cpu_seconds": [
+            6.7,
+            6.9,
+            3.4
+          ]
+        },
+        {
+          "query": 40,
+          "output_sha256": "e2f8ca91287f21045242639aa04f53f4edab349e07e6f24f4bd841decd81ce57",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.136,
+            0.033,
+            0.032
+          ],
+          "base_cpu_seconds": [
+            0.5,
+            0.2,
+            0.2
+          ],
+          "candidate_wall_seconds": [
+            0.138,
+            0.029,
+            0.03
+          ],
+          "candidate_cpu_seconds": [
+            0.6,
+            0.2,
+            0.2
+          ]
+        },
+        {
+          "query": 41,
+          "output_sha256": "66902b46c180a393cdb87a05e10082eb3c6fb5d8d6ef5b79b694c6d5f0e0fd06",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.091,
+            0.042,
+            0.039
+          ],
+          "base_cpu_seconds": [
+            0.3,
+            0.2,
+            0.2
+          ],
+          "candidate_wall_seconds": [
+            0.083,
+            0.034,
+            0.039
+          ],
+          "candidate_cpu_seconds": [
+            0.3,
+            0.2,
+            0.1
+          ]
+        },
+        {
+          "query": 42,
+          "output_sha256": "852d75893a0be63de0156646ff76340114540de4b390e64e2e9997eea6819a76",
+          "outputs_byte_identical": true,
+          "base_wall_seconds": [
+            0.245,
+            0.044,
+            0.138
+          ],
+          "base_cpu_seconds": [
+            1.7,
+            0.3,
+            1.7
+          ],
+          "candidate_wall_seconds": [
+            0.215,
+            0.046,
+            0.041
+          ],
+          "candidate_cpu_seconds": [
+            1.8,
+            0.3,
+            0.3
+          ]
+        }
+      ],
+      "serving_declines": {
+        "base": 0,
+        "candidate": 0
+      }
     }
   ]
 }

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
@@ -1,8 +1,8 @@
 {
-  "status": "provisional: measurement rig repair pending",
+  "status": "provisional: performance effect unverified pending measurement resolution",
   "performance_validated": false,
   "accepted_score": null,
-  "restriction": "All pre-repair timing figures are provisional. Do not use them for tuning, performance acceptance or delivery. Firstmate must grant a new 100M window after rig validation.",
+  "restriction": "All historical timing figures are provisional. Do not use them for tuning, performance acceptance or delivery. Firstmate reports a harness minimum detectable effect of approximately 1.345 ln; this is a measurement-resolution limit, not a performance result for this change. No 100M work is authorized, and merge remains held pending measurement resolution and Firstmate approval.",
   "tested_source_identity": {
     "head": "b3d34899b0320d35bcd166c0017d09c6c9a35e16",
     "head_subject": "Document accepted aggregation gain and exclusive measurement requirement",

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
@@ -1,0 +1,1266 @@
+{
+  "base_commit": "aa4d81d547fb0e2353ede959786d6e8ba442edf2",
+  "candidate_commit": "f13a32e68fbad8ade9e3f8d3140606e07726d4c5",
+  "lock_acquired": "2026-09-08T02:30:48.119121+00:00",
+  "lock_released": "2026-09-08T02:35:46.452368+00:00",
+  "runs": [
+    {
+      "label": "base",
+      "start": "2026-09-08T02:30:48.129069+00:00",
+      "exit": 0,
+      "end": "2026-09-08T02:33:31.056085+00:00"
+    },
+    {
+      "label": "candidate",
+      "start": "2026-09-08T02:33:31.075036+00:00",
+      "exit": 0,
+      "end": "2026-09-08T02:35:46.450952+00:00"
+    }
+  ],
+  "runtime": "Oracle GraalVM 25.0.3, C2, 20 query workers, Intel i7-12700H",
+  "jvm_flags": [
+    "--add-opens",
+    "java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens",
+    "java.base/java.nio=ALL-UNNAMED",
+    "--add-modules",
+    "jdk.incubator.vector",
+    "--enable-native-access=ALL-UNNAMED",
+    "--enable-preview",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:-UseJVMCICompiler",
+    "-Xms6g",
+    "-Xmx14g",
+    "-Dsirix.projection.eagerMaterializeBytes=5368709120",
+    "-Dsirix.offheap.bytes=10737418240",
+    "-Dsirix.query.autoVectorize=true",
+    "-Dsirix.chunkedBody.enable=true",
+    "-Dsirix.chunkedBody.targetChunkBytes=16384"
+  ],
+  "measurement": "43 queries, 3 tries, hot=min(try2,try3); one continuously held exclusive rig lock",
+  "correctness": "all 43 100M outputs byte-identical; zero serving declines; 1M DuckDB gate zero mismatch/missing/unverifiable/declines and all 43 baseline outputs byte-identical",
+  "sum_ln_saved": 2.225992125303854,
+  "tail_queries": [
+    5,
+    8,
+    9,
+    12,
+    13,
+    14,
+    16,
+    18,
+    28,
+    30,
+    31,
+    32,
+    33,
+    34
+  ],
+  "tail_geometric_speedup": 1.1755789457871717,
+  "queries": [
+    {
+      "query": 0,
+      "base_seconds": [
+        0.054,
+        0.002,
+        0.001
+      ],
+      "candidate_seconds": [
+        0.051,
+        0.001,
+        0.001
+      ],
+      "base_cpu_seconds": [
+        0.1,
+        0.0,
+        0.0
+      ],
+      "candidate_cpu_seconds": [
+        0.1,
+        0.0,
+        0.0
+      ],
+      "base_hot": 0.001,
+      "candidate_hot": 0.001,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "6274012ba71547fe2fc1d4a5fe09989ceb1568002642e429d13aca0e4de29324"
+    },
+    {
+      "query": 1,
+      "base_seconds": [
+        0.429,
+        0.031,
+        0.029
+      ],
+      "candidate_seconds": [
+        0.392,
+        0.036,
+        0.035
+      ],
+      "base_cpu_seconds": [
+        5.1,
+        0.2,
+        0.2
+      ],
+      "candidate_cpu_seconds": [
+        4.8,
+        0.4,
+        0.3
+      ],
+      "base_hot": 0.029,
+      "candidate_hot": 0.035,
+      "hot_speedup": 0.8285714285714285,
+      "ln_saved": -0.14310084364067344,
+      "output_sha256": "df271e2c68e1217c6218272ef6f3ed42574e60d6e137250523d3e7e72eacf2aa"
+    },
+    {
+      "query": 2,
+      "base_seconds": [
+        0.29,
+        0.075,
+        0.066
+      ],
+      "candidate_seconds": [
+        0.297,
+        0.053,
+        0.047
+      ],
+      "base_cpu_seconds": [
+        3.6,
+        1.0,
+        0.9
+      ],
+      "candidate_cpu_seconds": [
+        3.2,
+        0.6,
+        0.5
+      ],
+      "base_hot": 0.066,
+      "candidate_hot": 0.047,
+      "hot_speedup": 1.4042553191489362,
+      "ln_saved": 0.28768207245178085,
+      "output_sha256": "68d6acd8c4d6cb65ab89b275d8ff5db9e4edd064be63a642efaec968c2a51fcd"
+    },
+    {
+      "query": 3,
+      "base_seconds": [
+        0.642,
+        0.086,
+        0.032
+      ],
+      "candidate_seconds": [
+        0.618,
+        0.105,
+        0.032
+      ],
+      "base_cpu_seconds": [
+        7.2,
+        1.3,
+        0.4
+      ],
+      "candidate_cpu_seconds": [
+        5.7,
+        1.6,
+        0.4
+      ],
+      "base_hot": 0.032,
+      "candidate_hot": 0.032,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "56339714bc6ff65c968dec28d1847178d77ac735028e922f85fb6902b7790a9b"
+    },
+    {
+      "query": 4,
+      "base_seconds": [
+        0.469,
+        0.358,
+        0.273
+      ],
+      "candidate_seconds": [
+        0.421,
+        0.447,
+        0.311
+      ],
+      "base_cpu_seconds": [
+        6.7,
+        4.8,
+        3.5
+      ],
+      "candidate_cpu_seconds": [
+        5.5,
+        6.3,
+        3.9
+      ],
+      "base_hot": 0.273,
+      "candidate_hot": 0.311,
+      "hot_speedup": 0.8778135048231512,
+      "ln_saved": -0.12599422548677813,
+      "output_sha256": "2b756178cde1d94167b4ae6e4d24f9d20e73a7eddeef6d126b9326c709eb3f69"
+    },
+    {
+      "query": 5,
+      "base_seconds": [
+        2.304,
+        0.624,
+        0.591
+      ],
+      "candidate_seconds": [
+        2.243,
+        0.785,
+        0.747
+      ],
+      "base_cpu_seconds": [
+        29.3,
+        6.1,
+        5.8
+      ],
+      "candidate_cpu_seconds": [
+        28.1,
+        7.6,
+        7.1
+      ],
+      "base_hot": 0.591,
+      "candidate_hot": 0.747,
+      "hot_speedup": 0.7911646586345381,
+      "ln_saved": -0.2307683189022412,
+      "output_sha256": "34cdf1a69e01fc9438d5ae22fb8639ebc9f681249be45a214cf7392761624be2"
+    },
+    {
+      "query": 6,
+      "base_seconds": [
+        0.053,
+        0.029,
+        0.024
+      ],
+      "candidate_seconds": [
+        0.05,
+        0.028,
+        0.023
+      ],
+      "base_cpu_seconds": [
+        0.3,
+        0.2,
+        0.0
+      ],
+      "candidate_cpu_seconds": [
+        0.3,
+        0.1,
+        0.0
+      ],
+      "base_hot": 0.024,
+      "candidate_hot": 0.023,
+      "hot_speedup": 1.0434782608695652,
+      "ln_saved": 0.02985296314968113,
+      "output_sha256": "925d081ee74c49651addbd4a935e6b8eab9bd80ae8129ce0345b0304fd7cba2c"
+    },
+    {
+      "query": 7,
+      "base_seconds": [
+        0.257,
+        0.034,
+        0.032
+      ],
+      "candidate_seconds": [
+        0.225,
+        0.029,
+        0.035
+      ],
+      "base_cpu_seconds": [
+        2.4,
+        0.4,
+        0.4
+      ],
+      "candidate_cpu_seconds": [
+        2.3,
+        0.3,
+        0.4
+      ],
+      "base_hot": 0.032,
+      "candidate_hot": 0.029,
+      "hot_speedup": 1.103448275862069,
+      "ln_saved": 0.07410797215372204,
+      "output_sha256": "7826e1bf67eaee52ede7f99e2f5d6686922101168ccb03dcde7a4dc63cb95cd1"
+    },
+    {
+      "query": 8,
+      "base_seconds": [
+        1.834,
+        0.628,
+        0.562
+      ],
+      "candidate_seconds": [
+        1.398,
+        0.665,
+        0.659
+      ],
+      "base_cpu_seconds": [
+        26.7,
+        9.0,
+        8.5
+      ],
+      "candidate_cpu_seconds": [
+        21.1,
+        9.9,
+        9.6
+      ],
+      "base_hot": 0.562,
+      "candidate_hot": 0.659,
+      "hot_speedup": 0.8528072837632777,
+      "ln_saved": -0.15664506874843048,
+      "output_sha256": "be8bbbcf3956a0506fcf0b1a659a4c67c51b9805bd78b395db8cf1e79a1a64c1"
+    },
+    {
+      "query": 9,
+      "base_seconds": [
+        1.002,
+        0.799,
+        0.653
+      ],
+      "candidate_seconds": [
+        1.023,
+        0.778,
+        0.771
+      ],
+      "base_cpu_seconds": [
+        15.3,
+        11.1,
+        10.2
+      ],
+      "candidate_cpu_seconds": [
+        15.3,
+        11.4,
+        11.7
+      ],
+      "base_hot": 0.653,
+      "candidate_hot": 0.771,
+      "hot_speedup": 0.8469520103761349,
+      "ln_saved": -0.1638001596538235,
+      "output_sha256": "d6ad56d1ec86424944040abf7659bd52c59872ba2a1c0eab527ff361b0ded6c5"
+    },
+    {
+      "query": 10,
+      "base_seconds": [
+        2.258,
+        0.354,
+        0.248
+      ],
+      "candidate_seconds": [
+        1.414,
+        0.365,
+        0.349
+      ],
+      "base_cpu_seconds": [
+        16.1,
+        2.9,
+        1.6
+      ],
+      "candidate_cpu_seconds": [
+        13.9,
+        1.4,
+        2.4
+      ],
+      "base_hot": 0.248,
+      "candidate_hot": 0.349,
+      "hot_speedup": 0.7106017191977078,
+      "ln_saved": -0.3303628035666614,
+      "output_sha256": "371d54beabadf57bace382b5f7ab79169d5e0975ee22250e238458119a52dabf"
+    },
+    {
+      "query": 11,
+      "base_seconds": [
+        1.738,
+        0.247,
+        0.235
+      ],
+      "candidate_seconds": [
+        1.34,
+        0.265,
+        0.242
+      ],
+      "base_cpu_seconds": [
+        17.0,
+        2.1,
+        1.6
+      ],
+      "candidate_cpu_seconds": [
+        17.5,
+        2.1,
+        1.5
+      ],
+      "base_hot": 0.235,
+      "candidate_hot": 0.242,
+      "hot_speedup": 0.9710743801652892,
+      "ln_saved": -0.028170876966696335,
+      "output_sha256": "d13e37dfbf6e4eec136058921b2ac59496c5dd3f261c3e74c01b12692a3993fd"
+    },
+    {
+      "query": 12,
+      "base_seconds": [
+        2.1,
+        0.741,
+        0.737
+      ],
+      "candidate_seconds": [
+        1.758,
+        0.731,
+        0.746
+      ],
+      "base_cpu_seconds": [
+        20.9,
+        9.2,
+        9.2
+      ],
+      "candidate_cpu_seconds": [
+        25.0,
+        9.0,
+        9.0
+      ],
+      "base_hot": 0.737,
+      "candidate_hot": 0.731,
+      "hot_speedup": 1.0082079343365253,
+      "ln_saved": 0.008064559836730495,
+      "output_sha256": "fcc014a2ba3c83d3aabcda329d71337d1fdb82d065776908e10536f2f1e786e7"
+    },
+    {
+      "query": 13,
+      "base_seconds": [
+        3.266,
+        3.157,
+        2.376
+      ],
+      "candidate_seconds": [
+        1.563,
+        1.306,
+        1.271
+      ],
+      "base_cpu_seconds": [
+        31.7,
+        39.0,
+        26.8
+      ],
+      "candidate_cpu_seconds": [
+        19.7,
+        16.4,
+        16.3
+      ],
+      "base_hot": 2.376,
+      "candidate_hot": 1.271,
+      "hot_speedup": 1.8693941778127459,
+      "ln_saved": 0.6219773007611271,
+      "output_sha256": "674be045f937f8fc8504ffbc78c110e1eaa35c23031ec26161184660ebcf3117"
+    },
+    {
+      "query": 14,
+      "base_seconds": [
+        2.191,
+        0.986,
+        0.998
+      ],
+      "candidate_seconds": [
+        2.005,
+        0.807,
+        0.859
+      ],
+      "base_cpu_seconds": [
+        32.7,
+        13.4,
+        14.0
+      ],
+      "candidate_cpu_seconds": [
+        30.8,
+        10.6,
+        11.7
+      ],
+      "base_hot": 0.986,
+      "candidate_hot": 0.807,
+      "hot_speedup": 1.22180916976456,
+      "ln_saved": 0.19810816272459533,
+      "output_sha256": "9d02fdb0bdc35d9fb2e20bdff7c618092614725eac713d1663a4ef7f72a679fc"
+    },
+    {
+      "query": 15,
+      "base_seconds": [
+        0.954,
+        0.422,
+        0.42
+      ],
+      "candidate_seconds": [
+        0.57,
+        0.359,
+        0.448
+      ],
+      "base_cpu_seconds": [
+        16.6,
+        7.8,
+        7.8
+      ],
+      "candidate_cpu_seconds": [
+        9.8,
+        6.8,
+        8.2
+      ],
+      "base_hot": 0.42,
+      "candidate_hot": 0.359,
+      "hot_speedup": 1.16991643454039,
+      "ln_saved": 0.15298856464708083,
+      "output_sha256": "4984ef226b59ff43b5329c22928f051348d3212cafab52a907c1935d7645b0b1"
+    },
+    {
+      "query": 16,
+      "base_seconds": [
+        3.754,
+        2.06,
+        2.087
+      ],
+      "candidate_seconds": [
+        3.937,
+        1.693,
+        1.747
+      ],
+      "base_cpu_seconds": [
+        54.3,
+        28.3,
+        29.0
+      ],
+      "candidate_cpu_seconds": [
+        53.1,
+        21.9,
+        22.9
+      ],
+      "base_hot": 2.06,
+      "candidate_hot": 1.693,
+      "hot_speedup": 1.216774955699941,
+      "ln_saved": 0.19515720559672634,
+      "output_sha256": "9c2cb1d94a1a5e216dfadfbb39b0a69875ab3bd31ee7f219fcb2ea67c917f049"
+    },
+    {
+      "query": 17,
+      "base_seconds": [
+        0.264,
+        0.054,
+        0.064
+      ],
+      "candidate_seconds": [
+        0.271,
+        0.052,
+        0.055
+      ],
+      "base_cpu_seconds": [
+        3.5,
+        0.4,
+        0.4
+      ],
+      "candidate_cpu_seconds": [
+        3.8,
+        0.4,
+        0.3
+      ],
+      "base_hot": 0.054,
+      "candidate_hot": 0.052,
+      "hot_speedup": 1.0384615384615385,
+      "ln_saved": 0.03174869831458027,
+      "output_sha256": "d9f19c41559e311ae37aed66999d0216bbdec7cd510d3eac9761da1d4b4d8792"
+    },
+    {
+      "query": 18,
+      "base_seconds": [
+        7.019,
+        4.121,
+        3.956
+      ],
+      "candidate_seconds": [
+        5.072,
+        3.144,
+        3.116
+      ],
+      "base_cpu_seconds": [
+        104.5,
+        66.5,
+        63.9
+      ],
+      "candidate_cpu_seconds": [
+        78.0,
+        49.0,
+        49.0
+      ],
+      "base_hot": 3.956,
+      "candidate_hot": 3.116,
+      "hot_speedup": 1.269576379974326,
+      "ln_saved": 0.23800379809831929,
+      "output_sha256": "3562c975e7413e13bd61d5dff44397479ad93e032f421b4bbb2c8f4e7b8e59fc"
+    },
+    {
+      "query": 19,
+      "base_seconds": [
+        0.022,
+        0.015,
+        0.015
+      ],
+      "candidate_seconds": [
+        0.032,
+        0.015,
+        0.015
+      ],
+      "base_cpu_seconds": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "candidate_cpu_seconds": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "base_hot": 0.015,
+      "candidate_hot": 0.015,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "3250356ef481c5756db99d19a1aff7f72ac21d31da97cee5ec867e2abed33b27"
+    },
+    {
+      "query": 20,
+      "base_seconds": [
+        2.339,
+        0.03,
+        0.03
+      ],
+      "candidate_seconds": [
+        1.629,
+        0.03,
+        0.036
+      ],
+      "base_cpu_seconds": [
+        21.1,
+        0.4,
+        0.4
+      ],
+      "candidate_cpu_seconds": [
+        18.2,
+        0.4,
+        0.4
+      ],
+      "base_hot": 0.03,
+      "candidate_hot": 0.03,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "3561da5045e865e0b4da382b5f882246b0d0f9673d2b6447fdc679b4558fae58"
+    },
+    {
+      "query": 21,
+      "base_seconds": [
+        0.255,
+        0.236,
+        0.139
+      ],
+      "candidate_seconds": [
+        0.22,
+        0.137,
+        0.124
+      ],
+      "base_cpu_seconds": [
+        2.8,
+        2.8,
+        1.2
+      ],
+      "candidate_cpu_seconds": [
+        1.3,
+        1.1,
+        1.1
+      ],
+      "base_hot": 0.139,
+      "candidate_hot": 0.124,
+      "hot_speedup": 1.120967741935484,
+      "ln_saved": 0.10610650599454777,
+      "output_sha256": "a6569917873542718e52cec662b1fad8dd035e904362abd7287770879423894f"
+    },
+    {
+      "query": 22,
+      "base_seconds": [
+        5.989,
+        0.36,
+        0.344
+      ],
+      "candidate_seconds": [
+        5.29,
+        0.315,
+        0.302
+      ],
+      "base_cpu_seconds": [
+        23.4,
+        2.7,
+        2.7
+      ],
+      "candidate_cpu_seconds": [
+        24.0,
+        2.7,
+        2.6
+      ],
+      "base_hot": 0.344,
+      "candidate_hot": 0.302,
+      "hot_speedup": 1.1390728476821192,
+      "ln_saved": 0.12629372532429206,
+      "output_sha256": "c6972e15129b9cd0ba18263b3206a8a1734a9b97c7864c7722d3018145558fe8"
+    },
+    {
+      "query": 23,
+      "base_seconds": [
+        0.655,
+        0.137,
+        0.123
+      ],
+      "candidate_seconds": [
+        0.5,
+        0.133,
+        0.124
+      ],
+      "base_cpu_seconds": [
+        3.3,
+        0.4,
+        0.4
+      ],
+      "candidate_cpu_seconds": [
+        4.1,
+        0.4,
+        0.4
+      ],
+      "base_hot": 0.123,
+      "candidate_hot": 0.124,
+      "hot_speedup": 0.9919354838709677,
+      "ln_saved": -0.007490671729157626,
+      "output_sha256": "e3cd36c66ebf0a0d9611657bb32fc15b2f96487222160422fd25b139faa2dad1"
+    },
+    {
+      "query": 24,
+      "base_seconds": [
+        0.092,
+        0.022,
+        0.02
+      ],
+      "candidate_seconds": [
+        0.074,
+        0.018,
+        0.022
+      ],
+      "base_cpu_seconds": [
+        0.2,
+        0.0,
+        0.0
+      ],
+      "candidate_cpu_seconds": [
+        0.2,
+        0.0,
+        0.1
+      ],
+      "base_hot": 0.02,
+      "candidate_hot": 0.018,
+      "hot_speedup": 1.1111111111111112,
+      "ln_saved": 0.06899287148695142,
+      "output_sha256": "04ac5dddc732db72b94072eaad307d529300609e466fd2ece4fb6dac4327ae3b"
+    },
+    {
+      "query": 25,
+      "base_seconds": [
+        0.4,
+        0.214,
+        0.118
+      ],
+      "candidate_seconds": [
+        0.25,
+        0.17,
+        0.272
+      ],
+      "base_cpu_seconds": [
+        3.2,
+        2.6,
+        1.3
+      ],
+      "candidate_cpu_seconds": [
+        2.2,
+        1.8,
+        3.5
+      ],
+      "base_hot": 0.118,
+      "candidate_hot": 0.17,
+      "hot_speedup": 0.6941176470588234,
+      "ln_saved": -0.3409265869705933,
+      "output_sha256": "ecef47964fa651c24162085870df6dd047ca411dbafb5c0d40372318154474b2"
+    },
+    {
+      "query": 26,
+      "base_seconds": [
+        0.047,
+        0.02,
+        0.02
+      ],
+      "candidate_seconds": [
+        0.043,
+        0.02,
+        0.02
+      ],
+      "base_cpu_seconds": [
+        0.3,
+        0.1,
+        0.1
+      ],
+      "candidate_cpu_seconds": [
+        0.3,
+        0.0,
+        0.1
+      ],
+      "base_hot": 0.02,
+      "candidate_hot": 0.02,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "d5e5ad30fb7e79c7ea91bffc9971393d4a493951ee7dd11577e60810f8b59308"
+    },
+    {
+      "query": 27,
+      "base_seconds": [
+        1.428,
+        0.216,
+        0.217
+      ],
+      "candidate_seconds": [
+        1.396,
+        0.25,
+        0.235
+      ],
+      "base_cpu_seconds": [
+        22.0,
+        3.8,
+        4.0
+      ],
+      "candidate_cpu_seconds": [
+        23.7,
+        4.6,
+        4.5
+      ],
+      "base_hot": 0.216,
+      "candidate_hot": 0.235,
+      "hot_speedup": 0.9191489361702128,
+      "ln_saved": -0.08072321127244103,
+      "output_sha256": "2cb6b1ea1025878822b0b4cf52d32da45c5bc458921e9ed9ca80bbf808a80e9d"
+    },
+    {
+      "query": 28,
+      "base_seconds": [
+        12.499,
+        9.089,
+        8.867
+      ],
+      "candidate_seconds": [
+        11.577,
+        8.865,
+        8.864
+      ],
+      "base_cpu_seconds": [
+        118.4,
+        82.7,
+        77.7
+      ],
+      "candidate_cpu_seconds": [
+        111.2,
+        80.0,
+        77.4
+      ],
+      "base_hot": 8.867,
+      "candidate_hot": 8.864,
+      "hot_speedup": 1.0003384476534296,
+      "ln_saved": 0.0003380091294644796,
+      "output_sha256": "e66d2ca783d9b31ea45cc94f7f3aae773a04d008458932a864da15441f82fdff"
+    },
+    {
+      "query": 29,
+      "base_seconds": [
+        0.2,
+        0.035,
+        0.033
+      ],
+      "candidate_seconds": [
+        0.141,
+        0.037,
+        0.035
+      ],
+      "base_cpu_seconds": [
+        1.7,
+        0.3,
+        0.3
+      ],
+      "candidate_cpu_seconds": [
+        1.1,
+        0.3,
+        0.3
+      ],
+      "base_hot": 0.033,
+      "candidate_hot": 0.035,
+      "hot_speedup": 0.9428571428571428,
+      "ln_saved": -0.0454623740767574,
+      "output_sha256": "07030719e298cb26685c7587ce7cd73028f78521afa4a33b2cbcb5acfbc61259"
+    },
+    {
+      "query": 30,
+      "base_seconds": [
+        2.176,
+        0.539,
+        0.54
+      ],
+      "candidate_seconds": [
+        2.077,
+        0.348,
+        0.345
+      ],
+      "base_cpu_seconds": [
+        28.7,
+        9.2,
+        9.2
+      ],
+      "candidate_cpu_seconds": [
+        33.0,
+        6.2,
+        6.0
+      ],
+      "base_hot": 0.539,
+      "candidate_hot": 0.345,
+      "hot_speedup": 1.5623188405797104,
+      "ln_saved": 0.43598065203411496,
+      "output_sha256": "bcb3b6bf0903e37a66d537aacd06a689154790914bba4677d4b687271b5d3e40"
+    },
+    {
+      "query": 31,
+      "base_seconds": [
+        2.728,
+        1.645,
+        1.5
+      ],
+      "candidate_seconds": [
+        1.102,
+        1.146,
+        0.901
+      ],
+      "base_cpu_seconds": [
+        24.5,
+        26.8,
+        25.8
+      ],
+      "candidate_cpu_seconds": [
+        15.6,
+        16.4,
+        15.2
+      ],
+      "base_hot": 1.5,
+      "candidate_hot": 0.901,
+      "hot_speedup": 1.664816870144284,
+      "ln_saved": 0.5053220325490116,
+      "output_sha256": "3ed0b1ffb37fc60c0ea514df3b682a773d2fe8d853bbf249c718b06ceb75534a"
+    },
+    {
+      "query": 32,
+      "base_seconds": [
+        8.834,
+        6.811,
+        6.798
+      ],
+      "candidate_seconds": [
+        5.204,
+        4.179,
+        4.182
+      ],
+      "base_cpu_seconds": [
+        152.5,
+        126.3,
+        126.9
+      ],
+      "candidate_cpu_seconds": [
+        89.1,
+        77.6,
+        77.9
+      ],
+      "base_hot": 6.798,
+      "candidate_hot": 4.179,
+      "hot_speedup": 1.626704953338119,
+      "ln_saved": 0.4856363493061751,
+      "output_sha256": "adf4de00a0078c7868f0cfb32eb0909dcd0c9b971c6eb93097adf08bf2e466e9"
+    },
+    {
+      "query": 33,
+      "base_seconds": [
+        3.364,
+        2.365,
+        2.3
+      ],
+      "candidate_seconds": [
+        2.481,
+        2.203,
+        2.157
+      ],
+      "base_cpu_seconds": [
+        41.4,
+        31.8,
+        31.4
+      ],
+      "candidate_cpu_seconds": [
+        33.8,
+        30.3,
+        29.2
+      ],
+      "base_hot": 2.3,
+      "candidate_hot": 2.157,
+      "hot_speedup": 1.0662957811775613,
+      "ln_saved": 0.06390380197948005,
+      "output_sha256": "1625b2743dcb650f344dfcf296045d2db75387d94891bc9211a674f44f576bc9"
+    },
+    {
+      "query": 34,
+      "base_seconds": [
+        2.254,
+        2.242,
+        2.229
+      ],
+      "candidate_seconds": [
+        2.169,
+        2.126,
+        2.124
+      ],
+      "base_cpu_seconds": [
+        31.1,
+        30.8,
+        30.6
+      ],
+      "candidate_cpu_seconds": [
+        29.1,
+        29.0,
+        29.0
+      ],
+      "base_hot": 2.229,
+      "candidate_hot": 2.124,
+      "hot_speedup": 1.0494350282485876,
+      "ln_saved": 0.04803118473705606,
+      "output_sha256": "a5aab2614aafe82b7ca4623a9e08e2bb7096334e7e5e1855b84b15d087a45bb9"
+    },
+    {
+      "query": 35,
+      "base_seconds": [
+        0.498,
+        0.39,
+        0.388
+      ],
+      "candidate_seconds": [
+        0.64,
+        0.339,
+        0.343
+      ],
+      "base_cpu_seconds": [
+        9.3,
+        7.3,
+        7.2
+      ],
+      "candidate_cpu_seconds": [
+        12.1,
+        6.4,
+        6.5
+      ],
+      "base_hot": 0.388,
+      "candidate_hot": 0.339,
+      "hot_speedup": 1.1445427728613569,
+      "ln_saved": 0.1313800830820105,
+      "output_sha256": "55995b79571d8b725d8784700db64d46fce8f5bcee26120314e993f60e329e18"
+    },
+    {
+      "query": 36,
+      "base_seconds": [
+        0.252,
+        0.105,
+        0.06
+      ],
+      "candidate_seconds": [
+        0.337,
+        0.066,
+        0.064
+      ],
+      "base_cpu_seconds": [
+        1.9,
+        1.2,
+        0.3
+      ],
+      "candidate_cpu_seconds": [
+        3.3,
+        0.4,
+        0.3
+      ],
+      "base_hot": 0.06,
+      "candidate_hot": 0.064,
+      "hot_speedup": 0.9375,
+      "ln_saved": -0.055569851154810765,
+      "output_sha256": "5d21847795a6e050a5dce7647ce872bcb53714624b12a304f6398def4b1a89ce"
+    },
+    {
+      "query": 37,
+      "base_seconds": [
+        0.615,
+        0.05,
+        0.048
+      ],
+      "candidate_seconds": [
+        0.328,
+        0.045,
+        0.041
+      ],
+      "base_cpu_seconds": [
+        2.8,
+        0.3,
+        0.3
+      ],
+      "candidate_cpu_seconds": [
+        2.4,
+        0.3,
+        0.2
+      ],
+      "base_hot": 0.048,
+      "candidate_hot": 0.041,
+      "hot_speedup": 1.170731707317073,
+      "ln_saved": 0.12861737782209354,
+      "output_sha256": "c8703a4b5282c1d6d749ad70d6c319cf95405ca509cc0cc96ab0c543ba34a8fc"
+    },
+    {
+      "query": 38,
+      "base_seconds": [
+        0.445,
+        0.042,
+        0.04
+      ],
+      "candidate_seconds": [
+        0.249,
+        0.04,
+        0.044
+      ],
+      "base_cpu_seconds": [
+        3.4,
+        0.3,
+        0.3
+      ],
+      "candidate_cpu_seconds": [
+        1.9,
+        0.3,
+        0.3
+      ],
+      "base_hot": 0.04,
+      "candidate_hot": 0.04,
+      "hot_speedup": 1.0,
+      "ln_saved": 0.0,
+      "output_sha256": "8fb648551c53248efb46b4cbaa595c3d955e691afd652c36fd02e11c26eeb2ea"
+    },
+    {
+      "query": 39,
+      "base_seconds": [
+        0.488,
+        0.319,
+        0.264
+      ],
+      "candidate_seconds": [
+        0.512,
+        0.405,
+        0.401
+      ],
+      "base_cpu_seconds": [
+        5.0,
+        2.8,
+        2.3
+      ],
+      "candidate_cpu_seconds": [
+        5.3,
+        4.8,
+        4.6
+      ],
+      "base_hot": 0.264,
+      "candidate_hot": 0.401,
+      "hot_speedup": 0.6583541147132169,
+      "ln_saved": -0.40546510810816444,
+      "output_sha256": "8aca19fe3c2403c22c8baf14a7a7ad8b1e482bb358499f4ce30ceeaace0e6a0a"
+    },
+    {
+      "query": 40,
+      "base_seconds": [
+        0.128,
+        0.03,
+        0.039
+      ],
+      "candidate_seconds": [
+        0.107,
+        0.033,
+        0.022
+      ],
+      "base_cpu_seconds": [
+        0.5,
+        0.2,
+        0.2
+      ],
+      "candidate_cpu_seconds": [
+        0.4,
+        0.2,
+        0.1
+      ],
+      "base_hot": 0.03,
+      "candidate_hot": 0.022,
+      "hot_speedup": 1.3636363636363638,
+      "ln_saved": 0.22314355131420976,
+      "output_sha256": "e2f8ca91287f21045242639aa04f53f4edab349e07e6f24f4bd841decd81ce57"
+    },
+    {
+      "query": 41,
+      "base_seconds": [
+        0.088,
+        0.044,
+        0.044
+      ],
+      "candidate_seconds": [
+        0.077,
+        0.044,
+        0.036
+      ],
+      "base_cpu_seconds": [
+        0.3,
+        0.2,
+        0.2
+      ],
+      "candidate_cpu_seconds": [
+        0.3,
+        0.2,
+        0.2
+      ],
+      "base_hot": 0.044,
+      "candidate_hot": 0.036,
+      "hot_speedup": 1.2222222222222223,
+      "ln_saved": 0.16034265007517948,
+      "output_sha256": "66902b46c180a393cdb87a05e10082eb3c6fb5d8d6ef5b79b694c6d5f0e0fd06"
+    },
+    {
+      "query": 42,
+      "base_seconds": [
+        0.317,
+        0.053,
+        0.044
+      ],
+      "candidate_seconds": [
+        0.216,
+        0.047,
+        0.043
+      ],
+      "base_cpu_seconds": [
+        3.4,
+        0.2,
+        0.3
+      ],
+      "candidate_cpu_seconds": [
+        2.0,
+        0.4,
+        0.4
+      ],
+      "base_hot": 0.044,
+      "candidate_hot": 0.043,
+      "hot_speedup": 1.0232558139534884,
+      "ln_saved": 0.018692133012152546,
+      "output_sha256": "852d75893a0be63de0156646ff76340114540de4b390e64e2e9997eea6819a76"
+    }
+  ]
+}

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json
@@ -2314,5 +2314,17 @@
         "candidate": 0
       }
     }
-  ]
+  ],
+  "delivery_status": "Correctness review, tests and CI authorized now; Firstmate holds merge pending a repaired-rig performance verdict.",
+  "rig_audit_reported_by_firstmate": {
+    "source": "Firstmate instruction 2026-09-08T03:55:11Z",
+    "unchanged_code_sum_ln": [
+      65.398,
+      66.156,
+      69.803
+    ],
+    "sum_ln_spread": 4.405,
+    "peak_temperature_celsius_each_leg": 100,
+    "interpretation": "Thermal instability prevents an accepted performance verdict; these audit observations are not optimization gains."
+  }
 }

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -1,0 +1,54 @@
+# Shared aggregation: exclusive paired measurement, 8 September 2026
+
+The exclusive pair improves C6A hot geomean **4.496 → 4.269**, saving **2.225992 sum-ln**. Both heads rank **16/140** against the campaign's checked-in board snapshot. This is the accepted timing evidence for this candidate; earlier overlapping measurements are superseded.
+
+The fixed 14-query tail improves **1.175579×** by geometric mean, below the original task's **1.3×** acceptance floor. Delivery acceptance therefore remains a Firstmate decision. This change does not reach the captain's top-10 target by itself.
+
+## Changes
+
+- `NumericGroupAggTable` can place accumulator records sequentially behind a compact hash index. Index entries hold a 32-bit hash tag and a record handle; complete keys and exact identity lanes still prove equality. Index growth preserves record handles. All chunks remain at most 128 KiB. `GroupTableSpill` enables this layout and owns a separate scan-local index recycler; existing payload recycling and pass budgets remain unchanged. `sirix.projection.groupTable.denseIndex=false` restores sparse indexing.
+- Integral COUNT/SUM/AVG composite groups ordered solely by row count use present-count/sum operand pairs. The selector expands only the winning accumulators into the ordinary output layout. Other orders, HAVING, string/deferred operands, and MIN/MAX retain ordinary state.
+- Sliced numeric/composite DISTINCT aggregation feeds worker batches directly instead of retaining per-group sink objects. Singleton distinct sets hold their first value inline. Disjoint group stripes publish final counts on the existing query worker pool, and merge bucketing visits the count shards without constructing one large intermediate hash map. The original four value stripes per group remain in effect.
+
+There is no additional input scan, new global dictionary or data cache, persisted-format change, or database rebuild. Dictionary identity and value comparisons are unchanged. Row counts, checked sum overflow, missing operands, and first-seen tie ordering retain their existing semantics.
+
+## Validation
+
+Commit **`f13a32e68fbad8ade9e3f8d3140606e07726d4c5`** passed **123 focused tests** covering collisions, table growth, zero keys, pass ownership and spill, compact sums and overflow, parallel distinct publication/failure/retry, and interpreted-versus-vectorized grouping/top-n differentials with forced passes and ties.
+
+The full **1M** DuckDB gate reports **0 mismatch, 0 missing, 0 unverifiable, and 0 serving declines**. All 43 outputs match the original 1M baseline byte-for-byte. That database has two segments. Both exclusive **100M** legs completed 43 queries × 3 tries with no serving declines; all 43 result files are byte-identical between the heads.
+
+Only the nine changed Java files were formatted with the repository's Spotless/Eclipse profile. The benchmark runner is unmodified and uninstrumented.
+
+## Exclusive pair
+
+Baseline: `aa4d81d547fb0e2353ede959786d6e8ba442edf2`. Candidate: `f13a32e68fbad8ade9e3f8d3140606e07726d4c5`. Both ran from frozen runtime artifacts on the same host, using Oracle GraalVM 25.0.3 with C2, 20 workers, `-Xms6g -Xmx14g`, a 10 GiB off-heap arena, and the same read-only 100M database. The common lock was held continuously from **2026-09-08T02:30:48.119121+00:00** through **2026-09-08T02:35:46.452368+00:00**. No other JVM referenced the database when the lock was acquired or between legs. Firstmate was notified immediately on release.
+
+Baseline ended at `2026-09-08T02:33:31.056085+00:00`; candidate started at `2026-09-08T02:33:31.075036+00:00`. Hot time is the minimum of tries 2 and 3. The sum of hot query times decreases **37.544 → 31.904 seconds**. Full per-try times, CPU times, and output hashes are in [the measurement JSON](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json).
+
+| Tail query | Baseline hot seconds | Candidate hot seconds | Speedup |
+|---|---:|---:|---:|
+| q5 | 0.591 | 0.747 | 0.791× |
+| q8 | 0.562 | 0.659 | 0.853× |
+| q9 | 0.653 | 0.771 | 0.847× |
+| q12 | 0.737 | 0.731 | 1.008× |
+| q13 | 2.376 | 1.271 | 1.869× |
+| q14 | 0.986 | 0.807 | 1.222× |
+| q16 | 2.060 | 1.693 | 1.217× |
+| q18 | 3.956 | 3.116 | 1.270× |
+| q28 | 8.867 | 8.864 | 1.000× |
+| q30 | 0.539 | 0.345 | 1.562× |
+| q31 | 1.500 | 0.901 | 1.665× |
+| q32 | 6.798 | 4.179 | 1.627× |
+| q33 | 2.300 | 2.157 | 1.066× |
+| q34 | 2.229 | 2.124 | 1.049× |
+
+The improvements span count-only grouping and wider aggregate state: q13/q14/q15/q16/q18/q30/q31/q32/q33/q34/q35 all improve in this pair. Regressions remain visible in the aggregate score: q8 and q9 slow by about 17–18%; q5 changes 0.591 → 0.747 s, q10 0.248 → 0.349 s, q25 0.118 → 0.170 s, and q39 0.264 → 0.401 s. This pair does not establish a cause for every per-query regression. No gains from the parallel string worker are added to these measurements.
+
+## Profile and discarded experiments
+
+Exploratory JFR captures put 42–65% of original hot CPU samples for q16/q18/q30/q31/q32 inside the group table, including calls from spill/merge. Top-n was at most 1.6% and already bounded. q8/q9 concentrated approximately 92% of samples in grouped distinct aggregation. q13 also allocated many sinks, singleton sets and map entries; a later profile put 478 of 2552 samples in serial distinct-count publication and 98 in subsequent bucketing. These are CPU sample shares, not independent wall-time fractions.
+
+Row staging for high-uniqueness groups, fused fresh-stripe copying in the sparse table, and unrolled identity comparison were removed after exploratory measurements failed to show a useful broad gain. A lower pass-budget charge and increased distinct value striping were also removed. The budget-only explanation for an earlier q33/q34 slowdown was disproved by another run; Firstmate subsequently identified overlapping run windows. Those earlier timings and causal explanations are not delivery evidence.
+
+Rig mechanics and scoring commands remain documented in [the segment-lane handoff](HANDOFF_SEGMENT_LANE_2026-09-06.md) and `bundles/sirix-query/bench/clickbench/rig/`. Local raw evidence is under `bundles/sirix-query/build/diagnostics/groupby/exclusive1-*`; the paired driver uses one `fcntl.flock` context for both JVMs.

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -1,6 +1,8 @@
-# Shared aggregation: correctness banked, performance pending
+# Shared aggregation: correctness validation, performance unverified
 
-**All 100M timings collected before the rig repair are provisional.** They are not delivery evidence, and this change has no accepted performance gain or ranking claim. Firstmate's 8 September rig-handover instruction supersedes the earlier measurement acceptance: nominally comparable runs varied too much to establish the effect of these changes. Performance acceptance and delivery await the repaired rig and a new window granted by Firstmate.
+**The performance effect is unverified pending rig repair.** All earlier 100M timings are provisional; this change makes no accepted speedup or ranking claim. Correctness review, tests and CI may proceed to a green PR now. Firstmate will hold the merge until a new measurement window on the repaired rig establishes whether to land or withdraw the change.
+
+Firstmate's rig audit reports three legs of unchanged code at **65.398, 66.156 and 69.803 sum-ln**, a **4.405 sum-ln spread**, with every leg reaching **100 °C**. These are observations of rig instability, not performance results for this change. Thermal throttling and the resulting run-to-run variation prevent the pre-repair measurements from establishing an optimization's effect. The audit supersedes the earlier acceptance of those measurements.
 
 ## Implementation
 
@@ -21,7 +23,7 @@ The [provisional evidence JSON](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json) re
 
 ## Rig ownership and measurement requirements
 
-The last completed pair released the rig lock at **2026-09-08T03:39:26.704902+00:00**. The rig-repair lane owns 100M access until Firstmate grants another window. Do not run another 100M leg, tune against these provisional timings, or ship a performance claim from them.
+The last completed pair released the rig lock at **2026-09-08T03:39:26.704902+00:00**. The rig-repair lane owns 100M access until Firstmate grants another window. This validation run must not launch another 100M leg, tune against provisional timings, or publish a performance claim. Focused tests and 1M correctness validation remain authorized.
 
 Exclusive access remains necessary: hold one shared rig lock continuously across baseline and candidate, inspect live database JVMs after acquisition and between legs, and inherit the lock in child JVMs. A lock file's existence does not prove a live holder; never unlink a potentially held lock. Preserve the **6/14 GiB heap and 10 GiB arena** envelope, freeze the artifacts before measurement, and record source/artifact identity, complete flags and lock times. The rig repair must additionally establish repeatability; exclusivity alone did not make the collected timings dependable.
 

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -1,8 +1,8 @@
 # Shared aggregation: correctness validation, performance unverified
 
-**The performance effect is unverified pending rig repair.** All earlier 100M timings are provisional; this change makes no accepted speedup or ranking claim. Correctness review, tests and CI may proceed to a green PR now. Firstmate will hold the merge until a new measurement window on the repaired rig establishes whether to land or withdraw the change.
+**The performance effect is unverified pending measurement resolution.** All earlier 100M timings are provisional; this change makes no accepted speedup or ranking claim. Correctness review, tests and CI may proceed to a green PR now. Firstmate will hold the merge until reliable measurement establishes whether to land or withdraw the change.
 
-Firstmate's rig audit reports three legs of unchanged code at **65.398, 66.156 and 69.803 sum-ln**, a **4.405 sum-ln spread**, with every leg reaching **100 °C**. These are observations of rig instability, not performance results for this change. Thermal throttling and the resulting run-to-run variation prevent the pre-repair measurements from establishing an optimization's effect. The audit supersedes the earlier acceptance of those measurements.
+Firstmate's completed variance study reports a **minimum detectable effect of approximately 1.345 ln** for this harness on the current machine. A single paired run therefore cannot reliably distinguish a small gain from measurement noise. This is a measurement-resolution limit, not a performance result for this change. The study largely eliminated GC, CPU placement and thermal effects as explanations for the remaining noise; continuing JIT compilation during timed tries remains a hypothesis, with the cause unresolved. These findings supersede the earlier thermal diagnosis and acceptance of provisional timings.
 
 ## Implementation
 
@@ -10,6 +10,7 @@ Firstmate's rig audit reports three legs of unchanged code at **65.398, 66.156 a
 - Integral COUNT/SUM/AVG composite groups ordered solely by row count use present-count/sum operand pairs. Only winning accumulators expand into the ordinary output layout. Other orders, HAVING, string/deferred operands, and MIN/MAX retain ordinary state.
 - Sliced numeric/composite DISTINCT aggregation feeds worker batches directly. Singleton sets store their first value inline; promotion retains the previous 16-entry set sizing. Disjoint group stripes publish final counts on the existing worker pool, and merge bucketing visits the shards without building one intermediate map.
 - Incompatible-table diagnostics now include the `sumsOnly` flags, including the case where all other layout properties agree.
+- Aborted-pass cleanup drains the scan-local probe-index recycler before the restart measures live heap. The existing shared payload-pool guard remains in place.
 
 No additional input scan, global dictionary or data cache, persisted-format change, or database rebuild is introduced. Dictionary value comparisons, row multiplicity, checked sum overflow, missing operands, stable ties, existing pass budgets, and four distinct value stripes remain unchanged. The benchmark runner is unmodified and uninstrumented.
 
@@ -21,10 +22,12 @@ The no-mistakes review-fix round reached its 30-minute timeout before committing
 
 The [provisional evidence JSON](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json) retains raw per-try wall/CPU times and output hashes for those two completed narrowed-code pairs. It explicitly disallows using those timings for acceptance. It contains no selected best pair or accepted score. Previous timings remain historical diagnostics, superseded for delivery purposes.
 
+The subsequent probe-pool cleanup fix passed **88 tests** across 11 core test classes, with no failures, errors or skips. Its regression test exercises pooling, reuse and aborted-pass release; removing the drain reproduced the failure. The committed fix and test were recovered together after a paused review timed out. A later review also timed out without findings; neither timeout invalidated or replaced the preserved test evidence. Fresh pipeline validation is required for delivery.
+
 ## Rig ownership and measurement requirements
 
-The last completed pair released the rig lock at **2026-09-08T03:39:26.704902+00:00**. The rig-repair lane owns 100M access until Firstmate grants another window. This validation run must not launch another 100M leg, tune against provisional timings, or publish a performance claim. Focused tests and 1M correctness validation remain authorized.
+The instrument lane has released the box for builds, tests and review after completing its variance study. **No 100M work is authorized for this lane.** This validation run must not launch a 100M leg, profile or warm up the 100M database, tune against provisional timings, or publish a performance claim. Focused tests and 1M correctness validation remain authorized. Firstmate retains the merge hold and must explicitly grant any future measurement window.
 
-Exclusive access remains necessary: hold one shared rig lock continuously across baseline and candidate, inspect live database JVMs after acquisition and between legs, and inherit the lock in child JVMs. A lock file's existence does not prove a live holder; never unlink a potentially held lock. Preserve the **6/14 GiB heap and 10 GiB arena** envelope, freeze the artifacts before measurement, and record source/artifact identity, complete flags and lock times. The rig repair must additionally establish repeatability; exclusivity alone did not make the collected timings dependable.
+For a future authorized window, exclusive access remains necessary: hold one shared rig lock continuously across baseline and candidate, inspect live database JVMs after acquisition and between legs, and inherit the lock in child JVMs. A lock file's existence does not prove a live holder; never unlink a potentially held lock. Preserve the **6/14 GiB heap and 10 GiB arena** envelope, freeze the artifacts before measurement, and record source/artifact identity, complete flags and lock times. Measurement must resolve the proposed effect against the observed noise floor; exclusivity alone did not make the collected timings dependable.
 
 Compare the score across all 43 queries as well as elapsed seconds after the rig is validated. A decrease in total suite time does not establish an improvement in the geometric-mean score. Rig mechanics remain in [the segment-lane handoff](HANDOFF_SEGMENT_LANE_2026-09-06.md) and `bundles/sirix-query/bench/clickbench/rig/`.

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -1,60 +1,28 @@
-# Shared aggregation: exclusive paired measurement, 8 September 2026
+# Shared aggregation: correctness banked, performance pending
 
-The exclusive pair improves C6A hot geomean **4.496 → 4.269**, saving **2.226 sum-ln**. Both heads rank **16/140** against the campaign's checked-in board snapshot. This exclusive pair supersedes the earlier baseline-to-candidate sum-ln reading, which was taken under concurrent load and is not a valid performance result.
+**All 100M timings collected before the rig repair are provisional.** They are not delivery evidence, and this change has no accepted performance gain or ranking claim. Firstmate's 8 September rig-handover instruction supersedes the earlier measurement acceptance: nominally comparable runs varied too much to establish the effect of these changes. Performance acceptance and delivery await the repaired rig and a new window granted by Firstmate.
 
-The fixed 14-query tail improves **1.175579×** by geometric mean. The candidate remains above the campaign's top-10 geomean target; the measured generic gain is the result delivered here.
+## Implementation
 
-## Changes
+- `NumericGroupAggTable` supports sequential accumulator records behind a compact hash index. Full keys and exact identity lanes still prove equality; record handles survive index growth. `GroupTableSpill` owns the scan-local index recycler and enables the layout only for **stride >= 5**. At the three-quarter growth threshold, sparse storage reserves `(4/3) * stride` lanes per live group, versus `stride + 4/3` for dense records plus the index. They cross at stride 4. The gate records this rationale, and `sirix.projection.groupTable.denseIndex=false` retains the sparse layout.
+- Integral COUNT/SUM/AVG composite groups ordered solely by row count use present-count/sum operand pairs. Only winning accumulators expand into the ordinary output layout. Other orders, HAVING, string/deferred operands, and MIN/MAX retain ordinary state.
+- Sliced numeric/composite DISTINCT aggregation feeds worker batches directly. Singleton sets store their first value inline; promotion retains the previous 16-entry set sizing. Disjoint group stripes publish final counts on the existing worker pool, and merge bucketing visits the shards without building one intermediate map.
+- Incompatible-table diagnostics now include the `sumsOnly` flags, including the case where all other layout properties agree.
 
-- `NumericGroupAggTable` can place accumulator records sequentially behind a compact hash index. Index entries hold a 32-bit hash tag and a record handle; complete keys and exact identity lanes still prove equality. Index growth preserves record handles. All chunks remain at most 128 KiB. `GroupTableSpill` enables this layout and owns a separate scan-local index recycler; existing payload recycling and pass budgets remain unchanged. `sirix.projection.groupTable.denseIndex=false` restores sparse indexing.
-- Integral COUNT/SUM/AVG composite groups ordered solely by row count use present-count/sum operand pairs. The selector expands only the winning accumulators into the ordinary output layout. Other orders, HAVING, string/deferred operands, and MIN/MAX retain ordinary state.
-- Sliced numeric/composite DISTINCT aggregation feeds worker batches directly instead of retaining per-group sink objects. Singleton distinct sets hold their first value inline. Disjoint group stripes publish final counts on the existing query worker pool, and merge bucketing visits the count shards without constructing one large intermediate hash map. The original four value stripes per group remain in effect.
+No additional input scan, global dictionary or data cache, persisted-format change, or database rebuild is introduced. Dictionary value comparisons, row multiplicity, checked sum overflow, missing operands, stable ties, existing pass budgets, and four distinct value stripes remain unchanged. The benchmark runner is unmodified and uninstrumented.
 
-There is no additional input scan, new global dictionary or data cache, persisted-format change, or database rebuild. Dictionary identity and value comparisons are unchanged. Row counts, checked sum overflow, missing operands, and first-seen tie ordering retain their existing semantics.
+## Correctness and recovery
 
-## Validation
+The narrowed implementation passed **137 focused tests** and the full **1M** DuckDB gate: **0 mismatch, 0 missing, 0 unverifiable, and 0 serving declines**. All 43 outputs were byte-identical to the original 1M baseline. The database has two segments. Both completed post-narrowing 100M pairs also produced 43 byte-identical outputs without serving declines; their timing data remains provisional.
 
-Commit **`f13a32e68fbad8ade9e3f8d3140606e07726d4c5`** passed **123 focused tests** covering collisions, table growth, zero keys, pass ownership and spill, compact sums and overflow, parallel distinct publication/failure/retry, and interpreted-versus-vectorized grouping/top-n differentials with forced passes and ties.
+The no-mistakes review-fix round reached its 30-minute timeout before committing. Its managed worktree was removed and branch custody returned to the worker. All six edited source/test files were recovered from the tool transcript and matched the source hashes recorded before validation byte-for-byte. Subsequent local changes were formatting and two comment corrections; production tokens remain unchanged. A fresh local run of the three affected test classes passed **15 tests** with no failures, errors or skips. The original tested files, frozen runtime, correctness logs, result files, source hashes and completed run manifests are preserved under `bundles/sirix-query/build/diagnostics/groupby/recovered-fix-source/`, `nm-exclusive2-evidence/` and `nm-exclusive3-evidence/`.
 
-The full **1M** DuckDB gate reports **0 mismatch, 0 missing, 0 unverifiable, and 0 serving declines**. All 43 outputs match the original 1M baseline byte-for-byte. That database has two segments. Both exclusive **100M** legs completed 43 queries × 3 tries with no serving declines; all 43 result files are byte-identical between the heads.
+The [provisional evidence JSON](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json) retains raw per-try wall/CPU times and output hashes for those two completed narrowed-code pairs. It explicitly disallows using those timings for acceptance. It contains no selected best pair or accepted score. Previous timings remain historical diagnostics, superseded for delivery purposes.
 
-Only the nine changed Java files were formatted with the repository's Spotless/Eclipse profile. The benchmark runner is unmodified and uninstrumented.
+## Rig ownership and measurement requirements
 
-## Exclusive pair
+The last completed pair released the rig lock at **2026-09-08T03:39:26.704902+00:00**. The rig-repair lane owns 100M access until Firstmate grants another window. Do not run another 100M leg, tune against these provisional timings, or ship a performance claim from them.
 
-Baseline: `aa4d81d547fb0e2353ede959786d6e8ba442edf2`. Candidate: `f13a32e68fbad8ade9e3f8d3140606e07726d4c5`. Both ran from frozen runtime artifacts on the same host, using Oracle GraalVM 25.0.3 with C2, 20 workers, `-Xms6g -Xmx14g`, a 10 GiB off-heap arena, and the same read-only 100M database. The common lock was held continuously from **2026-09-08T02:30:48.119121+00:00** through **2026-09-08T02:35:46.452368+00:00**. No other JVM referenced the database when the lock was acquired or between legs. Firstmate was notified immediately on release.
+Exclusive access remains necessary: hold one shared rig lock continuously across baseline and candidate, inspect live database JVMs after acquisition and between legs, and inherit the lock in child JVMs. A lock file's existence does not prove a live holder; never unlink a potentially held lock. Preserve the **6/14 GiB heap and 10 GiB arena** envelope, freeze the artifacts before measurement, and record source/artifact identity, complete flags and lock times. The rig repair must additionally establish repeatability; exclusivity alone did not make the collected timings dependable.
 
-Baseline ended at `2026-09-08T02:33:31.056085+00:00`; candidate started at `2026-09-08T02:33:31.075036+00:00`. Hot time is the minimum of tries 2 and 3. The sum of hot query times decreases **37.544 → 31.904 seconds**. Full per-try times, CPU times, and output hashes are in [the measurement JSON](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.json).
-
-| Tail query | Baseline hot seconds | Candidate hot seconds | Speedup |
-|---|---:|---:|---:|
-| q5 | 0.591 | 0.747 | 0.791× |
-| q8 | 0.562 | 0.659 | 0.853× |
-| q9 | 0.653 | 0.771 | 0.847× |
-| q12 | 0.737 | 0.731 | 1.008× |
-| q13 | 2.376 | 1.271 | 1.869× |
-| q14 | 0.986 | 0.807 | 1.222× |
-| q16 | 2.060 | 1.693 | 1.217× |
-| q18 | 3.956 | 3.116 | 1.270× |
-| q28 | 8.867 | 8.864 | 1.000× |
-| q30 | 0.539 | 0.345 | 1.562× |
-| q31 | 1.500 | 0.901 | 1.665× |
-| q32 | 6.798 | 4.179 | 1.627× |
-| q33 | 2.300 | 2.157 | 1.066× |
-| q34 | 2.229 | 2.124 | 1.049× |
-
-The improvements span count-only grouping and wider aggregate state: q13/q14/q15/q16/q18/q30/q31/q32/q33/q34/q35 all improve in this pair. Regressions remain visible in the aggregate score: q8 and q9 slow by about 17–18%; q5 changes 0.591 → 0.747 s, q10 0.248 → 0.349 s, q25 0.118 → 0.170 s, and q39 0.264 → 0.401 s. This pair does not establish a cause for every per-query regression. No gains from the parallel string worker are added to these measurements.
-
-## Exclusive access is required
-
-Measurement on this box requires exclusive access. On the identical baseline head, q31's hot wall time was **3.031 s under overlapping load** and **1.500 s with exclusive access**. Its corresponding CPU times were **28.1 s** and **25.8 s**. That observed 2.02× wall-time spread can masquerade as an optimization even though the code has not changed. The larger provisional campaign reading is superseded by the clean **2.226 sum-ln** paired result above.
-
-Hold the shared rig lock continuously across baseline and candidate, check the process table for other JVMs against the 100M database after acquiring it and between legs, and serialize benchmark work on the box. A leftover lock file is not evidence of a live holder; never unlink a lock that may be held. Preserve the 6/14 GiB heap and 10 GiB arena envelope. Record the two heads, JVM flags, run times, and lock-release time with the results.
-
-## Profile and discarded experiments
-
-Exploratory JFR captures put 42–65% of original hot CPU samples for q16/q18/q30/q31/q32 inside the group table, including calls from spill/merge. Top-n was at most 1.6% and already bounded. q8/q9 concentrated approximately 92% of samples in grouped distinct aggregation. q13 also allocated many sinks, singleton sets and map entries; a later profile put 478 of 2552 samples in serial distinct-count publication and 98 in subsequent bucketing. These are CPU sample shares, not independent wall-time fractions.
-
-Row staging for high-uniqueness groups, fused fresh-stripe copying in the sparse table, and unrolled identity comparison were removed after exploratory measurements failed to show a useful broad gain. A lower pass-budget charge and increased distinct value striping were also removed. The budget-only explanation for an earlier q33/q34 slowdown was disproved by another run; Firstmate subsequently identified overlapping run windows. Those earlier timings and causal explanations are not delivery evidence.
-
-Rig mechanics and scoring commands remain documented in [the segment-lane handoff](HANDOFF_SEGMENT_LANE_2026-09-06.md) and `bundles/sirix-query/bench/clickbench/rig/`. Local raw evidence is under `bundles/sirix-query/build/diagnostics/groupby/exclusive1-*`; the paired driver uses one `fcntl.flock` context for both JVMs.
+Compare the score across all 43 queries as well as elapsed seconds after the rig is validated. A decrease in total suite time does not establish an improvement in the geometric-mean score. Rig mechanics remain in [the segment-lane handoff](HANDOFF_SEGMENT_LANE_2026-09-06.md) and `bundles/sirix-query/bench/clickbench/rig/`.

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -10,7 +10,7 @@ Firstmate's completed variance study reports a **minimum detectable effect of ap
 - Integral COUNT/SUM/AVG composite groups ordered solely by row count use present-count/sum operand pairs. Only winning accumulators expand into the ordinary output layout. Other orders, HAVING, string/deferred operands, and MIN/MAX retain ordinary state.
 - Sliced numeric/composite DISTINCT aggregation feeds worker batches directly. Singleton sets store their first value inline; promotion retains the previous 16-entry set sizing. Disjoint group stripes publish final counts on the existing worker pool, and merge bucketing visits the shards without building one intermediate map.
 - Incompatible-table diagnostics now include the `sumsOnly` flags, including the case where all other layout properties agree.
-- Aborted-pass cleanup drains the scan-local probe-index recycler before the restart measures live heap. The existing shared payload-pool guard remains in place.
+- Aborted-pass cleanup releases the finished workers' tables first and drains the scan-local probe-index recycler last, so every chunk is back in a pool before the restart measures live heap. The existing shared payload-pool guard remains in place.
 
 No additional input scan, global dictionary or data cache, persisted-format change, or database rebuild is introduced. Dictionary value comparisons, row multiplicity, checked sum overflow, missing operands, stable ties, existing pass budgets, and four distinct value stripes remain unchanged. The benchmark runner is unmodified and uninstrumented.
 

--- a/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
+++ b/docs/CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md
@@ -1,8 +1,8 @@
 # Shared aggregation: exclusive paired measurement, 8 September 2026
 
-The exclusive pair improves C6A hot geomean **4.496 → 4.269**, saving **2.225992 sum-ln**. Both heads rank **16/140** against the campaign's checked-in board snapshot. This is the accepted timing evidence for this candidate; earlier overlapping measurements are superseded.
+The exclusive pair improves C6A hot geomean **4.496 → 4.269**, saving **2.226 sum-ln**. Both heads rank **16/140** against the campaign's checked-in board snapshot. This exclusive pair supersedes the earlier baseline-to-candidate sum-ln reading, which was taken under concurrent load and is not a valid performance result.
 
-The fixed 14-query tail improves **1.175579×** by geometric mean, below the original task's **1.3×** acceptance floor. Delivery acceptance therefore remains a Firstmate decision. This change does not reach the captain's top-10 target by itself.
+The fixed 14-query tail improves **1.175579×** by geometric mean. The candidate remains above the campaign's top-10 geomean target; the measured generic gain is the result delivered here.
 
 ## Changes
 
@@ -44,6 +44,12 @@ Baseline ended at `2026-09-08T02:33:31.056085+00:00`; candidate started at `2026
 | q34 | 2.229 | 2.124 | 1.049× |
 
 The improvements span count-only grouping and wider aggregate state: q13/q14/q15/q16/q18/q30/q31/q32/q33/q34/q35 all improve in this pair. Regressions remain visible in the aggregate score: q8 and q9 slow by about 17–18%; q5 changes 0.591 → 0.747 s, q10 0.248 → 0.349 s, q25 0.118 → 0.170 s, and q39 0.264 → 0.401 s. This pair does not establish a cause for every per-query regression. No gains from the parallel string worker are added to these measurements.
+
+## Exclusive access is required
+
+Measurement on this box requires exclusive access. On the identical baseline head, q31's hot wall time was **3.031 s under overlapping load** and **1.500 s with exclusive access**. Its corresponding CPU times were **28.1 s** and **25.8 s**. That observed 2.02× wall-time spread can masquerade as an optimization even though the code has not changed. The larger provisional campaign reading is superseded by the clean **2.226 sum-ln** paired result above.
+
+Hold the shared rig lock continuously across baseline and candidate, check the process table for other JVMs against the 100M database after acquiring it and between legs, and serialize benchmark work on the box. A leftover lock file is not evidence of a live holder; never unlink a lock that may be held. Preserve the 6/14 GiB heap and 10 GiB arena envelope. Record the two heads, JVM flags, run times, and lock-release time with the results.
 
 ## Profile and discarded experiments
 

--- a/docs/HANDOFF_SEGMENT_LANE_2026-09-06.md
+++ b/docs/HANDOFF_SEGMENT_LANE_2026-09-06.md
@@ -19,10 +19,10 @@ Consequences that shape every decision:
 - **Seconds are not the metric.** 686.8 s total was rank 81; 32.13 s was rank 10. A lever is worth
   its Δln, summed over the queries it touches. Score every leg before claiming progress.
 - **The +0.01 s offset** on both sides means 0.05 s against a 0.000 s best still costs ln 6 ≈ 1.8 —
-  SEG5T's q17 measures exactly that (0.060 s against a 0.000 s best, 1.95 ln). Measured on SEG5T,
-  **19 of the 43 queries already answer in under 100 ms and still carry 21.48 of the 66.68 ln**;
-  the 16 under 50 ms carry 15.89 ln between them. See §4 for the largest measured contributions;
-  `python3 rank.py SEG5T` prints the fourteen largest C6A hot contributions.
+  SEG6T's q17 measures exactly that (0.047 s against a 0.000 s best, 1.74 ln). Measured on SEG6T,
+  **20 of the 43 queries already answer in under 100 ms and still carry 22.15 of the 63.44 ln**;
+  the 17 under 50 ms carry 17.63 ln between them. See §4 for the largest measured contributions;
+  `python3 rank.py SEG6T` prints the fourteen largest C6A hot contributions.
 - Only 3-try legs score (`suite100m.sh 3`). Never compare legs of different run shapes, and never a
   `-Dsirix.projDiag=true` run.
 
@@ -83,7 +83,10 @@ it replaced is above it.
 
 SEG5T measured `de2724c5c`, which **predates the q16 and q35 work on this branch**, so it scores
 neither q16 nor the q35 fold; its q35 row is the unrewritten query. SEG6T is the first leg past
-that point — §4's q35 row says what SEG6T's own row does and does not attribute.
+that point — §4's q35 row says what SEG6T's own row does and does not attribute. What no leg
+carries is this branch's shared group-aggregation change, which lands on top of `aa4d81d54`: it is
+unscored and claims no speedup, and its correctness and measurement standing are in
+[shared aggregation](CLICKBENCH_GROUP_AGGREGATION_2026-09-08.md).
 
 How we got here: on 2026-09-03 a global-dictionary build (`db100m-ovf`) scored rank 6 — but it
 needed a value **prepass** over the corpus to build its dictionaries. The user ruled the prepass out


### PR DESCRIPTION
## Intent

The captain's standing order is to reach the ClickBench top 10, and they have
explicitly authorized **generic approaches**: "give astra the permission to do
whatever is necessary to reach top 10 with generic approaches". They are asleep
and expect real movement by morning. Nothing about this task is speculative
research; it is the campaign's main line.

**Measured position.** The scored SEG6T leg on the current campaign head
`aa4d81d54` reads **4.372773 geomean, rank 16 of 140, 63.442089 ln**. Top 10 is
geomean 3.348, i.e. **sum-ln <= 51.99**. So **11.452 ln remain**. Today's five
landed levers (q25, q28, q32, q35, q21) bought 7.278 ln together and every one
of them was a single-query fix.

**The finding that changes the method.** Scoring is a geometric mean of
`(0.01 + ours) / (0.01 + best)` per query, so a query's ln contribution measures
*how far behind the board we are*, not *what a fix is worth*. Halving any query
whose hot time is above ~0.5 s buys **the same ~0.69 ln**, whether it is the
worst query on the board or the tenth. Ranking levers by ln contribution - which
is what this campaign has done all day - therefore ranks distance-from-board, not
return-on-effort, and that is why five hand-picked levers only moved 7.3 ln.

The arithmetic that actually matters, computed from the SEG6T table:

- A **1.37x uniform speedup across all 43 queries** reaches top 10.
- Equivalently, a **2x on just the 14 queries above 0.5 s** reaches it - those 14
hold **36.1 s of the 39.3 s** the whole suite spends.
- Equivalently, **17 individual queries halved**. There is no remaining single
lever worth more than ~3 ln, and the top query is only 3.08 ln.

So the campaign cannot arrive by finding eleven more q25s. It arrives by making a
shared path faster for many queries at once. That is the task.

**Where the time is.** The 14 queries above 0.5 s, hot seconds and current ln:

| q28 8.982s 1.929 | q32 6.743s 2.966 | q18 3.914s 1.523 | q31 3.013s 3.080 |
| q13 2.786s 2.171 | q33 2.272s 2.146 | q34 2.218s 2.122 | q16 2.027s 2.306 |
| q14 0.891s 1.541 | q12 0.758s 1.502 | q9 0.712s 1.114 | q5 0.675s 2.075 |
| q8 0.626s 1.319 | q30 0.512s 1.714 |

Read that list as shapes rather than as individual targets: the slow tail is
overwhelmingly **GROUP BY with high cardinality, then ORDER BY count DESC LIMIT
n**. That is one subsystem, and it owns most of the suite's remaining time.

## What Changed

- `NumericGroupAggTable` gains two alternative storage shapes: a dense layout (`useDenseIndex()`) that packs accumulator stripes sequentially behind a compact hash index of 32-bit tags plus record handles, and a count-and-sum layout (`sumsOnly(...)`) that stores a present-count/sum pair per operand instead of the four-lane block with extrema, with `expandSumsAccumulator` restoring the ordinary layout for selected winners. `GroupTableSpill` decides both: it enables dense indexing only for stripes of `DENSE_INDEX_MIN_STRIDE` (5) lanes or wider — the point where packed records plus one index lane beat the interleaved layout's reserved bucket per group — behind the `sirix.projection.groupTable.denseIndex` kill switch, and owns a separate scan-local recycler for index chunks. Merge compatibility checks and diagnostics now include the `sumsOnly` flag.
- `SirixVectorizedExecutor` selects the compact layout on the sliced composite arm via a new `countOrderedSums` guard (count/sum/avg aggregates ordered solely by row count; no HAVING, count-distinct, string-length or deferred operands), sizes the group budget from the matching `strideFor(..., compactSums)`, and expands only winning accumulators before record emission; a `compactSumGroupsServedCount()` counter exposes the path. `releaseAbortedPass` now releases worker tables before `spill.releaseTables()` drains the per-scan pools, so no chunk is re-pooled after the drain.
- `GroupDistinctAccumulator` stores a group's first distinct value inline and only promotes to a `LongOpenHashSet` on the second value, accepts rows directly through `addToGroup` instead of materializing a per-group sink, and publishes counts per disjoint group stripe through a caller-supplied `ParallelTasks` runner; `forEachGroupSize` lets merge bucketing visit the shards without building a combined map, which `groupSizes()` now materializes lazily. Adds tests for the dense index, its stride gate, the count-and-sum table, aborted-pass release, and top-k differential behaviour, plus campaign docs recording that the performance effect is unverified pending measurement resolution.

## Risk Assessment

⚠️ Medium: A ~600-line rewrite of the hottest shared group-aggregation path adds two alternate storage layouts, but both are tightly gated (structural `stride >= 5` for dense records; a semantic order/aggregate gate for the compact accumulator), carry a kill switch, and are differentially validated against the interpreter through the query engine — I traced the gates and every consumer that addresses `2 + 4*a` and found no reachable wrong-result path; the residual risk is the size and hot-path nature of the change plus the explicitly disclosed and authorized fact that its performance benefit is unmeasured and the merge is held.

## Testing

I exercised the changed grouped-aggregation path both at unit level and end-to-end as a user would meet it. 214 targeted tests across the 20 classes that touch NumericGroupAggTable, GroupTableSpill, GroupDistinctAccumulator, ProjectionColumnGroupScan and the executor's group-pass machinery pass with no failures or skips; the full repository suite was deliberately not run. I proved this run's aborted-pass release-order fix is a real regression fix by restoring the pre-fix ordering, watching GroupAbortedPassReleaseTest fail on 20 payload and 2 index chunks still pooled where it requires 0, then restoring the committed order and seeing it pass. For product-level evidence I loaded a fresh 1,000,000-row ClickBench database (the authorized scale; the 100M database and corpus were never touched) and ran the full 43-query CLI suite four ways over it: the default build with the new dense group-index and count-and-sum layouts, the same build with the sirix.projection.groupTable.denseIndex=false kill switch selecting the previous sparse layout, the generic interpreter, and DuckDB over byte-identical JSON. All 43 dumped answers are byte-identical between the dense and kill-switch legs, both legs report the same served-route census under --require-vectorized-serving so neither silently declined, the dense leg matches the interpreter on all 43, and strong bounded-oracle comparison against DuckDB returns 0 mismatch, 0 missing and 0 unverifiable (the 8 tie-ambiguous entries are LIMIT windows with tied boundary counts where several member sets are legal SQL, each proven legal against DuckDB's exact keys and multiplicities). Two limits stated plainly: this delivery is correctness-only under the standing authorization that forbids 100M work and any performance claim, so I did not validate the intent's underlying speedup goal and the timings in the captured transcripts are annotated as carrying no claim; and at 1M rows with a 12 GB heap no group pass ever aborted, so the release-order fix is covered by its focused regression test rather than by the end-to-end run. No screenshots apply — this is a database query engine, so the reviewer-visible surface is the ClickBench CLI transcript and the served answer rows, both captured. All transient artifacts (3.5 GB of generated corpus, database and dumps under /tmp) were removed and the worktree is clean.

<details>
<summary>Evidence: Dense-layout vs kill-switch: all 43 ClickBench answers byte-identical (1M rows)</summary>

<code>$ compare-results.py res-dense res-sparse&#10;summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)&#10;&#10;$ cmp each dumped answer file byte-for-byte&#10;byte-identical answer files: 43 differing: 0&#10;&#10;Both legs&#39; served-route census identical, so neither declined to the interpreter:&#10;groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 groupSliced=3</code>

```text
Dense group-index layout (this change, default) vs the sirix.projection.groupTable.denseIndex=false
kill switch (previous sparse interleaved layout) — SAME database, 1,000,000 hits rows, all 43 ClickBench queries.

Both legs ran with --require-vectorized-serving, and both report the identical served-route census,
so neither leg silently declined to the interpreter and the agreement below is not vacuous:

  A(dense)      # served: structuralArraySizes=2 predicateCounts=2 projectionAggregates=3 projectionCountDistinct=2 stringMinMax=2 doubleAggregates=0 binaryAggregates=0 computedAggregates=0 pathSummaryStats=0 groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 denseGlobalGroups=0 groupSliced=3 groupWindowedSlices=0 sortedScans=4 predicateScans=0 valueEmissions=1 rowMaterializations=0
  B(killswitch) # served: structuralArraySizes=2 predicateCounts=2 projectionAggregates=3 projectionCountDistinct=2 stringMinMax=2 doubleAggregates=0 binaryAggregates=0 computedAggregates=0 pathSummaryStats=0 groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 denseGlobalGroups=0 groupSliced=3 groupWindowedSlices=0 sortedScans=4 predicateScans=0 valueEmissions=1 rowMaterializations=0

$ compare-results.py res-dense res-sparse
query  verdict  detail
---------------------------------------------------------------------------
q00    MATCH  1 rows
q01    MATCH  1 rows
q02    MATCH  1 rows
q03    MATCH  1 rows
q04    MATCH  1 rows
q05    MATCH  1 rows
q06    MATCH  1 rows
q07    MATCH  20 rows
q08    MATCH  10 rows
q09    MATCH  10 rows
q10    MATCH  10 rows
q11    MATCH  10 rows
q12    MATCH  10 rows
q13    MATCH  10 rows
q14    MATCH  10 rows
q15    MATCH  10 rows
q16    MATCH  10 rows
q17    MATCH  10 rows
q18    MATCH  10 rows
q19    MATCH  179 rows
q20    MATCH  1 rows
q21    MATCH  10 rows
q22    MATCH  10 rows
q23    MATCH  10 rows
q24    MATCH  10 rows
q25    MATCH  10 rows
q26    MATCH  10 rows
q27    MATCH  1 rows
q28    MATCH  1 rows
q29    MATCH  1 rows
q30    MATCH  10 rows
q31    MATCH  10 rows
q32    MATCH  10 rows
q33    MATCH  10 rows
q34    MATCH  10 rows
q35    MATCH  10 rows
q36    MATCH  10 rows
q37    MATCH  10 rows
q38    MATCH  10 rows
q39    MATCH  10 rows
q40    MATCH  both empty
q41    MATCH  both empty
q42    MATCH  10 rows

summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)

$ cmp each dumped answer file byte-for-byte
  byte-identical answer files: 43    differing: 0
```
</details>
<details>
<summary>Evidence: Four-way ClickBench correctness differential at 1M rows (dense / kill switch / interpreter / DuckDB)</summary>

<code>== dense group-index layout (default) vs dense-index kill switch OFF ==&#10;summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)&#10;== dense group-index layout vs generic interpreter =====&#10;summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)&#10;== dense group-index layout vs DuckDB (strong, bounded oracle)&#10;summary: 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)&#10;== generic interpreter vs DuckDB (strong, bounded oracle) =====&#10;summary: 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)</code>

```text
ClickBench correctness differential — 1,000,000 synthetic hits rows, one SirixDB database,
all 43 queries, four arms:

  A  SirixDB default build            = dense group-index + count-and-sum accumulator (THIS CHANGE)
  B  SirixDB -Dsirix.projection.groupTable.denseIndex=false  = previous sparse interleaved layout
  C  SirixDB -Dsirix.query.autoVectorize=false               = generic interpreter (no fast path)
  D  DuckDB over the byte-identical hits.json                = independent oracle

Arms A and B both ran with --require-vectorized-serving and reported the same served-route
census (groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6
groupSliced=3), so neither declined to the interpreter and the agreement is not vacuous.

"tie-ambiguous" is not a mismatch: those are LIMIT windows whose boundary count is tied, where
more than one member set is a legal answer. --strong --bounded-oracle checked each of them
against DuckDB's exact window keys and full-relation multiplicities; "0 unverifiable" means
every one was proven legal.

================ dense group-index layout (default) vs dense-index kill switch OFF ================
query  verdict  detail
---------------------------------------------------------------------------
q00    MATCH  1 rows
q01    MATCH  1 rows
q02    MATCH  1 rows
q03    MATCH  1 rows
q04    MATCH  1 rows
q05    MATCH  1 rows
q06    MATCH  1 rows
q07    MATCH  20 rows
q08    MATCH  10 rows
q09    MATCH  10 rows
q10    MATCH  10 rows
q11    MATCH  10 rows
q12    MATCH  10 rows
q13    MATCH  10 rows
q14    MATCH  10 rows
q15    MATCH  10 rows
q16    MATCH  10 rows
q17    MATCH  10 rows
q18    MATCH  10 rows
q19    MATCH  179 rows
q20    MATCH  1 rows
q21    MATCH  10 rows
q22    MATCH  10 rows
q23    MATCH  10 rows
q24    MATCH  10 rows
q25    MATCH  10 rows
q26    MATCH  10 rows
q27    MATCH  1 rows
q28    MATCH  1 rows
q29    MATCH  1 rows
q30    MATCH  10 rows
q31    MATCH  10 rows
q32    MATCH  10 rows
q33    MATCH  10 rows
q34    MATCH  10 rows
q35    MATCH  10 rows
q36    MATCH  10 rows
q37    MATCH  10 rows
q38    MATCH  10 rows
q39    MATCH  10 rows
q40    MATCH  both empty
q41    MATCH  both empty
q42    MATCH  10 rows

summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)
exit=0

================ dense group-index layout vs generic interpreter =================================
query  verdict  detail
---------------------------------------------------------------------------
q00    MATCH  1 rows
q01    MATCH  1 rows
q02    MATCH  1 rows
q03    MATCH  1 rows
q04    MATCH  1 rows
q05    MATCH  1 rows
q06    MATCH  1 rows
q07    MATCH  20 rows
q08    MATCH  10 rows
q09    MATCH  10 rows
q10    MATCH  10 rows
q11    MATCH  10 rows
q12    MATCH  10 rows
q13    MATCH  10 rows
q14    MATCH  10 rows
q15    MATCH  10 rows
q16    MATCH  10 rows
q17    MATCH  10 rows
q18    MATCH  10 rows
q19    MATCH  179 rows
q20    MATCH  1 rows
q21    MATCH  10 rows
q22    MATCH  10 rows
q23    MATCH  10 rows
q24    MATCH  10 rows
q25    MATCH  10 rows
q26    MATCH  10 rows
q27    MATCH  1 rows
q28    MATCH  1 rows
q29    MATCH  1 rows
q30    MATCH  10 rows
q31    MATCH  10 rows
q32    MATCH  10 rows
q33    MATCH  10 rows
q34    MATCH  10 rows
q35    MATCH  10 rows
q36    MATCH  10 rows
q37    MATCH  10 rows
q38    MATCH  10 rows
q39    MATCH  10 rows
q40    MATCH  both empty
q41    MATCH  both empty
q42    MATCH  10 rows

summary: 43 match, 0 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)
exit=0

================ dense group-index layout vs DuckDB (strong, bounded oracle) =====================
query  verdict        detail
-----------------------------------------------------------------------------------
q00    MATCH          1 rows
q01    MATCH          1 rows
q02    MATCH          1 rows
q03    MATCH          1 rows
q04    MATCH          1 rows
q05    MATCH          1 rows
q06    MATCH          1 rows
q07    MATCH          20 rows
q08    MATCH          10 rows
q09    MATCH          10 rows
q10    MATCH          10 rows
q11    TIE-AMBIGUOUS  STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q12    MATCH          10 rows
q13    MATCH          10 rows
q14    MATCH          10 rows
q15    MATCH          10 rows
q16    MATCH          10 rows
q17    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q18    MATCH          10 rows
q19    MATCH          179 rows
q20    MATCH          1 rows
q21    MATCH          10 rows
q22    MATCH          10 rows
q23    MATCH          10 rows
q24    MATCH          10 rows
q25    MATCH          10 rows
q26    MATCH          10 rows
q27    MATCH          1 rows
q28    MATCH          1 rows
q29    MATCH          1 rows
q30    TIE-AMBIGUOUS  STRONGLY VERIFIED: 2 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q31    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q32    TIE-AMBIGUOUS  STRONGLY VERIFIED: 9 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q33    MATCH          10 rows
q34    MATCH          10 rows
q35    TIE-AMBIGUOUS  STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q36    MATCH          10 rows
q37    MATCH          10 rows
q38    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q39    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q40    MATCH          both empty
q41    MATCH          both empty
q42    MATCH          10 rows

--- q11 TIE-AMBIGUOUS: STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [1,"Explay",268]
    res-duckdb only [5,"Sony Tablet",268]

--- q17 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [59661370187015547,"",1]
    res-dense only  [76884132602494921,"buy laptop",1]
    res-dense only  [177229338304012371,"",3]
    res-dense only  [203602022210227726,"",1]
    res-dense only  [300159395479065758,"",3]
    res-dense only  ... 5 more
    res-duckdb only [440089918494246996,"photo of smartphone",1]
    res-duckdb only [577844995671569666,"buy winter tyres",1]
    res-duckdb only [671864616548949065,"manual for washing machine",1]
    res-duckdb only [693060162443800423,"",1]
    res-duckdb only [808869942912283548,"used hotel in berlin",1]
    res-duckdb only ... 5 more

--- q30 TIE-AMBIGUOUS: STRONGLY VERIFIED: 2 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [0,523115142,16,1,1573.75]
    res-dense only  [0,1995488625,16,0,1630.75]
    res-duckdb only [0,325764854,16,1,1514.125]
    res-duckdb only [0,1136382866,16,0,1586.125]

--- q31 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [113510840765342711,1133981908,1,0,1024]
    res-dense only  [209281791369584213,695419406,1,0,1280]
    res-dense only  [209847195302141196,1272888965,1,0,1920]
    res-dense only  [322056075271462780,523559234,1,0,2048]
    res-dense only  [811319444475102548,118284503,1,0,2048]
    res-dense only  ... 5 more
    res-duckdb only [92388015131609060,714413133,1,0,1680.0]
    res-duckdb only [97167114266558558,92229304,1,0,1366.0]
    res-duckdb only [187331233677449805,1210362864,1,0,1024.0]
    res-duckdb only [205060208075815524,1641082762,1,0,1280.0]
    res-duckdb only [232722034705550962,397591286,1,0,1280.0]
    res-duckdb only ... 5 more

--- q32 TIE-AMBIGUOUS: STRONGLY VERIFIED: 9 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [210439221050891364,537763450,1,0,2048]
    res-dense only  [218440338360764941,621160734,1,0,2560]
    res-dense only  [225225014155275223,1376698449,1,0,1280]
    res-dense only  [227314543606498742,497201734,1,0,1600]
    res-dense only  [267292956250414409,1389778476,1,0,1024]
    res-dens

... [1001 bytes truncated] ...

ravel",5]
    res-dense only  ... 5 more
    res-duckdb only ["http://amazon.com/",5]
    res-duckdb only ["http://avito.ru/news/",5]
    res-duckdb only ["http://check24.de/search",5]
    res-duckdb only ["http://en.wikipedia.org/blog/",5]
    res-duckdb only ["http://idealo.de/product/",5]
    res-duckdb only ... 5 more

--- q39 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-dense only  [-1,38,0,"","http://www.yandex.ru/news/",3]
    res-dense only  [0,0,0,"","http://ebay.com/checkout",3]
    res-dense only  [0,12,0,"","http://yandex.ru/catalog/tv",3]
    res-dense only  [0,22,0,"","http://m.vk.com/search/results",3]
    res-dense only  [0,38,0,"","http://yandex.ru/catalog/phones",3]
    res-dense only  ... 5 more
    res-duckdb only [-1,38,0,"","http://yandex.ru/",3]
    res-duckdb only [0,0,0,"","http://twitter.com/api/v1/items",3]
    res-duckdb only [0,22,0,"","http://news.google.fr/promo/winter",3]
    res-duckdb only [1,0,0,"","http://auto.ru/promo/winter",3]
    res-duckdb only [2,0,0,"","http://ria.ru/catalog/tv",3]
    res-duckdb only ... 5 more

summary: 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)
exit=0

================ generic interpreter vs DuckDB (strong, bounded oracle) ==========================
query  verdict        detail
-----------------------------------------------------------------------------------
q00    MATCH          1 rows
q01    MATCH          1 rows
q02    MATCH          1 rows
q03    MATCH          1 rows
q04    MATCH          1 rows
q05    MATCH          1 rows
q06    MATCH          1 rows
q07    MATCH          20 rows
q08    MATCH          10 rows
q09    MATCH          10 rows
q10    MATCH          10 rows
q11    TIE-AMBIGUOUS  STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q12    MATCH          10 rows
q13    MATCH          10 rows
q14    MATCH          10 rows
q15    MATCH          10 rows
q16    MATCH          10 rows
q17    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q18    MATCH          10 rows
q19    MATCH          179 rows
q20    MATCH          1 rows
q21    MATCH          10 rows
q22    MATCH          10 rows
q23    MATCH          10 rows
q24    MATCH          10 rows
q25    MATCH          10 rows
q26    MATCH          10 rows
q27    MATCH          1 rows
q28    MATCH          1 rows
q29    MATCH          1 rows
q30    TIE-AMBIGUOUS  STRONGLY VERIFIED: 2 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q31    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q32    TIE-AMBIGUOUS  STRONGLY VERIFIED: 9 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q33    MATCH          10 rows
q34    MATCH          10 rows
q35    TIE-AMBIGUOUS  STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q36    MATCH          10 rows
q37    MATCH          10 rows
q38    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q39    TIE-AMBIGUOUS  STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
q40    MATCH          both empty
q41    MATCH          both empty
q42    MATCH          10 rows

--- q11 TIE-AMBIGUOUS: STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [1,"Explay",268]
    res-duckdb only  [5,"Sony Tablet",268]

--- q17 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [59661370187015547,"",1]
    res-generic only [76884132602494921,"buy laptop",1]
    res-generic only [177229338304012371,"",3]
    res-generic only [203602022210227726,"",1]
    res-generic only [300159395479065758,"",3]
    res-generic only ... 5 more
    res-duckdb only  [440089918494246996,"photo of smartphone",1]
    res-duckdb only  [577844995671569666,"buy winter tyres",1]
    res-duckdb only  [671864616548949065,"manual for washing machine",1]
    res-duckdb only  [693060162443800423,"",1]
    res-duckdb only  [808869942912283548,"used hotel in berlin",1]
    res-duckdb only  ... 5 more

--- q30 TIE-AMBIGUOUS: STRONGLY VERIFIED: 2 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [0,523115142,16,1,1573.75]
    res-generic only [0,1995488625,16,0,1630.75]
    res-duckdb only  [0,325764854,16,1,1514.125]
    res-duckdb only  [0,1136382866,16,0,1586.125]

--- q31 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [113510840765342711,1133981908,1,0,1024]
    res-generic only [209281791369584213,695419406,1,0,1280]
    res-generic only [209847195302141196,1272888965,1,0,1920]
    res-generic only [322056075271462780,523559234,1,0,2048]
    res-generic only [811319444475102548,118284503,1,0,2048]
    res-generic only ... 5 more
    res-duckdb only  [92388015131609060,714413133,1,0,1680.0]
    res-duckdb only  [97167114266558558,92229304,1,0,1366.0]
    res-duckdb only  [187331233677449805,1210362864,1,0,1024.0]
    res-duckdb only  [205060208075815524,1641082762,1,0,1280.0]
    res-duckdb only  [232722034705550962,397591286,1,0,1280.0]
    res-duckdb only  ... 5 more

--- q32 TIE-AMBIGUOUS: STRONGLY VERIFIED: 9 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [210439221050891364,537763450,1,0,2048]
    res-generic only [218440338360764941,621160734,1,0,2560]
    res-generic only [225225014155275223,1376698449,1,0,1280]
    res-generic only [227314543606498742,497201734,1,0,1600]
    res-generic only [267292956250414409,1389778476,1,0,1024]
    res-generic only ... 4 more
    res-duckdb only  [297324183043086153,59413634,1,0,2560.0]
    res-duckdb only  [479056512469411107,2143822304,1,0,2048.0]
    res-duckdb only  [484399277629108552,1234856214,1,0,1920.0]
    res-duckdb only  [533902804592491264,545021710,1,0,1366.0]
    res-duckdb only  [584843142091853550,169919319,1,0,2048.0]
    res-duckdb only  ... 4 more

--- q35 TIE-AMBIGUOUS: STRONGLY VERIFIED: 1 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [61419558,61419557,61419556,61419555,83]
    res-duckdb only  [1278990948,1278990947,1278990946,1278990945,83]

--- q38 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only ["http://bild.de/cart",5]
    res-generic only ["http://booking.com/search/results",5]
    res-generic only ["http://en.wikipedia.org/search/results",5]
    res-generic only ["http://gazeta.ru/maps/place",5]
    res-generic only ["http://mail.google.com/tag/travel",5]
    res-generic only ... 5 more
    res-duckdb only  ["http://amazon.com/",5]
    res-duckdb only  ["http://avito.ru/news/",5]
    res-duckdb only  ["http://check24.de/search",5]
    res-duckdb only  ["http://en.wikipedia.org/blog/",5]
    res-duckdb only  ["http://idealo.de/product/",5]
    res-duckdb only  ... 5 more

--- q39 TIE-AMBIGUOUS: STRONGLY VERIFIED: 10 of 10 row(s) differ, but both are legal multiplicity-respecting windows
    res-generic only [-1,38,0,"","http://www.yandex.ru/news/",3]
    res-generic only [0,0,0,"","http://ebay.com/checkout",3]
    res-generic only [0,12,0,"","http://yandex.ru/catalog/tv",3]
    res-generic only [0,22,0,"","http://m.vk.com/search/results",3]
    res-generic only [0,38,0,"","http://yandex.ru/catalog/phones",3]
    res-generic only ... 5 more
    res-duckdb only  [-1,38,0,"","http://yandex.ru/",3]
    res-duckdb only  [0,0,0,"","http://twitter.com/api/v1/items",3]
    res-duckdb only  [0,22,0,"","http://news.google.fr/promo/winter",3]
    res-duckdb only  [1,0,0,"","http://auto.ru/promo/winter",3]
    res-duckdb only  [2,0,0,"","http://ria.ru/catalog/tv",3]
    res-duckdb only  ... 5 more

summary: 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing (of 43 queries)
exit=0
```
</details>
<details>
<summary>Evidence: Answers served for the 14 slow-tail GROUP BY queries the intent names, next to DuckDB</summary>

Source: Answers served for the 14 slow-tail GROUP BY queries the intent names, next to DuckDB (local file: <code>~/.no-mistakes/evidence/01M218SS3T8B17TFBM8Y1T03M2/clickbench-1m-slow-tail-answers.txt</code>)

```text
q33 SELECT URL, COUNT(*) AS c FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10;
SirixDB, dense group-index + count-and-sum accumulator (this change):
["", 19900]
["http://yandex.ru/tag/travel", 1483]
["http://yandex.ru/tag/tech", 1460]
["http://yandex.ru/promo/winter", 1450]
["http://yandex.ru/about", 1434]
DuckDB reference over the same JSON:
["", 19900]
["http://yandex.ru/tag/travel", 1483]
["http://yandex.ru/tag/tech", 1460]
["http://yandex.ru/promo/winter", 1450]
["http://yandex.ru/about", 1434]
-> byte-identical to the -Dsirix.projection.groupTable.denseIndex=false leg: True
-> vs DuckDB (strong, bounded oracle): MATCH 10 rows

kill-switch byte agreement on the intent's slow-tail shapes: 14/14
mismatches against DuckDB on those shapes: 0
```
</details>
<details>
<summary>Evidence: ClickBench CLI transcript, default build (dense group-index layout) — 43/43 served</summary>

<code>q | try1(s) | hot(s) | rows | note&#10;8 | 0.169 | 0.169 | 10 | route=group-aggregate+numeric-group-by+group-distinct&#10;16 | 0.407 | 0.407 | 10 | route=group-aggregate&#10;18 | 0.401 | 0.401 | 10 | route=group-aggregate&#10;32 | 0.350 | 0.350 | 10 | route=group-aggregate&#10;33 | 0.221 | 0.221 | 10 | route=group-aggregate&#10;# served: ... groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 groupSliced=3 ...&#10;(timings are from a single-try correctness run on a shared machine and carry NO performance claim)</code>

```text
ClickBench 43-query CLI transcript — SirixDB, 1,000,000 synthetic hits rows
Leg A: default build (dense group-index + count-and-sum accumulator, THIS CHANGE)
Command: ./gradlew :sirix-query:clickBench -Pclickbench.args="<db> --tries 1 --dump res-dense --require-vectorized-serving"

NOTE ON TIMINGS: the try1/hot columns come from a single-try CORRECTNESS run on a
synthetic 1M corpus on a shared, non-exclusive machine. They are NOT a performance
measurement and carry NO speedup, ranking or acceptance claim; this delivery is
correctness-only and its performance verdict is held pending measurement resolution.
The column that matters here is `note`, i.e. which serving route answered each query.


q    |    try1(s) |     hot(s) |       rows | note
0    |      0.054 |      0.054 |          1 | route=structural-array-size
1    |      0.084 |      0.084 |          1 | route=predicate-count
2    |      0.061 |      0.061 |          1 | route=structural-array-size+projection-aggregate
3    |      0.160 |      0.160 |          1 | route=projection-aggregate
4    |      0.073 |      0.073 |          1 | route=projection-count-distinct
5    |      0.075 |      0.075 |          1 | route=projection-count-distinct
6    |      0.003 |      0.003 |          1 | route=string-min-max
7    |      0.053 |      0.053 |         20 | route=group-aggregate+numeric-group-by
8    |      0.169 |      0.169 |         10 | route=group-aggregate+numeric-group-by+group-distinct
9    |      0.160 |      0.160 |         10 | route=group-aggregate+numeric-group-by+group-distinct
10   |      0.075 |      0.075 |         10 | route=group-aggregate+group-distinct
11   |      0.043 |      0.043 |         10 | route=group-aggregate+group-distinct
12   |      0.048 |      0.048 |         10 | route=group-aggregate
13   |      0.050 |      0.050 |         10 | route=group-aggregate+group-distinct
14   |      0.063 |      0.063 |         10 | route=group-aggregate
15   |      0.202 |      0.202 |         10 | route=group-aggregate+numeric-group-by
16   |      0.407 |      0.407 |         10 | route=group-aggregate
17   |      0.454 |      0.454 |         10 | route=group-aggregate
18   |      0.401 |      0.401 |         10 | route=group-aggregate
19   |      0.026 |      0.026 |        179 | route=predicate-value-emission
20   |      0.372 |      0.372 |          1 | route=predicate-count
21   |      0.075 |      0.075 |         10 | route=group-aggregate
22   |      0.100 |      0.100 |         10 | route=group-aggregate+group-distinct
23   |      0.166 |      0.166 |         10 | route=sorted-scan
24   |      0.063 |      0.063 |         10 | route=sorted-scan
25   |      0.074 |      0.074 |         10 | route=sorted-scan
26   |      0.009 |      0.009 |         10 | route=sorted-scan
27   |      0.218 |      0.218 |          1 | route=group-aggregate+numeric-group-by
28   |      0.443 |      0.443 |          1 | route=group-aggregate
29   |      0.071 |      0.071 |          1 | route=const-group-aggregate
30   |      0.073 |      0.073 |         10 | route=group-aggregate
31   |      0.060 |      0.060 |         10 | route=group-aggregate
32   |      0.251 |      0.251 |         10 | route=group-aggregate
33   |      0.021 |      0.021 |         10 | route=group-aggregate+numeric-group-by
34   |      0.026 |      0.026 |         10 | route=group-aggregate+numeric-group-by
35   |      0.031 |      0.031 |         10 | route=group-aggregate+numeric-group-by
36   |      0.096 |      0.096 |         10 | route=group-aggregate+numeric-group-by
37   |      0.031 |      0.031 |         10 | route=group-aggregate
38   |      0.024 |      0.024 |         10 | route=group-aggregate+numeric-group-by
39   |      0.190 |      0.190 |         10 | route=group-aggregate
40   |      0.014 |      0.014 |          0 | route=group-aggregate
41   |      0.025 |      0.025 |          0 | route=group-aggregate
42   |      0.095 |      0.095 |         10 | route=group-aggregate
# served: structuralArraySizes=2 predicateCounts=2 projectionAggregates=3 projectionCountDistinct=2 stringMinMax=2 doubleAggregates=0 binaryAggregates=0 computedAggregates=0 pathSummaryStats=0 groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 denseGlobalGroups=0 groupSliced=3 groupWindowedSlices=0 sortedScans=4 predicateScans=0 valueEmissions=1 rowMaterializations=0
# chunked: lazyLoads=0 chunkMaterializations=0 eagerFallbacks=1

Data size: 1619463022
```
</details>
<details>
<summary>Evidence: ClickBench CLI transcript, dense-index kill switch OFF (previous sparse layout)</summary>

```text
Leg B: same database, dense-index kill switch OFF (-Dsirix.projection.groupTable.denseIndex=false)

q    |    try1(s) |     hot(s) |       rows | note

NOTE ON TIMINGS: the try1/hot columns come from a single-try CORRECTNESS run on a
synthetic 1M corpus on a shared, non-exclusive machine. They are NOT a performance
measurement and carry NO speedup, ranking or acceptance claim; this delivery is
correctness-only and its performance verdict is held pending measurement resolution.
The column that matters here is `note`, i.e. which serving route answered each query.

0    |      0.050 |      0.050 |          1 | route=structural-array-size
1    |      0.087 |      0.087 |          1 | route=predicate-count
2    |      0.078 |      0.078 |          1 | route=structural-array-size+projection-aggregate
3    |      0.144 |      0.144 |          1 | route=projection-aggregate
4    |      0.062 |      0.062 |          1 | route=projection-count-distinct
5    |      0.078 |      0.078 |          1 | route=projection-count-distinct
6    |      0.004 |      0.004 |          1 | route=string-min-max
7    |      0.070 |      0.070 |         20 | route=group-aggregate+numeric-group-by
8    |      0.177 |      0.177 |         10 | route=group-aggregate+numeric-group-by+group-distinct
9    |      0.107 |      0.107 |         10 | route=group-aggregate+numeric-group-by+group-distinct
10   |      0.075 |      0.075 |         10 | route=group-aggregate+group-distinct
11   |      0.059 |      0.059 |         10 | route=group-aggregate+group-distinct
12   |      0.043 |      0.043 |         10 | route=group-aggregate
13   |      0.080 |      0.080 |         10 | route=group-aggregate+group-distinct
14   |      0.075 |      0.075 |         10 | route=group-aggregate
15   |      0.160 |      0.160 |         10 | route=group-aggregate+numeric-group-by
16   |      0.362 |      0.362 |         10 | route=group-aggregate
17   |      0.381 |      0.381 |         10 | route=group-aggregate
18   |      0.506 |      0.506 |         10 | route=group-aggregate
19   |      0.028 |      0.028 |        179 | route=predicate-value-emission
20   |      0.383 |      0.383 |          1 | route=predicate-count
21   |      0.067 |      0.067 |         10 | route=group-aggregate
22   |      0.096 |      0.096 |         10 | route=group-aggregate+group-distinct
23   |      0.167 |      0.167 |         10 | route=sorted-scan
24   |      0.059 |      0.059 |         10 | route=sorted-scan
25   |      0.098 |      0.098 |         10 | route=sorted-scan
26   |      0.009 |      0.009 |         10 | route=sorted-scan
27   |      0.214 |      0.214 |          1 | route=group-aggregate+numeric-group-by
28   |      0.455 |      0.455 |          1 | route=group-aggregate
29   |      0.104 |      0.104 |          1 | route=const-group-aggregate
30   |      0.087 |      0.087 |         10 | route=group-aggregate
31   |      0.088 |      0.088 |         10 | route=group-aggregate
32   |      0.350 |      0.350 |         10 | route=group-aggregate
33   |      0.221 |      0.221 |         10 | route=group-aggregate+numeric-group-by
34   |      0.068 |      0.068 |         10 | route=group-aggregate+numeric-group-by
35   |      0.034 |      0.034 |         10 | route=group-aggregate+numeric-group-by
36   |      0.129 |      0.129 |         10 | route=group-aggregate+numeric-group-by
37   |      0.034 |      0.034 |         10 | route=group-aggregate
38   |      0.028 |      0.028 |         10 | route=group-aggregate+numeric-group-by
39   |      0.273 |      0.273 |         10 | route=group-aggregate
40   |      0.012 |      0.012 |          0 | route=group-aggregate
41   |      0.021 |      0.021 |          0 | route=group-aggregate
42   |      0.114 |      0.114 |         10 | route=group-aggregate
# served: structuralArraySizes=2 predicateCounts=2 projectionAggregates=3 projectionCountDistinct=2 stringMinMax=2 doubleAggregates=0 binaryAggregates=0 computedAggregates=0 pathSummaryStats=0 groupAggregates=29 constGroupAggregates=1 numericGroupBys=10 groupDistinct=6 denseGlobalGroups=0 groupSliced=3 groupWindowedSlices=0 sortedScans=4 predicateScans=0 valueEmissions=1 rowMaterializations=0
# chunked: lazyLoads=0 chunkMaterializations=0 eagerFallbacks=1

Data size: 1619463022
```
</details>
<details>
<summary>Evidence: Fail-before/pass-after proof for the aborted-pass release-order fix</summary>

<code>--- WITH PRE-FIX ORDERING (spill.releaseTables() first) -&gt; FAILS ---&#10;GroupAbortedPassReleaseTest &gt; aSharedPayloadPoolIsRetainedWhileTheIndexRecyclerDrains():&#10;the per-scan index recycler still drains: LongChunkPool[lanes=16384 pooled=2/6 ...] ==&gt; expected: &lt;0&gt; but was: &lt;2&gt;&#10;GroupAbortedPassReleaseTest &gt; abortedPassLeavesNoChunkForTheBudgetRefreshToMeasure():&#10;no payload chunk survives into the restart&#39;s budget measurement: LongChunkPool[lanes=16384 pooled=20/5527 ...] ==&gt; expected: &lt;0&gt; but was: &lt;20&gt;&#10;2 tests completed, 2 failed&#10;&#10;--- WITH COMMITTED ORDERING -&gt; 2 tests pass ---</code>

```text
Regression check for commit 5b2ce9b63 "Fix aborted-pass release order"
=====================================================================
Method: temporarily restored the PRE-FIX ordering in
bundles/sirix-query/src/main/java/io/sirix/query/scan/SirixVectorizedExecutor.java
(releaseAbortedPass: spill.releaseTables() BEFORE the worker-table release loop),
re-ran the regression test, then restored the committed ordering.

--- WITH PRE-FIX ORDERING (spill.releaseTables() first) -> FAILS ---
FAILED-TEST: io.sirix.query.scan.GroupAbortedPassReleaseTest > aSharedPayloadPoolIsRetainedWhileTheIndexRecyclerDrains():
  org.opentest4j.AssertionFailedError: the per-scan index recycler still drains:
  LongChunkPool[lanes=16384 pooled=2/6 hits=0 misses=2 dropped=0] ==> expected: <0> but was: <2>
FAILED-TEST: io.sirix.query.scan.GroupAbortedPassReleaseTest > abortedPassLeavesNoChunkForTheBudgetRefreshToMeasure():
  org.opentest4j.AssertionFailedError: no payload chunk survives into the restart's budget measurement:
  LongChunkPool[lanes=16384 pooled=20/5527 hits=0 misses=20 dropped=0] ==> expected: <0> but was: <20>
2 tests completed, 2 failed

Interpretation: 20 payload chunks + 2 index chunks (16384 lanes = 128 KiB each)
were still strongly reachable from the per-scan recyclers when GroupPasses.restart
measures live heap, so they would be subtracted from the refreshed group budget.
```
</details>
<details>
<summary>Evidence: Targeted test results (214 tests, 20 classes, 0 failures)</summary>

<code>DenseGroupIndexTest tests= 3 failures=0 errors=0 skipped=0&#10;GroupTableDenseIndexGateTest tests= 4 failures=0 errors=0 skipped=0&#10;NumericGroupSumTableTest tests= 2 failures=0 errors=0 skipped=0&#10;GroupDistinctAccumulatorTest tests= 9 failures=0 errors=0 skipped=0&#10;GroupTopKDifferentialTest tests= 57 failures=0 errors=0 skipped=0&#10;GroupAbortedPassReleaseTest tests= 2 failures=0 errors=0 skipped=0&#10;...&#10;TOTAL tests=214 failures=0 errors=0 skipped=0</code>

```text
Targeted test classes exercising the changed group-aggregation classes
(NumericGroupAggTable, GroupTableSpill, GroupDistinctAccumulator, ProjectionColumnGroupScan,
 SirixVectorizedExecutor group-pass machinery). Full repository suite deliberately NOT run.

DenseGroupIndexTest                    tests=   3  failures=0  errors=0  skipped=0
GroupTableDenseIndexGateTest           tests=   4  failures=0  errors=0  skipped=0
NumericGroupSumTableTest               tests=   2  failures=0  errors=0  skipped=0
GroupDistinctAccumulatorTest           tests=   9  failures=0  errors=0  skipped=0
GroupTableSpillPassPlanTest            tests=  20  failures=0  errors=0  skipped=0
NumericGroupAggTableTest               tests=  17  failures=0  errors=0  skipped=0
GroupStripeSpillTest                   tests=   6  failures=0  errors=0  skipped=0
GroupStrideBudgetTest                  tests=   9  failures=0  errors=0  skipped=0
HeapHeadroomBudgetTest                 tests=   7  failures=0  errors=0  skipped=0
CompositeGroupIdentityCollisionTest    tests=   8  failures=0  errors=0  skipped=0
CompositeDiscardedFoldTest             tests=  10  failures=0  errors=0  skipped=0
SegmentLengthLaneGroupScanTest         tests=   6  failures=0  errors=0  skipped=0
GroupTopKDifferentialTest              tests=  57  failures=0  errors=0  skipped=0
GroupAbortedPassReleaseTest            tests=   2  failures=0  errors=0  skipped=0
GroupTableSpillDifferentialTest        tests=   1  failures=0  errors=0  skipped=0
GroupPassesBudgetRefreshTest           tests=   5  failures=0  errors=0  skipped=0
GroupHashRangePassTest                 tests=   4  failures=0  errors=0  skipped=0
GroupPassOutOfMemoryRestartTest        tests=   1  failures=0  errors=0  skipped=0
GroupWindowedSlicesTest                tests=  42  failures=0  errors=0  skipped=0
WindowedSliceRecyclingQueryTest        tests=   1  failures=0  errors=0  skipped=0

TOTAL  tests=214  failures=0  errors=0  skipped=0
```
</details>

- Evidence: Raw runner log, dense leg (full per-query stderr diagnostics) (local file: <code>~/.no-mistakes/evidence/01M218SS3T8B17TFBM8Y1T03M2/clickbench-1m-leg-dense.log</code>)
- Evidence: Raw runner log, kill-switch leg (local file: <code>~/.no-mistakes/evidence/01M218SS3T8B17TFBM8Y1T03M2/clickbench-1m-leg-killswitch.log</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7236d7d727bae9330cad5964d3f4487e3fb14fc0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `bundles/sirix-core/src/main/java/io/sirix/index/projection/ProjectionColumnGroupScan.java:1346` - `out.sumsOnly()` is evaluated per SELECTED ROW in both composite fold loops (also line 1512), inside `while (word != 0L)` nested in `for (w)` nested in `for (leaf)`. The layout is fixed for the whole scan — it is a final field of a final class chosen once by the spill&#39;s factory — so the branch is loop-invariant, exactly like the neighbouring `countOnly`, `aggCount` and `sumExactMask`, which the same method already hoists into locals before the leaf loop. AGENTS.md&#39;s hot-path rule (&#34;Avoid virtual method calls in tight loops where possible&#34;) is the project&#39;s own bar here, and this is the innermost loop the change exists to speed up. Remedy is mechanical and non-functional: hoist `final boolean compactFold = out.sumsOnly();` beside the existing `countOnly` local in `aggregateByGroupCompositeFlat` and test that instead at both sites. JIT will almost certainly fold this anyway, so the value is consistency with the surrounding hoists rather than a measurable win.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`./gradlew :sirix-core:test --tests io.sirix.index.projection.DenseGroupIndexTest --tests ...GroupTableDenseIndexGateTest --tests ...NumericGroupSumTableTest --tests ...GroupDistinctAccumulatorTest --tests ...GroupTableSpillPassPlanTest --tests ...NumericGroupAggTableTest --tests ...GroupStripeSpillTest --tests ...GroupStrideBudgetTest --tests ...HeapHeadroomBudgetTest --tests ...CompositeGroupIdentityCollisionTest --tests ...CompositeDiscardedFoldTest --tests ...SegmentLengthLaneGroupScanTest` (101 tests, all pass)</code>
- <code>`./gradlew :sirix-query:test --tests io.sirix.query.scan.GroupTopKDifferentialTest --tests ...GroupAbortedPassReleaseTest --tests ...GroupTableSpillDifferentialTest --tests ...GroupPassesBudgetRefreshTest --tests ...GroupHashRangePassTest --tests ...GroupPassOutOfMemoryRestartTest --tests ...GroupWindowedSlicesTest --tests ...WindowedSliceRecyclingQueryTest` (113 tests, all pass)</code>
- <code>Fail-before/pass-after regression proof: temporarily restored the pre-fix ordering in `SirixVectorizedExecutor.releaseAbortedPass` (spill.releaseTables() before the worker-table release loop), re-ran `GroupAbortedPassReleaseTest` -&gt; both tests FAIL (20 payload + 2 index chunks still pooled, expected 0); restored the committed ordering -&gt; pass. Worktree verified clean afterwards.</code>
- <code>`./gradlew :sirix-query:clickBenchGenerate -Pclickbench.args=&#34;hits.json 1000000 42&#34;` then `:sirix-query:clickBenchLoad` — built a fresh 1M-row SirixDB database with the projection index (no 100M database or corpus touched)</code>
- <code>Leg A (end-user CLI): `./gradlew :sirix-query:clickBench -Pclickbench.args=&#34;&lt;db&gt; --tries 1 --dump res-dense --require-vectorized-serving&#34;` — default build, dense group-index layout; all 43 queries served, 29 group-aggregate + 10 numeric-group-by + 6 group-distinct routes</code>
- <code>Leg B (kill switch): same command with `-Pclickbench.jvmArgs=&#34;-Dsirix.projection.groupTable.denseIndex=false&#34;` — previous sparse interleaved layout, identical served-route census (comparison provably not vacuous)</code>
- <code>Leg C (oracle): same command with `-Dsirix.query.autoVectorize=false --require-generic-serving` — generic interpreter</code>
- <code>Leg D (oracle): `python3 duckdb_reference.py --source hits.json --format json --out res-duckdb --tries 1 --candidate-reference vectorized=... --candidate-reference generic=...`</code>
- <code>`python3 compare-results.py res-dense res-sparse` -&gt; 43 match, 0 mismatch; plus `cmp` on every qNN.jsonl -&gt; 43/43 byte-identical</code>
- <code>`python3 compare-results.py res-dense res-generic` -&gt; 43 match, 0 mismatch</code>
- <code>`python3 compare-results.py --strong --bounded-oracle vectorized res-dense res-duckdb` -&gt; 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing</code>
- <code>`python3 compare-results.py --strong --bounded-oracle generic res-generic res-duckdb` -&gt; 35 match, 8 tie-ambiguous (0 unverifiable), 0 mismatch, 0 missing</code>
- `Manual answer inspection of the 14 slow-tail queries the intent names (q5, q8, q9, q12, q13, q14, q16, q18, q28, q30, q31, q32, q33, q34): SirixDB answers rendered next to DuckDB's, 14/14 byte-identical to the kill-switch leg, 0 mismatches`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
